### PR TITLE
unsupport import opentelekomcloud_logtank_topic_v2

### DIFF
--- a/opentelekomcloud/resource_opentelekomcloud_lts_logtopic.go
+++ b/opentelekomcloud/resource_opentelekomcloud_lts_logtopic.go
@@ -13,9 +13,6 @@ func resourceLTSTopicV2() *schema.Resource {
 		Create: resourceTopicV2Create,
 		Read:   resourceTopicV2Read,
 		Delete: resourceTopicV2Delete,
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
 
 		Schema: map[string]*schema.Schema{
 			"group_id": {

--- a/website/docs/r/lts_logtopic.html.markdown
+++ b/website/docs/r/lts_logtopic.html.markdown
@@ -47,10 +47,3 @@ The following attributes are exported:
 
 * `index_enabled` - Specifies the search switch. When index is enabled, the topic allows you to search for logs by keyword.
 
-## Import
-
-Log topic can be imported using the `id`, e.g.
-
-```
-$ terraform import opentelekomcloud_logtank_topic_v2.topic_1 72855918-20b1-11ea-80e0-286ed488c880
-```


### PR DESCRIPTION
we get the 'group_id' to construct the URL, but it always is empty when importing,
so we don't suppot import function temporarily.