### PR TITLE
add an optional 'auto recovery' field to compute instance

### DIFF
--- a/opentelekomcloud/build_param_util.go
+++ b/opentelekomcloud/build_param_util.go
@@ -1,0 +1,12 @@
+package opentelekomcloud
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// The result may be not correct when the type of param is string and user config it to 'param=""'
+// but, there is no other way.
+func hasFilledOpt(d *schema.ResourceData, param string) bool {
+	_, b := d.GetOkExists(param)
+	return b
+}

--- a/opentelekomcloud/ces_utils.go
+++ b/opentelekomcloud/ces_utils.go
@@ -9,7 +9,12 @@ import (
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/huaweicloud/golangsdk"
 )
+
+func chooseECSV1Client(d *schema.ResourceData, config *Config) (*golangsdk.ServiceClient, error) {
+	return config.loadECSV1Client(GetRegion(d, config))
+}
 
 func chooseCESClient(d *schema.ResourceData, config *Config) (*gophercloud.ServiceClient, error) {
 	return config.loadCESClient(GetRegion(d, config))

--- a/opentelekomcloud/config.go
+++ b/opentelekomcloud/config.go
@@ -410,3 +410,10 @@ func (c *Config) getHwEndpointType() golangsdk.Availability {
 	}
 	return golangsdk.AvailabilityPublic
 }
+
+func (c *Config) loadECSV1Client(region string) (*golangsdk.ServiceClient, error) {
+	return huaweisdk.NewComputeV1(c.HwClient, golangsdk.EndpointOpts{
+		Region:       c.determineRegion(region),
+		Availability: c.getHwEndpointType(),
+	})
+}

--- a/opentelekomcloud/resource_opentelekomcloud_compute_instance_v2.go
+++ b/opentelekomcloud/resource_opentelekomcloud_compute_instance_v2.go
@@ -346,6 +346,11 @@ func resourceComputeInstanceV2() *schema.Resource {
 				Type:     schema.TypeMap,
 				Computed: true,
 			},
+			"auto_recovery": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -484,6 +489,14 @@ func resourceComputeInstanceV2Create(d *schema.ResourceData, meta interface{}) e
 		}
 	}
 
+	if hasFilledOpt(d, "auto_recovery") {
+		ar := d.Get("auto_recovery").(bool)
+		log.Printf("[DEBUG] Set auto recovery of instance to %t", ar)
+		err = setAutoRecoveryForInstance(d, meta, server.ID, ar)
+		if err != nil {
+			log.Printf("[WARN] Error setting auto recovery of instance:%s, err=%s", server.ID, err)
+		}
+	}
 	return resourceComputeInstanceV2Read(d, meta)
 }
 
@@ -604,6 +617,12 @@ func resourceComputeInstanceV2Read(d *schema.ResourceData, meta interface{}) err
 		tagset.Remove(name)
 	}
 	d.Set("tags", tagset.List())
+
+	ar, err := resourceECSAutoRecoveryV1Read(d, meta, d.Id())
+	if err != nil {
+		return fmt.Errorf("Error reading auto recovery of instance:%s, err=%s", d.Id(), err)
+	}
+	d.Set("auto_recovery", ar)
 
 	return nil
 }
@@ -837,6 +856,15 @@ func resourceComputeInstanceV2Update(d *schema.ResourceData, meta interface{}) e
 			if err != nil {
 				return fmt.Errorf("Error creating tags for instance (%s): %s", d.Id(), err)
 			}
+		}
+	}
+
+	if d.HasChange("auto_recovery") {
+		ar := d.Get("auto_recovery").(bool)
+		log.Printf("[DEBUG] Update auto recovery of instance to %t", ar)
+		err = setAutoRecoveryForInstance(d, meta, d.Id(), ar)
+		if err != nil {
+			return fmt.Errorf("Error updating auto recovery of instance:%s, err:%s", d.Id(), err)
 		}
 	}
 

--- a/opentelekomcloud/resource_opentelekomcloud_compute_instance_v2_test.go
+++ b/opentelekomcloud/resource_opentelekomcloud_compute_instance_v2_test.go
@@ -320,6 +320,33 @@ func TestAccComputeV2Instance_timeout(t *testing.T) {
 	})
 }
 
+func TestAccComputeV2Instance_auto_recovery(t *testing.T) {
+	var instance servers.Server
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeV2InstanceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeV2Instance_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeV2InstanceExists("opentelekomcloud_compute_instance_v2.instance_1", &instance),
+					resource.TestCheckResourceAttr(
+						"opentelekomcloud_compute_instance_v2.instance_1", "auto_recovery", "false"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccComputeV2Instance_auto_recovery,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeV2InstanceExists("opentelekomcloud_compute_instance_v2.instance_1", &instance),
+					resource.TestCheckResourceAttr(
+						"opentelekomcloud_compute_instance_v2.instance_1", "auto_recovery", "true"),
+				),
+			},
+		},
+	})
+}
 func testAccCheckComputeV2InstanceDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 	computeClient, err := config.computeV2Client(OS_REGION_NAME)
@@ -1133,3 +1160,18 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   }
 }
 `, OS_NETWORK_ID)
+
+var testAccComputeV2Instance_auto_recovery = fmt.Sprintf(`
+resource "opentelekomcloud_compute_instance_v2" "instance_1" {
+  name = "instance_1"
+  security_groups = ["default"]
+  availability_zone = "%s"
+  metadata {
+    foo = "bar"
+  }
+  network {
+    uuid = "%s"
+  }
+  auto_recovery = true
+}
+`, OS_AVAILABILITY_ZONE, OS_NETWORK_ID)

--- a/opentelekomcloud/resource_opentelekomcloud_ecs_auto_recovery_v1.go
+++ b/opentelekomcloud/resource_opentelekomcloud_ecs_auto_recovery_v1.go
@@ -1,0 +1,55 @@
+package opentelekomcloud
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/huaweicloud/golangsdk/openstack/ecs/v1/auto_recovery"
+)
+
+func resourceECSAutoRecoveryV1Read(d *schema.ResourceData, meta interface{}, instanceID string) (bool, error) {
+	config := meta.(*Config)
+	client, err := chooseECSV1Client(d, config)
+	if err != nil {
+		return false, fmt.Errorf("Error creating OpenTelekomCloud client: %s", err)
+	}
+
+	rId := instanceID
+
+	r, err := auto_recovery.Get(client, rId).Extract()
+	if err != nil {
+		return false, CheckDeleted(d, err, "ECS-AutoRecovery")
+	}
+	log.Printf("[DEBUG] Retrieved ECS-AutoRecovery:%#v of instance:%s", rId, r)
+	return strconv.ParseBool(r.SupportAutoRecovery)
+}
+
+func setAutoRecoveryForInstance(d *schema.ResourceData, meta interface{}, instanceID string, ar bool) error {
+	config := meta.(*Config)
+	client, err := chooseECSV1Client(d, config)
+	if err != nil {
+		return fmt.Errorf("Error creating OpenTelekomCloud client: %s", err)
+	}
+
+	rId := instanceID
+
+	updateOpts := auto_recovery.UpdateOpts{SupportAutoRecovery: strconv.FormatBool(ar)}
+
+	timeout := d.Timeout(schema.TimeoutUpdate)
+
+	log.Printf("[DEBUG] Setting ECS-AutoRecovery for instance:%s with options: %#v", rId, updateOpts)
+	err = resource.Retry(timeout, func() *resource.RetryError {
+		err := auto_recovery.Update(client, rId, updateOpts)
+		if err != nil {
+			return checkForRetryableError(err)
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("Error setting ECS-AutoRecovery for instance%s: %s", rId, err)
+	}
+	return nil
+}

--- a/vendor/github.com/hashicorp/terraform/helper/schema/field_reader_diff.go
+++ b/vendor/github.com/hashicorp/terraform/helper/schema/field_reader_diff.go
@@ -29,29 +29,59 @@ type DiffFieldReader struct {
 	Diff   *terraform.InstanceDiff
 	Source FieldReader
 	Schema map[string]*Schema
+
+	// cache for memoizing ReadField calls.
+	cache map[string]cachedFieldReadResult
+}
+
+type cachedFieldReadResult struct {
+	val FieldReadResult
+	err error
 }
 
 func (r *DiffFieldReader) ReadField(address []string) (FieldReadResult, error) {
+	if r.cache == nil {
+		r.cache = make(map[string]cachedFieldReadResult)
+	}
+
+	// Create the cache key by joining around a value that isn't a valid part
+	// of an address. This assumes that the Source and Schema are not changed
+	// for the life of this DiffFieldReader.
+	cacheKey := strings.Join(address, "|")
+	if cached, ok := r.cache[cacheKey]; ok {
+		return cached.val, cached.err
+	}
+
 	schemaList := addrToSchema(address, r.Schema)
 	if len(schemaList) == 0 {
+		r.cache[cacheKey] = cachedFieldReadResult{}
 		return FieldReadResult{}, nil
 	}
+
+	var res FieldReadResult
+	var err error
 
 	schema := schemaList[len(schemaList)-1]
 	switch schema.Type {
 	case TypeBool, TypeInt, TypeFloat, TypeString:
-		return r.readPrimitive(address, schema)
+		res, err = r.readPrimitive(address, schema)
 	case TypeList:
-		return readListField(r, address, schema)
+		res, err = readListField(r, address, schema)
 	case TypeMap:
-		return r.readMap(address, schema)
+		res, err = r.readMap(address, schema)
 	case TypeSet:
-		return r.readSet(address, schema)
+		res, err = r.readSet(address, schema)
 	case typeObject:
-		return readObjectField(r, address, schema.Elem.(map[string]*Schema))
+		res, err = readObjectField(r, address, schema.Elem.(map[string]*Schema))
 	default:
 		panic(fmt.Sprintf("Unknown type: %#v", schema.Type))
 	}
+
+	r.cache[cacheKey] = cachedFieldReadResult{
+		val: res,
+		err: err,
+	}
+	return res, err
 }
 
 func (r *DiffFieldReader) readMap(

--- a/vendor/github.com/hashicorp/terraform/helper/schema/resource_data.go
+++ b/vendor/github.com/hashicorp/terraform/helper/schema/resource_data.go
@@ -104,6 +104,22 @@ func (d *ResourceData) GetOk(key string) (interface{}, bool) {
 	return r.Value, exists
 }
 
+// GetOkExists returns the data for a given key and whether or not the key
+// has been set to a non-zero value. This is only useful for determining
+// if boolean attributes have been set, if they are Optional but do not
+// have a Default value.
+//
+// This is nearly the same function as GetOk, yet it does not check
+// for the zero value of the attribute's type. This allows for attributes
+// without a default, to fully check for a literal assignment, regardless
+// of the zero-value for that type.
+// This should only be used if absolutely required/needed.
+func (d *ResourceData) GetOkExists(key string) (interface{}, bool) {
+	r := d.getRaw(key, getSourceSet)
+	exists := r.Exists && !r.Computed
+	return r.Value, exists
+}
+
 func (d *ResourceData) getRaw(key string, level getSource) getResult {
 	var parts []string
 	if key != "" {

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/client.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/client.go
@@ -407,3 +407,17 @@ func NewCESClient(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (
 	sc.ResourceBase = sc.Endpoint
 	return sc, err
 }
+
+// NewDRSServiceV2 creates a ServiceClient that may be used to access the v2 Data Replication Service.
+func NewDRSServiceV2(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
+	sc, err := initClientOpts(client, eo, "volumev2")
+	return sc, err
+}
+
+func NewComputeV1(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
+	sc, err := initClientOpts(client, eo, "compute")
+	e := strings.Replace(sc.Endpoint, "v2", "v1", 1)
+	sc.Endpoint = e
+	sc.ResourceBase = e
+	return sc, err
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/client_extension.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/client_extension.go
@@ -113,6 +113,13 @@ func NewElasticLoadBalancer(client *golangsdk.ProviderClient, eo golangsdk.Endpo
 	return sc, err
 }
 
+//NewVpcServiceV1 creates the a ServiceClient that may be used to access the v1
+//vpc service which is a service of public ip management of huawei cloud
+func NewVpcServiceV1(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
+	sc, err := initClientOpts(client, eo, "network")
+	return sc, err
+}
+
 // NewNatV2 creates a ServiceClient that may be used with the v2 nat package.
 func NewNatV2(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
 	sc, err := initClientOpts(client, eo, "network")

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/ecs/v1/auto_recovery/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/ecs/v1/auto_recovery/requests.go
@@ -1,0 +1,36 @@
+package auto_recovery
+
+import (
+	"log"
+
+	"github.com/huaweicloud/golangsdk"
+)
+
+type UpdateOpts struct {
+	SupportAutoRecovery string `json:"support_auto_recovery" required:"true"`
+}
+
+type UpdateOptsBuilder interface {
+	ToAutoRecoveryUpdateMap() (map[string]interface{}, error)
+}
+
+func (opts UpdateOpts) ToAutoRecoveryUpdateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+func Update(c *golangsdk.ServiceClient, id string, opts UpdateOptsBuilder) error {
+	b, err := opts.ToAutoRecoveryUpdateMap()
+	if err != nil {
+		return err
+	}
+	log.Printf("[DEBUG] update url:%q, body=%#v", updateURL(c, id), b)
+	_, err = c.Put(updateURL(c, id), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{204},
+	})
+	return err
+}
+
+func Get(c *golangsdk.ServiceClient, id string) (r GetResult) {
+	_, r.Err = c.Get(resourceURL(c, id), &r.Body, nil)
+	return
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/ecs/v1/auto_recovery/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/ecs/v1/auto_recovery/results.go
@@ -1,0 +1,16 @@
+package auto_recovery
+
+import "github.com/huaweicloud/golangsdk"
+
+type AutoRecovery struct {
+	SupportAutoRecovery string `json:"support_auto_recovery"`
+}
+
+type GetResult struct {
+	golangsdk.Result
+}
+
+func (r GetResult) Extract() (*AutoRecovery, error) {
+	s := &AutoRecovery{}
+	return s, r.ExtractInto(s)
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/ecs/v1/auto_recovery/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/ecs/v1/auto_recovery/urls.go
@@ -1,0 +1,16 @@
+package auto_recovery
+
+import "github.com/huaweicloud/golangsdk"
+
+const (
+	rootPath     = "cloudservers"
+	resourcePath = "autorecovery"
+)
+
+func updateURL(c *golangsdk.ServiceClient, id string) string {
+	return c.ServiceURL(rootPath, id, resourcePath)
+}
+
+func resourceURL(c *golangsdk.ServiceClient, id string) string {
+	return updateURL(c, id)
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -868,10 +868,10 @@
 			"revisionTime": "2018-02-26T07:57:01Z"
 		},
 		{
-			"checksumSHA1": "l7k3D1MR0PFMNGMkCaRCvEr4Yp8=",
+			"checksumSHA1": "9wStskuAkyPfyAeHDua8VLDzm2o=",
 			"path": "github.com/huaweicloud/golangsdk/openstack",
-			"revision": "98f31e4f21bec892b331ee55c5a5fff72d407abc",
-			"revisionTime": "2018-02-26T07:57:01Z"
+			"revision": "6c216c0dcd5ac8138897f0a14b1b1f1004394dfd",
+			"revisionTime": "2018-03-08T08:40:13Z"
 		},
 		{
 			"checksumSHA1": "plsG8kyRJhFGnhGfO0scQk5kRLw=",
@@ -884,6 +884,12 @@
 			"path": "github.com/huaweicloud/golangsdk/openstack/dns/v2/zones",
 			"revision": "98f31e4f21bec892b331ee55c5a5fff72d407abc",
 			"revisionTime": "2018-02-26T07:57:01Z"
+		},
+		{
+			"checksumSHA1": "/GtDTHl+01QKRmNPxxdWXfuJ/nw=",
+			"path": "github.com/huaweicloud/golangsdk/openstack/ecs/v1/auto_recovery",
+			"revision": "c2811194004bd21b96bbd4cb3e0129661041011f",
+			"revisionTime": "2018-03-15T04:07:47Z"
 		},
 		{
 			"checksumSHA1": "6cxgVwctlHbqIqO9rHVTwmDtxhk=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -810,12 +810,12 @@
 			"versionExact": "v0.10.0"
 		},
 		{
-			"checksumSHA1": "0smlb90amL15c/6nWtW4DV6Lqh8=",
+			"checksumSHA1": "juS4uWVIFt4ANQBvZ2j8mawtjlY=",
 			"path": "github.com/hashicorp/terraform/helper/schema",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "f6d16263a0389cfea95266d9e0072ccfc2bd4bf0",
+			"revisionTime": "2017-08-15T21:50:02Z",
+			"version": "v0.10.1",
+			"versionExact": "v0.10.1"
 		},
 		{
 			"checksumSHA1": "1yCGh/Wl4H4ODBBRmIRFcV025b0=",


### PR DESCRIPTION
TF_ACC=1 go test ./opentelekomcloud/ -v -run=TestAccComputeV2Instance_auto_recovery -timeout 240m
=== RUN   TestAccComputeV2Instance_auto_recovery
--- PASS: TestAccComputeV2Instance_auto_recovery (287.13s)
PASS
ok      github.com/terraform-providers/terraform-provider-opentelekomcloud/opentelekomcloud     287.139s