### PR TITLE
Fix couple of docs issue

### DIFF
--- a/website/docs/r/compute_instance_v2.html.markdown
+++ b/website/docs/r/compute_instance_v2.html.markdown
@@ -315,10 +315,7 @@ The following arguments are supported:
     Changing this creates a new server.
 
 * `security_groups` - (Optional) An array of one or more security group names
-    to associate with the server. Changing this results in adding/removing
-    security groups from the existing server. *Note*: When attaching the
-    instance to networks using Ports, place the security groups on the Port
-    and not the instance.
+    to associate with the server. Changing this creates a new server.
 
 * `availability_zone` - (Optional) The availability zone in which to create
     the server. Changing this creates a new server.

--- a/website/docs/r/s3_bucket.html.markdown
+++ b/website/docs/r/s3_bucket.html.markdown
@@ -113,11 +113,6 @@ resource "opentelekomcloud_s3_bucket" "bucket" {
     enabled = true
 
     prefix  = "log/"
-    tags {
-      "rule"      = "log"
-      "autoclean" = "true"
-    }
-
     expiration {
       days = 90
     }
@@ -197,7 +192,6 @@ The `lifecycle_rule` object supports the following:
 
 * `id` - (Optional) Unique identifier for the rule.
 * `prefix` - (Optional) Object key prefix identifying one or more objects to which the rule applies.
-* `tags` - (Optional) Specifies object tags key and value.
 * `enabled` - (Required) Specifies lifecycle rule status.
 * `abort_incomplete_multipart_upload_days` (Optional) Specifies the number of days after initiating a multipart upload when the multipart upload must be completed.
 * `expiration` - (Optional) Specifies a period in the object's expire (documented below).


### PR DESCRIPTION
1. Remove 'tags' from s3_bucket lifecycle_rule doc
2. Mark security_group as non-updatable on compute_instance doc