### PR TITLE
support some attributes in as group resource

### DIFF
--- a/opentelekomcloud/resource_opentelekomcloud_as_group_v1.go
+++ b/opentelekomcloud/resource_opentelekomcloud_as_group_v1.go
@@ -181,10 +181,17 @@ func resourceASGroup() *schema.Resource {
 			},
 			"instances": {
 				Type:        schema.TypeList,
-				Optional:    true,
+				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
-				ForceNew:    false,
 				Description: "The instances id list in the as group.",
+			},
+			"current_instance_number": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 		},
 	}
@@ -491,6 +498,8 @@ func resourceASGroupRead(d *schema.ResourceData, meta interface{}) error {
 
 	// set properties based on the read info
 	d.Set("scaling_group_name", asg.Name)
+	d.Set("status", asg.Status)
+	d.Set("current_instance_number", asg.ActualInstanceNumber)
 	d.Set("desire_instance_number", asg.DesireInstanceNumber)
 	d.Set("min_instance_number", asg.MinInstanceNumber)
 	d.Set("max_instance_number", asg.MaxInstanceNumber)

--- a/website/docs/r/as_group_v1.html.markdown
+++ b/website/docs/r/as_group_v1.html.markdown
@@ -180,6 +180,8 @@ The `lbaas_listeners` block supports:
 The following attributes are exported:
 
 * `scaling_group_name` - See Argument Reference above.
+* `status` - Indicates the status of the AS group.
+* `current_instance_number` - Indicates the number of current instances in the AS group.
 * `desire_instance_number` - See Argument Reference above.
 * `min_instance_number` - See Argument Reference above.
 * `max_instance_number` - See Argument Reference above.


### PR DESCRIPTION
add `status`, `instances` and `current_instance_number` as attributes in auto-scaling group resource.

Fixes #506 