### PR TITLE
More specific explaination for shared argument

### DIFF
--- a/website/docs/r/vpc_v1.html.markdown
+++ b/website/docs/r/vpc_v1.html.markdown
@@ -37,7 +37,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the VPC. The name must be unique for a tenant. The value is a string of no more than 64 characters and can contain digits, letters, underscores (_), and hyphens (-). Changing this updates the name of the existing VPC.
 
-* `shared` - (Optional) Specifies whether the cross-tenant sharing is supported.
+* `shared` - (Optional) Specifies whether the shared SNAT should be used or not. Is also required  for cross-tenant sharing.
 
 
 


### PR DESCRIPTION
As 'shared' will also allow the instances to reach the Internet via SNAT, this needs to be explained. Most people will probably look for a solution to avoid NAT Instances, so we should mention it in the README