### PR TITLE
prevent SIGSEGV in data_source_opentelekomcloud_networking_secgroup_v2

### DIFF
--- a/opentelekomcloud/data_source_opentelekomcloud_networking_secgroup_v2.go
+++ b/opentelekomcloud/data_source_opentelekomcloud_networking_secgroup_v2.go
@@ -49,6 +49,10 @@ func dataSourceNetworkingSecGroupV2Read(d *schema.ResourceData, meta interface{}
 	}
 
 	pages, err := groups.List(networkingClient, listOpts).AllPages()
+	if err != nil {
+		return fmt.Errorf("Unable to list security groups: %s", err)
+	}
+	
 	allSecGroups, err := groups.ExtractGroups(pages)
 	if err != nil {
 		return fmt.Errorf("Unable to retrieve security groups: %s", err)

--- a/opentelekomcloud/data_source_opentelekomcloud_networking_secgroup_v2.go
+++ b/opentelekomcloud/data_source_opentelekomcloud_networking_secgroup_v2.go
@@ -52,7 +52,7 @@ func dataSourceNetworkingSecGroupV2Read(d *schema.ResourceData, meta interface{}
 	if err != nil {
 		return fmt.Errorf("Unable to list security groups: %s", err)
 	}
-	
+
 	allSecGroups, err := groups.ExtractGroups(pages)
 	if err != nil {
 		return fmt.Errorf("Unable to retrieve security groups: %s", err)


### PR DESCRIPTION
## Summary of the Pull Request

prevent SIGSEGV in data_source_opentelekomcloud_networking_secgroup_v2

```
2020-12-07T11:13:34.753+0100 [DEBUG] plugin.terraform-provider-opentelekomcloud_v1.22.0: panic: runtime error: invalid memory address or nil pointer dereference
2020-12-07T11:13:34.754+0100 [DEBUG] plugin.terraform-provider-opentelekomcloud_v1.22.0: [signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0xf1b4c3]
2020-12-07T11:13:34.754+0100 [DEBUG] plugin.terraform-provider-opentelekomcloud_v1.22.0: 
2020-12-07T11:13:34.754+0100 [DEBUG] plugin.terraform-provider-opentelekomcloud_v1.22.0: goroutine 27 [running]:
2020-12-07T11:13:34.754+0100 [DEBUG] plugin.terraform-provider-opentelekomcloud_v1.22.0: github.com/opentelekomcloud/gophertelekomcloud.(*ServiceClient).ResourceBaseURL(...)
2020-12-07T11:13:34.754+0100 [DEBUG] plugin.terraform-provider-opentelekomcloud_v1.22.0: 	github.com/opentelekomcloud/gophertelekomcloud@v0.2.0/service_client.go:35
2020-12-07T11:13:34.755+0100 [DEBUG] plugin.terraform-provider-opentelekomcloud_v1.22.0: github.com/opentelekomcloud/gophertelekomcloud.(*ServiceClient).ServiceURL(...)
2020-12-07T11:13:34.755+0100 [DEBUG] plugin.terraform-provider-opentelekomcloud_v1.22.0: github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/security/groups.rootURL(0x0, 0xc000978280, 0xc0004d5320)
2020-12-07T11:13:34.755+0100 [DEBUG] plugin.terraform-provider-opentelekomcloud_v1.22.0: 	github.com/opentelekomcloud/gophertelekomcloud@v0.2.0/openstack/networking/v2/extensions/security/groups/urls.go:8 +0x43
2020-12-07T11:13:34.755+0100 [DEBUG] plugin.terraform-provider-opentelekomcloud_v1.22.0: github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/security/groups.List(0x0, 0x0, 0x0, 0xc00041ae70, 0x10, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
2020-12-07T11:13:34.755+0100 [DEBUG] plugin.terraform-provider-opentelekomcloud_v1.22.0: 	github.com/opentelekomcloud/gophertelekomcloud@v0.2.0/openstack/networking/v2/extensions/security/groups/requests.go:34 +0x139
2020-12-07T11:13:34.755+0100 [DEBUG] plugin.terraform-provider-opentelekomcloud_v1.22.0: github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud.dataSourceNetworkingSecGroupV2Read(0xc000258150, 0x161d1c0, 0xc0002296c0, 0xc000258150, 0x0)
2020-12-07T11:13:34.755+0100 [DEBUG] plugin.terraform-provider-opentelekomcloud_v1.22.0: 	github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/data_source_opentelekomcloud_networking_secgroup_v2.go:51 +0x278
2020-12-07T11:13:34.755+0100 [DEBUG] plugin.terraform-provider-opentelekomcloud_v1.22.0: github.com/hashicorp/terraform-plugin-sdk/helper/schema.(*Resource).ReadDataApply(0xc0000b95f0, 0xc000427da0, 0x161d1c0, 0xc0002296c0, 0xc0000e4590, 0x1, 0x0)
2020-12-07T11:13:34.755+0100 [DEBUG] plugin.terraform-provider-opentelekomcloud_v1.22.0: 	github.com/hashicorp/terraform-plugin-sdk@v1.15.0/helper/schema/resource.go:403 +0x88
2020-12-07T11:13:34.755+0100 [DEBUG] plugin.terraform-provider-opentelekomcloud_v1.22.0: github.com/hashicorp/terraform-plugin-sdk/helper/schema.(*Provider).ReadDataApply(0xc000210000, 0xc00031dad0, 0xc000427da0, 0xc000427da0, 0x0, 0x0)
2020-12-07T11:13:34.755+0100 [DEBUG] plugin.terraform-provider-opentelekomcloud_v1.22.0: 	github.com/hashicorp/terraform-plugin-sdk@v1.15.0/helper/schema/provider.go:451 +0x8f
2020-12-07T11:13:34.755+0100 [DEBUG] plugin.terraform-provider-opentelekomcloud_v1.22.0: github.com/hashicorp/terraform-plugin-sdk/internal/helper/plugin.(*GRPCProviderServer).ReadDataSource(0xc00020a010, 0x182cde0, 0xc000395b00, 0xc0000da8c0, 0xc00020a010, 0xc000395b00, 0xc0001b8b78)
2020-12-07T11:13:34.755+0100 [DEBUG] plugin.terraform-provider-opentelekomcloud_v1.22.0: 	github.com/hashicorp/terraform-plugin-sdk@v1.15.0/internal/helper/plugin/grpc_provider.go:1036 +0x42d
2020-12-07T11:13:34.755+0100 [DEBUG] plugin.terraform-provider-opentelekomcloud_v1.22.0: github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5._Provider_ReadDataSource_Handler(0x15d70c0, 0xc00020a010, 0x182cde0, 0xc000395b00, 0xc000956840, 0x0, 0x182cde0, 0xc000395b00, 0xc00004c540, 0x68)
2020-12-07T11:13:34.755+0100 [DEBUG] plugin.terraform-provider-opentelekomcloud_v1.22.0: 	github.com/hashicorp/terraform-plugin-sdk@v1.15.0/internal/tfplugin5/tfplugin5.pb.go:3341 +0x214
2020-12-07T11:13:34.755+0100 [DEBUG] plugin.terraform-provider-opentelekomcloud_v1.22.0: google.golang.org/grpc.(*Server).processUnaryRPC(0xc000001680, 0x1838240, 0xc0004b6600, 0xc000296800, 0xc00020c750, 0x20c1790, 0x0, 0x0, 0x0)
2020-12-07T11:13:34.755+0100 [DEBUG] plugin.terraform-provider-opentelekomcloud_v1.22.0: 	google.golang.org/grpc@v1.27.1/server.go:1024 +0x522
2020-12-07T11:13:34.755+0100 [DEBUG] plugin.terraform-provider-opentelekomcloud_v1.22.0: google.golang.org/grpc.(*Server).handleStream(0xc000001680, 0x1838240, 0xc0004b6600, 0xc000296800, 0x0)
2020/12/07 11:13:34 [TRACE] [walkRefresh] Entering eval tree: module.olxeudoajenkins10.opentelekomcloud_blockstorage_volume_v2.root_block_device[0]
```


## PR Checklist

* [x] Tests added/passed.
