### PR TITLE
add a method to check whether an opt is filled

### DIFF
--- a/opentelekomcloud/build_param_util.go
+++ b/opentelekomcloud/build_param_util.go
@@ -1,0 +1,12 @@
+package opentelekomcloud
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// The result may be not correct when the type of param is string and user config it to 'param=""'
+// but, there is no other way.
+func hasFilledOpt(d *schema.ResourceData, param string) bool {
+	_, b := d.GetOkExists(param)
+	return b
+}

--- a/vendor/github.com/hashicorp/terraform/helper/schema/field_reader_diff.go
+++ b/vendor/github.com/hashicorp/terraform/helper/schema/field_reader_diff.go
@@ -29,29 +29,59 @@ type DiffFieldReader struct {
 	Diff   *terraform.InstanceDiff
 	Source FieldReader
 	Schema map[string]*Schema
+
+	// cache for memoizing ReadField calls.
+	cache map[string]cachedFieldReadResult
+}
+
+type cachedFieldReadResult struct {
+	val FieldReadResult
+	err error
 }
 
 func (r *DiffFieldReader) ReadField(address []string) (FieldReadResult, error) {
+	if r.cache == nil {
+		r.cache = make(map[string]cachedFieldReadResult)
+	}
+
+	// Create the cache key by joining around a value that isn't a valid part
+	// of an address. This assumes that the Source and Schema are not changed
+	// for the life of this DiffFieldReader.
+	cacheKey := strings.Join(address, "|")
+	if cached, ok := r.cache[cacheKey]; ok {
+		return cached.val, cached.err
+	}
+
 	schemaList := addrToSchema(address, r.Schema)
 	if len(schemaList) == 0 {
+		r.cache[cacheKey] = cachedFieldReadResult{}
 		return FieldReadResult{}, nil
 	}
+
+	var res FieldReadResult
+	var err error
 
 	schema := schemaList[len(schemaList)-1]
 	switch schema.Type {
 	case TypeBool, TypeInt, TypeFloat, TypeString:
-		return r.readPrimitive(address, schema)
+		res, err = r.readPrimitive(address, schema)
 	case TypeList:
-		return readListField(r, address, schema)
+		res, err = readListField(r, address, schema)
 	case TypeMap:
-		return r.readMap(address, schema)
+		res, err = r.readMap(address, schema)
 	case TypeSet:
-		return r.readSet(address, schema)
+		res, err = r.readSet(address, schema)
 	case typeObject:
-		return readObjectField(r, address, schema.Elem.(map[string]*Schema))
+		res, err = readObjectField(r, address, schema.Elem.(map[string]*Schema))
 	default:
 		panic(fmt.Sprintf("Unknown type: %#v", schema.Type))
 	}
+
+	r.cache[cacheKey] = cachedFieldReadResult{
+		val: res,
+		err: err,
+	}
+	return res, err
 }
 
 func (r *DiffFieldReader) readMap(

--- a/vendor/github.com/hashicorp/terraform/helper/schema/resource_data.go
+++ b/vendor/github.com/hashicorp/terraform/helper/schema/resource_data.go
@@ -104,6 +104,22 @@ func (d *ResourceData) GetOk(key string) (interface{}, bool) {
 	return r.Value, exists
 }
 
+// GetOkExists returns the data for a given key and whether or not the key
+// has been set to a non-zero value. This is only useful for determining
+// if boolean attributes have been set, if they are Optional but do not
+// have a Default value.
+//
+// This is nearly the same function as GetOk, yet it does not check
+// for the zero value of the attribute's type. This allows for attributes
+// without a default, to fully check for a literal assignment, regardless
+// of the zero-value for that type.
+// This should only be used if absolutely required/needed.
+func (d *ResourceData) GetOkExists(key string) (interface{}, bool) {
+	r := d.getRaw(key, getSourceSet)
+	exists := r.Exists && !r.Computed
+	return r.Value, exists
+}
+
 func (d *ResourceData) getRaw(key string, level getSource) getResult {
 	var parts []string
 	if key != "" {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -810,12 +810,12 @@
 			"versionExact": "v0.10.0"
 		},
 		{
-			"checksumSHA1": "0smlb90amL15c/6nWtW4DV6Lqh8=",
+			"checksumSHA1": "juS4uWVIFt4ANQBvZ2j8mawtjlY=",
 			"path": "github.com/hashicorp/terraform/helper/schema",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "f6d16263a0389cfea95266d9e0072ccfc2bd4bf0",
+			"revisionTime": "2017-08-15T21:50:02Z",
+			"version": "v0.10.1",
+			"versionExact": "v0.10.1"
 		},
 		{
 			"checksumSHA1": "1yCGh/Wl4H4ODBBRmIRFcV025b0=",


### PR DESCRIPTION
This pr wants to offer a method to check whether an opt is filled. 
Take 'opentelekomcoud_networking_router_v2' for example. Its schema definition is at https://github.com/terraform-providers/terraform-provider-opentelekomcloud/blob/master/opentelekomcloud/resource_opentelekomcloud_networking_router_v2.go#L27-L68.

The contents of **.tf are as following:
resource "opentelekomcoud_networking_router_v2" "router" {
  name = "router"
  admin_state_up = "true"
}
Then hasFilledOpt("admin_state_up") will return true; but hasFilledOpt("distributed") will return false
