### PR TITLE
Fix region handling for the provider

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -144,8 +144,6 @@ See [OpenStack configuration documentation](https://docs.openstack.org/python-op
 
 ## Configuration Reference
 
--> **Note:** The `region`, `tenant_id`, `domain_id`, `user_id` arguments has been deprecated and `tenant_name`, `domain_name` changed to be `required`. Please update your configurations as it might be removed in the future releases.
-
 The following arguments are supported:
 
 * `access_key` - (Optional) The access key of the OpenTelekomCloud cloud to use.
@@ -166,9 +164,13 @@ The following arguments are supported:
 * `user_name` - (Optional) The Username to login with. If omitted, the
   `OS_USERNAME` environment variable is used.
 
-* `tenant_name` - (Required) The Name of the Tenant (Identity v2) or Project
+* `tenant_name` - (Optional) The Name of the Tenant (Identity v2) or Project
   (Identity v3) to login with. If omitted, the `OS_TENANT_NAME` or
   `OS_PROJECT_NAME` environment variable are used.
+
+* `region` - (Optional) The name of the region to be used. Required for some resources
+  (e.g. `s3_bucket`) in case no tenant name provided and no region is defined in the
+  resource. If omitted, the `OS_REGION` or `OS_REGION_NAME` environment variables are used.
 
 * `password` - (Optional) The Password to login with. If omitted, the
   `OS_PASSWORD` environment variable is used.
@@ -181,7 +183,7 @@ The following arguments are supported:
 
 * `security_token` - (Optional) Security token to use for OBS federated authentication.
 
-* `domain_name` - (Required) The Name of the Domain to scope to (Identity v3).
+* `domain_name` - (Optional) The Name of the Domain to scope to (Identity v3).
   If omitted, the following environment variables are checked (in this order):
   `OS_USER_DOMAIN_NAME`, `OS_PROJECT_DOMAIN_NAME`, `OS_DOMAIN_NAME`,
   `DEFAULT_DOMAIN`.
@@ -209,7 +211,7 @@ The following arguments are supported:
   Swift-native authentication system. If omitted, the `OS_SWAUTH` environment
   variable is used. You must also set `username` to the Swauth/Swift username
   such as `username:project`. Set the `password` to the Swauth/Swift key.
-  Finally, set `auth_url` as the location of the Swift service. 
+  Finally, set `auth_url` as the location of the Swift service.
 -> **Note:** This will only work when used with the OpenTelekomCloud Object Storage resources.
 
 * `agency_name` - (Optional) if authorized by assume role, it must be set. The

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -39,7 +39,10 @@ func Provider() terraform.ResourceProvider {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: descriptions["region"],
-				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
+				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
+					"OS_REGION_NAME",
+					"OS_REGION",
+				}, ""),
 			},
 
 			"user_name": {

--- a/opentelekomcloud/provider_test.go
+++ b/opentelekomcloud/provider_test.go
@@ -51,8 +51,10 @@ func init() {
 		"opentelekomcloud": testAccProvider,
 	}
 
-	testAccProvider.Configure(terraform.NewResourceConfigRaw(nil))
-	OS_REGION_NAME = GetRegion(nil, testAccProvider.Meta().(*Config))
+	err := testAccProvider.Configure(terraform.NewResourceConfigRaw(nil))
+	if err == nil {
+		OS_REGION_NAME = GetRegion(nil, testAccProvider.Meta().(*Config))
+	}
 }
 
 func getTenantName() ProjectName {

--- a/opentelekomcloud/provider_test.go
+++ b/opentelekomcloud/provider_test.go
@@ -50,12 +50,9 @@ func init() {
 	testAccProviders = map[string]terraform.ResourceProvider{
 		"opentelekomcloud": testAccProvider,
 	}
-	tn := os.Getenv("OS_TENANT_NAME")
-	if tn == "" {
-		tn = os.Getenv("OS_PROJECT_NAME")
-	}
-	OS_REGION_NAME = GetRegion(nil, &Config{TenantName: tn})
 
+	testAccProvider.Configure(terraform.NewResourceConfigRaw(nil))
+	OS_REGION_NAME = GetRegion(nil, testAccProvider.Meta().(*Config))
 }
 
 func getTenantName() ProjectName {

--- a/opentelekomcloud/resource_opentelekomcloud_compute_instance_v2.go
+++ b/opentelekomcloud/resource_opentelekomcloud_compute_instance_v2.go
@@ -1299,7 +1299,7 @@ func securityGroupsByIDs(diff *schema.ResourceDiff, meta interface{}) error {
 
 	// resolve IDs
 	config := meta.(*Config)
-	computeClient, err := config.computeV2HWClient(GetRegion(nil, config))
+	computeClient, err := config.computeV2HWClient(GetRegion(diff, config))
 	if err != nil {
 		return fmt.Errorf("error creating OpenTelekomCloud compute client: %s", err)
 	}


### PR DESCRIPTION
## Summary of the Pull Request
* Use `region` values from provider config and schema
* Use `OS_REGION` env var as `region` default in provider schema
* **Tests:** make `OS_REGION_NAME` to use provider config

## PR Checklist

* [x] Refers to: #690. Just related to, not actual fix.
* [x] Tests added/passed.
* [x] Documentation updated.

## Acceptance Steps Performed

```
=== RUN   TestAccS3Bucket_basic
--- PASS: TestAccS3Bucket_basic (25.11s)
=== RUN   TestAccAWSS3MultiBucket_withTags
--- PASS: TestAccAWSS3MultiBucket_withTags (27.27s)
=== RUN   TestAccS3Bucket_namePrefix
--- PASS: TestAccS3Bucket_namePrefix (27.02s)
=== RUN   TestAccS3Bucket_generatedName
--- PASS: TestAccS3Bucket_generatedName (27.06s)
=== RUN   TestAccS3Bucket_region
--- PASS: TestAccS3Bucket_region (27.16s)
=== RUN   TestAccS3Bucket_Policy
--- PASS: TestAccS3Bucket_Policy (72.65s)
=== RUN   TestAccS3Bucket_UpdateAcl
--- PASS: TestAccS3Bucket_UpdateAcl (49.43s)
=== RUN   TestAccS3Bucket_Website_Simple
--- PASS: TestAccS3Bucket_Website_Simple (74.89s)
=== RUN   TestAccS3Bucket_WebsiteRedirect
--- PASS: TestAccS3Bucket_WebsiteRedirect (76.92s)
=== RUN   TestAccS3Bucket_WebsiteRoutingRules
--- PASS: TestAccS3Bucket_WebsiteRoutingRules (52.85s)
=== RUN   TestAccS3Bucket_shouldFailNotFound
--- PASS: TestAccS3Bucket_shouldFailNotFound (21.06s)
=== RUN   TestAccS3Bucket_Versioning
--- PASS: TestAccS3Bucket_Versioning (75.27s)
=== RUN   TestAccS3Bucket_Cors
--- PASS: TestAccS3Bucket_Cors (51.61s)
=== RUN   TestAccS3Bucket_Logging
--- PASS: TestAccS3Bucket_Logging (36.69s)
=== RUN   TestAccS3Bucket_Lifecycle
--- PASS: TestAccS3Bucket_Lifecycle (73.20s)
=== RUN   TestS3BucketName
--- PASS: TestS3BucketName (0.00s)
PASS

Process finished with exit code 0

```
