### PR TITLE
Fix RDS subnet_id/network_id Confusion

### DIFF
--- a/opentelekomcloud/resource_opentelekomcloud_rds_instance_v3.go
+++ b/opentelekomcloud/resource_opentelekomcloud_rds_instance_v3.go
@@ -757,7 +757,7 @@ func buildRdsInstanceV3CreateParameters(opts map[string]interface{}, arrayIndex 
 	if e, err := isEmptyValue(reflect.ValueOf(v)); err != nil {
 		return nil, err
 	} else if !e {
-		params["network_id"] = v
+		params["subnet_id"] = v
 	}
 
 	v, err = expandRdsInstanceV3CreateVolume(opts, arrayIndex)

--- a/opentelekomcloud/resource_opentelekomcloud_rds_instance_v3.go
+++ b/opentelekomcloud/resource_opentelekomcloud_rds_instance_v3.go
@@ -110,7 +110,7 @@ func resourceRdsInstanceV3() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"subnet_id": {
+			"network_id": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
@@ -255,7 +255,7 @@ func resourceRdsInstanceV3UserInputParams(d *schema.ResourceData) map[string]int
 		"name":                    d.Get("name"),
 		"param_group_id":          d.Get("param_group_id"),
 		"security_group_id":       d.Get("security_group_id"),
-		"subnet_id":               d.Get("subnet_id"),
+		"network_id":              d.Get("network_id"),
 		"volume":                  d.Get("volume"),
 		"vpc_id":                  d.Get("vpc_id"),
 	}
@@ -750,14 +750,14 @@ func buildRdsInstanceV3CreateParameters(opts map[string]interface{}, arrayIndex 
 		params["security_group_id"] = v
 	}
 
-	v, err = navigateValue(opts, []string{"subnet_id"}, arrayIndex)
+	v, err = navigateValue(opts, []string{"network_id"}, arrayIndex)
 	if err != nil {
 		return nil, err
 	}
 	if e, err := isEmptyValue(reflect.ValueOf(v)); err != nil {
 		return nil, err
 	} else if !e {
-		params["subnet_id"] = v
+		params["network_id"] = v
 	}
 
 	v, err = expandRdsInstanceV3CreateVolume(opts, arrayIndex)
@@ -1131,12 +1131,12 @@ func setRdsInstanceV3Properties(d *schema.ResourceData, response map[string]inte
 		return fmt.Errorf("Error setting Instance:security_group_id, err: %s", err)
 	}
 
-	v, err = navigateValue(response, []string{"list", "subnet_id"}, nil)
+	v, err = navigateValue(response, []string{"list", "network_id"}, nil)
 	if err != nil {
-		return fmt.Errorf("Error reading Instance:subnet_id, err: %s", err)
+		return fmt.Errorf("Error reading Instance:network_id, err: %s", err)
 	}
-	if err = d.Set("subnet_id", v); err != nil {
-		return fmt.Errorf("Error setting Instance:subnet_id, err: %s", err)
+	if err = d.Set("network_id", v); err != nil {
+		return fmt.Errorf("Error setting Instance:network_id, err: %s", err)
 	}
 
 	v, _ = opts["volume"]

--- a/website/docs/r/rds_instance_v3.html.markdown
+++ b/website/docs/r/rds_instance_v3.html.markdown
@@ -30,7 +30,7 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
   }
   name = "terraform_test_rds_instance"
   security_group_id = "${opentelekomcloud_networking_secgroup_v2.secgroup.id}"
-  subnet_id = "{{ subnet_id }}"
+  network_id = "{{ network_id }}"
   vpc_id = "{{ vpc_id }}"
   volume {
     type = "COMMON"
@@ -66,7 +66,7 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
   }
   name = "terraform_test_rds_instance"
   security_group_id = "${opentelekomcloud_networking_secgroup_v2.secgroup.id}"
-  subnet_id = "{{ subnet_id }}"
+  network_id = "{{ network_id }}"
   vpc_id = "{{ vpc_id }}" 
   volume {
     type = "COMMON"
@@ -109,7 +109,7 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
   }
   name = "terraform_test_rds_instance"
   security_group_id = "${opentelekomcloud_networking_secgroup_v2.secgroup.id}"
-  subnet_id = "{{ subnet_id }}"
+  network_id = "{{ network_id }}"
   vpc_id = "{{ vpc_id }}"
   volume {
     disk_encryption_id = "${opentelekomcloud_kms_key_v1.key.id}"
@@ -153,9 +153,9 @@ The following arguments are supported:
   Specifies the security group which the RDS DB instance belongs to.
   Changing this parameter will create a new resource.
 
-* `subnet_id` -
+* `network_id` -
   (Required)
-  Specifies the subnet id. Changing this parameter will create a new resource.
+  Specifies the network id. Changing this parameter will create a new resource.
 
 * `volume` -
   (Required)


### PR DESCRIPTION
During my test I noticed, that when creating an RDS resource not the `subnet_id` is needed, but the `network_id` is required.

The fix replaces the variable `subnet_id` with `network_id`, both in the code and in the documentation.