### PR TITLE
Suppress rds name change

### DIFF
--- a/opentelekomcloud/diff_suppress_funcs.go
+++ b/opentelekomcloud/diff_suppress_funcs.go
@@ -118,3 +118,10 @@ func suppressAutoscalingGroupAvailabilityZoneDiffs(k, old, new string, d *schema
 
 	return false
 }
+
+func suppressRdsNameDiffs(k, old, new string, d *schema.ResourceData) bool {
+	if strings.HasPrefix(old, new) && strings.HasSuffix(old, "_node0") {
+		return true
+	}
+	return false
+}

--- a/opentelekomcloud/resource_opentelekomcloud_rds_instance_v1.go
+++ b/opentelekomcloud/resource_opentelekomcloud_rds_instance_v1.go
@@ -41,6 +41,7 @@ func resourceRdsInstance() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				ForceNew: false,
+				DiffSuppressFunc: suppressDiffAll,
 			},
 
 			"datastore": &schema.Schema{

--- a/opentelekomcloud/resource_opentelekomcloud_rds_instance_v1.go
+++ b/opentelekomcloud/resource_opentelekomcloud_rds_instance_v1.go
@@ -41,7 +41,7 @@ func resourceRdsInstance() *schema.Resource {
 				Optional:         true,
 				Computed:         true,
 				ForceNew:         false,
-				DiffSuppressFunc: suppressDiffAll,
+				DiffSuppressFunc: suppressRdsNameDiffs,
 			},
 
 			"datastore": &schema.Schema{

--- a/opentelekomcloud/resource_opentelekomcloud_rds_instance_v1.go
+++ b/opentelekomcloud/resource_opentelekomcloud_rds_instance_v1.go
@@ -37,10 +37,10 @@ func resourceRdsInstance() *schema.Resource {
 			},
 
 			"name": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: false,
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				ForceNew:         false,
 				DiffSuppressFunc: suppressDiffAll,
 			},
 

--- a/opentelekomcloud/resource_opentelekomcloud_rds_instance_v1_test.go
+++ b/opentelekomcloud/resource_opentelekomcloud_rds_instance_v1_test.go
@@ -28,7 +28,6 @@ func TestAccRDSV1Instance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"opentelekomcloud_rds_instance_v1.instance", "availabilityzone", "eu-de-01"),
 				),
-				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/website/docs/r/rds_instance_v1.html.markdown
+++ b/website/docs/r/rds_instance_v1.html.markdown
@@ -156,7 +156,7 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the DB instance name. The DB instance name of
     the same type is unique in the same tenant. The changes of the instance name
-	will be suppressed now.
+	will be suppressed in HA scenario.
 
 * `datastore` - (Required) Specifies database information. The structure is
     described below.

--- a/website/docs/r/rds_instance_v1.html.markdown
+++ b/website/docs/r/rds_instance_v1.html.markdown
@@ -155,7 +155,8 @@ resource "opentelekomcloud_rds_instance_v1" "instance" {
 The following arguments are supported:
 
 * `name` - (Required) Specifies the DB instance name. The DB instance name of
-    the same type is unique in the same tenant.
+    the same type is unique in the same tenant. The changes of the instance name
+	will be suppressed now.
 
 * `datastore` - (Required) Specifies database information. The structure is
     described below.


### PR DESCRIPTION
This suppresses the rds name changes as server side will change the name to name_node0 in HA scenario.

fixes #84 