### PR TITLE
added volume_type to resource documentation

### DIFF
--- a/website/docs/r/compute_instance_v2.html.markdown
+++ b/website/docs/r/compute_instance_v2.html.markdown
@@ -75,6 +75,7 @@ resource "opentelekomcloud_compute_instance_v2" "boot-from-volume" {
     boot_index            = 0
     destination_type      = "volume"
     delete_on_termination = true
+    volume_type           = "SSD"
   }
 
   network {
@@ -317,8 +318,8 @@ The following arguments are supported:
     the server. Changing this creates a new server.
 
 * `network` - (Optional) An array of one or more networks to attach to the
-    instance. Required when there are multiple networks defined for the tenant. 
-    The network object structure is documented below. Changing this creates a 
+    instance. Required when there are multiple networks defined for the tenant.
+    The network object structure is documented below. Changing this creates a
     new server.
 
 * `metadata` - (Optional) Metadata key/value pairs to make available from
@@ -393,6 +394,9 @@ The `block_device` block supports:
     in the following combinations: source=image and destination=volume,
     source=blank and destination=local, and source=blank and destination=volume.
     Changing this creates a new server.
+
+* `volume_type` - (Optional) Currently, the value can be `SSD` (ultra-I/O disk type), `SAS` (high I/O disk type), or `SATA` (common I/O disk type)
+    [OTC-API](https://docs.otc.t-systems.com/en-us/api/ecs/en-us_topic_0065817708.html)
 
 * `boot_index` - (Optional) The boot index of the volume. It defaults to 0.
     Changing this creates a new server.


### PR DESCRIPTION
Added `volume_type` was missing in `opentelekomcloud_compute_instance_v2` documentation.