### PR TITLE
Allow expanding r/blockstorage_volume_v2 without re-creation

### DIFF
--- a/docs/resources/blockstorage_volume_v2.md
+++ b/docs/resources/blockstorage_volume_v2.md
@@ -29,8 +29,8 @@ resource "opentelekomcloud_blockstorage_volume_v2" "volume_1" {
 
 The following arguments are supported:
 
-* `size` - (Required) The size of the volume to create (in gigabytes). Changing
-  this creates a new volume.
+* `size` - (Required) The size of the volume to create (in gigabytes). Decreasing
+  this parameter creates a new volume.
 
 * `availability_zone` - (Optional) The availability zone for the volume.
   Changing this creates a new volume.

--- a/opentelekomcloud/resource_opentelekomcloud_blockstorage_volume_v2_test.go
+++ b/opentelekomcloud/resource_opentelekomcloud_blockstorage_volume_v2_test.go
@@ -377,7 +377,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
 	uuid = "%s"
   }
   block_device {
-	uuid = "${opentelekomcloud_blockstorage_volume_v2.volume_1.id}"
+	uuid = opentelekomcloud_blockstorage_volume_v2.volume_1.id
 	source_type = "volume"
 	boot_index = 0
 	destination_type = "volume"

--- a/opentelekomcloud/resource_opentelekomcloud_blockstorage_volume_v2_test.go
+++ b/opentelekomcloud/resource_opentelekomcloud_blockstorage_volume_v2_test.go
@@ -66,6 +66,29 @@ func TestAccBlockStorageV2Volume_upscaleDownScale(t *testing.T) {
 		},
 	})
 }
+func TestAccBlockStorageV2Volume_upscaleDownScaleAssigned(t *testing.T) {
+	var volume volumes.Volume
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBlockStorageV2VolumeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBlockStorageV2Volume_assigned(10),
+				Check:  testAccCheckBlockStorageV2VolumeExists("opentelekomcloud_blockstorage_volume_v2.volume_1", &volume),
+			},
+			{
+				Config: testAccBlockStorageV2Volume_assigned(12),
+				Check:  testAccCheckBlockStorageV2VolumeSame("opentelekomcloud_blockstorage_volume_v2.volume_1", &volume),
+			},
+			{
+				Config: testAccBlockStorageV2Volume_assigned(10),
+				Check:  testAccCheckBlockStorageV2VolumeNew("opentelekomcloud_blockstorage_volume_v2.volume_1", &volume),
+			},
+		},
+	})
+}
 
 func TestAccBlockStorageV2Volume_policy(t *testing.T) {
 	resource.Test(t, resource.TestCase{
@@ -321,6 +344,9 @@ const testAccBlockStorageV2Volume_basic = `
 resource "opentelekomcloud_blockstorage_volume_v2" "volume_1" {
   name = "volume_1"
   description = "first test volume"
+  metadata = {
+    foo = "bar"
+  }
   size = 1
 }
 `
@@ -335,6 +361,31 @@ resource "opentelekomcloud_blockstorage_volume_v2" "volume_1" {
   size = 2
 }
 `
+
+func testAccBlockStorageV2Volume_assigned(size int) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_blockstorage_volume_v2" "volume_1" {
+  name = "volume_1"
+  size = %d
+  image_id = "%s"
+}
+
+resource "opentelekomcloud_compute_instance_v2" "instance_1" {
+  name = "instance_1"
+  security_groups = ["default"]
+  network {
+	uuid = "%s"
+  }
+  block_device {
+	uuid = "${opentelekomcloud_blockstorage_volume_v2.volume_1.id}"
+	source_type = "volume"
+	boot_index = 0
+	destination_type = "volume"
+	delete_on_termination = true
+  }
+}
+`, size, OS_IMAGE_ID, OS_NETWORK_ID)
+}
 
 const testAccBlockStorageV2Volume_update = `
 resource "opentelekomcloud_blockstorage_volume_v2" "volume_1" {

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/customdiff/compose.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/customdiff/compose.go
@@ -1,0 +1,72 @@
+package customdiff
+
+import (
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+// All returns a CustomizeDiffFunc that runs all of the given
+// CustomizeDiffFuncs and returns all of the errors produced.
+//
+// If one function produces an error, functions after it are still run.
+// If this is not desirable, use function Sequence instead.
+//
+// If multiple functions returns errors, the result is a multierror.
+//
+// For example:
+//
+//     &schema.Resource{
+//         // ...
+//         CustomizeDiff: customdiff.All(
+//             customdiff.ValidateChange("size", func (old, new, meta interface{}) error {
+//                 // If we are increasing "size" then the new value must be
+//                 // a multiple of the old value.
+//                 if new.(int) <= old.(int) {
+//                     return nil
+//                 }
+//                 if (new.(int) % old.(int)) != 0 {
+//                     return fmt.Errorf("new size value must be an integer multiple of old value %d", old.(int))
+//                 }
+//                 return nil
+//             }),
+//             customdiff.ForceNewIfChange("size", func (old, new, meta interface{}) bool {
+//                 // "size" can only increase in-place, so we must create a new resource
+//                 // if it is decreased.
+//                 return new.(int) < old.(int)
+//             }),
+//             customdiff.ComputedIf("version_id", func (d *schema.ResourceDiff, meta interface{}) bool {
+//                 // Any change to "content" causes a new "version_id" to be allocated.
+//                 return d.HasChange("content")
+//             }),
+//         ),
+//     }
+//
+func All(funcs ...schema.CustomizeDiffFunc) schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		var err error
+		for _, f := range funcs {
+			thisErr := f(d, meta)
+			if thisErr != nil {
+				err = multierror.Append(err, thisErr)
+			}
+		}
+		return err
+	}
+}
+
+// Sequence returns a CustomizeDiffFunc that runs all of the given
+// CustomizeDiffFuncs in sequence, stopping at the first one that returns
+// an error and returning that error.
+//
+// If all functions succeed, the combined function also succeeds.
+func Sequence(funcs ...schema.CustomizeDiffFunc) schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		for _, f := range funcs {
+			err := f(d, meta)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/customdiff/computed.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/customdiff/computed.go
@@ -1,0 +1,16 @@
+package customdiff
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+// ComputedIf returns a CustomizeDiffFunc that sets the given key's new value
+// as computed if the given condition function returns true.
+func ComputedIf(key string, f ResourceConditionFunc) schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		if f(d, meta) {
+			d.SetNewComputed(key)
+		}
+		return nil
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/customdiff/condition.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/customdiff/condition.go
@@ -1,0 +1,60 @@
+package customdiff
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+// ResourceConditionFunc is a function type that makes a boolean decision based
+// on an entire resource diff.
+type ResourceConditionFunc func(d *schema.ResourceDiff, meta interface{}) bool
+
+// ValueChangeConditionFunc is a function type that makes a boolean decision
+// by comparing two values.
+type ValueChangeConditionFunc func(old, new, meta interface{}) bool
+
+// ValueConditionFunc is a function type that makes a boolean decision based
+// on a given value.
+type ValueConditionFunc func(value, meta interface{}) bool
+
+// If returns a CustomizeDiffFunc that calls the given condition
+// function and then calls the given CustomizeDiffFunc only if the condition
+// function returns true.
+//
+// This can be used to include conditional customizations when composing
+// customizations using All and Sequence, but should generally be used only in
+// simple scenarios. Prefer directly writing a CustomizeDiffFunc containing
+// a conditional branch if the given CustomizeDiffFunc is already a
+// locally-defined function, since this avoids obscuring the control flow.
+func If(cond ResourceConditionFunc, f schema.CustomizeDiffFunc) schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		if cond(d, meta) {
+			return f(d, meta)
+		}
+		return nil
+	}
+}
+
+// IfValueChange returns a CustomizeDiffFunc that calls the given condition
+// function with the old and new values of the given key and then calls the
+// given CustomizeDiffFunc only if the condition function returns true.
+func IfValueChange(key string, cond ValueChangeConditionFunc, f schema.CustomizeDiffFunc) schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		old, new := d.GetChange(key)
+		if cond(old, new, meta) {
+			return f(d, meta)
+		}
+		return nil
+	}
+}
+
+// IfValue returns a CustomizeDiffFunc that calls the given condition
+// function with the new values of the given key and then calls the
+// given CustomizeDiffFunc only if the condition function returns true.
+func IfValue(key string, cond ValueConditionFunc, f schema.CustomizeDiffFunc) schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		if cond(d.Get(key), meta) {
+			return f(d, meta)
+		}
+		return nil
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/customdiff/doc.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/customdiff/doc.go
@@ -1,0 +1,11 @@
+// Package customdiff provides a set of reusable and composable functions
+// to enable more "declarative" use of the CustomizeDiff mechanism available
+// for resources in package helper/schema.
+//
+// The intent of these helpers is to make the intent of a set of diff
+// customizations easier to see, rather than lost in a sea of Go function
+// boilerplate. They should _not_ be used in situations where they _obscure_
+// intent, e.g. by over-using the composition functions where a single
+// function containing normal Go control flow statements would be more
+// straightforward.
+package customdiff

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/customdiff/force_new.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/customdiff/force_new.go
@@ -1,0 +1,40 @@
+package customdiff
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+// ForceNewIf returns a CustomizeDiffFunc that flags the given key as
+// requiring a new resource if the given condition function returns true.
+//
+// The return value of the condition function is ignored if the old and new
+// values of the field compare equal, since no attribute diff is generated in
+// that case.
+func ForceNewIf(key string, f ResourceConditionFunc) schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		if f(d, meta) {
+			d.ForceNew(key)
+		}
+		return nil
+	}
+}
+
+// ForceNewIfChange returns a CustomizeDiffFunc that flags the given key as
+// requiring a new resource if the given condition function returns true.
+//
+// The return value of the condition function is ignored if the old and new
+// values compare equal, since no attribute diff is generated in that case.
+//
+// This function is similar to ForceNewIf but provides the condition function
+// only the old and new values of the given key, which leads to more compact
+// and explicit code in the common case where the decision can be made with
+// only the specific field value.
+func ForceNewIfChange(key string, f ValueChangeConditionFunc) schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		old, new := d.GetChange(key)
+		if f(old, new, meta) {
+			d.ForceNew(key)
+		}
+		return nil
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/customdiff/validate.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/customdiff/validate.go
@@ -1,0 +1,38 @@
+package customdiff
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+// ValueChangeValidationFunc is a function type that validates the difference
+// (or lack thereof) between two values, returning an error if the change
+// is invalid.
+type ValueChangeValidationFunc func(old, new, meta interface{}) error
+
+// ValueValidationFunc is a function type that validates a particular value,
+// returning an error if the value is invalid.
+type ValueValidationFunc func(value, meta interface{}) error
+
+// ValidateChange returns a CustomizeDiffFunc that applies the given validation
+// function to the change for the given key, returning any error produced.
+func ValidateChange(key string, f ValueChangeValidationFunc) schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		old, new := d.GetChange(key)
+		return f(old, new, meta)
+	}
+}
+
+// ValidateValue returns a CustomizeDiffFunc that applies the given validation
+// function to value of the given key, returning any error produced.
+//
+// This should generally not be used since it is functionally equivalent to
+// a validation function applied directly to the schema attribute in question,
+// but is provided for situations where composing multiple CustomizeDiffFuncs
+// together makes intent clearer than spreading that validation across the
+// schema.
+func ValidateValue(key string, f ValueValidationFunc) schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		val := d.Get(key)
+		return f(val, meta)
+	}
+}

--- a/vendor/github.com/opentelekomcloud/gophertelekomcloud/openstack/blockstorage/extensions/volumeactions/doc.go
+++ b/vendor/github.com/opentelekomcloud/gophertelekomcloud/openstack/blockstorage/extensions/volumeactions/doc.go
@@ -1,0 +1,86 @@
+/*
+Package volumeactions provides information and interaction with volumes in the
+OpenStack Block Storage service. A volume is a detachable block storage
+device, akin to a USB hard drive.
+
+Example of Attaching a Volume to an Instance
+
+	attachOpts := volumeactions.AttachOpts{
+		MountPoint:   "/mnt",
+		Mode:         "rw",
+		InstanceUUID: server.ID,
+	}
+
+	err := volumeactions.Attach(client, volume.ID, attachOpts).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+	detachOpts := volumeactions.DetachOpts{
+		AttachmentID: volume.Attachments[0].AttachmentID,
+	}
+
+	err = volumeactions.Detach(client, volume.ID, detachOpts).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+
+Example of Creating an Image from a Volume
+
+	uploadImageOpts := volumeactions.UploadImageOpts{
+		ImageName: "my_vol",
+		Force:     true,
+	}
+
+	volumeImage, err := volumeactions.UploadImage(client, volume.ID, uploadImageOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v\n", volumeImage)
+
+Example of Extending a Volume's Size
+
+	extendOpts := volumeactions.ExtendSizeOpts{
+		NewSize: 100,
+	}
+
+	err := volumeactions.ExtendSize(client, volume.ID, extendOpts).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+Example of Initializing a Volume Connection
+
+	connectOpts := &volumeactions.InitializeConnectionOpts{
+		IP:        "127.0.0.1",
+		Host:      "stack",
+		Initiator: "iqn.1994-05.com.redhat:17cf566367d2",
+		Multipath: golangsdk.Disabled,
+		Platform:  "x86_64",
+		OSType:    "linux2",
+	}
+
+	connectionInfo, err := volumeactions.InitializeConnection(client, volume.ID, connectOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v\n", connectionInfo["data"])
+
+	terminateOpts := &volumeactions.InitializeConnectionOpts{
+		IP:        "127.0.0.1",
+		Host:      "stack",
+		Initiator: "iqn.1994-05.com.redhat:17cf566367d2",
+		Multipath: golangsdk.Disabled,
+		Platform:  "x86_64",
+		OSType:    "linux2",
+	}
+
+	err = volumeactions.TerminateConnection(client, volume.ID, terminateOpts).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package volumeactions

--- a/vendor/github.com/opentelekomcloud/gophertelekomcloud/openstack/blockstorage/extensions/volumeactions/requests.go
+++ b/vendor/github.com/opentelekomcloud/gophertelekomcloud/openstack/blockstorage/extensions/volumeactions/requests.go
@@ -1,0 +1,269 @@
+package volumeactions
+
+import (
+	"github.com/opentelekomcloud/gophertelekomcloud"
+)
+
+// AttachOptsBuilder allows extensions to add additional parameters to the
+// Attach request.
+type AttachOptsBuilder interface {
+	ToVolumeAttachMap() (map[string]interface{}, error)
+}
+
+// AttachMode describes the attachment mode for volumes.
+type AttachMode string
+
+// These constants determine how a volume is attached.
+const (
+	ReadOnly  AttachMode = "ro"
+	ReadWrite AttachMode = "rw"
+)
+
+// AttachOpts contains options for attaching a Volume.
+type AttachOpts struct {
+	// The mountpoint of this volume.
+	MountPoint string `json:"mountpoint,omitempty"`
+
+	// The nova instance ID, can't set simultaneously with HostName.
+	InstanceUUID string `json:"instance_uuid,omitempty"`
+
+	// The hostname of baremetal host, can't set simultaneously with InstanceUUID.
+	HostName string `json:"host_name,omitempty"`
+
+	// Mount mode of this volume.
+	Mode AttachMode `json:"mode,omitempty"`
+}
+
+// ToVolumeAttachMap assembles a request body based on the contents of a
+// AttachOpts.
+func (opts AttachOpts) ToVolumeAttachMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "os-attach")
+}
+
+// Attach will attach a volume based on the values in AttachOpts.
+func Attach(client *golangsdk.ServiceClient, id string, opts AttachOptsBuilder) (r AttachResult) {
+	b, err := opts.ToVolumeAttachMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(actionURL(client, id), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{202},
+	})
+	return
+}
+
+// BeginDetach will mark the volume as detaching.
+func BeginDetaching(client *golangsdk.ServiceClient, id string) (r BeginDetachingResult) {
+	b := map[string]interface{}{"os-begin_detaching": make(map[string]interface{})}
+	_, r.Err = client.Post(actionURL(client, id), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{202},
+	})
+	return
+}
+
+// DetachOptsBuilder allows extensions to add additional parameters to the
+// Detach request.
+type DetachOptsBuilder interface {
+	ToVolumeDetachMap() (map[string]interface{}, error)
+}
+
+// DetachOpts contains options for detaching a Volume.
+type DetachOpts struct {
+	// AttachmentID is the ID of the attachment between a volume and instance.
+	AttachmentID string `json:"attachment_id,omitempty"`
+}
+
+// ToVolumeDetachMap assembles a request body based on the contents of a
+// DetachOpts.
+func (opts DetachOpts) ToVolumeDetachMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "os-detach")
+}
+
+// Detach will detach a volume based on volume ID.
+func Detach(client *golangsdk.ServiceClient, id string, opts DetachOptsBuilder) (r DetachResult) {
+	b, err := opts.ToVolumeDetachMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(actionURL(client, id), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{202},
+	})
+	return
+}
+
+// Reserve will reserve a volume based on volume ID.
+func Reserve(client *golangsdk.ServiceClient, id string) (r ReserveResult) {
+	b := map[string]interface{}{"os-reserve": make(map[string]interface{})}
+	_, r.Err = client.Post(actionURL(client, id), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200, 201, 202},
+	})
+	return
+}
+
+// Unreserve will unreserve a volume based on volume ID.
+func Unreserve(client *golangsdk.ServiceClient, id string) (r UnreserveResult) {
+	b := map[string]interface{}{"os-unreserve": make(map[string]interface{})}
+	_, r.Err = client.Post(actionURL(client, id), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200, 201, 202},
+	})
+	return
+}
+
+// InitializeConnectionOptsBuilder allows extensions to add additional parameters to the
+// InitializeConnection request.
+type InitializeConnectionOptsBuilder interface {
+	ToVolumeInitializeConnectionMap() (map[string]interface{}, error)
+}
+
+// InitializeConnectionOpts hosts options for InitializeConnection.
+// The fields are specific to the storage driver in use and the destination
+// attachment.
+type InitializeConnectionOpts struct {
+	IP        string   `json:"ip,omitempty"`
+	Host      string   `json:"host,omitempty"`
+	Initiator string   `json:"initiator,omitempty"`
+	Wwpns     []string `json:"wwpns,omitempty"`
+	Wwnns     string   `json:"wwnns,omitempty"`
+	Multipath *bool    `json:"multipath,omitempty"`
+	Platform  string   `json:"platform,omitempty"`
+	OSType    string   `json:"os_type,omitempty"`
+}
+
+// ToVolumeInitializeConnectionMap assembles a request body based on the contents of a
+// InitializeConnectionOpts.
+func (opts InitializeConnectionOpts) ToVolumeInitializeConnectionMap() (map[string]interface{}, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "connector")
+	return map[string]interface{}{"os-initialize_connection": b}, err
+}
+
+// InitializeConnection initializes an iSCSI connection by volume ID.
+func InitializeConnection(client *golangsdk.ServiceClient, id string, opts InitializeConnectionOptsBuilder) (r InitializeConnectionResult) {
+	b, err := opts.ToVolumeInitializeConnectionMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(actionURL(client, id), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200, 201, 202},
+	})
+	return
+}
+
+// TerminateConnectionOptsBuilder allows extensions to add additional parameters to the
+// TerminateConnection request.
+type TerminateConnectionOptsBuilder interface {
+	ToVolumeTerminateConnectionMap() (map[string]interface{}, error)
+}
+
+// TerminateConnectionOpts hosts options for TerminateConnection.
+type TerminateConnectionOpts struct {
+	IP        string   `json:"ip,omitempty"`
+	Host      string   `json:"host,omitempty"`
+	Initiator string   `json:"initiator,omitempty"`
+	Wwpns     []string `json:"wwpns,omitempty"`
+	Wwnns     string   `json:"wwnns,omitempty"`
+	Multipath *bool    `json:"multipath,omitempty"`
+	Platform  string   `json:"platform,omitempty"`
+	OSType    string   `json:"os_type,omitempty"`
+}
+
+// ToVolumeTerminateConnectionMap assembles a request body based on the contents of a
+// TerminateConnectionOpts.
+func (opts TerminateConnectionOpts) ToVolumeTerminateConnectionMap() (map[string]interface{}, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "connector")
+	return map[string]interface{}{"os-terminate_connection": b}, err
+}
+
+// TerminateConnection terminates an iSCSI connection by volume ID.
+func TerminateConnection(client *golangsdk.ServiceClient, id string, opts TerminateConnectionOptsBuilder) (r TerminateConnectionResult) {
+	b, err := opts.ToVolumeTerminateConnectionMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(actionURL(client, id), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{202},
+	})
+	return
+}
+
+// ExtendSizeOptsBuilder allows extensions to add additional parameters to the
+// ExtendSize request.
+type ExtendSizeOptsBuilder interface {
+	ToVolumeExtendSizeMap() (map[string]interface{}, error)
+}
+
+// ExtendSizeOpts contains options for extending the size of an existing Volume.
+// This object is passed to the volumes.ExtendSize function.
+type ExtendSizeOpts struct {
+	// NewSize is the new size of the volume, in GB.
+	NewSize int `json:"new_size" required:"true"`
+}
+
+// ToVolumeExtendSizeMap assembles a request body based on the contents of an
+// ExtendSizeOpts.
+func (opts ExtendSizeOpts) ToVolumeExtendSizeMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "os-extend")
+}
+
+// ExtendSize will extend the size of the volume based on the provided information.
+// This operation does not return a response body.
+func ExtendSize(client *golangsdk.ServiceClient, id string, opts ExtendSizeOptsBuilder) (r ExtendSizeResult) {
+	b, err := opts.ToVolumeExtendSizeMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(actionURL(client, id), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{202},
+	})
+	return
+}
+
+// UploadImageOptsBuilder allows extensions to add additional parameters to the
+// UploadImage request.
+type UploadImageOptsBuilder interface {
+	ToVolumeUploadImageMap() (map[string]interface{}, error)
+}
+
+// UploadImageOpts contains options for uploading a Volume to image storage.
+type UploadImageOpts struct {
+	// Container format, may be bare, ofv, ova, etc.
+	ContainerFormat string `json:"container_format,omitempty"`
+
+	// Disk format, may be raw, qcow2, vhd, vdi, vmdk, etc.
+	DiskFormat string `json:"disk_format,omitempty"`
+
+	// The name of image that will be stored in glance.
+	ImageName string `json:"image_name,omitempty"`
+
+	// Force image creation, usable if volume attached to instance.
+	Force bool `json:"force,omitempty"`
+}
+
+// ToVolumeUploadImageMap assembles a request body based on the contents of a
+// UploadImageOpts.
+func (opts UploadImageOpts) ToVolumeUploadImageMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "os-volume_upload_image")
+}
+
+// UploadImage will upload an image based on the values in UploadImageOptsBuilder.
+func UploadImage(client *golangsdk.ServiceClient, id string, opts UploadImageOptsBuilder) (r UploadImageResult) {
+	b, err := opts.ToVolumeUploadImageMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(actionURL(client, id), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{202},
+	})
+	return
+}
+
+// ForceDelete will delete the volume regardless of state.
+func ForceDelete(client *golangsdk.ServiceClient, id string) (r ForceDeleteResult) {
+	_, r.Err = client.Post(actionURL(client, id), map[string]interface{}{"os-force_delete": ""}, nil, nil)
+	return
+}

--- a/vendor/github.com/opentelekomcloud/gophertelekomcloud/openstack/blockstorage/extensions/volumeactions/results.go
+++ b/vendor/github.com/opentelekomcloud/gophertelekomcloud/openstack/blockstorage/extensions/volumeactions/results.go
@@ -1,0 +1,191 @@
+package volumeactions
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/opentelekomcloud/gophertelekomcloud"
+)
+
+// AttachResult contains the response body and error from an Attach request.
+type AttachResult struct {
+	golangsdk.ErrResult
+}
+
+// BeginDetachingResult contains the response body and error from a BeginDetach
+// request.
+type BeginDetachingResult struct {
+	golangsdk.ErrResult
+}
+
+// DetachResult contains the response body and error from a Detach request.
+type DetachResult struct {
+	golangsdk.ErrResult
+}
+
+// UploadImageResult contains the response body and error from an UploadImage
+// request.
+type UploadImageResult struct {
+	golangsdk.Result
+}
+
+// ReserveResult contains the response body and error from a Reserve request.
+type ReserveResult struct {
+	golangsdk.ErrResult
+}
+
+// UnreserveResult contains the response body and error from an Unreserve
+// request.
+type UnreserveResult struct {
+	golangsdk.ErrResult
+}
+
+// TerminateConnectionResult contains the response body and error from a
+// TerminateConnection request.
+type TerminateConnectionResult struct {
+	golangsdk.ErrResult
+}
+
+// InitializeConnectionResult contains the response body and error from an
+// InitializeConnection request.
+type InitializeConnectionResult struct {
+	golangsdk.Result
+}
+
+// ExtendSizeResult contains the response body and error from an ExtendSize request.
+type ExtendSizeResult struct {
+	golangsdk.ErrResult
+}
+
+// Extract will get the connection information out of the
+// InitializeConnectionResult object.
+//
+// This will be a generic map[string]interface{} and the results will be
+// dependent on the type of connection made.
+func (r InitializeConnectionResult) Extract() (map[string]interface{}, error) {
+	var s struct {
+		ConnectionInfo map[string]interface{} `json:"connection_info"`
+	}
+	err := r.ExtractInto(&s)
+	return s.ConnectionInfo, err
+}
+
+// ImageVolumeType contains volume type information obtained from UploadImage
+// action.
+type ImageVolumeType struct {
+	// The ID of a volume type.
+	ID string `json:"id"`
+
+	// Human-readable display name for the volume type.
+	Name string `json:"name"`
+
+	// Human-readable description for the volume type.
+	Description string `json:"display_description"`
+
+	// Flag for public access.
+	IsPublic bool `json:"is_public"`
+
+	// Extra specifications for volume type.
+	ExtraSpecs map[string]interface{} `json:"extra_specs"`
+
+	// ID of quality of service specs.
+	QosSpecsID string `json:"qos_specs_id"`
+
+	// Flag for deletion status of volume type.
+	Deleted bool `json:"deleted"`
+
+	// The date when volume type was deleted.
+	DeletedAt time.Time `json:"-"`
+
+	// The date when volume type was created.
+	CreatedAt time.Time `json:"-"`
+
+	// The date when this volume was last updated.
+	UpdatedAt time.Time `json:"-"`
+}
+
+func (r *ImageVolumeType) UnmarshalJSON(b []byte) error {
+	type tmp ImageVolumeType
+	var s struct {
+		tmp
+		CreatedAt golangsdk.JSONRFC3339MilliNoZ `json:"created_at"`
+		UpdatedAt golangsdk.JSONRFC3339MilliNoZ `json:"updated_at"`
+		DeletedAt golangsdk.JSONRFC3339MilliNoZ `json:"deleted_at"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = ImageVolumeType(s.tmp)
+
+	r.CreatedAt = time.Time(s.CreatedAt)
+	r.UpdatedAt = time.Time(s.UpdatedAt)
+	r.DeletedAt = time.Time(s.DeletedAt)
+
+	return err
+}
+
+// VolumeImage contains information about volume uploaded to an image service.
+type VolumeImage struct {
+	// The ID of a volume an image is created from.
+	VolumeID string `json:"id"`
+
+	// Container format, may be bare, ofv, ova, etc.
+	ContainerFormat string `json:"container_format"`
+
+	// Disk format, may be raw, qcow2, vhd, vdi, vmdk, etc.
+	DiskFormat string `json:"disk_format"`
+
+	// Human-readable description for the volume.
+	Description string `json:"display_description"`
+
+	// The ID of the created image.
+	ImageID string `json:"image_id"`
+
+	// Human-readable display name for the image.
+	ImageName string `json:"image_name"`
+
+	// Size of the volume in GB.
+	Size int `json:"size"`
+
+	// Current status of the volume.
+	Status string `json:"status"`
+
+	// The date when this volume was last updated.
+	UpdatedAt time.Time `json:"-"`
+
+	// Volume type object of used volume.
+	VolumeType ImageVolumeType `json:"volume_type"`
+}
+
+func (r *VolumeImage) UnmarshalJSON(b []byte) error {
+	type tmp VolumeImage
+	var s struct {
+		tmp
+		UpdatedAt golangsdk.JSONRFC3339MilliNoZ `json:"updated_at"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = VolumeImage(s.tmp)
+
+	r.UpdatedAt = time.Time(s.UpdatedAt)
+
+	return err
+}
+
+// Extract will get an object with info about the uploaded image out of the
+// UploadImageResult object.
+func (r UploadImageResult) Extract() (VolumeImage, error) {
+	var s struct {
+		VolumeImage VolumeImage `json:"os-volume_upload_image"`
+	}
+	err := r.ExtractInto(&s)
+	return s.VolumeImage, err
+}
+
+// ForceDeleteResult contains the response body and error from a ForceDelete request.
+type ForceDeleteResult struct {
+	golangsdk.ErrResult
+}

--- a/vendor/github.com/opentelekomcloud/gophertelekomcloud/openstack/blockstorage/extensions/volumeactions/urls.go
+++ b/vendor/github.com/opentelekomcloud/gophertelekomcloud/openstack/blockstorage/extensions/volumeactions/urls.go
@@ -1,0 +1,7 @@
+package volumeactions
+
+import "github.com/opentelekomcloud/gophertelekomcloud"
+
+func actionURL(c *golangsdk.ServiceClient, id string) string {
+	return c.ServiceURL("volumes", id, "action")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -152,6 +152,7 @@ github.com/hashicorp/terraform-json
 ## explicit
 github.com/hashicorp/terraform-plugin-sdk/acctest
 github.com/hashicorp/terraform-plugin-sdk/helper/acctest
+github.com/hashicorp/terraform-plugin-sdk/helper/customdiff
 github.com/hashicorp/terraform-plugin-sdk/helper/hashcode
 github.com/hashicorp/terraform-plugin-sdk/helper/logging
 github.com/hashicorp/terraform-plugin-sdk/helper/mutexkv
@@ -246,6 +247,7 @@ github.com/opentelekomcloud/gophertelekomcloud/openstack/autoscaling/v1/configur
 github.com/opentelekomcloud/gophertelekomcloud/openstack/autoscaling/v1/groups
 github.com/opentelekomcloud/gophertelekomcloud/openstack/autoscaling/v1/instances
 github.com/opentelekomcloud/gophertelekomcloud/openstack/autoscaling/v1/policies
+github.com/opentelekomcloud/gophertelekomcloud/openstack/blockstorage/extensions/volumeactions
 github.com/opentelekomcloud/gophertelekomcloud/openstack/blockstorage/v2/volumes
 github.com/opentelekomcloud/gophertelekomcloud/openstack/bms/v2/flavors
 github.com/opentelekomcloud/gophertelekomcloud/openstack/bms/v2/keypairs


### PR DESCRIPTION
## Summary of the Pull Request
Add `customdiff.ForceNewIfChange` for `size` attribute of `r/blockstorage_volume_v2`

## PR Checklist

* [x] Refers to: #656
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
=== RUN   TestAccBlockStorageV2Volume_basic
--- PASS: TestAccBlockStorageV2Volume_basic (68.11s)
=== RUN   TestAccBlockStorageV2Volume_upscaleDownScale
--- PASS: TestAccBlockStorageV2Volume_upscaleDownScale (128.95s)
=== RUN   TestAccBlockStorageV2Volume_upscaleDownScaleAssigned
--- PASS: TestAccBlockStorageV2Volume_upscaleDownScaleAssigned (191.45s)
PASS

Process finished with exit code 0
```
