### PR TITLE
Update RDS doc for flavor ha speccode

### DIFF
--- a/website/docs/r/rds_instance_v1.html.markdown
+++ b/website/docs/r/rds_instance_v1.html.markdown
@@ -17,7 +17,7 @@ data "opentelekomcloud_rds_flavors_v1" "flavor" {
     region = "eu-de"
     datastore_name = "PostgreSQL"
     datastore_version = "9.5.5"
-    speccode = "rds.pg.s1.large"
+    speccode = "rds.pg.s1.large.ha"
 }
 
 resource "opentelekomcloud_compute_secgroup_v2" "secgrp_rds" {
@@ -161,7 +161,8 @@ The following arguments are supported:
     described below.
 
 * `flavorref` - (Required) Specifies the specification ID (flavors.id in the
-    response message in Obtaining All DB Instance Specifications).
+    response message in Obtaining All DB Instance Specifications). If you want
+    to enable ha for the rds instance, a flavor with ha speccode is required.
 
 * `volume` - (Required) Specifies the volume information. The structure is described
     below.


### PR DESCRIPTION
This adds the requirements of ha rds instance for flavor speccode.
for #80 