### PR TITLE
fix elb endpoint bug

### DIFF
--- a/opentelekomcloud/config.go
+++ b/opentelekomcloud/config.go
@@ -378,10 +378,10 @@ func (c *Config) objectStorageV1Client(region string) (*gophercloud.ServiceClien
 }
 
 func (c *Config) loadELBClient(region string) (*golangsdk.ServiceClient, error) {
-	return huaweisdk.NewElasticLoadBalancer(c.HwClient, golangsdk.EndpointOpts{
+	return huaweisdk.NewElbV1(c.HwClient, golangsdk.EndpointOpts{
 		Region:       c.determineRegion(region),
 		Availability: c.getHwEndpointType(),
-	})
+	}, "elb")
 }
 
 func (c *Config) SmnV2Client(region string) (*golangsdk.ServiceClient, error) {


### PR DESCRIPTION
The reason is the endpoint of ELB lacked of projectID

--- PASS: TestAccELBBackend_basic (192.43s)
This acceptance test includes all resources of ELB, so if it passed, then all the endpoint of ELB would be fixed.