### PR TITLE
Fix the timeout when creating internal elb

### DIFF
--- a/opentelekomcloud/resource_opentelekomcloud_elb_backend.go
+++ b/opentelekomcloud/resource_opentelekomcloud_elb_backend.go
@@ -12,7 +12,7 @@ import (
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/elbaas/backendmember"
 )
 
-const loadbalancerActiveTimeoutSeconds = 300
+const loadbalancerActiveTimeoutSeconds = 600
 const loadbalancerDeleteTimeoutSeconds = 300
 
 func resourceBackend() *schema.Resource {


### PR DESCRIPTION
when creating elb with internal type, the time of waiting status to be active is higher than current timeout time, it will cause the timeout issue. this is to propose increase the timeout.