### PR TITLE
RDSv3: Fix not assigning public IP

### DIFF
--- a/opentelekomcloud/resource_opentelekomcloud_rds_instance_v3.go
+++ b/opentelekomcloud/resource_opentelekomcloud_rds_instance_v3.go
@@ -268,6 +268,7 @@ func resourceRdsInstanceV3Create(d *schema.ResourceData, meta interface{}) error
 		"db":              0,
 		"volume":          0,
 	}
+	publicIPs := d.Get("public_ips").([]interface{})
 
 	params, err := buildRdsInstanceV3CreateParameters(opts, arrayIndex)
 	if err != nil {
@@ -325,7 +326,6 @@ func resourceRdsInstanceV3Create(d *schema.ResourceData, meta interface{}) error
 		}
 	}
 
-	publicIPs := d.Get("public_ips").([]interface{})
 	if len(publicIPs) > 0 {
 		if err := resourceRdsInstanceV3Read(d, meta); err != nil {
 			return err
@@ -1115,7 +1115,7 @@ func asyncWaitRdsInstanceV3Create(d *schema.ResourceData, config *Config, result
 
 	data := make(map[string]string)
 	pathParameters := map[string][]string{
-		"id": []string{"job_id"},
+		"id": {"job_id"},
 	}
 	for key, path := range pathParameters {
 		value, err := navigateValue(result, path, nil)

--- a/opentelekomcloud/resource_opentelekomcloud_rds_instance_v3_test.go
+++ b/opentelekomcloud/resource_opentelekomcloud_rds_instance_v3_test.go
@@ -24,13 +24,13 @@ func TestAccRdsInstanceV3_basic(t *testing.T) {
 					testAccCheckRdsInstanceV3Exists(),
 				),
 			},
-			//{
-			//	Config: testAccRdsInstanceV3_eip(name),
-			//	Check: resource.ComposeTestCheckFunc(
-			//		testAccCheckRdsInstanceV3Exists(),
-			//		resource.TestCheckResourceAttr("opentelekomcloud_rds_instance_v3.instance", "public_ips.#", "1"),
-			//	),
-			//},
+			{
+				Config: testAccRdsInstanceV3_eip(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRdsInstanceV3Exists(),
+					resource.TestCheckResourceAttr("opentelekomcloud_rds_instance_v3.instance", "public_ips.#", "1"),
+				),
+			},
 			{
 				Config: testAccRdsInstanceV3_update(name),
 				Check: resource.ComposeTestCheckFunc(


### PR DESCRIPTION
## Summary of the Pull Request

Somewhere `public_eips` field overrides, just up `d.Get("public_eips")` fixes this issue

## PR Checklist

* [x] Refers to: #653 

## Acceptance Steps Performed
```
=== RUN   TestAccRdsInstanceV3_basic
--- PASS: TestAccRdsInstanceV3_basic (663.19s)
=== RUN   TestAccRdsInstanceV3_ip_assign
--- PASS: TestAccRdsInstanceV3_ip_assign (722.43s)
PASS

Process finished with exit code 0
```
