### PR TITLE
Add missing fields to cce_cluster_v3

### DIFF
--- a/docs/resources/cce_cluster_v3.md
+++ b/docs/resources/cce_cluster_v3.md
@@ -84,15 +84,6 @@ The following arguments are supported:
 * `kubernetes_svc_ip_range` - (Optional) Service CIDR block, or the IP address range which the kubernetes
   clusterIp must fall within. This parameter is available only for clusters of v1.11.7 and later.
 
-* `kube_proxy_mode` - (Optional) Service forwarding mode. Two modes are available:
-  * `iptables`: Traditional kube-proxy uses iptables rules to implement service load balancing.
-  In this mode, too many iptables rules will be generated when many services are deployed.
-  In addition, non-incremental updates will cause a latency and even obvious performance issues
-  in the case of heavy service traffic.
-  * `ipvs`: Optimized kube-proxy mode with higher throughput and faster speed.
-  This mode supports incremental updates and can keep connections uninterrupted during service updates.
-  It is suitable for large-sized clusters.
-
 ## Attributes Reference
 
 All above argument parameters can be exported as attribute parameters along with attribute reference.
@@ -118,6 +109,15 @@ All above argument parameters can be exported as attribute parameters along with
 * `certificate_users/client_certificate_data` - The client certificate data.
 
 * `certificate_users/client_key_data` - The client key data.
+
+* `kube_proxy_mode` - (Optional) Service forwarding mode. Two modes are available:
+  * `iptables`: Traditional kube-proxy uses iptables rules to implement service load balancing.
+  In this mode, too many iptables rules will be generated when many services are deployed.
+  In addition, non-incremental updates will cause a latency and even obvious performance issues
+  in the case of heavy service traffic.
+  * `ipvs`: Optimized kube-proxy mode with higher throughput and faster speed.
+  This mode supports incremental updates and can keep connections uninterrupted during service updates.
+  It is suitable for large-sized clusters.
 
 ## Import
 

--- a/docs/resources/cce_cluster_v3.md
+++ b/docs/resources/cce_cluster_v3.md
@@ -81,6 +81,18 @@ The following arguments are supported:
 
 * `eip` - (Optional) EIP address of the cluster.
 
+* `kubernetes_svc_ip_range` - (Optional) Service CIDR block, or the IP address range which the kubernetes
+  clusterIp must fall within. This parameter is available only for clusters of v1.11.7 and later.
+
+* `kube_proxy_mode` - (Optional) Service forwarding mode. Two modes are available:
+  * `iptables`: Traditional kube-proxy uses iptables rules to implement service load balancing.
+  In this mode, too many iptables rules will be generated when many services are deployed.
+  In addition, non-incremental updates will cause a latency and even obvious performance issues
+  in the case of heavy service traffic.
+  * `ipvs`: Optimized kube-proxy mode with higher throughput and faster speed.
+  This mode supports incremental updates and can keep connections uninterrupted during service updates.
+  It is suitable for large-sized clusters.
+
 ## Attributes Reference
 
 All above argument parameters can be exported as attribute parameters along with attribute reference.

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a
 	github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.1.0
+	github.com/opentelekomcloud/gophertelekomcloud v0.1.1-0.20201109134936-60486dd33662
 	github.com/smartystreets/goconvey v0.0.0-20190306220146-200a235640ff // indirect
 	github.com/unknwon/com v1.0.1
 	gopkg.in/yaml.v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -200,8 +200,8 @@ github.com/mitchellh/reflectwalk v1.0.1 h1:FVzMWA5RllMAKIdUSC8mdWo3XtwoecrH79BY7
 github.com/mitchellh/reflectwalk v1.0.1/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.1.0 h1:hcD2iTaRs7WiWMlMlg7q6zIazsYJGOEGbFwwma3RezQ=
-github.com/opentelekomcloud/gophertelekomcloud v0.1.0/go.mod h1:fQE9cCBZDAbTaf5abj29mF8mQKHBD0QVtNO1iOyEtrg=
+github.com/opentelekomcloud/gophertelekomcloud v0.1.1-0.20201109134936-60486dd33662 h1:WHNAJCteugJ6Hc7zqf7uK4jBSmfc+r1+i7A3vYVPTAM=
+github.com/opentelekomcloud/gophertelekomcloud v0.1.1-0.20201109134936-60486dd33662/go.mod h1:Xb8wlPYSv1ieZvGyMCE1XwHllda6CyzyiJ2QrkGLv2g=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -212,6 +212,7 @@ github.com/posener/complete v1.2.1/go.mod h1:6gapUrK/U1TAN7ciCoNRIdVC5sbdBTUh1DK
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
+github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/assertions v0.0.0-20190116191733-b6c0e53d7304 h1:Jpy1PXuP99tXNrhbq2BaPz9B+jNAvH1JPQQpG/9GCXY=
@@ -305,6 +306,7 @@ golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0 h1:HyfiK1WMnHj5FXFXatD+Qs1A/xC2Run6RzeW1SyHxpc=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527 h1:uYVVQ9WP/Ds2ROhcaGPeIdVq0RIXVLwsHlnvJ+cT1So=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=

--- a/opentelekomcloud/resource_opentelekomcloud_cce_cluster_v3.go
+++ b/opentelekomcloud/resource_opentelekomcloud_cce_cluster_v3.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/cce/v3/clusters"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/layer3/floatingips"
@@ -119,21 +118,14 @@ func resourceCCEClusterV3() *schema.Resource {
 				Default:  "x509",
 			},
 			"kubernetes_svc_ip_range": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ForceNew:     true,
-				ValidateFunc: validateCIDR,
-			},
-			"kube_proxy_mode": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					"iptables",
-					"ipvs",
-				}, false),
+			},
+			"kube_proxy_mode": { // can't be set via API currently
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"multi_az": {
 				Type:     schema.TypeBool,
@@ -299,7 +291,6 @@ func resourceCCEClusterV3Create(d *schema.ResourceData, meta interface{}) error 
 	d.SetId(create.Metadata.Id)
 
 	return resourceCCEClusterV3Read(d, meta)
-
 }
 
 func resourceCCEClusterV3Read(d *schema.ResourceData, meta interface{}) error {

--- a/opentelekomcloud/resource_opentelekomcloud_cce_cluster_v3.go
+++ b/opentelekomcloud/resource_opentelekomcloud_cce_cluster_v3.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/opentelekomcloud/gophertelekomcloud"
@@ -115,6 +116,22 @@ func resourceCCEClusterV3() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 				Default:  "x509",
+			},
+			"kubernetes_svc_ip_range": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ValidateFunc: validateCIDR,
+			},
+			"kube_proxy_mode": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					return ValidateStringList(v, k, []string{"iptables", "ipvs"})
+				},
 			},
 			"multi_az": {
 				Type:     schema.TypeBool,
@@ -249,8 +266,10 @@ func resourceCCEClusterV3Create(d *schema.ResourceData, meta interface{}) error 
 				Cidr: d.Get("container_network_cidr").(string)},
 			Authentication: clusters.AuthenticationSpec{Mode: d.Get("authentication_mode").(string),
 				AuthenticatingProxy: make(map[string]string)},
-			BillingMode: d.Get("billing_mode").(int),
-			ExtendParam: resourceClusterExtendParamV3(d),
+			BillingMode:          d.Get("billing_mode").(int),
+			ExtendParam:          resourceClusterExtendParamV3(d),
+			KubernetesSvcIpRange: d.Get("kubernetes_svc_ip_range").(string),
+			KubeProxyMode:        d.Get("kube_proxy_mode").(string),
 		},
 	}
 
@@ -298,30 +317,37 @@ func resourceCCEClusterV3Read(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error retrieving opentelekomcloud CCE: %s", err)
 	}
 
-	d.Set("id", n.Metadata.Id)
-	d.Set("name", n.Metadata.Name)
-	d.Set("status", n.Status.Phase)
-	d.Set("flavor_id", n.Spec.Flavor)
-	d.Set("cluster_type", n.Spec.Type)
-	d.Set("cluster_version", n.Spec.Version)
-	d.Set("description", n.Spec.Description)
-	d.Set("billing_mode", n.Spec.BillingMode)
-	d.Set("vpc_id", n.Spec.HostNetwork.VpcId)
-	d.Set("subnet_id", n.Spec.HostNetwork.SubnetId)
-	d.Set("highway_subnet_id", n.Spec.HostNetwork.HighwaySubnet)
-	d.Set("container_network_type", n.Spec.ContainerNetwork.Mode)
-	d.Set("container_network_cidr", n.Spec.ContainerNetwork.Cidr)
-	d.Set("authentication_mode", n.Spec.Authentication.Mode)
-	d.Set("internal", n.Status.Endpoints[0].Internal)
-	d.Set("external", n.Status.Endpoints[0].External)
-	d.Set("external_otc", n.Status.Endpoints[0].ExternalOTC)
-	d.Set("region", GetRegion(d, config))
+	d.SetId(n.Metadata.Id)
+	mErr := multierror.Append(nil,
+		d.Set("name", n.Metadata.Name),
+		d.Set("status", n.Status.Phase),
+		d.Set("flavor_id", n.Spec.Flavor),
+		d.Set("cluster_type", n.Spec.Type),
+		d.Set("cluster_version", n.Spec.Version),
+		d.Set("description", n.Spec.Description),
+		d.Set("billing_mode", n.Spec.BillingMode),
+		d.Set("vpc_id", n.Spec.HostNetwork.VpcId),
+		d.Set("subnet_id", n.Spec.HostNetwork.SubnetId),
+		d.Set("highway_subnet_id", n.Spec.HostNetwork.HighwaySubnet),
+		d.Set("container_network_type", n.Spec.ContainerNetwork.Mode),
+		d.Set("container_network_cidr", n.Spec.ContainerNetwork.Cidr),
+		d.Set("authentication_mode", n.Spec.Authentication.Mode),
+		d.Set("kubernetes_svc_ip_range", n.Spec.KubernetesSvcIpRange),
+		d.Set("kube_proxy_mode", n.Spec.KubeProxyMode),
+		d.Set("internal", n.Status.Endpoints[0].Internal),
+		d.Set("external", n.Status.Endpoints[0].External),
+		d.Set("external_otc", n.Status.Endpoints[0].ExternalOTC),
+		d.Set("region", GetRegion(d, config)),
+	)
 	if n.Status.Endpoints[0].External != "" {
 		eip := strings.Split(n.Status.Endpoints[0].External, "//")
 		eip = strings.Split(eip[1], ":")
-		d.Set("eip", eip[0])
+		mErr = multierror.Append(mErr, d.Set("eip", eip[0]))
 	} else {
-		d.Set("eip", "")
+		mErr = multierror.Append(mErr, d.Set("eip", ""))
+	}
+	if err := mErr.ErrorOrNil(); err != nil {
+		return fmt.Errorf("error setting cce cluster fields: %s", err)
 	}
 
 	cert, err := clusters.GetCert(cceClient, d.Id()).Extract()
@@ -329,7 +355,7 @@ func resourceCCEClusterV3Read(d *schema.ResourceData, meta interface{}) error {
 		log.Printf("Error retrieving opentelekomcloud CCE cluster cert: %s", err)
 	}
 
-	//Set Certificate Clusters
+	// Set Certificate Clusters
 	var clusterList []map[string]interface{}
 	for _, clusterObj := range cert.Clusters {
 		clusterCert := make(map[string]interface{})
@@ -338,9 +364,11 @@ func resourceCCEClusterV3Read(d *schema.ResourceData, meta interface{}) error {
 		clusterCert["certificate_authority_data"] = clusterObj.Cluster.CertAuthorityData
 		clusterList = append(clusterList, clusterCert)
 	}
-	d.Set("certificate_clusters", clusterList)
+	if err := d.Set("certificate_clusters", clusterList); err != nil {
+		return err
+	}
 
-	//Set Certificate Users
+	// Set Certificate Users
 	var userList []map[string]interface{}
 	for _, userObj := range cert.Users {
 		userCert := make(map[string]interface{})
@@ -349,7 +377,9 @@ func resourceCCEClusterV3Read(d *schema.ResourceData, meta interface{}) error {
 		userCert["client_key_data"] = userObj.User.ClientKeyData
 		userList = append(userList, userCert)
 	}
-	d.Set("certificate_users", userList)
+	if err := d.Set("certificate_users", userList); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/opentelekomcloud/resource_opentelekomcloud_cce_cluster_v3_test.go
+++ b/opentelekomcloud/resource_opentelekomcloud_cce_cluster_v3_test.go
@@ -39,6 +39,8 @@ func TestAccCCEClusterV3_basic(t *testing.T) {
 						"opentelekomcloud_cce_cluster_v3.cluster_1", "authentication_mode", "x509"),
 					resource.TestCheckResourceAttr(
 						"opentelekomcloud_cce_cluster_v3.cluster_1", "kube_proxy_mode", "iptables"),
+					resource.TestCheckResourceAttr(
+						"opentelekomcloud_cce_cluster_v3.cluster_1", "kubernetes_svc_ip_range", "10.247.0.0/16"),
 				),
 			},
 			{
@@ -46,15 +48,6 @@ func TestAccCCEClusterV3_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"opentelekomcloud_cce_cluster_v3.cluster_1", "description", "new description"),
-				),
-			},
-			{
-				Config: testAccCCEClusterV3_reCreate,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_cce_cluster_v3.cluster_1", "kubernetes_svc_ip_range", "192.168.0.0/20"),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_cce_cluster_v3.cluster_1", "kube_proxy_mode", "ipvs"),
 				),
 			},
 		},
@@ -162,6 +155,7 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   vpc_id="%s"
   subnet_id="%s"
   container_network_type="overlay_l2"
+  kubernetes_svc_ip_range = "10.247.0.0/16"
 }`, clusterName, OS_VPC_ID, OS_NETWORK_ID)
 
 var testAccCCEClusterV3_update = fmt.Sprintf(`
@@ -173,19 +167,7 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   subnet_id="%s"
   container_network_type="overlay_l2"
   description="new description"
-}`, clusterName, OS_VPC_ID, OS_NETWORK_ID)
-
-var testAccCCEClusterV3_reCreate = fmt.Sprintf(`
-resource opentelekomcloud_cce_cluster_v3 cluster_1 {
-  name = "%s"
-  cluster_type="VirtualMachine"
-  flavor_id="cce.s1.small"
-  vpc_id="%s"
-  subnet_id="%s"
-  container_network_type="overlay_l2"
-  description="new description"
-  kubernetes_svc_ip_range = "192.168.0.0/24"
-  kube_proxy_mode = "ipvs"
+  kubernetes_svc_ip_range = "10.247.0.0/16"
 }`, clusterName, OS_VPC_ID, OS_NETWORK_ID)
 
 var testAccCCEClusterV3_timeout = fmt.Sprintf(`

--- a/opentelekomcloud/resource_opentelekomcloud_cce_cluster_v3_test.go
+++ b/opentelekomcloud/resource_opentelekomcloud_cce_cluster_v3_test.go
@@ -4,11 +4,14 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/cce/v3/clusters"
 )
+
+var clusterName = fmt.Sprintf("cce-%s", acctest.RandString(5))
 
 func TestAccCCEClusterV3_basic(t *testing.T) {
 	var cluster clusters.Clusters
@@ -23,7 +26,7 @@ func TestAccCCEClusterV3_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCCEClusterV3Exists("opentelekomcloud_cce_cluster_v3.cluster_1", &cluster),
 					resource.TestCheckResourceAttr(
-						"opentelekomcloud_cce_cluster_v3.cluster_1", "name", "opentelekomcloud-cce"),
+						"opentelekomcloud_cce_cluster_v3.cluster_1", "name", clusterName),
 					resource.TestCheckResourceAttr(
 						"opentelekomcloud_cce_cluster_v3.cluster_1", "status", "Available"),
 					resource.TestCheckResourceAttr(
@@ -31,11 +34,11 @@ func TestAccCCEClusterV3_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"opentelekomcloud_cce_cluster_v3.cluster_1", "flavor_id", "cce.s1.small"),
 					resource.TestCheckResourceAttr(
-						"opentelekomcloud_cce_cluster_v3.cluster_1", "cluster_version", "v1.9.2-r2"),
-					resource.TestCheckResourceAttr(
 						"opentelekomcloud_cce_cluster_v3.cluster_1", "container_network_type", "overlay_l2"),
 					resource.TestCheckResourceAttr(
 						"opentelekomcloud_cce_cluster_v3.cluster_1", "authentication_mode", "x509"),
+					resource.TestCheckResourceAttr(
+						"opentelekomcloud_cce_cluster_v3.cluster_1", "kube_proxy_mode", "iptables"),
 				),
 			},
 			{
@@ -43,6 +46,15 @@ func TestAccCCEClusterV3_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"opentelekomcloud_cce_cluster_v3.cluster_1", "description", "new description"),
+				),
+			},
+			{
+				Config: testAccCCEClusterV3_reCreate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"opentelekomcloud_cce_cluster_v3.cluster_1", "kubernetes_svc_ip_range", "192.168.0.0/20"),
+					resource.TestCheckResourceAttr(
+						"opentelekomcloud_cce_cluster_v3.cluster_1", "kube_proxy_mode", "ipvs"),
 				),
 			},
 		},
@@ -144,33 +156,44 @@ func TestAccCCEClusterV3_withVersionDiff(t *testing.T) {
 
 var testAccCCEClusterV3_basic = fmt.Sprintf(`
 resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
-  name = "opentelekomcloud-cce"
+  name = "%s"
   cluster_type="VirtualMachine"
   flavor_id="cce.s1.small"
-  cluster_version = "v1.9.2-r2"
   vpc_id="%s"
   subnet_id="%s"
   container_network_type="overlay_l2"
-}`, OS_VPC_ID, OS_NETWORK_ID)
+}`, clusterName, OS_VPC_ID, OS_NETWORK_ID)
 
 var testAccCCEClusterV3_update = fmt.Sprintf(`
 resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
-  name = "opentelekomcloud-cce"
+  name = "%s"
   cluster_type="VirtualMachine"
   flavor_id="cce.s1.small"
-  cluster_version = "v1.9.2-r2"
   vpc_id="%s"
   subnet_id="%s"
   container_network_type="overlay_l2"
   description="new description"
-}`, OS_VPC_ID, OS_NETWORK_ID)
+}`, clusterName, OS_VPC_ID, OS_NETWORK_ID)
+
+var testAccCCEClusterV3_reCreate = fmt.Sprintf(`
+resource opentelekomcloud_cce_cluster_v3 cluster_1 {
+  name = "%s"
+  cluster_type="VirtualMachine"
+  flavor_id="cce.s1.small"
+  vpc_id="%s"
+  subnet_id="%s"
+  container_network_type="overlay_l2"
+  description="new description"
+  kubernetes_svc_ip_range = "192.168.0.0/20"
+  kube_proxy_mode = "ipvs"
+}`, clusterName, OS_VPC_ID, OS_NETWORK_ID)
 
 var testAccCCEClusterV3_timeout = fmt.Sprintf(`
 resource "opentelekomcloud_networking_floatingip_v2" "fip_1" {
 }
 
 resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
-  name = "opentelekomcloud-cce"
+  name = "%s"
   cluster_type="VirtualMachine"
   flavor_id="cce.s2.small"
   cluster_version = "v1.9.2-r2"
@@ -185,11 +208,11 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   }
   multi_az = true
 }
-`, OS_VPC_ID, OS_NETWORK_ID)
+}`, clusterName, OS_VPC_ID, OS_NETWORK_ID)
 
 var testAccCCEClusterV3_withInvalidVersion = fmt.Sprintf(`
 resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
-  name = "opentelekomcloud-cce"
+  name = "%s"
   cluster_type="VirtualMachine"
   flavor_id="cce.s1.small"
   cluster_version = "v1.9.2"
@@ -197,4 +220,4 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   subnet_id="%s"
   container_network_type="overlay_l2"
   description="new description"
-}`, OS_VPC_ID, OS_NETWORK_ID)
+}`, clusterName, OS_VPC_ID, OS_NETWORK_ID)

--- a/opentelekomcloud/resource_opentelekomcloud_cce_cluster_v3_test.go
+++ b/opentelekomcloud/resource_opentelekomcloud_cce_cluster_v3_test.go
@@ -184,7 +184,7 @@ resource opentelekomcloud_cce_cluster_v3 cluster_1 {
   subnet_id="%s"
   container_network_type="overlay_l2"
   description="new description"
-  kubernetes_svc_ip_range = "192.168.0.0/20"
+  kubernetes_svc_ip_range = "192.168.0.0/24"
   kube_proxy_mode = "ipvs"
 }`, clusterName, OS_VPC_ID, OS_NETWORK_ID)
 

--- a/vendor/github.com/opentelekomcloud/gophertelekomcloud/go.mod
+++ b/vendor/github.com/opentelekomcloud/gophertelekomcloud/go.mod
@@ -3,6 +3,7 @@ module github.com/opentelekomcloud/gophertelekomcloud
 go 1.14
 
 require (
+	github.com/sirupsen/logrus v1.7.0
 	golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a
 	gopkg.in/yaml.v2 v2.3.0
 )

--- a/vendor/github.com/opentelekomcloud/gophertelekomcloud/go.sum
+++ b/vendor/github.com/opentelekomcloud/gophertelekomcloud/go.sum
@@ -1,3 +1,11 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sirupsen/logrus v1.7.0 h1:ShrD1U9pZB12TX0cVy0DtePoCH97K8EtX+mg7ZARUtM=
+github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a h1:vclmkQCjlDX5OydZ9wv8rBCcS0QyQY66Mpf/7BZbInM=
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -5,6 +13,8 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/vendor/github.com/opentelekomcloud/gophertelekomcloud/openstack/cce/v3/clusters/results.go
+++ b/vendor/github.com/opentelekomcloud/gophertelekomcloud/openstack/cce/v3/clusters/results.go
@@ -9,184 +9,189 @@ import (
 type ListCluster struct {
 	// API type, fixed value Cluster
 	Kind string `json:"kind"`
-	//API version, fixed value v3
+	// API version, fixed value v3
 	ApiVersion string `json:"apiVersion"`
-	//all Clusters
+	// all Clusters
 	Clusters []Clusters `json:"items"`
 }
 
 type Clusters struct {
 	// API type, fixed value Cluster
 	Kind string `json:"kind" required:"true"`
-	//API version, fixed value v3
+	// API version, fixed value v3
 	ApiVersion string `json:"apiversion" required:"true"`
-	//Metadata of a Cluster
+	// Metadata of a Cluster
 	Metadata MetaData `json:"metadata" required:"true"`
-	//specifications of a Cluster
+	// specifications of a Cluster
 	Spec Spec `json:"spec" required:"true"`
-	//status of a Cluster
+	// status of a Cluster
 	Status Status `json:"status"`
 }
 
-//Metadata required to create a cluster
+// Metadata required to create a cluster
 type MetaData struct {
-	//Cluster unique name
+	// Cluster unique name
 	Name string `json:"name"`
-	//Cluster unique Id
+	// Cluster unique Id
 	Id string `json:"uid"`
 	// Cluster tag, key/value pair format
 	Labels map[string]string `json:"labels,omitempty"`
-	//Cluster annotation, key/value pair format
+	// Cluster annotation, key/value pair format
 	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
-//Specifications to create a cluster
+// Specifications to create a cluster
 type Spec struct {
-	//Cluster Type: VirtualMachine, BareMetal, or Windows
+	// Cluster Type: VirtualMachine, BareMetal, or Windows
 	Type string `json:"type" required:"true"`
 	// Cluster specifications
 	Flavor string `json:"flavor" required:"true"`
-	// For the cluster version, please fill in v1.7.3-r10 or v1.9.2-r1. Currently only Kubernetes 1.7 and 1.9 clusters are supported.
+	// Cluster's baseline Kubernetes version. The latest version is recommended
 	Version string `json:"version,omitempty"`
-	//Cluster description
+	// Cluster description
 	Description string `json:"description,omitempty"`
-	//Public IP ID
+	// Public IP ID
 	PublicIP string `json:"publicip_id,omitempty"`
 	// Node network parameters
 	HostNetwork HostNetworkSpec `json:"hostNetwork" required:"true"`
-	//Container network parameters
+	// Container network parameters
 	ContainerNetwork ContainerNetworkSpec `json:"containerNetwork" required:"true"`
-	//Authentication parameters
+	// Authentication parameters
 	Authentication AuthenticationSpec `json:"authentication,omitempty"`
 	// Charging mode of the cluster, which is 0 (on demand)
 	BillingMode int `json:"billingMode,omitempty"`
-	//Extended parameter for a cluster
+	// Extended parameter for a cluster
 	ExtendParam map[string]string `json:"extendParam,omitempty"`
+	// KubernetesSvcIpRange Service CIDR block or the IP address range which the kubernetes clusterIp must fall within.
+	// This parameter is available only for clusters of v1.11.7 and later.
+	KubernetesSvcIpRange string `json:"kubernetesSvcIpRange,omitempty"`
+	// KubeProxyMode Service forwarding mode. One of `iptables`, `ipvs`
+	KubeProxyMode string `json:"kubeProxyMode,omitempty"`
 }
 
 // Node network parameters
 type HostNetworkSpec struct {
-	//The ID of the VPC used to create the node
+	// The ID of the VPC used to create the node
 	VpcId string `json:"vpc" required:"true"`
-	//The ID of the subnet used to create the node
+	// The ID of the subnet used to create the node
 	SubnetId string `json:"subnet" required:"true"`
 	// The ID of the high speed network used to create bare metal nodes.
 	// This parameter is required when creating a bare metal cluster.
 	HighwaySubnet string `json:"highwaySubnet,omitempty"`
-	//The ID of the Security Group used to create the node
+	// The ID of the Security Group used to create the node
 	SecurityGroup string `json:"SecurityGroup,omitempty"`
 }
 
-//Container network parameters
+// Container network parameters
 type ContainerNetworkSpec struct {
-	//Container network type: overlay_l2 , underlay_ipvlan or vpc-router
+	// Container network type: overlay_l2 , underlay_ipvlan or vpc-router
 	Mode string `json:"mode" required:"true"`
-	//Container network segment: 172.16.0.0/16 ~ 172.31.0.0/16. If there is a network segment conflict, it will be automatically reselected.
+	// Container network segment: 172.16.0.0/16 ~ 172.31.0.0/16. If there is a network segment conflict, it will be automatically reselected.
 	Cidr string `json:"cidr,omitempty"`
 }
 
-//Authentication parameters
+// Authentication parameters
 type AuthenticationSpec struct {
-	//Authentication mode: rbac , x509 or authenticating_proxy
+	// Authentication mode: rbac , x509 or authenticating_proxy
 	Mode                string            `json:"mode" required:"true"`
 	AuthenticatingProxy map[string]string `json:"authenticatingProxy" required:"true"`
 }
 
 type Status struct {
-	//The state of the cluster
+	// The state of the cluster
 	Phase string `json:"phase"`
-	//The ID of the Job that is operating asynchronously in the cluster
+	// The ID of the Job that is operating asynchronously in the cluster
 	JobID string `json:"jobID"`
-	//Reasons for the cluster to become current
+	// Reasons for the cluster to become current
 	Reason string `json:"reason"`
-	//The status of each component in the cluster
+	// The status of each component in the cluster
 	Conditions Conditions `json:"conditions"`
-	//Kube-apiserver access address in the cluster
+	// Kube-apiserver access address in the cluster
 	Endpoints []Endpoints `json:"-"`
 }
 
 type Conditions struct {
-	//The type of component
+	// The type of component
 	Type string `json:"type"`
-	//The state of the component
+	// The state of the component
 	Status string `json:"status"`
-	//The reason that the component becomes current
+	// The reason that the component becomes current
 	Reason string `json:"reason"`
 }
 
 type Endpoints struct {
-	//The address accessed within the user's subnet - OpenTelekomCloud
+	// The address accessed within the user's subnet - OpenTelekomCloud
 	Url string `json:"url"`
-	//Public network access address - OpenTelekomCloud
+	// Public network access address - OpenTelekomCloud
 	Type string `json:"type"`
-	//Internal network address - OTC
+	// Internal network address - OTC
 	Internal string `json:"internal"`
-	//External network address - OTC
+	// External network address - OTC
 	External string `json:"external"`
-	//Endpoint of the cluster to be accessed through API Gateway - OTC
+	// Endpoint of the cluster to be accessed through API Gateway - OTC
 	ExternalOTC string `json:"external_otc"`
 }
 
 type Certificate struct {
-	//API type, fixed value Config
+	// API type, fixed value Config
 	Kind string `json:"kind"`
-	//API version, fixed value v1
+	// API version, fixed value v1
 	ApiVersion string `json:"apiVersion"`
-	//Cluster list
+	// Cluster list
 	Clusters []CertClusters `json:"clusters"`
-	//User list
+	// User list
 	Users []CertUsers `json:"users"`
-	//Context list
+	// Context list
 	Contexts []CertContexts `json:"contexts"`
-	//The current context
+	// The current context
 	CurrentContext string `json:"current-context"`
 }
 
 type CertClusters struct {
-	//Cluster name
+	// Cluster name
 	Name string `json:"name"`
-	//Cluster information
+	// Cluster information
 	Cluster CertCluster `json:"cluster"`
 }
 
 type CertCluster struct {
-	//Server IP address
+	// Server IP address
 	Server string `json:"server"`
-	//Certificate data
+	// Certificate data
 	CertAuthorityData string `json:"certificate-authority-data"`
 }
 
 type CertUsers struct {
-	//User name
+	// User name
 	Name string `json:"name"`
-	//Cluster information
+	// Cluster information
 	User CertUser `json:"user"`
 }
 
 type CertUser struct {
-	//Client certificate
+	// Client certificate
 	ClientCertData string `json:"client-certificate-data"`
-	//Client key data
+	// Client key data
 	ClientKeyData string `json:"client-key-data"`
 }
 
 type CertContexts struct {
-	//Context name
+	// Context name
 	Name string `json:"name"`
-	//Context information
+	// Context information
 	Context CertContext `json:"context"`
 }
 
 type CertContext struct {
-	//Cluster name
+	// Cluster name
 	Cluster string `json:"cluster"`
-	//User name
+	// User name
 	User string `json:"user"`
 }
 
 // UnmarshalJSON helps to unmarshal Status fields into needed values.
-//OTC and Huawei have different data types and child fields for `endpoints` field in Cluster Status.
-//This function handles the unmarshal for both
+// OTC and Huawei have different data types and child fields for `endpoints` field in Cluster Status.
+// This function handles the unmarshal for both
 func (r *Status) UnmarshalJSON(b []byte) error {
 	type tmp Status
 	var s struct {
@@ -198,7 +203,7 @@ func (r *Status) UnmarshalJSON(b []byte) error {
 
 	if err != nil {
 		switch err.(type) {
-		case *json.UnmarshalTypeError: //check if type error occurred (handles the different endpoint structure for huawei and otc)
+		case *json.UnmarshalTypeError: // check if type error occurred (handles the different endpoint structure for huawei and otc)
 			var s struct {
 				tmp
 				Endpoints Endpoints `json:"endpoints"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -237,7 +237,7 @@ github.com/mitchellh/mapstructure
 github.com/mitchellh/reflectwalk
 # github.com/oklog/run v1.0.0
 github.com/oklog/run
-# github.com/opentelekomcloud/gophertelekomcloud v0.1.0
+# github.com/opentelekomcloud/gophertelekomcloud v0.1.1-0.20201109134936-60486dd33662
 ## explicit
 github.com/opentelekomcloud/gophertelekomcloud
 github.com/opentelekomcloud/gophertelekomcloud/internal


### PR DESCRIPTION
# Summary of the Pull Request
Add `kubernetes_svc_ip_range` and `kube_proxy_mode` fields to `cce_cluster_v3` resource
Update `opentelekomcloud/gophertelekomcloud` dependency

Resolves #680 

## Reference:
https://docs.otc.t-systems.com/en-us/api2/cce/cce_02_0236.html

## PR Checklist

* [x] Refers to: #680 
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed
```
=== RUN   TestAccCCEClusterV3_basic
--- PASS: TestAccCCEClusterV3_basic (1580.83s)
PASS
```

