### PR TITLE
fix acc test of TestAccS3Bucket_Logging

### DIFF
--- a/opentelekomcloud/resource_opentelekomcloud_s3_bucket_test.go
+++ b/opentelekomcloud/resource_opentelekomcloud_s3_bucket_test.go
@@ -1217,11 +1217,11 @@ func testAccS3BucketConfigWithLogging(randInt int) string {
 resource "opentelekomcloud_s3_bucket" "log_bucket" {
 	bucket = "tf-test-log-bucket-%d"
 	acl = "log-delivery-write"
+	force_destroy = "true"
 }
 resource "opentelekomcloud_s3_bucket" "bucket" {
 	bucket = "tf-test-bucket-%d"
 	acl = "private"
-	force_destroy = "true"
 	logging {
 		target_bucket = "${opentelekomcloud_s3_bucket.log_bucket.id}"
 		target_prefix = "log/"


### PR DESCRIPTION
It should add an additional option of 'force_destroy = "true"' to the config, otherwise it will receive the following error. Because bucket of 'tf-test-log-bucket-2284383012466717063' stored the log of another bucket, and it can not be destroyed directly.

run /home/slob/gopath/src/github.com/terraform-providers/terraform-provider-opentelekomcloud: TestAccS3Bucket_Logging
=== RUN   TestAccS3Bucket_Logging
--- FAIL: TestAccS3Bucket_Logging (103.20s)
        testing.go:499: Error destroying resource! WARNING: Dangling resources
                may exist. The full state and error is shown below.

                Error: Error applying: 1 error(s) occurred:

                * opentelekomcloud_s3_bucket.log_bucket (destroy): 1 error(s) occurred:

                * opentelekomcloud_s3_bucket.log_bucket: Error deleting S3 Bucket: BucketNotEmpty: The bucket you tried to delete is not empty
                        status code: 409, request id: 05340000016265735260CB30B431CF6F, host id: lUAgRKuBtMUbIGXc45GH+uglzdRv2Z6lT3i7CuPIscs+vBnjz1whOwAGrbzTItrw "tf-test-log-bucket-2284383012466717063"

                State: opentelekomcloud_s3_bucket.log_bucket:
                  ID = tf-test-log-bucket-2284383012466717063
                  acl = log-delivery-write
                  bucket = tf-test-log-bucket-2284383012466717063
                  bucket_domain_name = tf-test-log-bucket-2284383012466717063.s3.amazonaws.com
                  force_destroy = false
                  logging.# = 0
                  region = eu-de
                  tags.% = 0
                  versioning.# = 1
                  versioning.0.enabled = false
                  versioning.0.mfa_delete = false
                  website.# = 0
FAIL
exit status 1
FAIL    github.com/terraform-providers/terraform-provider-opentelekomcloud/opentelekomcloud     103.207s

