### PR TITLE
Quick fix of UDP-CONNECT

### DIFF
--- a/opentelekomcloud/resource_opentelekomcloud_lb_monitor_v2.go
+++ b/opentelekomcloud/resource_opentelekomcloud_lb_monitor_v2.go
@@ -56,7 +56,7 @@ func resourceMonitorV2() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
-					"TCP", "UDP-CONNECT", "HTTP",
+					"TCP", "UDP_CONNECT", "HTTP",
 				}, false),
 			},
 			"delay": {


### PR DESCRIPTION
`"UDP-CONNECT"` should be `"UDP_CONNECT"` as (correctly) stated in the [docs](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/blob/master/docs/resources/lb_monitor_v2.md#argument-reference) an by the API:

```
Error: Unable to create monitor: Bad request with: [POST https://vpc.eu-de.otc.t-systems.com/v2.0/lbaas/healthmonitors], error message: {"NeutronError": {"message": "Invalid input for type. Reason: 'UDP-CONNECT' is not in ('HTTP', 'TCP', 'UDP_CONNECT').", "type": "HTTPBadRequest", "detail": ""}}
```

As it seems to be a very simple validation bug (typo?) I just created a quick fix, not a proper PR.
I leave it to others to turn this into a proper PR and maybe add a proper test case.