### PR TITLE
Add specific description for network parameter

### DIFF
--- a/website/docs/r/compute_instance_v2.html.markdown
+++ b/website/docs/r/compute_instance_v2.html.markdown
@@ -317,8 +317,9 @@ The following arguments are supported:
     the server. Changing this creates a new server.
 
 * `network` - (Optional) An array of one or more networks to attach to the
-    instance. The network object structure is documented below. Changing this
-    creates a new server.
+    instance. Required when there are multiple networks difined for the tenant
+    The network object structure is documented below. Changing this creates a 
+    new server.
 
 * `metadata` - (Optional) Metadata key/value pairs to make available from
     within the instance. Changing this updates the existing server metadata.

--- a/website/docs/r/compute_instance_v2.html.markdown
+++ b/website/docs/r/compute_instance_v2.html.markdown
@@ -317,7 +317,7 @@ The following arguments are supported:
     the server. Changing this creates a new server.
 
 * `network` - (Optional) An array of one or more networks to attach to the
-    instance. Required when there are multiple networks difined for the tenant
+    instance. Required when there are multiple networks defined for the tenant. 
     The network object structure is documented below. Changing this creates a 
     new server.
 


### PR DESCRIPTION
The parameter of network in instance would have specific description. it should be a required parameter when there are multiple networks for the tenant. this PR proposes to update the description in doc.

Resolves: #12 