### PR TITLE
[IMS] Rename image_tags to tags and update them with v2 interface

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/go-hclog v0.8.0 // indirect
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/terraform v0.12.8
-	github.com/huaweicloud/golangsdk v0.0.0-20191016030911-ec58ae847d04
+	github.com/huaweicloud/golangsdk v0.0.0-20191017023450-85d4de133080
 	github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/smartystreets/assertions v0.0.0-20190116191733-b6c0e53d7304 // indirect

--- a/go.sum
+++ b/go.sum
@@ -226,8 +226,8 @@ github.com/hashicorp/vault v0.10.4/go.mod h1:KfSyffbKxoVyspOdlaGVjIuwLobi07qD1bA
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb h1:b5rjCoWHc7eqmAS4/qyk21ZsHyb6Mxv/jykxvNTkU4M=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/huaweicloud/golangsdk v0.0.0-20191016030911-ec58ae847d04 h1:noZ2Z9eLcJMjQcKLME8TuepII2L16JDNcH78plqMknQ=
-github.com/huaweicloud/golangsdk v0.0.0-20191016030911-ec58ae847d04/go.mod h1:WQBcHRNX9shz3928lWEvstQJtAtYI7ks6XlgtRT9Tcw=
+github.com/huaweicloud/golangsdk v0.0.0-20191017023450-85d4de133080 h1:8UqbdbwvWDOn7ybZUDkMKW6gFAPzmF4lFCgw5pn8dIE=
+github.com/huaweicloud/golangsdk v0.0.0-20191017023450-85d4de133080/go.mod h1:WQBcHRNX9shz3928lWEvstQJtAtYI7ks6XlgtRT9Tcw=
 github.com/jellevandenhooff/dkim v0.0.0-20150330215556-f50fe3d243e1/go.mod h1:E0B/fFc00Y+Rasa88328GlI/XbtyysCtTHZS8h7IrBU=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a h1:FyS/ubzBR5xJlnJGRTwe7GUHpJOR4ukYK3y+LFNffuA=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a/go.mod h1:uoIMjNxUfXi48Ci40IXkPRbghZ1vbti6v9LCbNqRgHY=

--- a/opentelekomcloud/resource_opentelekomcloud_ims_image_v2_test.go
+++ b/opentelekomcloud/resource_opentelekomcloud_ims_image_v2_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/huaweicloud/golangsdk/openstack/ims/v2/cloudimages"
+	"github.com/huaweicloud/golangsdk/openstack/ims/v2/tags"
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -22,8 +23,21 @@ func TestAccImsImageV2_basic(t *testing.T) {
 				Config: testAccImsImageV2_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckImsImageV2Exists("opentelekomcloud_ims_image_v2.image_1", &image),
+					testAccCheckImsImageV2Tags("opentelekomcloud_ims_image_v2.image_1", "foo", "bar"),
+					testAccCheckImsImageV2Tags("opentelekomcloud_ims_image_v2.image_1", "key", "value"),
 					resource.TestCheckResourceAttr(
 						"opentelekomcloud_ims_image_v2.image_1", "name", "TFTest_image"),
+				),
+			},
+			{
+				Config: testAccImsImageV2_update,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckImsImageV2Exists("opentelekomcloud_ims_image_v2.image_1", &image),
+					testAccCheckImsImageV2Tags("opentelekomcloud_ims_image_v2.image_1", "foo", "bar"),
+					testAccCheckImsImageV2Tags("opentelekomcloud_ims_image_v2.image_1", "key", "value1"),
+					testAccCheckImsImageV2Tags("opentelekomcloud_ims_image_v2.image_1", "key2", "value2"),
+					resource.TestCheckResourceAttr(
+						"opentelekomcloud_ims_image_v2.image_1", "name", "TFTest_image_update"),
 				),
 			},
 		},
@@ -55,7 +69,7 @@ func testAccCheckImsImageV2Exists(n string, image *cloudimages.Image) resource.T
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return fmt.Errorf("IMS Resource not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
@@ -78,6 +92,46 @@ func testAccCheckImsImageV2Exists(n string, image *cloudimages.Image) resource.T
 	}
 }
 
+func testAccCheckImsImageV2Tags(n string, k string, v string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("IMS Resource not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+		imageClient, err := config.imageV2Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating OpenTelekomCloud image client: %s", err)
+		}
+
+		found, err := tags.Get(imageClient, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.Tags == nil {
+			return fmt.Errorf("IMS Tags not found")
+		}
+
+		for _, tag := range found.Tags {
+			if k != tag.Key {
+				continue
+			}
+
+			if v == tag.Value {
+				return nil
+			}
+			return fmt.Errorf("Bad value for %s: %s", k, tag.Value)
+		}
+		return fmt.Errorf("Tag not found: %s", k)
+	}
+}
+
 var testAccImsImageV2_basic = fmt.Sprintf(`
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name = "instance_1"
@@ -95,9 +149,34 @@ resource "opentelekomcloud_ims_image_v2" "image_1" {
   name   = "TFTest_image"
   instance_id = "${opentelekomcloud_compute_instance_v2.instance_1.id}"
   description = "created by TerraformAccTest"
-  image_tags = {
+  tags = {
     foo = "bar"
     key = "value"
+  }
+}
+`, OS_AVAILABILITY_ZONE, OS_NETWORK_ID)
+
+var testAccImsImageV2_update = fmt.Sprintf(`
+resource "opentelekomcloud_compute_instance_v2" "instance_1" {
+  name = "instance_1"
+  security_groups = ["default"]
+  availability_zone = "%s"
+  metadata = {
+    foo = "bar"
+  }
+  network {
+    uuid = "%s"
+  }
+}
+
+resource "opentelekomcloud_ims_image_v2" "image_1" {
+  name   = "TFTest_image_update"
+  instance_id = "${opentelekomcloud_compute_instance_v2.instance_1.id}"
+  description = "created by TerraformAccTest"
+  tags = {
+    foo  = "bar"
+    key  = "value1"
+    key2 = "value2"
   }
 }
 `, OS_AVAILABILITY_ZONE, OS_NETWORK_ID)

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/ims/v2/tags/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/ims/v2/tags/requests.go
@@ -1,0 +1,61 @@
+package tags
+
+import (
+	"github.com/huaweicloud/golangsdk"
+)
+
+// Tag is a structure of key value pair.
+type Tag struct {
+	//tag key
+	Key string `json:"key" required:"true"`
+	//tag value
+	Value string `json:"value" required:"true"`
+}
+
+// BatchOptsBuilder allows extensions to add additional parameters to the
+// BatchAction request.
+type BatchOptsBuilder interface {
+	ToTagsBatchMap() (map[string]interface{}, error)
+}
+
+// BatchOpts contains all the values needed to perform BatchAction on the image tags.
+type BatchOpts struct {
+	//List of tags to perform batch operation
+	Tags []Tag `json:"tags,omitempty"`
+	//Operator , Possible values are:create or delete
+	Action ActionType `json:"action" required:"true"`
+}
+
+//ActionType specifies the type of batch operation action to be performed
+type ActionType string
+
+var (
+	// ActionCreate is used to set action operator to create
+	ActionCreate ActionType = "create"
+	// ActionDelete is used to set action operator to delete
+	ActionDelete ActionType = "delete"
+)
+
+// ToTagsBatchMap builds a BatchAction request body from BatchOpts.
+func (opts BatchOpts) ToTagsBatchMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+//BatchAction is used to create ,update or delete the tags of a specified image.
+func BatchAction(client *golangsdk.ServiceClient, imageID string, opts BatchOptsBuilder) (r ActionResults) {
+	b, err := opts.ToTagsBatchMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(actionURL(client, imageID), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{204},
+	})
+	return
+}
+
+// Get retrieves the tags of a specific image.
+func Get(client *golangsdk.ServiceClient, imageID string) (r GetResult) {
+	_, r.Err = client.Get(resourceURL(client, imageID), &r.Body, nil)
+	return
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/ims/v2/tags/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/ims/v2/tags/results.go
@@ -1,0 +1,28 @@
+package tags
+
+import (
+	"github.com/huaweicloud/golangsdk"
+)
+
+type RespTags struct {
+	//contains list of tags, i.e.key value pair
+	Tags []Tag `json:"tags"`
+}
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+type ActionResults struct {
+	commonResult
+}
+
+type GetResult struct {
+	commonResult
+}
+
+func (r commonResult) Extract() (*RespTags, error) {
+	var response RespTags
+	err := r.ExtractInto(&response)
+	return &response, err
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/ims/v2/tags/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/ims/v2/tags/urls.go
@@ -1,0 +1,17 @@
+package tags
+
+import "github.com/huaweicloud/golangsdk"
+
+const (
+	rootPath     = "images"
+	resourcePath = "tags"
+	actionPath   = "tags/action"
+)
+
+func actionURL(c *golangsdk.ServiceClient, id string) string {
+	return c.ServiceURL(c.ProjectID, rootPath, id, actionPath)
+}
+
+func resourceURL(c *golangsdk.ServiceClient, id string) string {
+	return c.ServiceURL(c.ProjectID, rootPath, id, resourcePath)
+}

--- a/website/docs/r/ims_image_v2.html.markdown
+++ b/website/docs/r/ims_image_v2.html.markdown
@@ -19,7 +19,7 @@ resource "opentelekomcloud_ims_image_v2" "ims_test" {
   name   = "imt_test"
   instance_id = "54a6c3a4-8511-4d01-818f-3fe5177cbb06"
   description = "Create an image using an ECS."
-  image_tags = {
+  tags = {
     foo = "bar"
     key = "value"
   }
@@ -34,7 +34,7 @@ resource "opentelekomcloud_ims_image_v2" "ims_test_file" {
   image_url = "ims-image:centos70.qcow2"
   min_disk = 40
   description = "Create an image using a file in the OBS bucket."
-  image_tags = {
+  tags = {
     foo = "bar1"
     key = "value"
   }
@@ -56,7 +56,7 @@ The following arguments are supported:
 * `max_ram` - (Optional) The maximum memory of the image in the unit of MB.
     Changing this creates a new image.
 
-* `image_tags` - (Optional) The tags of the image.
+* `tags` - (Optional) The tags of the image.
 
 * `instance_id` - (Optional) The ID of the ECS that needs to be converted into an image.
     This parameter is mandatory when you create a privete image from an ECS.
@@ -64,7 +64,8 @@ The following arguments are supported:
 
 * `image_url` - (Optional) The URL of the external image file in the OBS bucket.
     This parameter is mandatory when you create a private image from an external file
-	uploaded to an OBS bucket. Changing this creates a new image.
+	uploaded to an OBS bucket. The format is *OBS bucket name:Image file name*.
+	Changing this creates a new image.
 
 * `min_disk` - (Optional) The minimum size of the system disk in the unit of GB.
     This parameter is mandatory when you create a private image from an external file
@@ -93,7 +94,7 @@ The following attributes are exported:
 * `description` - See Argument Reference above.
 * `min_ram` - See Argument Reference above.
 * `max_ram` - See Argument Reference above.
-* `image_tags` - See Argument Reference above.
+* `tags` - See Argument Reference above.
 * `instance_id` - See Argument Reference above.
 * `image_url` - See Argument Reference above.
 * `min_disk` - See Argument Reference above.
@@ -102,7 +103,7 @@ The following attributes are exported:
 * `cmk_id` - See Argument Reference above.
 * `type` - See Argument Reference above.
 * `visibility` - Whether the image is visible to other tenants.
-* `data_origin` - The image resource. The pattern can be 'instance,*{instance_id}*' or 'file,*{image_url}*'.
+* `data_origin` - The image resource. The pattern can be 'instance,*instance_id*' or 'file,*image_url*'.
 * `disk_format` - The image file format. The value can be vhd, zvhd, raw, zvhd2, or qcow2.
 * `image_size` - The size(bytes) of the image file format.
 


### PR DESCRIPTION
Rename "image_tags" argument of opentelekomcloud_ims_image_v2 to "tags";
Use ims/v2/tags interface to update tags;

Signed-off-by: ShiChangkuo <shichangkuo90@gmail.com>