### PR TITLE
support tags for dns record set resource

### DIFF
--- a/opentelekomcloud/resource_opentelekomcloud_dns_ptrrecord_v2_test.go
+++ b/opentelekomcloud/resource_opentelekomcloud_dns_ptrrecord_v2_test.go
@@ -38,6 +38,8 @@ func TestAccDNSV2PtrRecord_basic(t *testing.T) {
 					testAccCheckDNSV2PtrRecordExists("opentelekomcloud_dns_ptrrecord_v2.ptr_1", &ptrrecord),
 					resource.TestCheckResourceAttr(
 						"opentelekomcloud_dns_ptrrecord_v2.ptr_1", "description", "ptr record updated"),
+					resource.TestCheckResourceAttr(
+						"opentelekomcloud_dns_ptrrecord_v2.ptr_1", "foo", "bar"),
 				),
 			},
 		},
@@ -103,12 +105,12 @@ resource "opentelekomcloud_networking_floatingip_v2" "fip_1" {
 }
 
 resource "opentelekomcloud_dns_ptrrecord_v2" "ptr_1" {
-	name = "%s"
-	description = "a ptr record"
-	floatingip_id = opentelekomcloud_networking_floatingip_v2.fip_1.id
-	ttl = 6000
+  name = "%s"
+  description = "a ptr record"
+  floatingip_id = opentelekomcloud_networking_floatingip_v2.fip_1.id
+  ttl = 6000
 }
-	`, ptrName)
+`, ptrName)
 }
 
 func testAccDNSV2PtrRecord_update(ptrName string) string {
@@ -117,13 +119,13 @@ resource "opentelekomcloud_networking_floatingip_v2" "fip_1" {
 }
 
 resource "opentelekomcloud_dns_ptrrecord_v2" "ptr_1" {
-	name = "%s"
-	description = "ptr record updated"
-	floatingip_id = opentelekomcloud_networking_floatingip_v2.fip_1.id
-	ttl = 6000
-	tags = {
-		foo = "bar"
-	}
+  name = "%s"
+  description = "ptr record updated"
+  floatingip_id = opentelekomcloud_networking_floatingip_v2.fip_1.id
+  ttl = 6000
+  tags = {
+    foo = "bar"
+  }
 }
-	`, ptrName)
+`, ptrName)
 }

--- a/opentelekomcloud/resource_opentelekomcloud_dns_recordset_v2.go
+++ b/opentelekomcloud/resource_opentelekomcloud_dns_recordset_v2.go
@@ -6,11 +6,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/huaweicloud/golangsdk"
-	"github.com/huaweicloud/golangsdk/openstack/dns/v2/recordsets"
-
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/common/tags"
+	"github.com/huaweicloud/golangsdk/openstack/dns/v2/recordsets"
+	"github.com/huaweicloud/golangsdk/openstack/dns/v2/zones"
 )
 
 func resourceDNSRecordSetV2() *schema.Resource {
@@ -74,6 +75,7 @@ func resourceDNSRecordSetV2() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -130,6 +132,20 @@ func resourceDNSRecordSetV2Create(d *schema.ResourceData, meta interface{}) erro
 	id := fmt.Sprintf("%s/%s", zoneID, n.ID)
 	d.SetId(id)
 
+	// set tags
+	tagRaw := d.Get("tags").(map[string]interface{})
+	if len(tagRaw) > 0 {
+		resourceType, err := getDNSRecordSetResourceType(dnsClient, zoneID)
+		if err != nil {
+			return fmt.Errorf("Error getting resource type of DNS record set %s: %s", n.ID, err)
+		}
+
+		taglist := expandResourceTags(tagRaw)
+		if tagErr := tags.Create(dnsClient, resourceType, n.ID, taglist).ExtractErr(); tagErr != nil {
+			return fmt.Errorf("Error setting tags of DNS record set %s: %s", n.ID, tagErr)
+		}
+	}
+
 	log.Printf("[DEBUG] Created OpenTelekomCloud DNS record set %s: %#v", n.ID, n)
 	return resourceDNSRecordSetV2Read(d, meta)
 }
@@ -163,6 +179,21 @@ func resourceDNSRecordSetV2Read(d *schema.ResourceData, meta interface{}) error 
 	}
 	d.Set("region", GetRegion(d, config))
 	d.Set("zone_id", zoneID)
+
+	// save tags
+	resourceType, err := getDNSRecordSetResourceType(dnsClient, zoneID)
+	if err != nil {
+		return fmt.Errorf("Error getting resource type of DNS record set %s: %s", recordsetID, err)
+	}
+	resourceTags, err := tags.Get(dnsClient, resourceType, recordsetID).Extract()
+	if err != nil {
+		return fmt.Errorf("Error fetching OpenTelekomCloud DNS record set tags: %s", err)
+	}
+
+	tagmap := tagsToMap(resourceTags.Tags)
+	if err := d.Set("tags", tagmap); err != nil {
+		return fmt.Errorf("Error saving tags for OpenTelekomCloud DNS record set %s: %s", recordsetID, err)
+	}
 
 	return nil
 }
@@ -219,6 +250,17 @@ func resourceDNSRecordSetV2Update(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf(
 			"Error waiting for record set (%s) to become ACTIVE for updation: %s",
 			recordsetID, err)
+	}
+
+	// update tags
+	resourceType, err := getDNSRecordSetResourceType(dnsClient, zoneID)
+	if err != nil {
+		return fmt.Errorf("Error getting resource type of DNS record set %s: %s", d.Id(), err)
+	}
+
+	tagErr := UpdateResourceTags(dnsClient, d, resourceType, recordsetID)
+	if tagErr != nil {
+		return fmt.Errorf("Error updating tags of DNS record set %s: %s", d.Id(), tagErr)
 	}
 
 	return resourceDNSRecordSetV2Read(d, meta)
@@ -289,4 +331,20 @@ func parseDNSV2RecordSetID(id string) (string, string, error) {
 	recordsetID := idParts[1]
 
 	return zoneID, recordsetID, nil
+}
+
+// get resource type of DNS record set from zone_id
+func getDNSRecordSetResourceType(client *golangsdk.ServiceClient, zone_id string) (string, error) {
+	zone, err := zones.Get(client, zone_id).Extract()
+	if err != nil {
+		return "", err
+	}
+
+	zoneType := zone.ZoneType
+	if zoneType == "public" {
+		return "DNS-public_recordset", nil
+	} else if zoneType == "private" {
+		return "DNS-private_recordset", nil
+	}
+	return "", fmt.Errorf("invalid zone type: %s", zoneType)
 }

--- a/opentelekomcloud/resource_opentelekomcloud_dns_recordset_v2_test.go
+++ b/opentelekomcloud/resource_opentelekomcloud_dns_recordset_v2_test.go
@@ -29,47 +29,29 @@ func TestAccDNSV2RecordSet_basic(t *testing.T) {
 			{
 				Config: testAccDNSV2RecordSet_basic(zoneName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDNSV2RecordSetExists("opentelekomcloud_dns_recordset_v2.recordset_1", &recordset),
+					testAccCheckDNSV2RecordSetExists(
+						"opentelekomcloud_dns_recordset_v2.recordset_1", &recordset),
+					resource.TestCheckResourceAttr(
+						"opentelekomcloud_dns_recordset_v2.recordset_1", "name", zoneName),
 					resource.TestCheckResourceAttr(
 						"opentelekomcloud_dns_recordset_v2.recordset_1", "description", "a record set"),
+					resource.TestCheckResourceAttr(
+						"opentelekomcloud_dns_recordset_v2.recordset_1", "type", "A"),
+					resource.TestCheckResourceAttr(
+						"opentelekomcloud_dns_recordset_v2.recordset_1", "ttl", "3000"),
+					resource.TestCheckResourceAttr(
+						"opentelekomcloud_dns_recordset_v2.recordset_1", "tags.key", "value"),
 				),
 			},
 			{
 				Config: testAccDNSV2RecordSet_update(zoneName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("opentelekomcloud_dns_recordset_v2.recordset_1", "name", zoneName),
-					resource.TestCheckResourceAttr("opentelekomcloud_dns_recordset_v2.recordset_1", "ttl", "6000"),
-					resource.TestCheckResourceAttr("opentelekomcloud_dns_recordset_v2.recordset_1", "type", "A"),
+					resource.TestCheckResourceAttr(
+						"opentelekomcloud_dns_recordset_v2.recordset_1", "ttl", "6000"),
+					resource.TestCheckResourceAttr(
+						"opentelekomcloud_dns_recordset_v2.recordset_1", "tags.key", "value_updated"),
 					resource.TestCheckResourceAttr(
 						"opentelekomcloud_dns_recordset_v2.recordset_1", "description", "an updated record set"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccDNSV2RecordSet_updateTTL(t *testing.T) {
-	var recordset recordsets.RecordSet
-	zoneName := randomZoneName()
-	newTTL := 1500
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckDNSV2RecordSetDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDNSV2RecordSet_basic(zoneName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDNSV2RecordSetExists("opentelekomcloud_dns_recordset_v2.recordset_1", &recordset),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_dns_recordset_v2.recordset_1", "description", "a record set"),
-				),
-			},
-			{
-				Config: testAccDNSV2RecordSet_updateTTL(zoneName, newTTL),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("opentelekomcloud_dns_recordset_v2.recordset_1", "name", zoneName),
 				),
 			},
 		},
@@ -195,6 +177,11 @@ func testAccDNSV2RecordSet_basic(zoneName string) string {
 			description = "a record set"
 			ttl = 3000
 			records = ["10.1.0.0"]
+
+			tags = {
+			  foo = "bar"
+			  key = "value"
+			}
 		}
 	`, zoneName, zoneName)
 }
@@ -215,28 +202,13 @@ func testAccDNSV2RecordSet_update(zoneName string) string {
 			description = "an updated record set"
 			ttl = 6000
 			records = ["10.1.0.1"]
+
+			tags = {
+			  foo = "bar"
+			  key = "value_updated"
+			}
 		}
 	`, zoneName, zoneName)
-}
-
-func testAccDNSV2RecordSet_updateTTL(zoneName string, ttl int) string {
-	return fmt.Sprintf(`
-		resource "opentelekomcloud_dns_zone_v2" "zone_1" {
-			name = "%s"
-			email = "email2@example.com"
-			description = "a zone"
-			ttl = 6000
-		}
-
-		resource "opentelekomcloud_dns_recordset_v2" "recordset_1" {
-			zone_id = "${opentelekomcloud_dns_zone_v2.zone_1.id}"
-			name = "%s"
-			type = "A"
-			description = "a record set"
-			ttl = %d
-			records = ["10.1.0.0"]
-		}
-	`, zoneName, zoneName, ttl)
 }
 
 func testAccDNSV2RecordSet_readTTL(zoneName string) string {

--- a/website/docs/r/dns_recordset_v2.html.markdown
+++ b/website/docs/r/dns_recordset_v2.html.markdown
@@ -20,11 +20,11 @@ resource "opentelekomcloud_dns_zone_v2" "example_zone" {
   email = "email2@example.com"
   description = "a zone"
   ttl = 6000
-  type = "PRIMARY"
+  type = "public"
 }
 
 resource "opentelekomcloud_dns_recordset_v2" "rs_example_com" {
-  zone_id = "${opentelekomcloud_dns_zone_v2.example_zone.id}"
+  zone_id = opentelekomcloud_dns_zone_v2.example_zone.id
   name = "rs.example.com."
   description = "An example record set"
   ttl = 3000
@@ -52,6 +52,8 @@ The following arguments are supported:
 
 * `records` - (Optional) An array of DNS records.
 
+* `tags` - (Optional) The key/value pairs to associate with the zone.
+
 * `value_specs` - (Optional) Map of additional options. Changing this creates a
   new record set.
 
@@ -62,8 +64,9 @@ The following attributes are exported:
 * `name` - See Argument Reference above.
 * `type` - See Argument Reference above.
 * `ttl` - See Argument Reference above.
-* `description` - See Argument Reference above.
 * `records` - See Argument Reference above.
+* `description` - See Argument Reference above.
+* `tags` - See Argument Reference above.
 * `zone_id` - See Argument Reference above.
 * `value_specs` - See Argument Reference above.
 


### PR DESCRIPTION
fixes #498 

In this PR, we will support tags for dns record set resource, and we can set tags of dns ptrrecords using by APIs of common tags