### PR TITLE
Allow using OBS client without AK/SK

### DIFF
--- a/opentelekomcloud/resource_opentelekomcloud_obs_bucket_object_test.go
+++ b/opentelekomcloud/resource_opentelekomcloud_obs_bucket_object_test.go
@@ -27,7 +27,7 @@ func TestAccObsBucketObject_source(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckS3(t) },
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckObsBucketObjectDestroy,
 		Steps: []resource.TestStep{
@@ -59,7 +59,7 @@ func TestAccObsBucketObject_content(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckS3(t) },
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckObsBucketObjectDestroy,
 		Steps: []resource.TestStep{
@@ -101,7 +101,7 @@ func testAccCheckObsBucketObjectDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 	obsClient, err := config.newObjectStorageClient(OS_REGION_NAME)
 	if err != nil {
-		return fmt.Errorf("Error creating OpenTelekomCloud OBS client: %s", err)
+		return fmt.Errorf("error creating OpenTelekomCloud OBS client: %s", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -120,7 +120,7 @@ func testAccCheckObsBucketObjectDestroy(s *terraform.State) error {
 			if obsError, ok := err.(obs.ObsError); ok && obsError.Code == "NoSuchBucket" {
 				return nil
 			}
-			return fmt.Errorf("Error listing objects of OBS bucket %s: %s", bucket, err)
+			return fmt.Errorf("error listing objects of OBS bucket %s: %s", bucket, err)
 		}
 
 		var exist bool
@@ -131,7 +131,7 @@ func testAccCheckObsBucketObjectDestroy(s *terraform.State) error {
 			}
 		}
 		if exist {
-			return fmt.Errorf("Resource %s still exists in bucket %s", rs.Primary.ID, bucket)
+			return fmt.Errorf("resource %s still exists in bucket %s", rs.Primary.ID, bucket)
 		}
 	}
 
@@ -142,17 +142,17 @@ func testAccCheckObsBucketObjectExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Not Found: %s", n)
+			return fmt.Errorf("not Found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No OBS Bucket Object ID is set")
+			return fmt.Errorf("no OBS Bucket Object ID is set")
 		}
 
 		config := testAccProvider.Meta().(*Config)
 		obsClient, err := config.newObjectStorageClient(OS_REGION_NAME)
 		if err != nil {
-			return fmt.Errorf("Error creating OpenTelekomCloud OBS client: %s", err)
+			return fmt.Errorf("error creating OpenTelekomCloud OBS client: %s", err)
 		}
 
 		bucket := rs.Primary.Attributes["bucket"]
@@ -163,7 +163,7 @@ func testAccCheckObsBucketObjectExists(n string) resource.TestCheckFunc {
 
 		resp, err := obsClient.ListObjects(input)
 		if err != nil {
-			return getObsError("Error listing objects of OBS bucket", bucket, err)
+			return getObsError("error listing objects of OBS bucket", bucket, err)
 		}
 
 		var exist bool
@@ -174,7 +174,7 @@ func testAccCheckObsBucketObjectExists(n string) resource.TestCheckFunc {
 			}
 		}
 		if !exist {
-			return fmt.Errorf("Resource %s not found in bucket %s", rs.Primary.ID, bucket)
+			return fmt.Errorf("resource %s not found in bucket %s", rs.Primary.ID, bucket)
 		}
 
 		return nil

--- a/opentelekomcloud/resource_opentelekomcloud_obs_bucket_test.go
+++ b/opentelekomcloud/resource_opentelekomcloud_obs_bucket_test.go
@@ -14,7 +14,7 @@ func TestAccObsBucket_basic(t *testing.T) {
 	resourceName := "opentelekomcloud_obs_bucket.bucket"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckS3(t) },
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckObsBucketDestroy,
 		Steps: []resource.TestStep{
@@ -68,7 +68,7 @@ func TestAccObsBucket_tags(t *testing.T) {
 	resourceName := "opentelekomcloud_obs_bucket.bucket"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheckS3(t) },
+		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -91,7 +91,7 @@ func TestAccObsBucket_versioning(t *testing.T) {
 	resourceName := "opentelekomcloud_obs_bucket.bucket"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckS3(t) },
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckObsBucketDestroy,
 		Steps: []resource.TestStep{
@@ -121,7 +121,7 @@ func TestAccObsBucket_logging(t *testing.T) {
 	resourceName := "opentelekomcloud_obs_bucket.bucket"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckS3(t) },
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckObsBucketDestroy,
 		Steps: []resource.TestStep{
@@ -141,7 +141,7 @@ func TestAccObsBucket_lifecycle(t *testing.T) {
 	resourceName := "opentelekomcloud_obs_bucket.bucket"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckS3(t) },
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckObsBucketDestroy,
 		Steps: []resource.TestStep{
@@ -180,7 +180,7 @@ func TestAccObsBucket_website(t *testing.T) {
 	resourceName := "opentelekomcloud_obs_bucket.bucket"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckS3(t) },
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckObsBucketDestroy,
 		Steps: []resource.TestStep{
@@ -203,7 +203,7 @@ func TestAccObsBucket_cors(t *testing.T) {
 	resourceName := "opentelekomcloud_obs_bucket.bucket"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckS3(t) },
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckObsBucketDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
## Summary of the Pull Request
If no AK/SK is provided, issue a temporary one.

This affects following resources:
- `opentelekomcloud_obs_bucket`
- `opentelekomcloud_obs_bucket_object`

Fix #713: Temporary AK/SK is tested (in opentelekomcloud/gophertelekomcloud#53) to work with the agency auth

## PR Checklist

* [x] Refers to: #713 
* [x] Tests added/passed.

## Acceptance Steps Performed

### Bucket
```
=== RUN   TestAccObsBucket_basic
--- PASS: TestAccObsBucket_basic (17.22s)
=== RUN   TestAccObsBucket_aksk
    provider_test.go:186: OS_ACCESS_KEY and OS_SECRET_KEY must be set for OBS/S3 acceptance tests
--- SKIP: TestAccObsBucket_aksk (0.00s)

Test ignored.
=== RUN   TestAccObsBucket_tags
--- PASS: TestAccObsBucket_tags (10.11s)
=== RUN   TestAccObsBucket_versioning
--- PASS: TestAccObsBucket_versioning (18.27s)
=== RUN   TestAccObsBucket_logging
--- PASS: TestAccObsBucket_logging (14.13s)
=== RUN   TestAccObsBucket_lifecycle
--- PASS: TestAccObsBucket_lifecycle (9.87s)
=== RUN   TestAccObsBucket_website
--- PASS: TestAccObsBucket_website (10.01s)
=== RUN   TestAccObsBucket_cors
--- PASS: TestAccObsBucket_cors (11.15s)
PASS

Process finished with exit code 0
```

### Object
```
=== RUN   TestAccObsBucketObject_source
--- PASS: TestAccObsBucketObject_source (18.56s)
=== RUN   TestAccObsBucketObject_content
--- PASS: TestAccObsBucketObject_content (11.24s)
=== RUN   TestAccObsBucketObject_contentAKSK
    provider_test.go:186: OS_ACCESS_KEY and OS_SECRET_KEY must be set for OBS/S3 acceptance tests
--- SKIP: TestAccObsBucketObject_contentAKSK (0.00s)

Test ignored.
PASS

Process finished with exit code 0
```
