### PR TITLE
Fix missing required `frequency` value in VBS policy v2 update

### DIFF
--- a/opentelekomcloud/resource_opentelekomcloud_vbs_backup_policy_v2.go
+++ b/opentelekomcloud/resource_opentelekomcloud_vbs_backup_policy_v2.go
@@ -189,9 +189,6 @@ func resourceVBSBackupPolicyV2Update(d *schema.ResourceData, meta interface{}) e
 		if d.HasChange("start_time") {
 			updateOpts.ScheduledPolicy.StartTime = d.Get("start_time").(string)
 		}
-		if d.HasChange("frequency") {
-			updateOpts.ScheduledPolicy.Frequency = d.Get("frequency").(int)
-		}
 		if d.HasChange("rentention_num") {
 			updateOpts.ScheduledPolicy.RententionNum = d.Get("rentention_num").(int)
 		}
@@ -202,6 +199,7 @@ func resourceVBSBackupPolicyV2Update(d *schema.ResourceData, meta interface{}) e
 			updateOpts.ScheduledPolicy.Status = d.Get("status").(string)
 		}
 
+		updateOpts.ScheduledPolicy.Frequency = d.Get("frequency").(int)
 		_, err = policies.Update(vbsClient, d.Id(), updateOpts).Extract()
 		if err != nil {
 			return fmt.Errorf("Error updating OpenTelekomCloud backup policy: %s", err)


### PR DESCRIPTION
Fix #466 

Make frequency to be always sent during update
Either frequency or week_frequency is required:
https://docs.otc.t-systems.com/en-us/api/vbs/en-us_topic_0043410559.html

No new tests, as existing acceptance tests cover the issue