### PR TITLE
Minor refactoring r/networking_secgroup_v2

### DIFF
--- a/opentelekomcloud/resource_opentelekomcloud_networking_secgroup_v2.go
+++ b/opentelekomcloud/resource_opentelekomcloud_networking_secgroup_v2.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/opentelekomcloud/gophertelekomcloud"
@@ -19,6 +20,7 @@ func resourceNetworkingSecGroupV2() *schema.Resource {
 		Read:   resourceNetworkingSecGroupV2Read,
 		Update: resourceNetworkingSecGroupV2Update,
 		Delete: resourceNetworkingSecGroupV2Delete,
+
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -59,11 +61,10 @@ func resourceNetworkingSecGroupV2() *schema.Resource {
 }
 
 func resourceNetworkingSecGroupV2Create(d *schema.ResourceData, meta interface{}) error {
-
 	config := meta.(*Config)
 	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating OpenTelekomCloud networking client: %s", err)
+		return fmt.Errorf("error creating OpenTelekomCloud NetworkingV2 client: %s", err)
 	}
 
 	opts := groups.CreateOpts{
@@ -74,7 +75,7 @@ func resourceNetworkingSecGroupV2Create(d *schema.ResourceData, meta interface{}
 
 	log.Printf("[DEBUG] Create OpenTelekomCloud Neutron Security Group: %#v", opts)
 
-	security_group, err := groups.Create(networkingClient, opts).Extract()
+	securityGroup, err := groups.Create(networkingClient, opts).Extract()
 	if err != nil {
 		return err
 	}
@@ -82,21 +83,19 @@ func resourceNetworkingSecGroupV2Create(d *schema.ResourceData, meta interface{}
 	// Delete the default security group rules if it has been requested.
 	deleteDefaultRules := d.Get("delete_default_rules").(bool)
 	if deleteDefaultRules {
-		security_group, err := groups.Get(networkingClient, security_group.ID).Extract()
+		securityGroup, err := groups.Get(networkingClient, securityGroup.ID).Extract()
 		if err != nil {
 			return err
 		}
-		for _, rule := range security_group.Rules {
+		for _, rule := range securityGroup.Rules {
 			if err := rules.Delete(networkingClient, rule.ID).ExtractErr(); err != nil {
-				return fmt.Errorf(
-					"There was a problem deleting a default security group rule: %s", err)
+				return fmt.Errorf("there was a problem deleting a default security group rule: %s", err)
 			}
 		}
 	}
+	log.Printf("[DEBUG] OpenTelekomCloud Neutron Security Group created: %#v", securityGroup)
 
-	log.Printf("[DEBUG] OpenTelekomCloud Neutron Security Group created: %#v", security_group)
-
-	d.SetId(security_group.ID)
+	d.SetId(securityGroup.ID)
 
 	return resourceNetworkingSecGroupV2Read(d, meta)
 }
@@ -107,49 +106,44 @@ func resourceNetworkingSecGroupV2Read(d *schema.ResourceData, meta interface{}) 
 	config := meta.(*Config)
 	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating OpenTelekomCloud networking client: %s", err)
+		return fmt.Errorf("error creating OpenTelekomCloud NetworkingV2 client: %s", err)
 	}
 
-	security_group, err := groups.Get(networkingClient, d.Id()).Extract()
-
+	securityGroup, err := groups.Get(networkingClient, d.Id()).Extract()
 	if err != nil {
 		return CheckDeleted(d, err, "OpenTelekomCloud Neutron Security group")
 	}
 
-	d.Set("description", security_group.Description)
-	d.Set("tenant_id", security_group.TenantID)
-	d.Set("name", security_group.Name)
-	d.Set("region", GetRegion(d, config))
+	me := multierror.Append(nil,
+		d.Set("description", securityGroup.Description),
+		d.Set("tenant_id", securityGroup.TenantID),
+		d.Set("name", securityGroup.Name),
+		d.Set("region", GetRegion(d, config)),
+	)
 
-	return nil
+	return me.ErrorOrNil()
 }
 
 func resourceNetworkingSecGroupV2Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating OpenTelekomCloud networking client: %s", err)
+		return fmt.Errorf("error creating OpenTelekomCloud Networkingv2 client: %s", err)
 	}
-
-	var update bool
 	var updateOpts groups.UpdateOpts
 
 	if d.HasChange("name") {
-		update = true
 		updateOpts.Name = d.Get("name").(string)
 	}
 
 	if d.HasChange("description") {
-		update = true
 		updateOpts.Description = d.Get("description").(string)
 	}
 
-	if update {
-		log.Printf("[DEBUG] Updating SecGroup %s with options: %#v", d.Id(), updateOpts)
-		_, err = groups.Update(networkingClient, d.Id(), updateOpts).Extract()
-		if err != nil {
-			return fmt.Errorf("Error updating OpenTelekomCloud SecGroup: %s", err)
-		}
+	log.Printf("[DEBUG] Updating SecGroup %s with options: %#v", d.Id(), updateOpts)
+	_, err = groups.Update(networkingClient, d.Id(), updateOpts).Extract()
+	if err != nil {
+		return fmt.Errorf("error updating OpenTelekomCloud networking SecGroup: %s", err)
 	}
 
 	return resourceNetworkingSecGroupV2Read(d, meta)
@@ -161,7 +155,7 @@ func resourceNetworkingSecGroupV2Delete(d *schema.ResourceData, meta interface{}
 	config := meta.(*Config)
 	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating OpenTelekomCloud networking client: %s", err)
+		return fmt.Errorf("error creating OpenTelekomCloud NetworkingV2 client: %s", err)
 	}
 
 	stateConf := &resource.StateChangeConf{
@@ -175,7 +169,7 @@ func resourceNetworkingSecGroupV2Delete(d *schema.ResourceData, meta interface{}
 
 	_, err = stateConf.WaitForState()
 	if err != nil {
-		return fmt.Errorf("Error deleting OpenTelekomCloud Neutron Security Group: %s", err)
+		return fmt.Errorf("error deleting OpenTelekomCloud Neutron Security Group: %s", err)
 	}
 
 	d.SetId("")
@@ -201,10 +195,8 @@ func waitForSecGroupDelete(networkingClient *golangsdk.ServiceClient, secGroupId
 				log.Printf("[DEBUG] Successfully deleted OpenTelekomCloud Neutron Security Group %s", secGroupId)
 				return r, "DELETED", nil
 			}
-			if errCode, ok := err.(golangsdk.ErrUnexpectedResponseCode); ok {
-				if errCode.Actual == 409 {
-					return r, "ACTIVE", nil
-				}
+			if _, ok := err.(golangsdk.ErrDefault409); ok {
+				return r, "ACTIVE", nil
 			}
 			return r, "ACTIVE", err
 		}

--- a/opentelekomcloud/resource_opentelekomcloud_networking_secgroup_v2_test.go
+++ b/opentelekomcloud/resource_opentelekomcloud_networking_secgroup_v2_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestAccNetworkingV2SecGroup_basic(t *testing.T) {
-	var security_group groups.SecGroup
+	var securityGroup groups.SecGroup
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -21,18 +21,15 @@ func TestAccNetworkingV2SecGroup_basic(t *testing.T) {
 			{
 				Config: testAccNetworkingV2SecGroup_basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNetworkingV2SecGroupExists(
-						"opentelekomcloud_networking_secgroup_v2.secgroup_1", &security_group),
-					testAccCheckNetworkingV2SecGroupRuleCount(&security_group, 2),
+					testAccCheckNetworkingV2SecGroupExists("opentelekomcloud_networking_secgroup_v2.secgroup_1", &securityGroup),
+					testAccCheckNetworkingV2SecGroupRuleCount(&securityGroup, 2),
 				),
 			},
 			{
 				Config: testAccNetworkingV2SecGroup_update,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrPtr(
-						"opentelekomcloud_networking_secgroup_v2.secgroup_1", "id", &security_group.ID),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_networking_secgroup_v2.secgroup_1", "name", "security_group_2"),
+					resource.TestCheckResourceAttrPtr("opentelekomcloud_networking_secgroup_v2.secgroup_1", "id", &securityGroup.ID),
+					resource.TestCheckResourceAttr("opentelekomcloud_networking_secgroup_v2.secgroup_1", "name", "security_group_2"),
 				),
 			},
 		},
@@ -40,7 +37,7 @@ func TestAccNetworkingV2SecGroup_basic(t *testing.T) {
 }
 
 func TestAccNetworkingV2SecGroup_noDefaultRules(t *testing.T) {
-	var security_group groups.SecGroup
+	var securityGroup groups.SecGroup
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -50,9 +47,8 @@ func TestAccNetworkingV2SecGroup_noDefaultRules(t *testing.T) {
 			{
 				Config: testAccNetworkingV2SecGroup_noDefaultRules,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNetworkingV2SecGroupExists(
-						"opentelekomcloud_networking_secgroup_v2.secgroup_1", &security_group),
-					testAccCheckNetworkingV2SecGroupRuleCount(&security_group, 0),
+					testAccCheckNetworkingV2SecGroupExists("opentelekomcloud_networking_secgroup_v2.secgroup_1", &securityGroup),
+					testAccCheckNetworkingV2SecGroupRuleCount(&securityGroup, 0),
 				),
 			},
 		},
@@ -60,7 +56,7 @@ func TestAccNetworkingV2SecGroup_noDefaultRules(t *testing.T) {
 }
 
 func TestAccNetworkingV2SecGroup_timeout(t *testing.T) {
-	var security_group groups.SecGroup
+	var securityGroup groups.SecGroup
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -70,8 +66,7 @@ func TestAccNetworkingV2SecGroup_timeout(t *testing.T) {
 			{
 				Config: testAccNetworkingV2SecGroup_timeout,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNetworkingV2SecGroupExists(
-						"opentelekomcloud_networking_secgroup_v2.secgroup_1", &security_group),
+					testAccCheckNetworkingV2SecGroupExists("opentelekomcloud_networking_secgroup_v2.secgroup_1", &securityGroup),
 				),
 			},
 		},
@@ -82,7 +77,7 @@ func testAccCheckNetworkingV2SecGroupDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 	networkingClient, err := config.networkingV2Client(OS_REGION_NAME)
 	if err != nil {
-		return fmt.Errorf("Error creating OpenTelekomCloud networking client: %s", err)
+		return fmt.Errorf("error creating OpenTelekomCloud Networkingv2 client: %s", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -92,28 +87,28 @@ func testAccCheckNetworkingV2SecGroupDestroy(s *terraform.State) error {
 
 		_, err := groups.Get(networkingClient, rs.Primary.ID).Extract()
 		if err == nil {
-			return fmt.Errorf("Security group still exists")
+			return fmt.Errorf("security group still exists")
 		}
 	}
 
 	return nil
 }
 
-func testAccCheckNetworkingV2SecGroupExists(n string, security_group *groups.SecGroup) resource.TestCheckFunc {
+func testAccCheckNetworkingV2SecGroupExists(n string, securityGroup *groups.SecGroup) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return fmt.Errorf("not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
+			return fmt.Errorf("no ID is set")
 		}
 
 		config := testAccProvider.Meta().(*Config)
 		networkingClient, err := config.networkingV2Client(OS_REGION_NAME)
 		if err != nil {
-			return fmt.Errorf("Error creating OpenTelekomCloud networking client: %s", err)
+			return fmt.Errorf("error creating OpenTelekomCloud networking client: %s", err)
 		}
 
 		found, err := groups.Get(networkingClient, rs.Primary.ID).Extract()
@@ -122,10 +117,10 @@ func testAccCheckNetworkingV2SecGroupExists(n string, security_group *groups.Sec
 		}
 
 		if found.ID != rs.Primary.ID {
-			return fmt.Errorf("Security group not found")
+			return fmt.Errorf("security group not found")
 		}
 
-		*security_group = *found
+		*securityGroup = *found
 
 		return nil
 	}
@@ -138,36 +133,36 @@ func testAccCheckNetworkingV2SecGroupRuleCount(
 			return nil
 		}
 
-		return fmt.Errorf("Unexpected number of rules in group %s. Expected %d, got %d",
+		return fmt.Errorf("unexpected number of rules in group %s. Expected %d, got %d",
 			sg.ID, count, len(sg.Rules))
 	}
 }
 
 const testAccNetworkingV2SecGroup_basic = `
 resource "opentelekomcloud_networking_secgroup_v2" "secgroup_1" {
-  name = "security_group"
+  name        = "security_group"
   description = "terraform security group acceptance test"
 }
 `
 
 const testAccNetworkingV2SecGroup_update = `
 resource "opentelekomcloud_networking_secgroup_v2" "secgroup_1" {
-  name = "security_group_2"
+  name        = "security_group_2"
   description = "terraform security group acceptance test"
 }
 `
 
 const testAccNetworkingV2SecGroup_noDefaultRules = `
 resource "opentelekomcloud_networking_secgroup_v2" "secgroup_1" {
-	name = "security_group_1"
-	description = "terraform security group acceptance test"
-	delete_default_rules = true
+  name                 = "security_group_1"
+  description          = "terraform security group acceptance test"
+  delete_default_rules = true
 }
 `
 
 const testAccNetworkingV2SecGroup_timeout = `
 resource "opentelekomcloud_networking_secgroup_v2" "secgroup_1" {
-  name = "security_group"
+  name        = "security_group"
   description = "terraform security group acceptance test"
 
   timeouts {


### PR DESCRIPTION
## Summary of the Pull Request

Update gophertelekomcloud version to v0.1.0 

Minor changes in secgroup

## PR Checklist

* [x] Refers to: #660
* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
=== RUN   TestAccNetworkingV2SecGroup_basic
--- PASS: TestAccNetworkingV2SecGroup_basic (62.92s)
=== RUN   TestAccNetworkingV2SecGroup_noDefaultRules
--- PASS: TestAccNetworkingV2SecGroup_noDefaultRules (40.36s)
=== RUN   TestAccNetworkingV2SecGroup_timeout
--- PASS: TestAccNetworkingV2SecGroup_timeout (39.03s)
PASS

Process finished with exit code 0
```
