### PR TITLE
add info about bandwidth objects

### DIFF
--- a/website/docs/r/compute_floatingip_v2.html.markdown
+++ b/website/docs/r/compute_floatingip_v2.html.markdown
@@ -13,6 +13,11 @@ that can be used for compute instances.
 These are similar to Neutron (networking) floating IP resources,
 but only networking floating IPs can be used with load balancers.
 
+Floating IPs created with this module will have a bandwidth of 1000Mbit/s,
+for manually specifying the bandwidth please use the
+[`opentelekomcloud_vpc_eip_v1`](vpc_eip_v1.html) module.
+
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
When creating FloatingIP/EIP with this module, the associated bandwidth object will be set to 1000Mbit/s. In case somebody doesn't want that, let's point to the EIP module.

Maybe deprecate the usage of `opentelekomcloud_compute_floatingip_v2` in favor of the eip module?