### PR TITLE
Increased CCE delete timeout

### DIFF
--- a/opentelekomcloud/resource_opentelekomcloud_cce_cluster_v3.go
+++ b/opentelekomcloud/resource_opentelekomcloud_cce_cluster_v3.go
@@ -25,7 +25,7 @@ func resourceCCEClusterV3() *schema.Resource {
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),
-			Delete: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{


### PR DESCRIPTION
## Summary of the Pull Request
For fix:
=== RUN   TestAccCCEClusterV3_basic
    testing.go:745: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: errors during apply: Error deleting opentelekomcloud CCE cluster: timeout while waiting for state to become 'Deleted' (last state: 'Deleting', timeout: 10m0s)

## PR Checklist

* [ ] Refers to: #xxx
* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
=== RUN   TestAccCCEClusterV3_basic
--- PASS: TestAccCCEClusterV3_basic (1638.36s)
PASS

Process finished with exit code 0
```
