### PR TITLE
Add obs_bucket_policy resource

### DIFF
--- a/docs/resources/obs_bucket_policy.md
+++ b/docs/resources/obs_bucket_policy.md
@@ -1,0 +1,43 @@
+---
+subcategory: "Object Storage Service (OBS)"
+---
+
+# opentelekomcloud_obs_bucket_policy
+
+Attaches a policy to an OBS bucket resource within OpenTelekomCloud.
+
+## Example Usage
+
+```hcl
+resource "opentelekomcloud_obs_bucket" "bucket" {
+  bucket = "my-tf-test-bucket"
+}
+
+resource "opentelekomcloud_obs_bucket_policy" "policy" {
+  bucket = opentelekomcloud_obs_bucket.bucket.id
+  policy = <<POLICY
+  {
+  "Id": "MYBUCKETPOLICY",
+  "Statement": [
+    {
+      "Sid": "IPAllow",
+      "Effect": "Deny",
+      "Principal": "*",
+      "Action": "s3:*",
+      "Resource": "arn:aws:s3:::${opentelekomcloud_obs_bucket.bucket.id}/*",
+      "Condition": {
+         "IpAddress": {"aws:SourceIp": "8.8.8.8/32"}
+      }
+    }
+  ]}
+POLICY
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `bucket` - (Required) The name of the bucket to which to apply the policy.
+
+* `policy` - (Required) The text of the policy.

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -322,6 +322,7 @@ func Provider() terraform.ResourceProvider {
 			"opentelekomcloud_networking_vip_associate_v2":        resourceNetworkingVIPAssociateV2(),
 			"opentelekomcloud_obs_bucket":                         resourceObsBucket(),
 			"opentelekomcloud_obs_bucket_object":                  resourceObsBucketObject(),
+			"opentelekomcloud_obs_bucket_policy":                  resourceObsBucketPolicy(),
 			"opentelekomcloud_rds_instance_v1":                    resourceRdsInstance(),
 			"opentelekomcloud_rds_instance_v3":                    resourceRdsInstanceV3(),
 			"opentelekomcloud_rds_parametergroup_v3":              resourceRdsConfigurationV3(),

--- a/opentelekomcloud/resource_opentelekomcloud_obs_bucket_policy.go
+++ b/opentelekomcloud/resource_opentelekomcloud_obs_bucket_policy.go
@@ -29,7 +29,7 @@ func resourceObsBucketPolicy() *schema.Resource {
 			},
 			"policy": {
 				Type:             schema.TypeString,
-				Optional:         true,
+				Required:         true,
 				ValidateFunc:     validateJsonString,
 				DiffSuppressFunc: suppressEquivalentAwsPolicyDiffs,
 			},

--- a/opentelekomcloud/resource_opentelekomcloud_obs_bucket_policy.go
+++ b/opentelekomcloud/resource_opentelekomcloud_obs_bucket_policy.go
@@ -1,0 +1,117 @@
+package opentelekomcloud
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/obs"
+)
+
+const (
+	version = "2008-10-17"
+)
+
+func resourceObsBucketPolicy() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceObsBucketPolicyPut,
+		Read:   resourceObsBucketPolicyRead,
+		Update: resourceObsBucketPolicyPut,
+		Delete: resourceObsBucketPolicyDelete,
+
+		Schema: map[string]*schema.Schema{
+			"bucket": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"policy": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateFunc:     validateJsonString,
+				DiffSuppressFunc: suppressEquivalentAwsPolicyDiffs,
+			},
+		},
+	}
+}
+
+func resourceObsBucketPolicyPut(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	client, err := config.newObjectStorageClient(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("error creating OBS client: %s", err)
+	}
+
+	policy := d.Get("policy").(string)
+	bucket := d.Get("bucket").(string)
+	d.SetId(bucket)
+
+	log.Printf("[DEBUG] OBS bucket: %s, put policy: %s", bucket, policy)
+
+	params := &obs.SetBucketPolicyInput{
+		Bucket: bucket,
+		Policy: policy,
+	}
+
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		if _, err := client.SetBucketPolicy(params); err != nil {
+			if err, ok := err.(obs.ObsError); ok {
+				if err.Code == "MalformedPolicy" {
+					return resource.RetryableError(err)
+				}
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("error putting OBS policy: %s", err)
+	}
+
+	return nil
+}
+
+func resourceObsBucketPolicyRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	client, err := config.newObjectStorageClient(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("error creating OBS client: %s", err)
+	}
+
+	log.Printf("[DEBUG] OBS bucket policy, read for bucket: %s", d.Id())
+	pol, err := client.GetBucketPolicy(d.Id())
+
+	if err != nil {
+		return fmt.Errorf("error getting bucket policy")
+	}
+
+	if err := d.Set("policy", pol.Policy); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceObsBucketPolicyDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	client, err := config.newObjectStorageClient(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("error creating OBS client: %s", err)
+	}
+
+	bucket := d.Get("bucket").(string)
+
+	log.Printf("[DEBUG] OBS bucket: %s, delete policy", bucket)
+	_, err = client.DeleteBucketPolicy(bucket)
+
+	if err != nil {
+		if obsErr, ok := err.(obs.ObsError); ok && obsErr.Code == "NoSuchBucket" {
+			return nil
+		}
+		return fmt.Errorf("error deleting OBS policy: %s", err)
+	}
+	return nil
+}

--- a/opentelekomcloud/resource_opentelekomcloud_obs_bucket_policy_test.go
+++ b/opentelekomcloud/resource_opentelekomcloud_obs_bucket_policy_test.go
@@ -1,0 +1,166 @@
+package opentelekomcloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	awspolicy "github.com/jen20/awspolicyequivalence"
+)
+
+func TestAccObsBucketPolicy_basic(t *testing.T) {
+	name := fmt.Sprintf("tf-test-bucket-%d", acctest.RandInt())
+
+	expectedPolicyText := fmt.Sprintf(
+		`{"Version":"2008-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":["*"]},"Action":["s3:*"],"Resource":["arn:aws:s3:::%s/*","arn:aws:s3:::%s"]}]}`,
+		name, name)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckObsBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccObsBucketPolicyConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketExists("opentelekomcloud_obs_bucket.bucket"),
+					testAccCheckObsBucketHasPolicy("opentelekomcloud_obs_bucket.bucket", expectedPolicyText),
+				),
+			},
+		},
+	})
+}
+
+func TestAccObsBucketPolicy_policyUpdate(t *testing.T) {
+	name := fmt.Sprintf("tf-test-bucket-%d", acctest.RandInt())
+
+	expectedPolicyText1 := fmt.Sprintf(
+		`{"Version":"2008-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":["*"]},"Action":["s3:*"],"Resource":["arn:aws:s3:::%s/*","arn:aws:s3:::%s"]}]}`,
+		name, name)
+
+	expectedPolicyText2 := fmt.Sprintf(
+		`{"Version":"2008-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":["*"]},"Action":["s3:DeleteBucket", "s3:ListBucket", "s3:ListBucketVersions"], "Resource":["arn:aws:s3:::%s/*","arn:aws:s3:::%s"]}]}`,
+		name, name)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckObsBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccObsBucketPolicyConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketExists("opentelekomcloud_obs_bucket.bucket"),
+					testAccCheckObsBucketHasPolicy("opentelekomcloud_obs_bucket.bucket", expectedPolicyText1),
+				),
+			},
+
+			{
+				Config: testAccObsBucketPolicyConfig_updated(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketExists("opentelekomcloud_obs_bucket.bucket"),
+					testAccCheckObsBucketHasPolicy("opentelekomcloud_obs_bucket.bucket", expectedPolicyText2),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckObsBucketHasPolicy(n string, expectedPolicyText string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no Obs Bucket ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+		client, err := config.newObjectStorageClient(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("error creating OBS client: %s", err)
+		}
+
+		policy, err := client.GetBucketPolicy(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("GetBucketPolicy error: %v", err)
+		}
+
+		equivalent, err := awspolicy.PoliciesAreEquivalent(policy.Policy, expectedPolicyText)
+		if err != nil {
+			return fmt.Errorf("error testing policy equivalence: %s", err)
+		}
+		if !equivalent {
+			return fmt.Errorf("non-equivalent policy error:\n\nexpected: %s\n\n     got: %s\n",
+				expectedPolicyText, policy.Policy)
+		}
+
+		return nil
+	}
+}
+
+func testAccObsBucketPolicyConfig(bucketName string) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_obs_bucket" "bucket" {
+  bucket = "%s"
+}
+
+resource "opentelekomcloud_obs_bucket_policy" "bucket" {
+  bucket = opentelekomcloud_obs_bucket.bucket.bucket
+  policy =<<POLICY
+{
+	"Version": "2008-10-17",
+	"Statement": [{
+		"Effect": "Allow",
+		"Principal": {
+			"AWS": ["*"]
+		},
+		"Action": [
+			"s3:*"
+		],
+		"Resource": [
+			"arn:aws:s3:::%s",
+			"arn:aws:s3:::%s/*"
+		]
+	}]
+}
+POLICY
+}
+`, bucketName, bucketName, bucketName)
+}
+
+func testAccObsBucketPolicyConfig_updated(bucketName string) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_obs_bucket" "bucket" {
+  bucket = "%s"
+}
+
+resource "opentelekomcloud_obs_bucket_policy" "bucket" {
+  bucket = opentelekomcloud_obs_bucket.bucket.bucket
+  policy =<<POLICY
+{
+	"Version": "2008-10-17",
+	"Statement": [{
+		"Effect": "Allow",
+		"Principal": {
+			"AWS": ["*"]
+		},
+		"Action": [
+			"s3:DeleteBucket",
+			"s3:ListBucket",
+			"s3:ListBucketVersions"
+		],
+		"Resource": [
+			"arn:aws:s3:::%s",
+			"arn:aws:s3:::%s/*"
+		]
+	}]
+}
+POLICY
+}
+`, bucketName, bucketName, bucketName)
+}


### PR DESCRIPTION
## Summary of the Pull Request
Add `obs_bucket_policy` resource
Unlike `s3_` resources requiring AK/SK set, `obs_` resources can work using with token/password authentication

Resolve #770

## PR Checklist

* [x] Refers to: #770
* [x] Documentation updated.
* [x] Tests added/passed.

## Acceptance Steps Performed

```
=== RUN   TestAccObsBucketPolicy_basic
--- PASS: TestAccObsBucketPolicy_basic (23.09s)
=== RUN   TestAccObsBucketPolicy_policyUpdate
--- PASS: TestAccObsBucketPolicy_policyUpdate (42.26s)
PASS

Process finished with exit code 0
```
