### PR TITLE
support tags for vpc and subnet resources

### DIFF
--- a/opentelekomcloud/resource_opentelekomcloud_vpc_subnet_v1_test.go
+++ b/opentelekomcloud/resource_opentelekomcloud_vpc_subnet_v1_test.go
@@ -32,6 +32,10 @@ func TestAccOTCVpcSubnetV1_basic(t *testing.T) {
 						"opentelekomcloud_vpc_subnet_v1.subnet_1", "availability_zone", "eu-de-02"),
 					resource.TestCheckResourceAttr(
 						"opentelekomcloud_vpc_subnet_v1.subnet_1", "ntp_addresses", "10.100.0.33,10.100.0.34"),
+					resource.TestCheckResourceAttr(
+						"opentelekomcloud_vpc_subnet_v1.subnet_1", "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(
+						"opentelekomcloud_vpc_subnet_v1.subnet_1", "tags.key", "value"),
 				),
 			},
 			{
@@ -41,6 +45,8 @@ func TestAccOTCVpcSubnetV1_basic(t *testing.T) {
 						"opentelekomcloud_vpc_subnet_v1.subnet_1", "name", "opentelekomcloud_subnet_1"),
 					resource.TestCheckResourceAttr(
 						"opentelekomcloud_vpc_subnet_v1.subnet_1", "ntp_addresses", "10.100.0.35,10.100.0.36"),
+					resource.TestCheckResourceAttr(
+						"opentelekomcloud_vpc_subnet_v1.subnet_1", "tags.key", "value_update"),
 				),
 			},
 		},
@@ -131,8 +137,13 @@ resource "opentelekomcloud_vpc_subnet_v1" "subnet_1" {
   availability_zone = "eu-de-02"
   ntp_addresses = "10.100.0.33,10.100.0.34"
 
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
 }
 `
+
 const testAccOTCVpcSubnetV1_update = `
 resource "opentelekomcloud_vpc_v1" "vpc_1" {
   name = "vpc_test"
@@ -146,7 +157,12 @@ resource "opentelekomcloud_vpc_subnet_v1" "subnet_1" {
   vpc_id = "${opentelekomcloud_vpc_v1.vpc_1.id}"
   availability_zone = "eu-de-02"
   ntp_addresses = "10.100.0.35,10.100.0.36"
- }
+
+  tags = {
+    foo = "bar"
+    key = "value_update"
+  }
+}
 `
 
 const testAccOTCVpcSubnetV1_timeout = `

--- a/opentelekomcloud/resource_opentelekomcloud_vpc_v1_test.go
+++ b/opentelekomcloud/resource_opentelekomcloud_vpc_v1_test.go
@@ -30,6 +30,10 @@ func TestAccOTCVpcV1_basic(t *testing.T) {
 						"opentelekomcloud_vpc_v1.vpc_1", "status", "OK"),
 					resource.TestCheckResourceAttr(
 						"opentelekomcloud_vpc_v1.vpc_1", "shared", "true"),
+					resource.TestCheckResourceAttr(
+						"opentelekomcloud_vpc_v1.vpc_1", "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(
+						"opentelekomcloud_vpc_v1.vpc_1", "tags.key", "value"),
 				),
 			},
 		},
@@ -52,6 +56,8 @@ func TestAccOTCVpcV1_update(t *testing.T) {
 						"opentelekomcloud_vpc_v1.vpc_1", "name", "terraform_provider_test"),
 					resource.TestCheckResourceAttr(
 						"opentelekomcloud_vpc_v1.vpc_1", "shared", "true"),
+					resource.TestCheckResourceAttr(
+						"opentelekomcloud_vpc_v1.vpc_1", "tags.key", "value"),
 				),
 			},
 			{
@@ -62,6 +68,8 @@ func TestAccOTCVpcV1_update(t *testing.T) {
 						"opentelekomcloud_vpc_v1.vpc_1", "name", "terraform_provider_test1"),
 					resource.TestCheckResourceAttr(
 						"opentelekomcloud_vpc_v1.vpc_1", "shared", "false"),
+					resource.TestCheckResourceAttr(
+						"opentelekomcloud_vpc_v1.vpc_1", "tags.key", "value_update"),
 				),
 			},
 		},
@@ -141,23 +149,34 @@ func testAccCheckOTCVpcV1Exists(n string, vpc *vpcs.Vpc) resource.TestCheckFunc 
 
 const testAccVpcV1_basic = `
 resource "opentelekomcloud_vpc_v1" "vpc_1" {
-	name   = "terraform_provider_test"
-	cidr   = "192.168.0.0/16"
-	shared = true
+  name   = "terraform_provider_test"
+  cidr   = "192.168.0.0/16"
+  shared = true
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
 }
 `
 
 const testAccVpcV1_update = `
 resource "opentelekomcloud_vpc_v1" "vpc_1" {
-    name   = "terraform_provider_test1"
-	cidr   = "192.168.0.0/16"
-	shared = false
+  name   = "terraform_provider_test1"
+  cidr   = "192.168.0.0/16"
+  shared = false
+
+  tags = {
+    foo = "bar"
+    key = "value_update"
+  }
 }
 `
+
 const testAccVpcV1_timeout = `
 resource "opentelekomcloud_vpc_v1" "vpc_1" {
-	name = "terraform_provider_test"
-	cidr="192.168.0.0/16"
+  name = "terraform_provider_test"
+  cidr="192.168.0.0/16"
 
   timeouts {
     create = "5m"

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v1/tags/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v1/tags/requests.go
@@ -1,0 +1,63 @@
+package tags
+
+import (
+	"github.com/huaweicloud/golangsdk"
+)
+
+//ActionOptsBuilder is an interface from which can build the request of creating/deleting tags
+type ActionOptsBuilder interface {
+	ToTagsActionMap() (map[string]interface{}, error)
+}
+
+//ActionOpts is a struct contains the parameters of creating/deleting tags
+type ActionOpts struct {
+	Action string        `json:"action" required:"ture"`
+	Tags   []ResourceTag `json:"tags" required:"true"`
+}
+
+//ToTagsActionMap build the action request in json format
+func (opts ActionOpts) ToTagsActionMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+func doAction(client *golangsdk.ServiceClient, srvType, id string, opts ActionOptsBuilder) (r ActionResult) {
+	b, err := opts.ToTagsActionMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(actionURL(client, srvType, id), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200, 204},
+	})
+	return
+}
+
+//Create is a method of creating tags by id
+func Create(client *golangsdk.ServiceClient, srvType, id string, tags []ResourceTag) (r ActionResult) {
+	opts := ActionOpts{
+		Tags:   tags,
+		Action: "create",
+	}
+	return doAction(client, srvType, id, opts)
+}
+
+//Delete is a method of deleting tags by id
+func Delete(client *golangsdk.ServiceClient, srvType, id string, tags []ResourceTag) (r ActionResult) {
+	opts := ActionOpts{
+		Tags:   tags,
+		Action: "delete",
+	}
+	return doAction(client, srvType, id, opts)
+}
+
+//Get is a method of getting the tags by id
+func Get(client *golangsdk.ServiceClient, srvType, id string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, srvType, id), &r.Body, nil)
+	return
+}
+
+//List is a method of getting the tags of all service
+func List(client *golangsdk.ServiceClient, srvType string) (r ListResult) {
+	_, r.Err = client.Get(listURL(client, srvType), &r.Body, nil)
+	return
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v1/tags/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v1/tags/results.go
@@ -1,0 +1,45 @@
+package tags
+
+import (
+	"github.com/huaweicloud/golangsdk"
+)
+
+//ResourceTags represents the tags response
+type ResourceTags struct {
+	Tags []ResourceTag `json:"tags"`
+}
+
+//ResourceTag is in key-value format
+type ResourceTag struct {
+	Key   string `json:"key" required:"ture"`
+	Value string `json:"value,omitempty"`
+}
+
+//ActionResult is the action result which is the result of create or delete operations
+type ActionResult struct {
+	golangsdk.ErrResult
+}
+
+//GetResult contains the body of getting detailed tags request
+type GetResult struct {
+	golangsdk.Result
+}
+
+//Extract method will parse the result body into ResourceTags struct
+func (r GetResult) Extract() (ResourceTags, error) {
+	var tags ResourceTags
+	err := r.Result.ExtractInto(&tags)
+	return tags, err
+}
+
+//ListResult contains the body of getting all tags request
+type ListResult struct {
+	golangsdk.Result
+}
+
+//Extract method will parse the result body into ResourceTags struct
+func (r ListResult) Extract() (ResourceTags, error) {
+	var tags ResourceTags
+	err := r.Result.ExtractInto(&tags)
+	return tags, err
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v1/tags/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v1/tags/urls.go
@@ -1,0 +1,18 @@
+package tags
+
+import (
+	"github.com/huaweicloud/golangsdk"
+)
+
+// supported resourceType: "vpcs", "subnets", "publicips"
+func actionURL(c *golangsdk.ServiceClient, resourceType, id string) string {
+	return c.ServiceURL(c.ProjectID, resourceType, id, "tags/action")
+}
+
+func getURL(c *golangsdk.ServiceClient, resourceType, id string) string {
+	return c.ServiceURL(c.ProjectID, resourceType, id, "tags")
+}
+
+func listURL(c *golangsdk.ServiceClient, resourceType string) string {
+	return c.ServiceURL(c.ProjectID, resourceType, "tags")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -265,6 +265,7 @@ github.com/huaweicloud/golangsdk/openstack/networking/v1/bandwidths
 github.com/huaweicloud/golangsdk/openstack/networking/v1/eips
 github.com/huaweicloud/golangsdk/openstack/networking/v1/flowlogs
 github.com/huaweicloud/golangsdk/openstack/networking/v1/subnets
+github.com/huaweicloud/golangsdk/openstack/networking/v1/tags
 github.com/huaweicloud/golangsdk/openstack/networking/v1/vpcs
 github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/elbaas/backendmember
 github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/elbaas/healthcheck

--- a/website/docs/r/vpc_subnet_v1.html.md
+++ b/website/docs/r/vpc_subnet_v1.html.md
@@ -12,21 +12,39 @@ Provides an VPC subnet resource.
 
 # Example Usage
 
+## Basic Usage
+
  ```hcl
 resource "opentelekomcloud_vpc_v1" "vpc_v1" {
-  name = "${var.vpc_name}"
-  cidr = "${var.vpc_cidr}"
+  name = var.vpc_name
+  cidr = var.vpc_cidr
 }
 
-
 resource "opentelekomcloud_vpc_subnet_v1" "subnet_v1" {
-  name = "${var.subnet_name}"
-  cidr = "${var.subnet_cidr}"
-  gateway_ip = "${var.subnet_gateway_ip}"
-  vpc_id = "${opentelekomcloud_vpc_v1.vpc_v1.id}"
+  name   = var.subnet_name
+  cidr   = var.subnet_cidr
+  vpc_id = opentelekomcloud_vpc_v1.vpc_v1.id
+  gateway_ip    = var.subnet_gateway_ip
   ntp_addresses = "10.100.0.33,10.100.0.34"
 }
  ```
+
+## Subnet with tags
+
+```hcl
+resource "opentelekomcloud_vpc_subnet_v1" "subnet_with_tags" {
+  name   = var.subnet_name
+  cidr   = var.subnet_cidr
+  vpc_id = opentelekomcloud_vpc_v1.vpc_v1.id
+  gateway_ip    = var.subnet_gateway_ip
+  ntp_addresses = "10.100.0.33,10.100.0.34"
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+```
 
 # Argument Reference
 
@@ -51,6 +69,8 @@ The following arguments are supported:
 * `availability_zone` (Optional) - Identifies the availability zone (AZ) to which the subnet belongs. The value must be an existing AZ in the system. Changing this creates a new Subnet.
 
 * `ntp_addresses` (Optional) - Specifies the NTP server address configured for the subnet.
+
+* `tags` - (Optional) The key/value pairs to associate with the subnet.
 
 
 # Attributes Reference

--- a/website/docs/r/vpc_v1.html.markdown
+++ b/website/docs/r/vpc_v1.html.markdown
@@ -12,8 +12,9 @@ Manages a VPC resource within OpenTelekomCloud.
 
 ## Example Usage
 
-```hcl
+### Basic Usage
 
+```hcl
 variable "vpc_name" {
   default = "opentelekomcloud_vpc"
 }
@@ -23,10 +24,23 @@ variable "vpc_cidr" {
 }
 
 resource "opentelekomcloud_vpc_v1" "vpc_v1" {
-  name = "${var.vpc_name}"
-  cidr = "${var.vpc_cidr}"
+  name = var.vpc_name
+  cidr = var.vpc_cidr
 }
+```
 
+### VPC with tags
+
+```hcl
+resource "opentelekomcloud_vpc_v1" "vpc_with_tags" {
+  name = var.vpc_name
+  cidr = var.vpc_cidr
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
 ```
 
 ## Argument Reference
@@ -39,6 +53,7 @@ The following arguments are supported:
 
 * `shared` - (Optional) Specifies whether the shared SNAT should be used or not. Is also required  for cross-tenant sharing.
 
+* `tags` - (Optional) The key/value pairs to associate with the VPC.
 
 
 ## Attributes Reference
@@ -47,9 +62,11 @@ The following attributes are exported:
 
 * `id` -  ID of the VPC.
 
-* `name` -  See Argument Reference above.
+* `name` - See Argument Reference above.
 
 * `cidr` - See Argument Reference above.
+
+* `tags` - See Argument Reference above.
 
 * `status` - The current status of the desired VPC. Can be either CREATING, OK, DOWN, PENDING_UPDATE, PENDING_DELETE, or ERROR.
 


### PR DESCRIPTION
the tag format as follows:
```
resource "opentelekomcloud_vpc_subnet_v1" "subnet_with_tags" {
  ...
  tags = {
    foo = "bar"
    key = "value"
  }
}
```
fixes #499 
fixes #500 