### PR TITLE
Updated list of values for volume_type

### DIFF
--- a/website/docs/r/blockstorage_volume_v2.html.markdown
+++ b/website/docs/r/blockstorage_volume_v2.html.markdown
@@ -68,7 +68,7 @@ The following arguments are supported:
 * `source_vol_id` - (Optional) The volume ID from which to create the volume.
     Changing this creates a new volume.
 
-* `volume_type` - (Optional) Currently, the value can be `SSD` (ultra-high I/O disk type), `SAS` (high I/O disk type), `SATA` (common I/O disk type), `co-p1` (Excluise HPC/ SAP HANA: high I/O performance optimized), or `uh-l1` (Excluise HPC/ SAP HANA: ultra-high-I/O latency optimized), Read Note for `uh-l1` and `co-p1`: [OTC-API](https://docs.otc.t-systems.com/en-us/api/ecs/en-us_topic_0065817708.html). Changing this creates a new volume.
+* `volume_type` - (Optional) Currently, the value can be `SSD` (ultra-high I/O disk type), `SAS` (high I/O disk type), `SATA` (common I/O disk type), `co-p1` (Exclusive HPC/ SAP HANA: high I/O, performance optimized), or `uh-l1` (Exclusive HPC/ SAP HANA: ultra-high-I/O, latency optimized), Read Note for `uh-l1` and `co-p1`: [OTC-API](https://docs.otc.t-systems.com/en-us/api/ecs/en-us_topic_0065817708.html). Changing this creates a new volume.
 
 * `volume_type` - (Optional) The type of volume to create.
     Changing this creates a new volume. Currently, the value can be SSD, SAS, SATA, co-p1, or uh-l1. Changing this creates a new volume.

--- a/website/docs/r/blockstorage_volume_v2.html.markdown
+++ b/website/docs/r/blockstorage_volume_v2.html.markdown
@@ -70,9 +70,6 @@ The following arguments are supported:
 
 * `volume_type` - (Optional) Currently, the value can be `SSD` (ultra-high I/O disk type), `SAS` (high I/O disk type), `SATA` (common I/O disk type), `co-p1` (Exclusive HPC/ SAP HANA: high I/O, performance optimized), or `uh-l1` (Exclusive HPC/ SAP HANA: ultra-high-I/O, latency optimized), Read Note for `uh-l1` and `co-p1`: [OTC-API](https://docs.otc.t-systems.com/en-us/api/ecs/en-us_topic_0065817708.html). Changing this creates a new volume.
 
-* `volume_type` - (Optional) The type of volume to create.
-    Changing this creates a new volume. Currently, the value can be SSD, SAS, SATA, co-p1, or uh-l1. Changing this creates a new volume.
-
 * `device_type` - (Optional) The device type of volume to create. Valid options are VBD and SCSI.
 	Defaults to VBD. Changing this creates a new volume.
 

--- a/website/docs/r/blockstorage_volume_v2.html.markdown
+++ b/website/docs/r/blockstorage_volume_v2.html.markdown
@@ -69,7 +69,7 @@ The following arguments are supported:
     Changing this creates a new volume.
 
 * `volume_type` - (Optional) The type of volume to create.
-    Changing this creates a new volume.
+    Changing this creates a new volume. Currently, the value can be SSD, SAS, SATA, co-p1, or uh-l1. Changing this creates a new volume.
 
 * `device_type` - (Optional) The device type of volume to create. Valid options are VBD and SCSI.
 	Defaults to VBD. Changing this creates a new volume.

--- a/website/docs/r/blockstorage_volume_v2.html.markdown
+++ b/website/docs/r/blockstorage_volume_v2.html.markdown
@@ -68,6 +68,8 @@ The following arguments are supported:
 * `source_vol_id` - (Optional) The volume ID from which to create the volume.
     Changing this creates a new volume.
 
+* `volume_type` - (Optional) Currently, the value can be `SSD` (ultra-high I/O disk type), `SAS` (high I/O disk type), `SATA` (common I/O disk type), `co-p1` (Excluise HPC/ SAP HANA: high I/O performance optimized), or `uh-l1` (Excluise HPC/ SAP HANA: ultra-high-I/O latency optimized), Read Note for `uh-l1` and `co-p1`: [OTC-API](https://docs.otc.t-systems.com/en-us/api/ecs/en-us_topic_0065817708.html). Changing this creates a new volume.
+
 * `volume_type` - (Optional) The type of volume to create.
     Changing this creates a new volume. Currently, the value can be SSD, SAS, SATA, co-p1, or uh-l1. Changing this creates a new volume.
 


### PR DESCRIPTION
The original documentation does not refer to volumes, so the documentation needs to be updated accordingly

Sadly, the Volume Creation in Line 88 on [resource_opentelekomcloud_blockstorage_volume_v2.g](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/blob/master/opentelekomcloud/resource_opentelekomcloud_blockstorage_volume_v2.go) lacks the validation changes made in [evs_volume_v3](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/blob/master/website/docs/r/evs_volume_v3.html.markdown), that is referred, might pull errors that confuse.

Also it is not clear what every Option does, there is only Trial&Error.
Maybe order from Common I/O to High Performance I/O and Low Latency I/O