### PR TITLE
revise dns zone according to the definition of API

### DIFF
--- a/opentelekomcloud/import_opentelekomcloud_dns_zone_v2_test.go
+++ b/opentelekomcloud/import_opentelekomcloud_dns_zone_v2_test.go
@@ -10,7 +10,7 @@ import (
 
 // PASS, but normally skip
 func TestAccDNSV2Zone_importBasic(t *testing.T) {
-	var zoneName = fmt.Sprintf("ACPTTEST%s.com.", acctest.RandString(5))
+	var zoneName = fmt.Sprintf("accepttest%s.com.", acctest.RandString(5))
 	resourceName := "opentelekomcloud_dns_zone_v2.zone_1"
 
 	resource.Test(t, resource.TestCase{
@@ -19,8 +19,7 @@ func TestAccDNSV2Zone_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckDNSV2ZoneDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config:             testAccDNSV2Zone_basic(zoneName),
-				ExpectNonEmptyPlan: true,
+				Config: testAccDNSV2Zone_basic(zoneName),
 			},
 
 			resource.TestStep{

--- a/opentelekomcloud/resource_opentelekomcloud_dns_zone_v2_test.go
+++ b/opentelekomcloud/resource_opentelekomcloud_dns_zone_v2_test.go
@@ -16,7 +16,7 @@ import (
 func TestAccDNSV2Zone_basic(t *testing.T) {
 	var zone zones.Zone
 	// TODO: Why does it lowercase names in back-end?
-	var zoneName = fmt.Sprintf("acpttest%s.com.", acctest.RandString(5))
+	var zoneName = fmt.Sprintf("accepttest%s.com.", acctest.RandString(5))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheckDNS(t) },
@@ -24,8 +24,7 @@ func TestAccDNSV2Zone_basic(t *testing.T) {
 		CheckDestroy: testAccCheckDNSV2ZoneDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config:             testAccDNSV2Zone_basic(zoneName),
-				ExpectNonEmptyPlan: true,
+				Config: testAccDNSV2Zone_basic(zoneName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDNSV2ZoneExists("opentelekomcloud_dns_zone_v2.zone_1", &zone),
 					resource.TestCheckResourceAttr(
@@ -33,8 +32,7 @@ func TestAccDNSV2Zone_basic(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				Config:             testAccDNSV2Zone_update(zoneName),
-				ExpectNonEmptyPlan: true,
+				Config: testAccDNSV2Zone_update(zoneName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("opentelekomcloud_dns_zone_v2.zone_1", "name", zoneName),
 					resource.TestCheckResourceAttr("opentelekomcloud_dns_zone_v2.zone_1", "email", "email2@example.com"),
@@ -154,7 +152,7 @@ func testAccDNSV2Zone_basic(zoneName string) string {
 			email = "email1@example.com"
 			description = "a zone"
 			ttl = 3000
-			type = "PRIMARY"
+			type = "public"
 		}
 	`, zoneName)
 }
@@ -166,7 +164,7 @@ func testAccDNSV2Zone_update(zoneName string) string {
 			email = "email2@example.com"
 			description = "an updated zone"
 			ttl = 6000
-			type = "PRIMARY"
+			type = "public"
 		}
 	`, zoneName)
 }

--- a/opentelekomcloud/resource_opentelekomcloud_dns_zone_v2_test.go
+++ b/opentelekomcloud/resource_opentelekomcloud_dns_zone_v2_test.go
@@ -47,6 +47,31 @@ func TestAccDNSV2Zone_basic(t *testing.T) {
 	})
 }
 
+func TestAccDNSV2Zone_private(t *testing.T) {
+	var zone zones.Zone
+	// TODO: Why does it lowercase names in back-end?
+	var zoneName = fmt.Sprintf("acpttest%s.com.", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckDNS(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDNSV2ZoneDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDNSV2Zone_private(zoneName),
+				//ExpectNonEmptyPlan: true,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDNSV2ZoneExists("opentelekomcloud_dns_zone_v2.zone_1", &zone),
+					resource.TestCheckResourceAttr(
+						"opentelekomcloud_dns_zone_v2.zone_1", "description", "a zone"),
+					resource.TestCheckResourceAttr(
+						"opentelekomcloud_dns_zone_v2.zone_1", "type", "private"),
+				),
+			},
+		},
+	})
+}
+
 // PASS, but normally skip
 func TestAccDNSV2Zone_readTTL(t *testing.T) {
 	var zone zones.Zone
@@ -155,6 +180,22 @@ func testAccDNSV2Zone_basic(zoneName string) string {
 			type = "public"
 		}
 	`, zoneName)
+}
+
+func testAccDNSV2Zone_private(zoneName string) string {
+	return fmt.Sprintf(`
+		resource "opentelekomcloud_dns_zone_v2" "zone_1" {
+			name = "%s"
+			email = "email1@example.com"
+			description = "a zone"
+			ttl = 3000
+			type = "private"
+			router = {
+				router_id = "%s"
+				router_region = "%s"
+			}
+		}
+	`, zoneName, OS_VPC_ID, OS_REGION_NAME)
 }
 
 func testAccDNSV2Zone_update(zoneName string) string {

--- a/opentelekomcloud/types.go
+++ b/opentelekomcloud/types.go
@@ -330,7 +330,7 @@ func (opts SubnetCreateOpts) ToSubnetCreateMap() (map[string]interface{}, error)
 // ZoneCreateOpts represents the attributes used when creating a new DNS zone.
 type ZoneCreateOpts struct {
 	zones.CreateOpts
-	ValueSpecs map[string]string `json:"value_specs,omitempty"`
+	ValueSpecs map[string]interface{} `json:"value_specs,omitempty"`
 }
 
 // ToZoneCreateMap casts a CreateOpts struct to a map.

--- a/opentelekomcloud/util.go
+++ b/opentelekomcloud/util.go
@@ -69,6 +69,15 @@ func MapValueSpecs(d *schema.ResourceData) map[string]string {
 	return m
 }
 
+// MapResourceProp converts ResourceData property into a map
+func MapResourceProp(d *schema.ResourceData, prop string) map[string]interface{} {
+	m := make(map[string]interface{})
+	for key, val := range d.Get(prop).(map[string]interface{}) {
+		m[key] = val.(string)
+	}
+	return m
+}
+
 // List of headers that need to be redacted
 var REDACT_HEADERS = []string{"x-auth-token", "x-auth-key", "x-service-token",
 	"x-storage-token", "x-account-meta-temp-url-key", "x-account-meta-temp-url-key-2",


### PR DESCRIPTION
The first commit of "revise dns zone according to the definition of API" revises the schema definitions according to the API[1]. The main modifications include: 1. Remove two options of  'attributes' and 'masters' which are the input parameter before. 2.  Use 'zone_type' instead of 'type' as the Create and Get parameter.

The second commit of 'add opts for creating private dns zone' is based on API[2], which can be used to create private dns zone.

[1] https://docs.otc.t-systems.com/en-us/api/dns/en-us_topic_0057310891.html
[2] https://docs.otc.t-systems.com/en-us/api/dns/en-us_topic_0057311027.html