### PR TITLE
Increase LB v1 bandwidth range to 1000

### DIFF
--- a/opentelekomcloud/resource_opentelekomcloud_elb_loadbalancer.go
+++ b/opentelekomcloud/resource_opentelekomcloud_elb_loadbalancer.go
@@ -52,7 +52,7 @@ func resourceELoadBalancer() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					return ValidateIntRange(v, k, 1, 500)
+					return ValidateIntRange(v, k, 1, 1000)
 				},
 			},
 

--- a/website/docs/r/elb_loadbalancer.html.markdown
+++ b/website/docs/r/elb_loadbalancer.html.markdown
@@ -39,7 +39,7 @@ The following arguments are supported:
 
 * `bandwidth` - (Optional) Specifies the bandwidth (Mbit/s). This parameter
     is mandatory when type is set to External, and it is invalid when type
-    is set to Internal. The value ranges from 1 to 300.
+    is set to Internal. The value ranges from 1 to 1000.
 
 * `type` - (Required) Specifies the load balancer type. The value can be
     Internal or External. Changing this creates a new elb loadbalancer.


### PR DESCRIPTION
Resolves #458

Maximum range value is checked to be working on `eu-de.otc.t-systems.com`

Tested with following configuration:

```hcl
resource "opentelekomcloud_vpc_v1" "vpc" {
  cidr = "192.168.0.0/16"
  name = "vpc-test"
}

resource "opentelekomcloud_elb_loadbalancer" "lb" {
  name = "lb-test"
  type = "External"
  vpc_id = opentelekomcloud_vpc_v1.vpc.id
  bandwidth = 1000
}
```