### PR TITLE
Update opentelekomcloud/gophertelekomcloud to v0.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a
 	github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.1.1-0.20201202074602-ed5944d36c96
+	github.com/opentelekomcloud/gophertelekomcloud v0.2.0
 	github.com/smartystreets/goconvey v0.0.0-20190306220146-200a235640ff // indirect
 	github.com/unknwon/com v1.0.1
 	gopkg.in/yaml.v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -200,8 +200,8 @@ github.com/mitchellh/reflectwalk v1.0.1 h1:FVzMWA5RllMAKIdUSC8mdWo3XtwoecrH79BY7
 github.com/mitchellh/reflectwalk v1.0.1/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.1.1-0.20201202074602-ed5944d36c96 h1:lY/TngY8FgwFmqaXUIwrAz8xfQ4LtA9mE1lvXjuTeek=
-github.com/opentelekomcloud/gophertelekomcloud v0.1.1-0.20201202074602-ed5944d36c96/go.mod h1:Xb8wlPYSv1ieZvGyMCE1XwHllda6CyzyiJ2QrkGLv2g=
+github.com/opentelekomcloud/gophertelekomcloud v0.2.0 h1:mA/+aYiJz8FjX3+aqAvbgsuFAYWlHfsjGM1sachI5NA=
+github.com/opentelekomcloud/gophertelekomcloud v0.2.0/go.mod h1:2VmHKlpPMgw4mBsmmwaEeBo0xXqAVCjHmIOomsTD4TU=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
## Summary of the Pull Request
Update SDK to version [`v0.2.0`](https://github.com/opentelekomcloud/gophertelekomcloud/releases/tag/v0.2.0)
