### PR TITLE
Remove `credentials` from `obs_bucket` and `obs_bucket_object`

### DIFF
--- a/docs/resources/obs_bucket.md
+++ b/docs/resources/obs_bucket.md
@@ -139,23 +139,6 @@ resource "opentelekomcloud_obs_bucket" "bucket" {
 }
 ```
 
-### Using ak/sk defined in the resource
-
-```hcl
-variable ak {}
-variable sk {}
-
-resource "opentelekomcloud_obs_bucket" "bucket" {
-  bucket        = "my-bucket"
-  storage_class = "STANDARD"
-  acl           = "private"
-  credentials {
-    access_key = var.ak
-    secret_key = var.sk
-  }
-}
-```
-
 ## Argument Reference
 
 The following arguments are supported:
@@ -189,8 +172,6 @@ The following arguments are supported:
 * `force_destroy` - (Optional) A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. Default to `false`.
 
 * `region` - (Optional) If specified, the region this bucket should reside in. Otherwise, the region used by the provider.
-
-* `credentials` - (Optional) Access key information for a single bucket only.
 
 The `logging` object supports the following:
 
@@ -274,12 +255,6 @@ The `noncurrent_version_transition` object supports the following
 * `days` - (Required) Specifies the number of days when noncurrent object versions are automatically transitioned to the specified storage class.
 
 * `storage_class` - (Required) The class of storage used to store the object. Only `WARM` and `COLD` are supported.
-
-The `credentials` object supports the following:
-
-* `access_key` - (Required) Access key ID.
-
-* `secret_key` - (Required) Access key secret.
 
 ## Attributes Reference
 

--- a/docs/resources/obs_bucket_object.md
+++ b/docs/resources/obs_bucket_object.md
@@ -45,33 +45,6 @@ resource "opentelekomcloud_obs_bucket_object" "examplebucket_object" {
 }
 ```
 
-### Using ak/sk defined in the resource
-
-```hcl
-variable ak {}
-variable sk {}
-
-resource "opentelekomcloud_obs_bucket" "object_bucket" {
-  bucket        = "my-bucket"
-  storage_class = "STANDARD"
-  acl           = "private"
-  credentials {
-    access_key = var.ak
-    secret_key = var.sk
-  }
-}
-
-resource "opentelekomcloud_obs_bucket_object" "object" {
-  bucket  = opentelekomcloud_obs_bucket.object_bucket.bucket
-  key     = "test-key"
-  content = "some_bucket_content"
-  credentials {
-    access_key = var.ak
-    secret_key = var.sk
-  }
-}
-```
-
 ## Argument Reference
 
 The following arguments are supported:
@@ -97,12 +70,6 @@ The following arguments are supported:
 
 * `etag` - (Optional) Specifies the unique identifier of the object content. It can be used to trigger updates.
   The only meaningful value is `md5(file("path_to_file"))`.
-
-* `credentials` - (Optional) Access key information for a single bucket object.
-
-    * `access_key` - (Required) Access key ID.
-
-    * `secret_key` - (Required) Access key secret.
 
 Either `source` or `content` must be provided to specify the bucket content.
 These two arguments are mutually-exclusive.

--- a/opentelekomcloud/resource_opentelekomcloud_obs_bucket_object.go
+++ b/opentelekomcloud/resource_opentelekomcloud_obs_bucket_object.go
@@ -121,11 +121,10 @@ func resourceObsBucketObjectPut(d *schema.ResourceData, meta interface{}) error 
 	var err error
 
 	config := meta.(*Config)
-	client, err := obsClient(d, config)
+	client, err := config.newObjectStorageClient(GetRegion(d, config))
 	if err != nil {
-		return err
+		return fmt.Errorf("error creating OBS client: %s", err)
 	}
-
 	source := d.Get("source").(string)
 	content := d.Get("content").(string)
 	if source == "" && content == "" {
@@ -238,9 +237,9 @@ func putFileToObject(obsClient *obs.ObsClient, d *schema.ResourceData) (*obs.Put
 
 func resourceObsBucketObjectRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := obsClient(d, config)
+	client, err := config.newObjectStorageClient(GetRegion(d, config))
 	if err != nil {
-		return err
+		return fmt.Errorf("error creating OBS client: %s", err)
 	}
 
 	bucket := d.Get("bucket").(string)
@@ -289,9 +288,9 @@ func resourceObsBucketObjectRead(d *schema.ResourceData, meta interface{}) error
 
 func resourceObsBucketObjectDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := obsClient(d, config)
+	client, err := config.newObjectStorageClient(GetRegion(d, config))
 	if err != nil {
-		return err
+		return fmt.Errorf("error creating OBS client: %s", err)
 	}
 
 	bucket := d.Get("bucket").(string)

--- a/opentelekomcloud/resource_opentelekomcloud_obs_bucket_object_test.go
+++ b/opentelekomcloud/resource_opentelekomcloud_obs_bucket_object_test.go
@@ -78,25 +78,6 @@ func TestAccObsBucketObject_content(t *testing.T) {
 	})
 }
 
-func TestAccObsBucketObject_contentAKSK(t *testing.T) {
-	rInt := acctest.RandInt()
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckS3(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckObsBucketObjectDestroy,
-		Steps: []resource.TestStep{
-			{
-				PreConfig: func() {},
-				Config:    testAccObsBucketObjectConfigContent_aksk(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckObsBucketObjectExists("opentelekomcloud_obs_bucket_object.object"),
-				),
-			},
-		},
-	})
-}
-
 func testAccCheckObsBucketObjectDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 	obsClient, err := config.newObjectStorageClient(OS_REGION_NAME)
@@ -179,31 +160,6 @@ func testAccCheckObsBucketObjectExists(n string) resource.TestCheckFunc {
 
 		return nil
 	}
-}
-
-func testAccObsBucketObjectConfigContent_aksk(randInt int) string {
-	return fmt.Sprintf(`
-resource "opentelekomcloud_obs_bucket" "object_bucket" {
-  bucket        = "tf-test-bucket-%d"
-  storage_class = "STANDARD"
-  acl           = "private"
-  credentials {
-    access_key = "%[2]s"
-    secret_key = "%[3]s"
-  }
-}
-
-resource "opentelekomcloud_obs_bucket_object" "object" {
-  bucket  = opentelekomcloud_obs_bucket.object_bucket.bucket
-  key     = "test-key"
-  content = "some_bucket_content"
-  credentials {
-    access_key = "%[2]s"
-    secret_key = "%[3]s"
-  }
-}
-
-`, randInt, OS_ACCESS_KEY, OS_SECRET_KEY)
 }
 
 func testAccObsBucketObjectConfigSource(randInt int, source string) string {

--- a/opentelekomcloud/resource_opentelekomcloud_obs_bucket_test.go
+++ b/opentelekomcloud/resource_opentelekomcloud_obs_bucket_test.go
@@ -48,21 +48,6 @@ func TestAccObsBucket_basic(t *testing.T) {
 	})
 }
 
-func TestAccObsBucket_aksk(t *testing.T) {
-	rInt := acctest.RandInt()
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckS3(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckObsBucketDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccObsBucket_aksk(rInt),
-			},
-		},
-	})
-}
-
 func TestAccObsBucket_tags(t *testing.T) {
 	rInt := acctest.RandInt()
 	resourceName := "opentelekomcloud_obs_bucket.bucket"
@@ -320,19 +305,6 @@ resource "opentelekomcloud_obs_bucket" "bucket" {
   acl           = "private"
 }
 `, randInt)
-}
-func testAccObsBucket_aksk(randInt int) string {
-	return fmt.Sprintf(`
-resource "opentelekomcloud_obs_bucket" "bucket" {
-  bucket        = "tf-test-bucket-%d"
-  storage_class = "STANDARD"
-  acl           = "private"
-  credentials {
-    access_key = "%s"
-    secret_key = "%s"
-  }
-}
-`, randInt, OS_ACCESS_KEY, OS_SECRET_KEY)
 }
 
 func testAccObsBucket_basic_update(randInt int) string {


### PR DESCRIPTION
## Summary of the Pull Request
Revert #732

The existing implementation is no more useful after implementing #745 
As it's implemented during the same release, so no deprecation needs to be done

## PR Checklist

* [x] Refers to: #745, #732
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

### W/o AK/SK

#### Bucket:
```
=== RUN   TestAccObsBucket_basic
--- PASS: TestAccObsBucket_basic (18.81s)
=== RUN   TestAccObsBucket_tags
--- PASS: TestAccObsBucket_tags (10.10s)
=== RUN   TestAccObsBucket_versioning
--- PASS: TestAccObsBucket_versioning (18.33s)
=== RUN   TestAccObsBucket_logging
--- PASS: TestAccObsBucket_logging (14.59s)
=== RUN   TestAccObsBucket_lifecycle
--- PASS: TestAccObsBucket_lifecycle (10.89s)
=== RUN   TestAccObsBucket_website
--- PASS: TestAccObsBucket_website (10.43s)
=== RUN   TestAccObsBucket_cors
--- PASS: TestAccObsBucket_cors (10.37s)
PASS

Process finished with exit code 0
```

#### Bucket object:

```
=== RUN   TestAccObsBucketObject_source
--- PASS: TestAccObsBucketObject_source (19.73s)
=== RUN   TestAccObsBucketObject_content
--- PASS: TestAccObsBucketObject_content (11.54s)
PASS

Process finished with exit code 0
```

### W/ AK/SK

#### Bucket:

```
=== RUN   TestAccObsBucket_basic
--- PASS: TestAccObsBucket_basic (54.21s)
=== RUN   TestAccObsBucket_tags
--- PASS: TestAccObsBucket_tags (21.75s)
=== RUN   TestAccObsBucket_versioning
--- PASS: TestAccObsBucket_versioning (44.25s)
=== RUN   TestAccObsBucket_logging
--- PASS: TestAccObsBucket_logging (29.93s)
=== RUN   TestAccObsBucket_lifecycle
--- PASS: TestAccObsBucket_lifecycle (55.16s)
=== RUN   TestAccObsBucket_website
--- PASS: TestAccObsBucket_website (28.94s)
=== RUN   TestAccObsBucket_cors
--- PASS: TestAccObsBucket_cors (32.77s)
PASS

Process finished with exit code 0
```

#### Object:
```
=== RUN   TestAccObsBucketObject_source
--- PASS: TestAccObsBucketObject_source (42.59s)
=== RUN   TestAccObsBucketObject_content
--- PASS: TestAccObsBucketObject_content (22.90s)
PASS

Process finished with exit code 0
```
