### PR TITLE
Fix panic creating `s3_bucket` without `tenant_name` in provider config

### DIFF
--- a/opentelekomcloud/config.go
+++ b/opentelekomcloud/config.go
@@ -530,14 +530,15 @@ func (c *Config) computeS3conn(region string) (*s3.S3, error) {
 		return nil, fmt.Errorf("Missing credentials for Swift S3 Provider, need access_key and secret_key values for provider.")
 	}
 
-	client, err := openstack.NewImageServiceV2(c.HwClient, golangsdk.EndpointOpts{
+	client, err := openstack.NewOBSService(c.HwClient, golangsdk.EndpointOpts{
 		Region:       region,
 		Availability: c.getHwEndpointType(),
 	})
-	// Bit of a hack, seems the only way to compute this.
-	endpoint := strings.Replace(client.Endpoint, "//ims", "//obs", 1)
+	if err != nil {
+		return nil, err
+	}
 
-	awsS3Sess := c.s3sess.Copy(&aws.Config{Endpoint: aws.String(endpoint)})
+	awsS3Sess := c.s3sess.Copy(&aws.Config{Endpoint: aws.String(client.Endpoint)})
 	s3conn := s3.New(awsS3Sess)
 
 	return s3conn, err


### PR DESCRIPTION
## Summary of the Pull Request
Add error handling in `computeS3conn`
Fix #690

## PR Checklist

* [x] Refers to: #690
* [x] Tests added/passed.

## Acceptance Steps Performed
No more panic.

#### w/ `tenant_name` in config:
```
opentelekomcloud_s3_bucket_policy.b: Modifying... [id=my-tf-test-bucket-akachuri]
opentelekomcloud_s3_bucket_policy.b: Modifications complete after 0s [id=my-tf-test-bucket-akachuri]
```

#### w/o `tenant_name` in config: 
```
opentelekomcloud_s3_bucket.b: Refreshing state... [id=my-tf-test-bucket-akachuri]

Error: Error creating OpenTelekomCloud s3 client: No suitable endpoint could be found in the service catalog.

```
