### PR TITLE
Add setting `cluster_version` on resource read

### DIFF
--- a/opentelekomcloud/resource_opentelekomcloud_cce_cluster_v3.go
+++ b/opentelekomcloud/resource_opentelekomcloud_cce_cluster_v3.go
@@ -302,6 +302,7 @@ func resourceCCEClusterV3Read(d *schema.ResourceData, meta interface{}) error {
 	d.Set("status", n.Status.Phase)
 	d.Set("flavor_id", n.Spec.Flavor)
 	d.Set("cluster_type", n.Spec.Type)
+	d.Set("cluster_version", n.Spec.Version)
 	d.Set("description", n.Spec.Description)
 	d.Set("billing_mode", n.Spec.BillingMode)
 	d.Set("vpc_id", n.Spec.HostNetwork.VpcId)

--- a/website/docs/d/cce_cluster_v3.html.md
+++ b/website/docs/d/cce_cluster_v3.html.md
@@ -19,7 +19,6 @@ description: |-
 
   data "opentelekomcloud_cce_cluster_v3" "cluster" {
    name = "${var.cluster_name}"
-   id= "${var.cluster_id}"
    status= "Available"
   }
 ```
@@ -29,8 +28,6 @@ description: |-
 The following arguments are supported:
 
 * `name` -  (Optional)The Name of the cluster resource.
- 
-* `id` - (Optional) The ID of container cluster.
 
 * `status` - (Optional) The state of the cluster.
 


### PR DESCRIPTION
Fix not reading `cluster_version` on `resource/opentelekomcloud_cce_cluster_v3` read
DOC: remove ID from `data_source/opentelekomcloud_cce_cluster_v3` arguments
