### PR TITLE
Make `user_id` optional in `identity_credential_v3`

### DIFF
--- a/docs/resources/identity_credential_v3.md
+++ b/docs/resources/identity_credential_v3.md
@@ -8,13 +8,9 @@ Manages permanent access key for an OpenTelekomCloud user.
 
 ## Example Usage
 
-#### Create AK/SK for exact user
+#### Create AK/SK for yourself
 ```hcl
-variable user_id {}
-
-resource opentelekomcloud_identity_credential_v3 aksk {
-  user_id = var.user_id
-}
+resource opentelekomcloud_identity_credential_v3 aksk {}
 ```
 
 #### Create user with AK/SK
@@ -35,7 +31,7 @@ resource opentelekomcloud_identity_credential_v3 aksk {
 
 The following arguments are supported:
 
-* `user_id` - (Required) IAM user ID.
+* `user_id` - (Optional) IAM user ID. If not set, will create AK/SK for yourself.
 
 * `description` - (Optional) Description of the access key.
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a
 	github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.1.1-0.20201130152443-bb08866de936
+	github.com/opentelekomcloud/gophertelekomcloud v0.1.1-0.20201202074602-ed5944d36c96
 	github.com/smartystreets/goconvey v0.0.0-20190306220146-200a235640ff // indirect
 	github.com/unknwon/com v1.0.1
 	gopkg.in/yaml.v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -200,8 +200,8 @@ github.com/mitchellh/reflectwalk v1.0.1 h1:FVzMWA5RllMAKIdUSC8mdWo3XtwoecrH79BY7
 github.com/mitchellh/reflectwalk v1.0.1/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.1.1-0.20201130152443-bb08866de936 h1:XDQ8wr8jwg6qgDaNlLsjr0TK+dkw8cqRPdXB/B6G0KM=
-github.com/opentelekomcloud/gophertelekomcloud v0.1.1-0.20201130152443-bb08866de936/go.mod h1:Xb8wlPYSv1ieZvGyMCE1XwHllda6CyzyiJ2QrkGLv2g=
+github.com/opentelekomcloud/gophertelekomcloud v0.1.1-0.20201202074602-ed5944d36c96 h1:lY/TngY8FgwFmqaXUIwrAz8xfQ4LtA9mE1lvXjuTeek=
+github.com/opentelekomcloud/gophertelekomcloud v0.1.1-0.20201202074602-ed5944d36c96/go.mod h1:Xb8wlPYSv1ieZvGyMCE1XwHllda6CyzyiJ2QrkGLv2g=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/opentelekomcloud/data_source_opentelekomcloud_identity_credential_v3.go
+++ b/opentelekomcloud/data_source_opentelekomcloud_identity_credential_v3.go
@@ -52,7 +52,7 @@ func dataSourceIdentityCredentialV3Read(d *schema.ResourceData, meta interface{}
 	config := meta.(*Config)
 	client, err := config.identityV30Client()
 	if err != nil {
-		return fmt.Errorf("error creating OpenStack identity client: %s", err)
+		return fmt.Errorf("error creating identity v3.0 client: %s", err)
 	}
 	userID := d.Get("user_id").(string)
 	credentialList, err := credentials.List(client, credentials.ListOpts{UserID: userID}).Extract()

--- a/opentelekomcloud/import_opentelekomcloud_identity_credential_v3_test.go
+++ b/opentelekomcloud/import_opentelekomcloud_identity_credential_v3_test.go
@@ -1,0 +1,30 @@
+package opentelekomcloud
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccIdentityV3Credential_importBasic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIdentityV3UserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIdentityV3CredentialBasic,
+			},
+			{
+				ResourceName:      "opentelekomcloud_identity_credential_v3.aksk",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"secret",
+				},
+			},
+		},
+	})
+}

--- a/opentelekomcloud/provider_test.go
+++ b/opentelekomcloud/provider_test.go
@@ -39,7 +39,6 @@ var (
 	OS_TO_TENANT_ID           = os.Getenv("OS_TO_TENANT_ID")
 	OS_TENANT_NAME            = getTenantName()
 	OS_VPN_ENVIRONMENT        = os.Getenv("OS_VPN_ENVIRONMENT")
-	OS_USER_ID                = os.Getenv("OS_USER_ID")
 )
 
 var testAccProviders map[string]terraform.ResourceProvider

--- a/opentelekomcloud/resource_opentelekomcloud_identity_credential_v3.go
+++ b/opentelekomcloud/resource_opentelekomcloud_identity_credential_v3.go
@@ -63,6 +63,11 @@ func resourceIdentityCredentialV3Create(d *schema.ResourceData, meta interface{}
 		userID = client.UserID
 	}
 
+	if userID == "" {
+		return fmt.Errorf("error defining current user ID, please either provide " +
+			"`user_id` or authenticate with token auth (not using AK/SK)")
+	}
+
 	credential, err := credentials.Create(client, credentials.CreateOpts{
 		UserID:      userID.(string),
 		Description: d.Get("description").(string),

--- a/opentelekomcloud/resource_opentelekomcloud_identity_credential_v3.go
+++ b/opentelekomcloud/resource_opentelekomcloud_identity_credential_v3.go
@@ -20,7 +20,7 @@ func resourceIdentityCredentialV3() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"user_id": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 			"description": {
 				Type:     schema.TypeString,
@@ -58,8 +58,13 @@ func resourceIdentityCredentialV3Create(d *schema.ResourceData, meta interface{}
 		return fmt.Errorf("error creating OpenStack identity client: %s", err)
 	}
 
+	userID, ok := d.GetOk("user_id")
+	if !ok {
+		userID = client.UserID
+	}
+
 	credential, err := credentials.Create(client, credentials.CreateOpts{
-		UserID:      d.Get("user_id").(string),
+		UserID:      userID.(string),
 		Description: d.Get("description").(string),
 	}).Extract()
 	if err != nil {

--- a/opentelekomcloud/resource_opentelekomcloud_identity_credential_v3.go
+++ b/opentelekomcloud/resource_opentelekomcloud_identity_credential_v3.go
@@ -21,6 +21,7 @@ func resourceIdentityCredentialV3() *schema.Resource {
 			"user_id": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"description": {
 				Type:     schema.TypeString,

--- a/opentelekomcloud/resource_opentelekomcloud_identity_credential_v3_test.go
+++ b/opentelekomcloud/resource_opentelekomcloud_identity_credential_v3_test.go
@@ -11,7 +11,10 @@ import (
 
 func TestAccIdentityV3Credential_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			checkAKSKUnset(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccIdentityV3CredentialDestroy,
 		Steps: []resource.TestStep{
@@ -43,7 +46,7 @@ func testAccIdentityV3CredentialDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 	client, err := config.identityV3Client(OS_REGION_NAME)
 	if err != nil {
-		return fmt.Errorf("error creating OpenStack identity client: %s", err)
+		return fmt.Errorf("error creating identity v3 client: %s", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -59,6 +62,12 @@ func testAccIdentityV3CredentialDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func checkAKSKUnset(t *testing.T) {
+	if OS_SECRET_KEY != "" && OS_ACCESS_KEY != "" {
+		t.Error("AK/SK should not be set for AK/SK creation test")
+	}
 }
 
 const (

--- a/opentelekomcloud/resource_opentelekomcloud_identity_credential_v3_test.go
+++ b/opentelekomcloud/resource_opentelekomcloud_identity_credential_v3_test.go
@@ -11,15 +11,12 @@ import (
 
 func TestAccIdentityV3Credential_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-			testIdentityCredentialPrecheck(t)
-		},
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccIdentityV3CredentialDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccIdentityV3CredentialBasic, OS_USER_ID),
+				Config: testAccIdentityV3CredentialBasic,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("opentelekomcloud_identity_credential_v3.aksk", "user_id"),
 					resource.TestCheckResourceAttrSet("opentelekomcloud_identity_credential_v3.aksk", "description"),
@@ -40,12 +37,6 @@ func TestAccIdentityV3Credential_basic(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testIdentityCredentialPrecheck(t *testing.T) {
-	if OS_USER_ID == "" {
-		t.Error("OS_USER_ID is required for credentials test")
-	}
 }
 
 func testAccIdentityV3CredentialDestroy(s *terraform.State) error {
@@ -72,9 +63,7 @@ func testAccIdentityV3CredentialDestroy(s *terraform.State) error {
 
 const (
 	testAccIdentityV3CredentialBasic = `
-
 resource opentelekomcloud_identity_credential_v3 aksk {
-  user_id = "%s"
   description = "This is one and unique test AK/SK"
 }
 `

--- a/opentelekomcloud/resource_opentelekomcloud_identity_credential_v3_test.go
+++ b/opentelekomcloud/resource_opentelekomcloud_identity_credential_v3_test.go
@@ -31,11 +31,17 @@ func TestAccIdentityV3Credential_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: fmt.Sprintf(testAccIdentityV3CredentialUpdate, OS_USER_ID),
+				Config: testAccIdentityV3CredentialUpdateStatus,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("opentelekomcloud_identity_credential_v3.aksk", "access"),
 					resource.TestCheckResourceAttrSet("opentelekomcloud_identity_credential_v3.aksk", "secret"),
 					resource.TestCheckResourceAttr("opentelekomcloud_identity_credential_v3.aksk", "status", "inactive"),
+				),
+			},
+			{
+				Config: testAccIdentityV3CredentialUpdateDescription,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("opentelekomcloud_identity_credential_v3.aksk", "description", "This is one and unique test AK/SK 2"),
 				),
 			},
 		},
@@ -76,10 +82,15 @@ resource opentelekomcloud_identity_credential_v3 aksk {
   description = "This is one and unique test AK/SK"
 }
 `
-	testAccIdentityV3CredentialUpdate = `
+	testAccIdentityV3CredentialUpdateStatus = `
 resource opentelekomcloud_identity_credential_v3 aksk {
-  user_id = "%s"
   description = "This is one and unique test AK/SK"
+  status  = "inactive"
+}
+`
+	testAccIdentityV3CredentialUpdateDescription = `
+resource opentelekomcloud_identity_credential_v3 aksk {
+  description = "This is one and unique test AK/SK 2"
   status  = "inactive"
 }
 `

--- a/vendor/github.com/opentelekomcloud/gophertelekomcloud/openstack/client.go
+++ b/vendor/github.com/opentelekomcloud/gophertelekomcloud/openstack/client.go
@@ -196,6 +196,7 @@ func v3auth(client *golangsdk.ProviderClient, endpoint string, opts tokens3.Auth
 	}
 	if user != nil {
 		client.UserID = user.ID
+		client.DomainID = user.Domain.ID
 	}
 
 	if opts.CanReauth() {

--- a/vendor/github.com/opentelekomcloud/gophertelekomcloud/openstack/utils/utils.go
+++ b/vendor/github.com/opentelekomcloud/gophertelekomcloud/openstack/utils/utils.go
@@ -1,13 +1,12 @@
 package utils
 
 import (
-	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"os"
 	"reflect"
 	"strings"
-)
 
-const defaultRegion = "eu-de"
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+)
 
 func DeleteNotPassParams(params *map[string]interface{}, notPassParams []string) {
 	for _, i := range notPassParams {
@@ -75,21 +74,19 @@ func In(item interface{}, slice interface{}) bool {
 }
 
 // GetRegion returns the region that was specified in the auth options. If a
-// region was not set it returns value from env OS_REGION_NAME or defaultRegion
-// "eu-de"
+// region was not set it returns value from env OS_REGION_NAME
 func GetRegion(authOpts golangsdk.AuthOptions) string {
 	n := authOpts.TenantName
+	region := ""
 	if n == "" {
 		n = authOpts.DelegatedProject
+	} else {
+		region = strings.Split(n, "_")[0]
 	}
-	defRegion := defaultRegion
-	if len(n) != 0 {
-		defRegion = strings.Split(n, "_")[0]
-	}
-	return getenv("OS_REGION_NAME", defRegion)
+	return getenv("OS_REGION_NAME", region)
 }
 
-//getenv returns value from env is present or default value
+// getenv returns value from env is present or default value
 func getenv(key, fallback string) string {
 	value := os.Getenv(key)
 	if value == "" {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -237,7 +237,7 @@ github.com/mitchellh/mapstructure
 github.com/mitchellh/reflectwalk
 # github.com/oklog/run v1.0.0
 github.com/oklog/run
-# github.com/opentelekomcloud/gophertelekomcloud v0.1.1-0.20201130152443-bb08866de936
+# github.com/opentelekomcloud/gophertelekomcloud v0.1.1-0.20201202074602-ed5944d36c96
 ## explicit
 github.com/opentelekomcloud/gophertelekomcloud
 github.com/opentelekomcloud/gophertelekomcloud/internal


### PR DESCRIPTION
## Summary of the Pull Request
Passing `user_id` is not required when creating AK/SK for yourself: we have information about user ID in credentials

Resolves #730

## PR Checklist

* [x] Refers to: #730
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

Resource:
```
=== RUN   TestAccIdentityV3Credential_basic
--- PASS: TestAccIdentityV3Credential_basic (18.55s)
PASS

Process finished with exit code 0
```

Import:
```
=== RUN   TestAccIdentityV3Credential_importBasic
--- PASS: TestAccIdentityV3Credential_importBasic (7.94s)
PASS

Process finished with exit code 0
```
