### PR TITLE
Fix admin_state_up bool required Issue for ELB Load Balancer

### DIFF
--- a/examples/basic-examples/modules/as/main.tf
+++ b/examples/basic-examples/modules/as/main.tf
@@ -98,7 +98,7 @@ resource "opentelekomcloud_elb_loadbalancer" "elb_as" {
   name = "elb_as"
   type = "External"
   vpc_id = "${opentelekomcloud_vpc_v1.vpc_as.id}"
-  admin_state_up = 1
+  admin_state_up = "true"
   #vip_subnet_id  = "${opentelekomcloud_vpc_subnet_v1.subnet_as.subnet_id}"
  
   security_group_id = "${opentelekomcloud_networking_secgroup_v2.secgroup_as.id}"

--- a/examples/basic-examples/modules/elb/elb.tf
+++ b/examples/basic-examples/modules/elb/elb.tf
@@ -3,7 +3,7 @@ resource "opentelekomcloud_elb_loadbalancer" "elb" {
   type = "External"
   description = "${var.elb_desc}"
   vpc_id = "${var.vpc_id}"
-  admin_state_up = 1
+  admin_state_up = "true"
   bandwidth = "${var.bw_size}"  
   }
 
@@ -11,7 +11,7 @@ resource "opentelekomcloud_elb_loadbalancer" "elb" {
  # name = "${var.elb_name}_internal"
  # type = "Internal"
  # vpc_id = "${var.vpc_id}"
- # admin_state_up = 0
+ # admin_state_up = "false"
  # vip_subnet_id  = "${var.vip_subnet_id}"
  # security_group_id = "${var.security_group_id}"
  # }

--- a/examples/elb-with-autoscaling/README.md
+++ b/examples/elb-with-autoscaling/README.md
@@ -13,7 +13,7 @@ resource "opentelekomcloud_elb_loadbalancer" "lb_example" {
   type = "External"
   description = "This is an example configuration for LB"
   vpc_id = "${var.vpc_id}"
-  admin_state_up = 1
+  admin_state_up = "true"
   bandwidth = 5
 }
 

--- a/examples/elb-with-autoscaling/main.tf
+++ b/examples/elb-with-autoscaling/main.tf
@@ -5,7 +5,7 @@ resource "opentelekomcloud_elb_loadbalancer" "lb_example" {
   type = "External"
   description = "This is an example configuration for LB"
   vpc_id = "${var.vpc_id}"
-  admin_state_up = 1
+  admin_state_up = "true"
   bandwidth = 5
 }
 

--- a/website/docs/r/elb_backend.html.markdown
+++ b/website/docs/r/elb_backend.html.markdown
@@ -18,7 +18,7 @@ resource "opentelekomcloud_elb_loadbalancer" "elb" {
   type = "External"
   description = "test elb"
   vpc_id = "e346dc4a-d9a6-46f4-90df-10153626076e"
-  admin_state_up = 1
+  admin_state_up = "true"
   bandwidth = 5
 }
 

--- a/website/docs/r/elb_health.html.markdown
+++ b/website/docs/r/elb_health.html.markdown
@@ -18,7 +18,7 @@ resource "opentelekomcloud_elb_loadbalancer" "elb" {
   type = "External"
   description = "test elb"
   vpc_id = "e346dc4a-d9a6-46f4-90df-10153626076e"
-  admin_state_up = 1
+  admin_state_up = "true"
   bandwidth = 5
 }
 

--- a/website/docs/r/elb_listener.html.markdown
+++ b/website/docs/r/elb_listener.html.markdown
@@ -18,7 +18,7 @@ resource "opentelekomcloud_elb_loadbalancer" "elb" {
   type = "External"
   description = "test elb"
   vpc_id = "e346dc4a-d9a6-46f4-90df-10153626076e"
-  admin_state_up = 1
+  admin_state_up = "true"
   bandwidth = 5
 }
 

--- a/website/docs/r/elb_loadbalancer.html.markdown
+++ b/website/docs/r/elb_loadbalancer.html.markdown
@@ -18,7 +18,7 @@ resource "opentelekomcloud_elb_loadbalancer" "elb" {
   type = "External"
   description = "test elb"
   vpc_id = "e346dc4a-d9a6-46f4-90df-10153626076e"
-  admin_state_up = 1
+  admin_state_up = "true"
   bandwidth = 5
 }
 ```
@@ -45,9 +45,9 @@ The following arguments are supported:
     Internal or External. Changing this creates a new elb loadbalancer.
 
 * `admin_state_up` - (Required) Specifies the status of the load balancer.
-    Value range: 0 or false: indicates that the load balancer is stopped. Only
-    tenants are allowed to enter these two values. 1 or true: indicates that
-    the load balancer is running properly. 2 or false: indicates that the load
+    Value range: false: indicates that the load balancer is stopped. Only
+    tenants are allowed to enter these two values. true: indicates that
+    the load balancer is running properly. false: indicates that the load
     balancer is frozen. Only tenants are allowed to enter these two values.
 
 * `vip_subnet_id` - (Optional) Specifies the ID of the private network

--- a/website/docs/r/elb_loadbalancer.html.markdown
+++ b/website/docs/r/elb_loadbalancer.html.markdown
@@ -45,10 +45,9 @@ The following arguments are supported:
     Internal or External. Changing this creates a new elb loadbalancer.
 
 * `admin_state_up` - (Required) Specifies the status of the load balancer.
-    Value range: false: indicates that the load balancer is stopped. Only
-    tenants are allowed to enter these two values. true: indicates that
-    the load balancer is running properly. false: indicates that the load
-    balancer is frozen. Only tenants are allowed to enter these two values.
+    Value range: false: indicates that the load balancer is stopped or
+    frozen; true: indicates that the load balancer is running properly.
+    Only tenants are allowed to enter these two values.
 
 * `vip_subnet_id` - (Optional) Specifies the ID of the private network
     to be added. This parameter is mandatory when type is set to Internal,


### PR DESCRIPTION
The pull request fixes the documentation issue for the variable `admin_state_up` of "opentelekomcloud_elb_loadbalancer". By correcting the use of Booleans for variable `admin_state_up`, instead of the values `1` or `0` as documented.

The error was shown by Terraform when I planed my infrastructure:

Code:
```
...
resource "opentelekomcloud_elb_loadbalancer" "frontend-elb" {
  name           = "frontend-elb"
  type           = "Internal"
  description    = "ELB of the frontend instances"
  vpc_id         = "${opentelekomcloud_networking_network_v2.tier-3.id}"
  admin_state_up = 1
}
...

```
Error:
```
Error: Incorrect attribute value type

  on modules/network/main.tf line 92, in resource "opentelekomcloud_elb_loadbalancer" "frontend-elb":
  92:   admin_state_up = 1

Inappropriate value for attribute "admin_state_up": bool required.
```