### PR TITLE
Revise record set

### DIFF
--- a/opentelekomcloud/import_opentelekomcloud_dns_recordset_v2_test.go
+++ b/opentelekomcloud/import_opentelekomcloud_dns_recordset_v2_test.go
@@ -17,8 +17,7 @@ func TestAccDNSV2RecordSet_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckDNSV2RecordSetDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config:             testAccDNSV2RecordSet_basic(zoneName),
-				ExpectNonEmptyPlan: true,
+				Config: testAccDNSV2RecordSet_basic(zoneName),
 			},
 			resource.TestStep{
 				ResourceName:      resourceName,

--- a/opentelekomcloud/import_opentelekomcloud_dns_zone_v2_test.go
+++ b/opentelekomcloud/import_opentelekomcloud_dns_zone_v2_test.go
@@ -10,7 +10,7 @@ import (
 
 // PASS, but normally skip
 func TestAccDNSV2Zone_importBasic(t *testing.T) {
-	var zoneName = fmt.Sprintf("ACPTTEST%s.com.", acctest.RandString(5))
+	var zoneName = fmt.Sprintf("accepttest%s.com.", acctest.RandString(5))
 	resourceName := "opentelekomcloud_dns_zone_v2.zone_1"
 
 	resource.Test(t, resource.TestCase{
@@ -19,8 +19,7 @@ func TestAccDNSV2Zone_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckDNSV2ZoneDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config:             testAccDNSV2Zone_basic(zoneName),
-				ExpectNonEmptyPlan: true,
+				Config: testAccDNSV2Zone_basic(zoneName),
 			},
 
 			resource.TestStep{

--- a/opentelekomcloud/resource_opentelekomcloud_dns_recordset_v2.go
+++ b/opentelekomcloud/resource_opentelekomcloud_dns_recordset_v2.go
@@ -53,20 +53,20 @@ func resourceDNSRecordSetV2() *schema.Resource {
 			},
 			"records": &schema.Schema{
 				Type:     schema.TypeList,
-				Optional: true,
+				Required: true,
 				ForceNew: false,
 				Elem:     &schema.Schema{Type: schema.TypeString},
+				MinItems: 1,
 			},
 			"ttl": &schema.Schema{
 				Type:     schema.TypeInt,
 				Optional: true,
-				Computed: true,
 				ForceNew: false,
+				Default:  300,
 			},
 			"type": &schema.Schema{
 				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Required: true,
 				ForceNew: true,
 			},
 			"value_specs": &schema.Schema{
@@ -121,6 +121,11 @@ func resourceDNSRecordSetV2Create(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf(
+			"Error waiting for record set (%s) to become ACTIVE for creation: %s",
+			n.ID, err)
+	}
 
 	id := fmt.Sprintf("%s/%s", zoneID, n.ID)
 	d.SetId(id)
@@ -211,6 +216,11 @@ func resourceDNSRecordSetV2Update(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf(
+			"Error waiting for record set (%s) to become ACTIVE for updation: %s",
+			recordsetID, err)
+	}
 
 	return resourceDNSRecordSetV2Read(d, meta)
 }
@@ -230,13 +240,13 @@ func resourceDNSRecordSetV2Delete(d *schema.ResourceData, meta interface{}) erro
 
 	err = recordsets.Delete(dnsClient, zoneID, recordsetID).ExtractErr()
 	if err != nil {
-		return fmt.Errorf("Error deleting OpenTelekomCloud DNS  record set: %s", err)
+		return fmt.Errorf("Error deleting OpenTelekomCloud DNS record set: %s", err)
 	}
 
 	log.Printf("[DEBUG] Waiting for DNS record set (%s) to be deleted", recordsetID)
 	stateConf := &resource.StateChangeConf{
 		Target:     []string{"DELETED"},
-		Pending:    []string{"ACTIVE", "PENDING"},
+		Pending:    []string{"ACTIVE", "PENDING", "ERROR"},
 		Refresh:    waitForDNSRecordSet(dnsClient, zoneID, recordsetID),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
 		Delay:      5 * time.Second,
@@ -244,6 +254,11 @@ func resourceDNSRecordSetV2Delete(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf(
+			"Error waiting for record set (%s) to become DELETED for deletion: %s",
+			recordsetID, err)
+	}
 
 	d.SetId("")
 	return nil
@@ -261,7 +276,7 @@ func waitForDNSRecordSet(dnsClient *golangsdk.ServiceClient, zoneID, recordsetId
 		}
 
 		log.Printf("[DEBUG] OpenTelekomCloud DNS record set (%s) current status: %s", recordset.ID, recordset.Status)
-		return recordset, recordset.Status, nil
+		return recordset, parseStatus(recordset.Status), nil
 	}
 }
 

--- a/opentelekomcloud/resource_opentelekomcloud_dns_recordset_v2_test.go
+++ b/opentelekomcloud/resource_opentelekomcloud_dns_recordset_v2_test.go
@@ -28,8 +28,7 @@ func TestAccDNSV2RecordSet_basic(t *testing.T) {
 		CheckDestroy: testAccCheckDNSV2RecordSetDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config:             testAccDNSV2RecordSet_basic(zoneName),
-				ExpectNonEmptyPlan: true,
+				Config: testAccDNSV2RecordSet_basic(zoneName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDNSV2RecordSetExists("opentelekomcloud_dns_recordset_v2.recordset_1", &recordset),
 					resource.TestCheckResourceAttr(
@@ -39,8 +38,7 @@ func TestAccDNSV2RecordSet_basic(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				Config:             testAccDNSV2RecordSet_update(zoneName),
-				ExpectNonEmptyPlan: true,
+				Config: testAccDNSV2RecordSet_update(zoneName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("opentelekomcloud_dns_recordset_v2.recordset_1", "name", zoneName),
 					resource.TestCheckResourceAttr("opentelekomcloud_dns_recordset_v2.recordset_1", "ttl", "6000"),
@@ -66,8 +64,7 @@ func TestAccDNSV2RecordSet_readTTL(t *testing.T) {
 		CheckDestroy: testAccCheckDNSV2RecordSetDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config:             testAccDNSV2RecordSet_readTTL(zoneName),
-				ExpectNonEmptyPlan: true,
+				Config: testAccDNSV2RecordSet_readTTL(zoneName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDNSV2RecordSetExists("opentelekomcloud_dns_recordset_v2.recordset_1", &recordset),
 					resource.TestMatchResourceAttr(
@@ -89,8 +86,7 @@ func TestAccDNSV2RecordSet_timeout(t *testing.T) {
 		CheckDestroy: testAccCheckDNSV2RecordSetDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config:             testAccDNSV2RecordSet_timeout(zoneName),
-				ExpectNonEmptyPlan: true,
+				Config: testAccDNSV2RecordSet_timeout(zoneName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDNSV2RecordSetExists("opentelekomcloud_dns_recordset_v2.recordset_1", &recordset),
 				),
@@ -169,7 +165,6 @@ func testAccDNSV2RecordSet_basic(zoneName string) string {
 			email = "email2@example.com"
 			description = "a zone"
 			ttl = 6000
-			type = "PRIMARY"
 		}
 
 		resource "opentelekomcloud_dns_recordset_v2" "recordset_1" {
@@ -190,7 +185,6 @@ func testAccDNSV2RecordSet_update(zoneName string) string {
 			email = "email2@example.com"
 			description = "an updated zone"
 			ttl = 6000
-			type = "PRIMARY"
 		}
 
 		resource "opentelekomcloud_dns_recordset_v2" "recordset_1" {
@@ -211,7 +205,6 @@ func testAccDNSV2RecordSet_readTTL(zoneName string) string {
 			email = "email2@example.com"
 			description = "an updated zone"
 			ttl = 6000
-			type = "PRIMARY"
 		}
 
 		resource "opentelekomcloud_dns_recordset_v2" "recordset_1" {
@@ -230,7 +223,6 @@ func testAccDNSV2RecordSet_timeout(zoneName string) string {
 			email = "email2@example.com"
 			description = "an updated zone"
 			ttl = 6000
-			type = "PRIMARY"
 		}
 
 		resource "opentelekomcloud_dns_recordset_v2" "recordset_1" {

--- a/opentelekomcloud/resource_opentelekomcloud_dns_zone_v2_test.go
+++ b/opentelekomcloud/resource_opentelekomcloud_dns_zone_v2_test.go
@@ -16,7 +16,7 @@ import (
 func TestAccDNSV2Zone_basic(t *testing.T) {
 	var zone zones.Zone
 	// TODO: Why does it lowercase names in back-end?
-	var zoneName = fmt.Sprintf("acpttest%s.com.", acctest.RandString(5))
+	var zoneName = fmt.Sprintf("accepttest%s.com.", acctest.RandString(5))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheckDNS(t) },
@@ -24,8 +24,7 @@ func TestAccDNSV2Zone_basic(t *testing.T) {
 		CheckDestroy: testAccCheckDNSV2ZoneDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config:             testAccDNSV2Zone_basic(zoneName),
-				ExpectNonEmptyPlan: true,
+				Config: testAccDNSV2Zone_basic(zoneName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDNSV2ZoneExists("opentelekomcloud_dns_zone_v2.zone_1", &zone),
 					resource.TestCheckResourceAttr(
@@ -33,8 +32,7 @@ func TestAccDNSV2Zone_basic(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				Config:             testAccDNSV2Zone_update(zoneName),
-				ExpectNonEmptyPlan: true,
+				Config: testAccDNSV2Zone_update(zoneName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("opentelekomcloud_dns_zone_v2.zone_1", "name", zoneName),
 					resource.TestCheckResourceAttr("opentelekomcloud_dns_zone_v2.zone_1", "email", "email2@example.com"),
@@ -154,7 +152,7 @@ func testAccDNSV2Zone_basic(zoneName string) string {
 			email = "email1@example.com"
 			description = "a zone"
 			ttl = 3000
-			type = "PRIMARY"
+			type = "public"
 		}
 	`, zoneName)
 }
@@ -166,7 +164,7 @@ func testAccDNSV2Zone_update(zoneName string) string {
 			email = "email2@example.com"
 			description = "an updated zone"
 			ttl = 6000
-			type = "PRIMARY"
+			type = "public"
 		}
 	`, zoneName)
 }

--- a/opentelekomcloud/resource_opentelekomcloud_dns_zone_v2_test.go
+++ b/opentelekomcloud/resource_opentelekomcloud_dns_zone_v2_test.go
@@ -47,6 +47,31 @@ func TestAccDNSV2Zone_basic(t *testing.T) {
 	})
 }
 
+func TestAccDNSV2Zone_private(t *testing.T) {
+	var zone zones.Zone
+	// TODO: Why does it lowercase names in back-end?
+	var zoneName = fmt.Sprintf("acpttest%s.com.", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckDNS(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDNSV2ZoneDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDNSV2Zone_private(zoneName),
+				//ExpectNonEmptyPlan: true,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDNSV2ZoneExists("opentelekomcloud_dns_zone_v2.zone_1", &zone),
+					resource.TestCheckResourceAttr(
+						"opentelekomcloud_dns_zone_v2.zone_1", "description", "a zone"),
+					resource.TestCheckResourceAttr(
+						"opentelekomcloud_dns_zone_v2.zone_1", "type", "private"),
+				),
+			},
+		},
+	})
+}
+
 // PASS, but normally skip
 func TestAccDNSV2Zone_readTTL(t *testing.T) {
 	var zone zones.Zone
@@ -155,6 +180,22 @@ func testAccDNSV2Zone_basic(zoneName string) string {
 			type = "public"
 		}
 	`, zoneName)
+}
+
+func testAccDNSV2Zone_private(zoneName string) string {
+	return fmt.Sprintf(`
+		resource "opentelekomcloud_dns_zone_v2" "zone_1" {
+			name = "%s"
+			email = "email1@example.com"
+			description = "a zone"
+			ttl = 3000
+			type = "private"
+			router = {
+				router_id = "%s"
+				router_region = "%s"
+			}
+		}
+	`, zoneName, OS_VPC_ID, OS_REGION_NAME)
 }
 
 func testAccDNSV2Zone_update(zoneName string) string {

--- a/opentelekomcloud/types.go
+++ b/opentelekomcloud/types.go
@@ -330,7 +330,7 @@ func (opts SubnetCreateOpts) ToSubnetCreateMap() (map[string]interface{}, error)
 // ZoneCreateOpts represents the attributes used when creating a new DNS zone.
 type ZoneCreateOpts struct {
 	zones.CreateOpts
-	ValueSpecs map[string]string `json:"value_specs,omitempty"`
+	ValueSpecs map[string]interface{} `json:"value_specs,omitempty"`
 }
 
 // ToZoneCreateMap casts a CreateOpts struct to a map.

--- a/opentelekomcloud/util.go
+++ b/opentelekomcloud/util.go
@@ -69,6 +69,15 @@ func MapValueSpecs(d *schema.ResourceData) map[string]string {
 	return m
 }
 
+// MapResourceProp converts ResourceData property into a map
+func MapResourceProp(d *schema.ResourceData, prop string) map[string]interface{} {
+	m := make(map[string]interface{})
+	for key, val := range d.Get(prop).(map[string]interface{}) {
+		m[key] = val.(string)
+	}
+	return m
+}
+
 // List of headers that need to be redacted
 var REDACT_HEADERS = []string{"x-auth-token", "x-auth-key", "x-service-token",
 	"x-storage-token", "x-account-meta-temp-url-key", "x-account-meta-temp-url-key-2",


### PR DESCRIPTION
Revise schema of record set according to the definitions of API[1]. These codes are synchronized from https://github.com/gator1/terraform-provider-opentelekomcloud
This pr depends on #11 

https://docs.otc.t-systems.com/en-us/api/dns/en-us_topic_0037134404.html 

```shell
TF_ACC=1 go test ./opentelekomcloud/ -v -run=TestAccDNSV2RecordSet_basic -timeout 240m
=== RUN TestAccDNSV2RecordSet_basic
--- PASS: TestAccDNSV2RecordSet_basic (110.83s)
PASS
ok github.com/terraform-providers/terraform-provider-opentelekomcloud/opentelekomcloud 110.836s

TF_ACC=1 go test ./opentelekomcloud/ -v -run=TestAccDNSV2RecordSet_readTTL -timeout 240m
=== RUN TestAccDNSV2RecordSet_readTTL
--- PASS: TestAccDNSV2RecordSet_readTTL (62.01s)
PASS
ok github.com/terraform-providers/terraform-provider-opentelekomcloud/opentelekomcloud 62.017s

TF_ACC=1 go test ./opentelekomcloud/ -v -run=TestAccDNSV2RecordSet_timeout -timeout 240m
=== RUN TestAccDNSV2RecordSet_timeout
--- PASS: TestAccDNSV2RecordSet_timeout (52.94s)
PASS
ok github.com/terraform-providers/terraform-provider-opentelekomcloud/opentelekomcloud 52.951s
```