### PR TITLE
Add Link for WAF Policy in Sidebar Navigation

### DIFF
--- a/website/opentelekomcloud.erb
+++ b/website/opentelekomcloud.erb
@@ -576,6 +576,9 @@
             <li<%= sidebar_current("docs-opentelekomcloud-resource-waf-domain-v1") %>>
               <a href="/docs/providers/opentelekomcloud/r/waf_domain_v1.html">opentelekomcloud_waf_domain_v1</a>
             </li>
+	    <li<%= sidebar_current("docs-opentelekomcloud-resource-waf-policy-v1") %>>
+              <a href="/docs/providers/opentelekomcloud/r/waf_policy_v1.html">opentelekomcloud_waf_policy_v1</a>
+            </li>
           </ul>
         </li>
       </ul>


### PR DESCRIPTION
@niuzhenguo : In the Sidebar the link to the WAF Policy resource iss missing. I added it.

References:
- #277
- #293 