### PR TITLE
do not use armor for signing

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,7 +40,6 @@ signs:
     args:
       - "--output"
       - "${signature}"
-      - "--armor"
       - "--detach-sign"
       - "${artifact}"
 release:


### PR DESCRIPTION
This solves provider publishing (at least after manual resigning without --armor and reuploading signature solved it immediately)