### PR TITLE
fix the bug of creating vm failed

### DIFF
--- a/opentelekomcloud/resource_opentelekomcloud_compute_instance_v2.go
+++ b/opentelekomcloud/resource_opentelekomcloud_compute_instance_v2.go
@@ -619,7 +619,7 @@ func resourceComputeInstanceV2Read(d *schema.ResourceData, meta interface{}) err
 	d.Set("tags", tagset.List())
 
 	ar, err := resourceECSAutoRecoveryV1Read(d, meta, d.Id())
-	if err != nil {
+	if err != nil && !isResourceNotFound(err) {
 		return fmt.Errorf("Error reading auto recovery of instance:%s, err=%s", d.Id(), err)
 	}
 	d.Set("auto_recovery", ar)

--- a/opentelekomcloud/resource_opentelekomcloud_ecs_auto_recovery_v1.go
+++ b/opentelekomcloud/resource_opentelekomcloud_ecs_auto_recovery_v1.go
@@ -21,7 +21,7 @@ func resourceECSAutoRecoveryV1Read(d *schema.ResourceData, meta interface{}, ins
 
 	r, err := auto_recovery.Get(client, rId).Extract()
 	if err != nil {
-		return false, CheckDeleted(d, err, "ECS-AutoRecovery")
+		return false, err
 	}
 	log.Printf("[DEBUG] Retrieved ECS-AutoRecovery:%#v of instance:%s", rId, r)
 	return strconv.ParseBool(r.SupportAutoRecovery)


### PR DESCRIPTION
for issue #44
The reason is that the service of auto recovery is not online at some region. To keep backwards compatibility, it should check the error type when reading auto recovery failed.

=== RUN   TestAccComputeV2Instance_auto_recovery
--- PASS: TestAccComputeV2Instance_auto_recovery (222.13s)
PASS
ok      github.com/terraform-providers/terraform-provider-opentelekomcloud/opentelekomcloud     222.136s