### PR TITLE
Update compute_instance_v2.md

### DIFF
--- a/docs/resources/compute_instance_v2.md
+++ b/docs/resources/compute_instance_v2.md
@@ -286,7 +286,7 @@ The following arguments are supported:
 * `user_data` - (Optional) The user data to provide when launching the instance.
   Changing this creates a new server.
 
-* `security_groups` - (Optional) An array of one or more security group names
+* `security_groups` - (Optional) An array of one or more security group ids
   to associate with the server. Changing this results in adding/removing
   security groups from the existing server. 
 -> **Note:** When attaching the instance to networks using Ports, 


### PR DESCRIPTION
As stated in the api docs, the security_group parameter expects the ids of security groups, not their names: https://docs.otc.t-systems.com/en-us/api/ecs/en-us_topic_0167957246.html#EN-US_TOPIC_0167957246__table1698566599

## Summary of the Pull Request


## PR Checklist

* [ ] Refers to: #xxx
* [ ] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (101.71s)
=== RUN   TestAccSomethingV0_timeout
--- PASS: TestAccSomethingV0_timeout (128.67s)
PASS

Process finished with exit code 0
```
