### PR TITLE
Fix not creating obs bucket with security_token

### DIFF
--- a/opentelekomcloud/config.go
+++ b/opentelekomcloud/config.go
@@ -544,8 +544,8 @@ func (c *Config) computeS3conn(region string) (*s3.S3, error) {
 }
 
 func (c *Config) newObjectStorageClient(region string) (*obs.ObsClient, error) {
-	if c.AccessKey == "" || c.SecretKey == "" {
-		return nil, fmt.Errorf("Missing credentials for OBS, need access_key and secret_key values for provider.")
+	if (c.AccessKey == "" || c.SecretKey == "") && c.SecurityToken == "" {
+		return nil, fmt.Errorf("missing credentials for OBS, need access_key and secret_key or security_token values for provider")
 	}
 
 	client, err := huaweisdk.NewOBSService(c.HwClient, golangsdk.EndpointOpts{
@@ -565,7 +565,7 @@ func (c *Config) newObjectStorageClient(region string) (*obs.ObsClient, error) {
 		}
 	}
 
-	return obs.New(c.AccessKey, c.SecretKey, client.Endpoint)
+	return obs.New(c.AccessKey, c.SecretKey, client.Endpoint, obs.WithSecurityToken(c.SecurityToken))
 }
 
 func (c *Config) blockStorageV1Client(region string) (*golangsdk.ServiceClient, error) {


### PR DESCRIPTION
## Summary of the Pull Request
Add missing `obs.WithSecurityToken` configurer during OBS client creation

## PR Checklist

* [x] Refers to: #625
* [x] Tests added/passed.

## Acceptance Steps Performed

Run terraform with configuration mentioned in #625. Provider binary replaced with locally built provider.

```hcl
resource "opentelekomcloud_obs_bucket" "fail" {
  bucket = "otc-akachuri-test3"
  acl    = "private"
  region = "eu-de"
}
```
Log:
```
$ tf apply --auto-approve
opentelekomcloud_obs_bucket.fail: Creating...
opentelekomcloud_obs_bucket.fail: Creation complete after 2s [id=otc-akachuri-test2]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

```
