### PR TITLE
bugfix for cce node resource and network data source

### DIFF
--- a/opentelekomcloud/data_source_opentelekomcloud_networking_network_v2.go
+++ b/opentelekomcloud/data_source_opentelekomcloud_networking_network_v2.go
@@ -69,6 +69,10 @@ func dataSourceNetworkingNetworkV2Read(d *schema.ResourceData, meta interface{})
 	}
 
 	pages, err := networks.List(networkingClient, listOpts).AllPages()
+	if err != nil {
+		return err
+	}
+
 	allNetworks, err := networks.ExtractNetworks(pages)
 	if err != nil {
 		return fmt.Errorf("Unable to retrieve networks: %s", err)

--- a/opentelekomcloud/data_source_opentelekomcloud_networking_network_v2_test.go
+++ b/opentelekomcloud/data_source_opentelekomcloud_networking_network_v2_test.go
@@ -2,72 +2,41 @@ package opentelekomcloud
 
 import (
 	"fmt"
+	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccOpenTelekomCloudNetworkingNetworkV2DataSource_basic(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccOpenTelekomCloudNetworkingNetworkV2DataSource_network,
-			},
-			{
-				Config: testAccOpenTelekomCloudNetworkingNetworkV2DataSource_basic,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNetworkingNetworkV2DataSourceID("data.opentelekomcloud_networking_network_v2.net"),
-					resource.TestCheckResourceAttr(
-						"data.opentelekomcloud_networking_network_v2.net", "name", "tf_test_network"),
-					resource.TestCheckResourceAttr(
-						"data.opentelekomcloud_networking_network_v2.net", "admin_state_up", "true"),
-				),
-			},
-		},
-	})
-}
+func TestAccNetworkingNetworkV2DataSource_basic(t *testing.T) {
+	rand.Seed(time.Now().UTC().UnixNano())
+	network := fmt.Sprintf("acc_test_network-%06x", rand.Int31n(1000000))
+	cidr := fmt.Sprintf("192.168.%d.0/24", rand.Intn(200))
 
-func TestAccOpenTelekomCloudNetworkingNetworkV2DataSource_subnet(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccOpenTelekomCloudNetworkingNetworkV2DataSource_network,
-			},
-			{
-				Config: testAccOpenTelekomCloudNetworkingNetworkV2DataSource_subnet,
+				Config: testAccNetworkingNetworkV2DataSource_basic(network, cidr),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNetworkingNetworkV2DataSourceID("data.opentelekomcloud_networking_network_v2.net"),
+					testAccCheckNetworkingNetworkV2DataSourceID("data.opentelekomcloud_networking_network_v2.net_by_name"),
+					testAccCheckNetworkingNetworkV2DataSourceID("data.opentelekomcloud_networking_network_v2.net_by_id"),
+					testAccCheckNetworkingNetworkV2DataSourceID("data.opentelekomcloud_networking_network_v2.net_by_cidr"),
 					resource.TestCheckResourceAttr(
-						"data.opentelekomcloud_networking_network_v2.net", "name", "tf_test_network"),
+						"data.opentelekomcloud_networking_network_v2.net_by_name", "name", network),
 					resource.TestCheckResourceAttr(
-						"data.opentelekomcloud_networking_network_v2.net", "admin_state_up", "true"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccOpenTelekomCloudNetworkingNetworkV2DataSource_networkID(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccOpenTelekomCloudNetworkingNetworkV2DataSource_network,
-			},
-			{
-				Config: testAccOpenTelekomCloudNetworkingNetworkV2DataSource_networkID,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNetworkingNetworkV2DataSourceID("data.opentelekomcloud_networking_network_v2.net"),
+						"data.opentelekomcloud_networking_network_v2.net_by_id", "name", network),
 					resource.TestCheckResourceAttr(
-						"data.opentelekomcloud_networking_network_v2.net", "name", "tf_test_network"),
+						"data.opentelekomcloud_networking_network_v2.net_by_cidr", "name", network),
 					resource.TestCheckResourceAttr(
-						"data.opentelekomcloud_networking_network_v2.net", "admin_state_up", "true"),
+						"data.opentelekomcloud_networking_network_v2.net_by_name", "admin_state_up", "true"),
+					resource.TestCheckResourceAttr(
+						"data.opentelekomcloud_networking_network_v2.net_by_id", "admin_state_up", "true"),
+					resource.TestCheckResourceAttr(
+						"data.opentelekomcloud_networking_network_v2.net_by_cidr", "matching_subnet_cidr", cidr),
 				),
 			},
 		},
@@ -89,40 +58,30 @@ func testAccCheckNetworkingNetworkV2DataSourceID(n string) resource.TestCheckFun
 	}
 }
 
-const testAccOpenTelekomCloudNetworkingNetworkV2DataSource_network = `
+func testAccNetworkingNetworkV2DataSource_basic(name, cidr string) string {
+	return fmt.Sprintf(`
 resource "opentelekomcloud_networking_network_v2" "net" {
-        name = "tf_test_network"
-        admin_state_up = "true"
+  name = "%s"
+  admin_state_up = "true"
 }
 
 resource "opentelekomcloud_networking_subnet_v2" "subnet" {
-  name = "tf_test_subnet"
-  cidr = "192.168.199.0/24"
+  name = "opentelekomcloud_test_subnet"
+  cidr = "%s"
   no_gateway = true
-  network_id = "${opentelekomcloud_networking_network_v2.net.id}"
+  network_id = opentelekomcloud_networking_network_v2.net.id
 }
-`
 
-var testAccOpenTelekomCloudNetworkingNetworkV2DataSource_basic = fmt.Sprintf(`
-%s
-
-data "opentelekomcloud_networking_network_v2" "net" {
-	name = "${opentelekomcloud_networking_network_v2.net.name}"
+data "opentelekomcloud_networking_network_v2" "net_by_name" {
+	name = opentelekomcloud_networking_network_v2.net.name
 }
-`, testAccOpenTelekomCloudNetworkingNetworkV2DataSource_network)
 
-var testAccOpenTelekomCloudNetworkingNetworkV2DataSource_subnet = fmt.Sprintf(`
-%s
-
-data "opentelekomcloud_networking_network_v2" "net" {
-	matching_subnet_cidr = "${opentelekomcloud_networking_subnet_v2.subnet.cidr}"
+data "opentelekomcloud_networking_network_v2" "net_by_id" {
+	network_id = opentelekomcloud_networking_network_v2.net.id
 }
-`, testAccOpenTelekomCloudNetworkingNetworkV2DataSource_network)
 
-var testAccOpenTelekomCloudNetworkingNetworkV2DataSource_networkID = fmt.Sprintf(`
-%s
-
-data "opentelekomcloud_networking_network_v2" "net" {
-	network_id = "${opentelekomcloud_networking_network_v2.net.id}"
+data "opentelekomcloud_networking_network_v2" "net_by_cidr" {
+	matching_subnet_cidr = opentelekomcloud_networking_subnet_v2.subnet.cidr
 }
-`, testAccOpenTelekomCloudNetworkingNetworkV2DataSource_network)
+`, name, cidr)
+}

--- a/opentelekomcloud/resource_opentelekomcloud_cce_node_v3.go
+++ b/opentelekomcloud/resource_opentelekomcloud_cce_node_v3.go
@@ -21,6 +21,9 @@ func resourceCCENodeV3() *schema.Resource {
 		Read:   resourceCCENodeV3Read,
 		Update: resourceCCENodeV3Update,
 		Delete: resourceCCENodeV3Delete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),
@@ -53,7 +56,6 @@ func resourceCCENodeV3() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: true,
-				Computed: true,
 			},
 			"flavor_id": {
 				Type:     schema.TypeString,

--- a/opentelekomcloud/resource_opentelekomcloud_cce_node_v3_test.go
+++ b/opentelekomcloud/resource_opentelekomcloud_cce_node_v3_test.go
@@ -126,12 +126,12 @@ func testAccCheckCCENodeV3Exists(n string, cluster string, node *nodes.Nodes) re
 var testAccCCENodeV3_basic = fmt.Sprintf(`
 resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   name = "opentelekomcloud-cce"
-  cluster_type="VirtualMachine"
-  flavor_id="cce.s1.small"
-  cluster_version = "v1.9.2-r2"
-  vpc_id="%s"
-  subnet_id="%s"
-  container_network_type="overlay_l2"
+  cluster_type = "VirtualMachine"
+  flavor_id = "cce.s1.small"
+  vpc_id = "%s"
+  subnet_id = "%s"
+  container_network_type = "overlay_l2"
+  authentication_mode = "rbac"
 }
 
 resource "opentelekomcloud_cce_node_v3" "node_1" {
@@ -153,12 +153,12 @@ cluster_id = "${opentelekomcloud_cce_cluster_v3.cluster_1.id}"
 var testAccCCENodeV3_update = fmt.Sprintf(`
 resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   name = "opentelekomcloud-cce"
-  cluster_type="VirtualMachine"
-  flavor_id="cce.s1.small"
-  cluster_version = "v1.9.2-r2"
-  vpc_id="%s"
-  subnet_id="%s"
-  container_network_type="overlay_l2"
+  cluster_type = "VirtualMachine"
+  flavor_id = "cce.s1.small"
+  vpc_id = "%s"
+  subnet_id = "%s"
+  container_network_type = "overlay_l2"
+  authentication_mode = "rbac"
 }
 
 resource "opentelekomcloud_cce_node_v3" "node_1" {
@@ -180,12 +180,12 @@ cluster_id = "${opentelekomcloud_cce_cluster_v3.cluster_1.id}"
 var testAccCCENodeV3_timeout = fmt.Sprintf(`
 resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   name = "opentelekomcloud-cce"
-  cluster_type="VirtualMachine"
-  flavor_id="cce.s1.small"
-  cluster_version = "v1.9.2-r2"
-  vpc_id="%s"
-  subnet_id="%s"
-  container_network_type="overlay_l2"
+  cluster_type = "VirtualMachine"
+  flavor_id = "cce.s1.small"
+  vpc_id = "%s"
+  subnet_id = "%s"
+  container_network_type = "overlay_l2"
+  authentication_mode = "rbac"
 }
 
 resource "opentelekomcloud_cce_node_v3" "node_1" {

--- a/website/docs/r/cce_node_v3.html.md
+++ b/website/docs/r/cce_node_v3.html.md
@@ -58,7 +58,8 @@ The following arguments are supported:
 * `eip_ids` - (Optional) List of existing elastic IP IDs. Changing this parameter will create a new resource.
 
 **Note:**
-If the eip_ids parameter is configured, you do not need to configure the eip_count and bandwidth parameters: iptype, charge_mode, bandwidth_size and share_type.
+If the eip_ids parameter is configured, you do not need to configure the eip_count and bandwidth parameters:
+iptype, charge_mode, bandwidth_size and share_type.
 
 * `eip_count` - (Optional) Number of elastic IPs to be dynamically created. Changing this parameter will create a new resource.
 
@@ -74,7 +75,8 @@ If the eip_ids parameter is configured, you do not need to configure the eip_cou
 
 * `ecs_performance_type` - (Optional) Classification of cloud server specifications. Changing this parameter will create a new cluster resource.
 
-* `order_id` - (Optional) Order ID, mandatory when the node payment type is the automatic payment package period type. Changing this parameter will create a new cluster resource.
+* `order_id` - (Optional) Order ID, mandatory when the node payment type is the automatic payment package period type.
+    Changing this parameter will create a new cluster resource.
 
 * `product_id` - (Optional) The Product ID. Changing this parameter will create a new cluster resource.
 


### PR DESCRIPTION
- Update test case for data.opentelekomcloud_networking_network_v2
    use rand number to make sure the network name is unique

- bugfix for cce node resource
    due to some parameters are  missing from the response API, we unset the Computed attribute for `labels` and `annotations`.
    fixes #468 