### PR TITLE
Fix `rds_parametergroup_v3` recreation

### DIFF
--- a/docs/resources/rds_parametergroup_v3.md
+++ b/docs/resources/rds_parametergroup_v3.md
@@ -4,15 +4,15 @@ subcategory: "Relational Database Service (RDS)"
 
 # opentelekomcloud_rds_parametergroup_v3
 
-Manages a V3 RDS parametergroup resource within OpenTelekomCloud.
+Manages a RDSv3 parametergroup resource within OpenTelekomCloud.
 
 ## Example Usage
 
 ```hcl
 resource "opentelekomcloud_rds_parametergroup_v3" "pg_1" {
   name        = "pg_1"
-  description = "description_1"
-  
+  description = "some description here"
+
    values = {
     max_connections = "10"
     autocommit      = "OFF"
@@ -30,8 +30,8 @@ The following arguments are supported:
 
 * `name` - (Required) The parameter group name. It contains a maximum of 64 characters.
 
-* `description` - (Optional) The parameter group description. It contains a maximum of 256 characters 
-  and cannot contain the following special characters:>!<"&'= the value is left blank by default.
+* `description` - (Optional) The parameter group description. It contains a maximum of 256 characters
+  and cannot contain the following special characters: `>!<"&'=` the value is left blank by default.
 
 * `values` - (Optional) Parameter group values key/value pairs defined by users based on the default parameter groups.
 
@@ -39,13 +39,13 @@ The following arguments are supported:
 
 The `datastore` block supports:
 
-* `type` - (Required) The DB engine. Currently, MySQL, PostgreSQL, and Microsoft SQL Server are supported. 
-  The value is case-insensitive and can be mysql, postgresql, or sqlserver.
+* `type` - (Required) Specifies the DB engine. Currently, MySQL, PostgreSQL and MS SQLServer are supported.
+  The value is case-insensitive and can be `mysql`, `postgresql` or `sqlserver`.
 
 * `version` - (Required) Specifies the database version.
-  * MySQL databases support MySQL 5.6 and 5.7. Example value: 5.7.
-  * PostgreSQL databases support PostgreSQL 9.5 and 9.6. Example value: 9.5.
-  * Microsoft SQL Server databases support 2014 SE, 2016 SE, and 2016 EE. Example value: 2014_SE.
+  * MySQL databases support MySQL `5.6`, `5.7`, `8.0`. Example value: `5.7`.
+  * PostgreSQL databases support PostgreSQL `9.5`, `9.6`, `10` and `11`. Example value: `9.5`.
+  * Microsoft SQL Server databases support `2014 SE`, `2016 SE`, and `2016 EE`. Example value: `2014_SE`.
 
 
 ## Attributes Reference
@@ -69,6 +69,10 @@ The following attributes are exported:
 * `type` - Indicates the parameter type.
 
 * `description` - Indicates the parameter description.
+
+* `created` - Indicates the creation time in the following format: `yyyy-MM-ddTHH:mm:ssZ`.
+
+* `updated` - Indicates the update time in the following format: `yyyy-MM-ddTHH:mm:ssZ`.
 
 ## Import
 

--- a/opentelekomcloud/resource_opentelekomcloud_rds_parametergroup_v3_test.go
+++ b/opentelekomcloud/resource_opentelekomcloud_rds_parametergroup_v3_test.go
@@ -23,9 +23,9 @@ func TestAccRdsConfigurationV3_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRdsConfigV3Exists("opentelekomcloud_rds_parametergroup_v3.pg_1", &config),
 					resource.TestCheckResourceAttr(
-						"opentelekomcloud_rds_parametergroup_v3.pg_1", "name", "pg_1"),
+						"opentelekomcloud_rds_parametergroup_v3.pg_1", "name", "pg_create"),
 					resource.TestCheckResourceAttr(
-						"opentelekomcloud_rds_parametergroup_v3.pg_1", "description", "description_1"),
+						"opentelekomcloud_rds_parametergroup_v3.pg_1", "description", "some description"),
 				),
 			},
 			{
@@ -35,7 +35,7 @@ func TestAccRdsConfigurationV3_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"opentelekomcloud_rds_parametergroup_v3.pg_1", "name", "pg_update"),
 					resource.TestCheckResourceAttr(
-						"opentelekomcloud_rds_parametergroup_v3.pg_1", "description", "description_update"),
+						"opentelekomcloud_rds_parametergroup_v3.pg_1", "description", "updated description"),
 				),
 			},
 		},
@@ -46,7 +46,7 @@ func testAccCheckRdsConfigV3Destroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 	rdsClient, err := config.rdsV3Client(OS_REGION_NAME)
 	if err != nil {
-		return fmt.Errorf("Error creating OpenTelekomCloud RDS client: %s", err)
+		return fmt.Errorf("error creating OpenTelekomCloud RDSv3 client: %s", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -56,7 +56,7 @@ func testAccCheckRdsConfigV3Destroy(s *terraform.State) error {
 
 		_, err := configurations.Get(rdsClient, rs.Primary.ID).Extract()
 		if err == nil {
-			return fmt.Errorf("Rds configuration still exists")
+			return fmt.Errorf("RDSv3 configuration still exists")
 		}
 	}
 
@@ -67,26 +67,26 @@ func testAccCheckRdsConfigV3Exists(n string, configuration *configurations.Confi
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return fmt.Errorf("not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
+			return fmt.Errorf("no ID is set")
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		rdsClient, err := config.rdsV3Client(OS_REGION_NAME)
+		client, err := config.rdsV3Client(OS_REGION_NAME)
 		if err != nil {
-			return fmt.Errorf("Error creating OpenTelekomCloud RDS client: %s", err)
+			return fmt.Errorf("error creating OpenTelekomCloud RDSv3 client: %s", err)
 		}
 
-		found, err := configurations.Get(rdsClient, rs.Primary.ID).Extract()
+		found, err := configurations.Get(client, rs.Primary.ID).Extract()
 		if err != nil {
 			return err
 		}
 
 		if found.ID != rs.Primary.ID {
-			return fmt.Errorf("Rds configuration not found")
+			return fmt.Errorf("RDSv3 configuration not found")
 		}
 
 		*configuration = *found
@@ -97,30 +97,34 @@ func testAccCheckRdsConfigV3Exists(n string, configuration *configurations.Confi
 
 const testAccRdsConfigV3_basic = `
 resource "opentelekomcloud_rds_parametergroup_v3" "pg_1" {
-	name = "pg_1"
-	description = "description_1"
-	values = {
-		max_connections = "10"
-		autocommit = "OFF"
-	}
-	datastore {
-		type = "mysql"
-		version = "5.6"
-	}
+  name        = "pg_create"
+  description = "some description"
+
+  values = {
+    max_connections = "10"
+    autocommit      = "OFF"
+  }
+
+  datastore {
+    type    = "mysql"
+    version = "5.6"
+  }
 }
 `
 
 const testAccRdsConfigV3_update = `
 resource "opentelekomcloud_rds_parametergroup_v3" "pg_1" {
-	name = "pg_update"
-	description = "description_update"
-	values = {
-		max_connections = "10"
-		autocommit = "OFF"
-	}
-	datastore {
-		type = "mysql"
-		version = "5.6"
-	}
+  name        = "pg_update"
+  description = "updated description"
+
+  values = {
+    max_connections = "10"
+    autocommit      = "OFF"
+  }
+
+  datastore {
+    type    = "mysql"
+    version = "5.6"
+  }
 }
 `


### PR DESCRIPTION
## Summary of the Pull Request
Fix bug with `datastore` arg in schema. Now if `datastore` is change it will recreate resource.

Add `ForceNew` for `datastore` args. 

Add new schema fields: `created` and `updated`

Resolve: #783

## PR Checklist

* [x] Refers to: #783 
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
=== RUN   TestAccRdsConfigurationV3_basic
--- PASS: TestAccRdsConfigurationV3_basic (24.81s)
PASS

Process finished with exit code 0
```
