### PR TITLE
fix waf_domain_v1 using old waf api

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/terraform-plugin-sdk v1.0.0
-	github.com/huaweicloud/golangsdk v0.0.0-20200423085757-3f861cf4abeb
+	github.com/huaweicloud/golangsdk v0.0.0-20200511121243-f08855b1031a
 	github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/smartystreets/goconvey v0.0.0-20190306220146-200a235640ff // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/terraform-plugin-sdk v1.0.0
-	github.com/huaweicloud/golangsdk v0.0.0-20200512100449-5e429b2d48e3
+	github.com/huaweicloud/golangsdk v0.0.0-20200514093704-9d7dc5ea5e68
 	github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/smartystreets/goconvey v0.0.0-20190306220146-200a235640ff // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/terraform-plugin-sdk v1.0.0
-	github.com/huaweicloud/golangsdk v0.0.0-20200511121243-f08855b1031a
+	github.com/huaweicloud/golangsdk v0.0.0-20200512100449-5e429b2d48e3
 	github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/smartystreets/goconvey v0.0.0-20190306220146-200a235640ff // indirect

--- a/go.sum
+++ b/go.sum
@@ -128,12 +128,8 @@ github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKe
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/huaweicloud/golangsdk v0.0.0-20200226090834-31e7d87f9e61 h1:cHkhULuZneNT7GRwigfbRM8IXxLH4mNdDEUezszJ3go=
-github.com/huaweicloud/golangsdk v0.0.0-20200226090834-31e7d87f9e61/go.mod h1:WQBcHRNX9shz3928lWEvstQJtAtYI7ks6XlgtRT9Tcw=
-github.com/huaweicloud/golangsdk v0.0.0-20200414012957-3b8a408c2816 h1:odMiLWHZ8AdQpBMJFD8mrQzKgUy09rKdFkr4TUNwols=
-github.com/huaweicloud/golangsdk v0.0.0-20200414012957-3b8a408c2816/go.mod h1:WQBcHRNX9shz3928lWEvstQJtAtYI7ks6XlgtRT9Tcw=
-github.com/huaweicloud/golangsdk v0.0.0-20200423085757-3f861cf4abeb h1:dAHBqcuk7ukdQlnGJ5Sj8ElIV5tjsbMHQsE+tTNBmuQ=
-github.com/huaweicloud/golangsdk v0.0.0-20200423085757-3f861cf4abeb/go.mod h1:WQBcHRNX9shz3928lWEvstQJtAtYI7ks6XlgtRT9Tcw=
+github.com/huaweicloud/golangsdk v0.0.0-20200514093704-9d7dc5ea5e68 h1:XCfFmAzrHy/WBiRrdFGd5GCE/2IHl/dCfTbZtC85Ej0=
+github.com/huaweicloud/golangsdk v0.0.0-20200514093704-9d7dc5ea5e68/go.mod h1:WQBcHRNX9shz3928lWEvstQJtAtYI7ks6XlgtRT9Tcw=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a h1:FyS/ubzBR5xJlnJGRTwe7GUHpJOR4ukYK3y+LFNffuA=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a/go.mod h1:uoIMjNxUfXi48Ci40IXkPRbghZ1vbti6v9LCbNqRgHY=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=

--- a/opentelekomcloud/resource_opentelekomcloud_waf_domain_v1.go
+++ b/opentelekomcloud/resource_opentelekomcloud_waf_domain_v1.go
@@ -237,8 +237,8 @@ func resourceWafDomainV1Read(d *schema.ResourceData, meta interface{}) error {
 	servers := make([]map[string]interface{}, len(n.Server))
 	for i, server := range n.Server {
 		servers[i] = make(map[string]interface{})
-		servers[i]["client_protocol"] = server.FrontProtocol
-		servers[i]["server_protocol"] = server.BackProtocol
+		servers[i]["client_protocol"] = server.ClientProtocol
+		servers[i]["server_protocol"] = server.ServerProtocol
 		servers[i]["address"] = server.Address
 		servers[i]["port"] = strconv.Itoa(server.Port)
 	}

--- a/opentelekomcloud/resource_opentelekomcloud_waf_domain_v1.go
+++ b/opentelekomcloud/resource_opentelekomcloud_waf_domain_v1.go
@@ -45,11 +45,11 @@ func resourceWafDomainV1() *schema.Resource {
 				ForceNew: false,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"front_protocol": {
+						"client_protocol": {
 							Type:     schema.TypeString,
 							Required: true,
 						},
-						"back_protocol": {
+						"server_protocol": {
 							Type:     schema.TypeString,
 							Required: true,
 						},
@@ -128,10 +128,10 @@ func getAllServers(d *schema.ResourceData) []domains.ServerOpts {
 		server := v.(map[string]interface{})
 
 		v := domains.ServerOpts{
-			FrontProtocol: server["front_protocol"].(string),
-			BackProtocol:  server["back_protocol"].(string),
-			Address:       server["address"].(string),
-			Port:          server["port"].(string),
+			ClientProtocol: server["client_protocol"].(string),
+			ServerProtocol: server["server_protocol"].(string),
+			Address:        server["address"].(string),
+			Port:           server["port"].(string),
 		}
 		serverOpts = append(serverOpts, v)
 	}
@@ -237,8 +237,8 @@ func resourceWafDomainV1Read(d *schema.ResourceData, meta interface{}) error {
 	servers := make([]map[string]interface{}, len(n.Server))
 	for i, server := range n.Server {
 		servers[i] = make(map[string]interface{})
-		servers[i]["front_protocol"] = server.FrontProtocol
-		servers[i]["back_protocol"] = server.BackProtocol
+		servers[i]["client_protocol"] = server.FrontProtocol
+		servers[i]["server_protocol"] = server.BackProtocol
 		servers[i]["address"] = server.Address
 		servers[i]["port"] = strconv.Itoa(server.Port)
 	}

--- a/opentelekomcloud/resource_opentelekomcloud_waf_domain_v1_test.go
+++ b/opentelekomcloud/resource_opentelekomcloud_waf_domain_v1_test.go
@@ -117,8 +117,8 @@ resource "opentelekomcloud_waf_policy_v1" "policy_1" {
 resource "opentelekomcloud_waf_domain_v1" "domain_1" {
 	hostname = "www.b.com"
 	server {
-		front_protocol = "HTTPS"
-		back_protocol = "HTTP"
+		client_protocol = "HTTPS"
+		server_protocol = "HTTP"
 		address = "${opentelekomcloud_networking_floatingip_v2.fip_1.address}"
 		port = "8080"
 	}
@@ -152,8 +152,8 @@ resource "opentelekomcloud_waf_policy_v1" "policy_1" {
 resource "opentelekomcloud_waf_domain_v1" "domain_1" {
 	hostname = "www.b.com"
 	server {
-		front_protocol = "HTTPS"
-		back_protocol = "HTTP"
+		client_protocol = "HTTPS"
+		server_protocol = "HTTP"
 		address = "${opentelekomcloud_networking_floatingip_v2.fip_1.address}"
 		port = "80"
 	}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/cce/v3/nodes/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/cce/v3/nodes/results.go
@@ -60,8 +60,22 @@ type Spec struct {
 	BillingMode int `json:"billingMode,omitempty"`
 	// Number of nodes when creating in batch
 	Count int `json:"count" required:"true"`
+	// The node nic spec
+	NodeNicSpec NodeNicSpec `json:"nodeNicSpec,omitempty"`
 	// Extended parameter
 	ExtendParam ExtendParam `json:"extendParam,omitempty"`
+}
+
+// Gives the Nic spec of the node
+type NodeNicSpec struct {
+	// The primary Nic of the Node
+	PrimaryNic PrimaryNic `json:"primaryNic,omitempty"`
+}
+
+// Gives the Primary Nic of the node
+type PrimaryNic struct {
+	// The Subnet ID of the primary Nic
+	SubnetId string `json:"subnetId,omitempty"`
 }
 
 // Gives the current status of the node

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/client.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/client.go
@@ -576,6 +576,15 @@ func initcommonServiceClient(client *golangsdk.ProviderClient, eo golangsdk.Endp
 	return sc, err
 }
 
+// TODO: Need to change to apig client type from apig once available
+// ApiGateWayV1 creates a service client that is used for Huawei cloud for API gateway.
+func ApiGateWayV1(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
+	sc, err := initClientOpts(client, eo, "network")
+	sc.Endpoint = strings.Replace(sc.Endpoint, "vpc", "apig", 1)
+	sc.ResourceBase = sc.Endpoint + "v1.0/apigw/"
+	return sc, err
+}
+
 // NewObjectStorageV1 creates a ServiceClient that may be used with the v1
 // object storage package.
 func NewObjectStorageV1(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
@@ -820,6 +829,15 @@ func NewMapReduceV1(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts)
 	return sc, err
 }
 
+// AntiDDoSV1 creates a ServiceClient that may be used with the v1 Anti DDoS service.
+func AntiDDoSV1(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
+	sc, err := initClientOpts(client, eo, "network")
+	sc.Endpoint = strings.Replace(sc.Endpoint, "vpc", "antiddos", 1)
+	sc.Endpoint = sc.Endpoint + "v1/"
+	sc.ResourceBase = sc.Endpoint + client.ProjectID + "/"
+	return sc, err
+}
+
 // NewAntiDDoSV1 creates a ServiceClient that may be used with the v1 Anti DDoS Service
 // package.
 func NewAntiDDoSV1(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
@@ -1019,6 +1037,15 @@ func SDRSV1(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*golan
 	sc, err := initClientOpts(client, eo, "network")
 	sc.Endpoint = strings.Replace(sc.Endpoint, "vpc", "sdrs", 1)
 	sc.Endpoint = sc.Endpoint + "v1/" + client.ProjectID + "/"
+	sc.ResourceBase = sc.Endpoint
+	return sc, err
+}
+
+// CCIV1 creates a ServiceClient that may be used with the v1 CCI service.
+func CCIV1(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
+	sc, err := initClientOpts(client, eo, "network")
+	sc.Endpoint = strings.Replace(sc.Endpoint, "vpc", "cci", 1)
+	sc.Endpoint = sc.Endpoint + "apis/networking.cci.io/v1beta1/"
 	sc.ResourceBase = sc.Endpoint
 	return sc, err
 }

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/ecs/v1/cloudservers/results_order.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/ecs/v1/cloudservers/results_order.go
@@ -60,6 +60,10 @@ func WaitForOrderSuccess(client *golangsdk.ServiceClient, secs int, orderID stri
 			return false, err
 		}
 		time.Sleep(5 * time.Second)
+
+		if len(order.Resources) == 0 {
+			return false, nil
+		}
 		instance := order.Resources[0]
 
 		if instance.Status == 1 {
@@ -82,6 +86,10 @@ func WaitForOrderDeleteSuccess(client *golangsdk.ServiceClient, secs int, orderI
 			return false, err
 		}
 		time.Sleep(5 * time.Second)
+
+		if len(order.Resources) == 0 {
+			return false, nil
+		}
 		instance := order.Resources[0]
 
 		if instance.Status == 8 {

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/mrs/v1/cluster/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/mrs/v1/cluster/requests.go
@@ -23,8 +23,9 @@ type CreateOpts struct {
 	VpcID                 string          `json:"vpc_id" required:"true"`
 	SubnetID              string          `json:"subnet_id" required:"true"`
 	SubnetName            string          `json:"subnet_name" required:"true"`
-	ClusterVersion        string          `json:"cluster_version,omitempty"`
-	ClusterType           int             `json:"cluster_type,omitempty"`
+	SecurityGroupsID      string          `json:"security_groups_id,omitempty"`
+	ClusterVersion        string          `json:"cluster_version" required:"true"`
+	ClusterType           int             `json:"cluster_type"`
 	MasterDataVolumeType  string          `json:"master_data_volume_type,omitempty"`
 	MasterDataVolumeSize  int             `json:"master_data_volume_size,omitempty"`
 	MasterDataVolumeCount int             `json:"master_data_volume_count,omitempty"`
@@ -33,9 +34,11 @@ type CreateOpts struct {
 	CoreDataVolumeCount   int             `json:"core_data_volume_count,omitempty"`
 	VolumeType            string          `json:"volume_type,omitempty"`
 	VolumeSize            int             `json:"volume_size,omitempty"`
-	NodePublicCertName    string          `json:"node_public_cert_name" required:"true"`
 	SafeMode              int             `json:"safe_mode"`
-	ClusterAdminSecret    string          `json:"cluster_admin_secret,omitempty"`
+	ClusterAdminSecret    string          `json:"cluster_admin_secret" required:"true"`
+	LoginMode             int             `json:"login_mode"`
+	ClusterMasterSecret   string          `json:"cluster_master_secret,omitempty"`
+	NodePublicCertName    string          `json:"node_public_cert_name,omitempty"`
 	LogCollection         int             `json:"log_collection,omitempty"`
 	ComponentList         []ComponentOpts `json:"component_list" required:"true"`
 	AddJobs               []JobOpts       `json:"add_jobs,omitempty"`

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/lbaas_v2/listeners/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/lbaas_v2/listeners/requests.go
@@ -106,11 +106,17 @@ type CreateOpts struct {
 	// The maximum number of connections allowed for the Listener.
 	ConnLimit *int `json:"connection_limit,omitempty"`
 
+	// whether to use HTTP2.
+	Http2Enable *bool `json:"http2_enable,omitempty"`
+
 	// A reference to a Barbican container of TLS secrets.
 	DefaultTlsContainerRef string `json:"default_tls_container_ref,omitempty"`
 
 	// A list of references to TLS secrets.
 	SniContainerRefs []string `json:"sni_container_refs,omitempty"`
+
+	// the ID of the CA certificate used by the listener.
+	CAContainerRef string `json:"client_ca_tls_container_ref,omitempty"`
 
 	// Specifies the security policy used by the listener.
 	TlsCiphersPolicy string `json:"tls_ciphers_policy,omitempty"`
@@ -165,11 +171,17 @@ type UpdateOpts struct {
 	// The maximum number of connections allowed for the Listener.
 	ConnLimit *int `json:"connection_limit,omitempty"`
 
+	// whether to use HTTP2.
+	Http2Enable *bool `json:"http2_enable,omitempty"`
+
 	// A reference to a Barbican container of TLS secrets.
 	DefaultTlsContainerRef string `json:"default_tls_container_ref,omitempty"`
 
 	// A list of references to TLS secrets.
 	SniContainerRefs []string `json:"sni_container_refs,omitempty"`
+
+	// the ID of the CA certificate used by the listener.
+	CAContainerRef string `json:"client_ca_tls_container_ref,omitempty"`
 
 	// Specifies the security policy used by the listener.
 	TlsCiphersPolicy string `json:"tls_ciphers_policy,omitempty"`

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/lbaas_v2/listeners/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/lbaas_v2/listeners/results.go
@@ -44,8 +44,14 @@ type Listener struct {
 	// Default is -1, meaning no limit.
 	ConnLimit int `json:"connection_limit"`
 
+	// whether to use HTTP2.
+	Http2Enable bool `json:"http2_enable"`
+
 	// The list of references to TLS secrets.
 	SniContainerRefs []string `json:"sni_container_refs"`
+
+	// the ID of the CA certificate used by the listener.
+	CAContainerRef string `json:"client_ca_tls_container_ref"`
 
 	// A reference to a Barbican container of TLS secrets.
 	DefaultTlsContainerRef string `json:"default_tls_container_ref"`

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/waf/v1/domains/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/waf/v1/domains/requests.go
@@ -32,9 +32,9 @@ type CreateOpts struct {
 
 type ServerOpts struct {
 	//Protocol type of the client
-	FrontProtocol string `json:"front_protocol" required:"true"`
+	ClientProtocol string `json:"client_protocol" required:"true"`
 	//Protocol used by WAF to forward client requests to the server
-	BackProtocol string `json:"back_protocol" required:"true"`
+	ServerProtocol string `json:"server_protocol" required:"true"`
 	//IP address or domain name of the web server that the client accesses.
 	Address string `json:"address" required:"true"`
 	//Port number used by the web server

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/waf/v1/domains/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/waf/v1/domains/results.go
@@ -39,9 +39,9 @@ type Domain struct {
 
 type Server struct {
 	//Protocol type of the client
-	FrontProtocol string `json:"front_protocol" required:"true"`
+	ClientProtocol string `json:"client_protocol" required:"true"`
 	//Protocol used by WAF to forward client requests to the server
-	BackProtocol string `json:"back_protocol" required:"true"`
+	ServerProtocol string `json:"server_protocol" required:"true"`
 	//IP address or domain name of the web server that the client accesses.
 	Address string `json:"address" required:"true"`
 	//Port number used by the web server

--- a/website/docs/r/waf_domain_v1.html.markdown
+++ b/website/docs/r/waf_domain_v1.html.markdown
@@ -23,8 +23,8 @@ resource "opentelekomcloud_waf_certificate_v1" "certificate_1" {
 resource "opentelekomcloud_waf_domain_v1" "domain_1" {
 	hostname = "www.b.com"
 	server {
-		front_protocol = "HTTPS"
-		back_protocol = "HTTP"
+		client_protocol = "HTTPS"
+		server_protocol = "HTTP"
 		address = "80.158.42.162"
 		port = "8080"
 	}
@@ -42,7 +42,7 @@ The following arguments are supported:
 
 * `hostname` - (Required) The domain name. For example, www.example.com or *.example.com. Changing this creates a new domain.
 
-* `certificate_id` - (Optional) The certificate ID. This parameter is mandatory when front_protocol is set to HTTPS.
+* `certificate_id` - (Optional) The certificate ID. This parameter is mandatory when client_protocol is set to HTTPS.
 
 * `server` - (Required) Array of server object. The server object structure is documented below.
 
@@ -61,9 +61,9 @@ The following arguments are supported:
 
 The `server` block supports:
 
-* `front_protocol` - (Required) Protocol type of the client. The options are HTTP and HTTPS.
+* `client_protocol` - (Required) Protocol type of the client. The options are HTTP and HTTPS.
 
-* `back_protocol` - (Required) Protocl used by WAF to forward client requests to the server. The options are HTTP and HTTPS.
+* `server_protocol` - (Required) Protocol used by WAF to forward client requests to the server. The options are HTTP and HTTPS.
 
 * `address` - (Required) IP address or domain name of the web server that the client accesses. For example, 192.168.1.1 or www.a.com.
 


### PR DESCRIPTION
The server props were changed from front_ and back_protocol
to client_ and server_protocol without changing api version.

This depends on huaweicloud/golangsdk#253 and will probably require a change to go.mod after that's merged.