### PR TITLE
Remove non-existing credential instead returning error

### DIFF
--- a/opentelekomcloud/util.go
+++ b/opentelekomcloud/util.go
@@ -147,8 +147,7 @@ func isResourceNotFound(err error) bool {
 		return false
 	}
 	_, ok := err.(golangsdk.ErrDefault404)
-	_, ok1 := err.(golangsdk.ErrDefault404)
-	return ok || ok1
+	return ok
 }
 
 func expandToStringSlice(v []interface{}) []string {


### PR DESCRIPTION
## Summary of the Pull Request
Fix #752

Unset ID instead returning error during `identity_credential_v3` read operation

Remove the second redundant check at `isResourceNotFound`


## PR Checklist

* [x] Refers to: #752 
* [x] Tests added/passed.

## Acceptance Steps Performed

```
=== RUN   TestAccIdentityV3Credential_basic
--- PASS: TestAccIdentityV3Credential_basic (18.92s)
PASS

Process finished with exit code 0
```
