### PR TITLE
delay to read resources

### DIFF
--- a/opentelekomcloud/resource_opentelekomcloud_blockstorage_volume_v2.go
+++ b/opentelekomcloud/resource_opentelekomcloud_blockstorage_volume_v2.go
@@ -252,6 +252,7 @@ func resourceBlockStorageVolumeV2Read(d *schema.ResourceData, meta interface{}) 
 	if err := d.Set("attachment", attachments); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving attachment to state for OpenTelekomCloud block storage (%s): %s", d.Id(), err)
 	}
+	time.Sleep(2 * time.Second)
 	taglist, err := GetVolumeTags(blockStorageClient, "volumes", v.ID)
 	if err != nil {
 		return fmt.Errorf("Error fetching tags for volume (%s): %s", v.ID, err)

--- a/opentelekomcloud/resource_opentelekomcloud_compute_instance_v2.go
+++ b/opentelekomcloud/resource_opentelekomcloud_compute_instance_v2.go
@@ -494,6 +494,7 @@ func resourceComputeInstanceV2Read(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("Error creating OpenTelekomCloud compute client: %s", err)
 	}
 
+	time.Sleep(2 * time.Second)
 	server, err := servers.Get(computeClient, d.Id()).Extract()
 	if err != nil {
 		return CheckDeleted(d, err, "server")
@@ -592,6 +593,7 @@ func resourceComputeInstanceV2Read(d *schema.ResourceData, meta interface{}) err
 	// Set the region
 	d.Set("region", GetRegion(d, config))
 
+	time.Sleep(2 * time.Second)
 	taglist, err := GetServerTags(computeClient, d.Id())
 	if err != nil {
 		return err

--- a/opentelekomcloud/resource_opentelekomcloud_compute_volume_attach_v2.go
+++ b/opentelekomcloud/resource_opentelekomcloud_compute_volume_attach_v2.go
@@ -120,6 +120,7 @@ func resourceComputeVolumeAttachV2Read(d *schema.ResourceData, meta interface{})
 		return err
 	}
 
+	time.Sleep(2 * time.Second)
 	attachment, err := volumeattach.Get(computeClient, instanceId, attachmentId).Extract()
 	if err != nil {
 		return CheckDeleted(d, err, "compute_volume_attach")
@@ -152,7 +153,7 @@ func resourceComputeVolumeAttachV2Delete(d *schema.ResourceData, meta interface{
 		Target:     []string{"DETACHED"},
 		Refresh:    resourceComputeVolumeAttachV2DetachFunc(computeClient, instanceId, attachmentId),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
-		Delay:      15 * time.Second,
+		Delay:      30 * time.Second,
 		MinTimeout: 15 * time.Second,
 	}
 

--- a/opentelekomcloud/resource_opentelekomcloud_dns_recordset_v2.go
+++ b/opentelekomcloud/resource_opentelekomcloud_dns_recordset_v2.go
@@ -142,6 +142,7 @@ func resourceDNSRecordSetV2Read(d *schema.ResourceData, meta interface{}) error 
 		return err
 	}
 
+	time.Sleep(2 * time.Second)
 	n, err := recordsets.Get(dnsClient, zoneID, recordsetID).Extract()
 	if err != nil {
 		return CheckDeleted(d, err, "record_set")


### PR DESCRIPTION
It should delay to read these resources, otherwise it may impact the performance of corresponding services.
This pr is from https://github.com/gator1/terraform-provider-opentelekomcloud/pull/15