### PR TITLE
Implement `d/opentelekomcloud_rds_versions_v3`

### DIFF
--- a/docs/data-sources/rds_versions_v3.md
+++ b/docs/data-sources/rds_versions_v3.md
@@ -1,0 +1,25 @@
+---
+subcategory: "Relational Database Service (RDS)"
+---
+
+# opentelekomcloud_rds_versions_v3
+
+Use this data source to get available OpenTelekomCloud rds versions.
+
+## Example Usage
+
+```hcl
+data "opentelekomcloud_rds_versions_v3" "versions" {
+  database_name = "mysql"
+}
+```
+
+## Argument Reference
+
+* `database_name` - (Required) Specifies the DB engine. Value: MySQL, PostgreSQL, SQLServer. Case-insensitive.
+
+## Attributes Reference
+
+In addition, the following attributes are exported:
+
+* `versions` - List of version names, sorted by a version (higher to lower). Example: `["11", "10", "9.6", "9.5"]`.

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/go-multierror v1.0.0
+	github.com/hashicorp/go-version v1.2.0
 	github.com/hashicorp/terraform-plugin-sdk v1.15.0
 	github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a
 	github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a

--- a/opentelekomcloud/data_source_opentelekomcloud_rds_versions_v3.go
+++ b/opentelekomcloud/data_source_opentelekomcloud_rds_versions_v3.go
@@ -2,9 +2,6 @@ package opentelekomcloud
 
 import (
 	"fmt"
-	"sort"
-	"strconv"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -52,43 +49,6 @@ func dataSourceRdsVersionsV3Read(d *schema.ResourceData, meta interface{}) error
 	return nil
 }
 
-type DataStoresSorting struct {
-	sort.StringSlice
-}
-
-type Version struct {
-	Major int
-	Minor int
-}
-
-func (d DataStoresSorting) Less(i, j int) bool {
-	v1 := strings.Split(d.StringSlice[i], ".")
-	v2 := strings.Split(d.StringSlice[j], ".")
-	v1Maj, err := strconv.Atoi(v1[0])
-	if err != nil {
-		return d.StringSlice.Less(i, j)
-	}
-	v2Maj, err := strconv.Atoi(v2[0])
-	if err != nil {
-		return d.StringSlice.Less(i, j)
-	}
-	if v1Maj < v2Maj {
-		return true
-	}
-	if v1Maj > v2Maj {
-		return false
-	}
-	v1Min, err := strconv.Atoi(v1[1])
-	if err != nil {
-		return d.StringSlice.Less(i, j)
-	}
-	v2Min, err := strconv.Atoi(v2[1])
-	if err != nil {
-		return d.StringSlice.Less(i, j)
-	}
-	return v1Min < v2Min
-}
-
 func getRdsV3VersionList(client *golangsdk.ServiceClient, dbName string) ([]string, error) {
 	pages, err := datastores.List(client, dbName).AllPages()
 	if err != nil {
@@ -102,7 +62,6 @@ func getRdsV3VersionList(client *golangsdk.ServiceClient, dbName string) ([]stri
 	for i, store := range stores.DataStores {
 		result[i] = store.Name
 	}
-	resultSorted := DataStoresSorting{StringSlice: result}
-	sort.Sort(sort.Reverse(resultSorted))
-	return resultSorted.StringSlice, nil
+	resultSorted := SortVersions(result)
+	return resultSorted, nil
 }

--- a/opentelekomcloud/data_source_opentelekomcloud_rds_versions_v3.go
+++ b/opentelekomcloud/data_source_opentelekomcloud_rds_versions_v3.go
@@ -1,0 +1,108 @@
+package opentelekomcloud
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/rds/v3/datastores"
+)
+
+func dataSourceRdsVersionsV3() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceRdsVersionsV3Read,
+		Schema: map[string]*schema.Schema{
+			"database_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"MySQL", "PostgreSQL", "SQLServer",
+				}, true),
+			},
+
+			"versions": {
+				Type: schema.TypeList,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceRdsVersionsV3Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	client, err := config.rdsV3Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("error creating RDSv3 client: %s", err)
+	}
+	name := d.Get("database_name").(string)
+	stores, err := getRdsV3VersionList(client, name)
+
+	if err := d.Set("versions", stores); err != nil {
+		return fmt.Errorf("error setting version list: %s", err)
+	}
+	d.SetId(fmt.Sprintf("%s_versions", name))
+
+	return nil
+}
+
+type DataStoresSorting struct {
+	sort.StringSlice
+}
+
+type Version struct {
+	Major int
+	Minor int
+}
+
+func (d DataStoresSorting) Less(i, j int) bool {
+	v1 := strings.Split(d.StringSlice[i], ".")
+	v2 := strings.Split(d.StringSlice[j], ".")
+	v1Maj, err := strconv.Atoi(v1[0])
+	if err != nil {
+		return d.StringSlice.Less(i, j)
+	}
+	v2Maj, err := strconv.Atoi(v2[0])
+	if err != nil {
+		return d.StringSlice.Less(i, j)
+	}
+	if v1Maj < v2Maj {
+		return true
+	}
+	if v1Maj > v2Maj {
+		return false
+	}
+	v1Min, err := strconv.Atoi(v1[1])
+	if err != nil {
+		return d.StringSlice.Less(i, j)
+	}
+	v2Min, err := strconv.Atoi(v2[1])
+	if err != nil {
+		return d.StringSlice.Less(i, j)
+	}
+	return v1Min < v2Min
+}
+
+func getRdsV3VersionList(client *golangsdk.ServiceClient, dbName string) ([]string, error) {
+	pages, err := datastores.List(client, dbName).AllPages()
+	if err != nil {
+		return nil, fmt.Errorf("error listing RDSv3 versions: %s", err)
+	}
+	stores, err := datastores.ExtractDataStores(pages)
+	if err != nil {
+		return nil, fmt.Errorf("error extracting RDSv3 versions: %s", err)
+	}
+	result := make([]string, len(stores.DataStores))
+	for i, store := range stores.DataStores {
+		result[i] = store.Name
+	}
+	resultSorted := DataStoresSorting{StringSlice: result}
+	sort.Sort(sort.Reverse(resultSorted))
+	return resultSorted.StringSlice, nil
+}

--- a/opentelekomcloud/data_source_opentelekomcloud_rds_versions_v3_test.go
+++ b/opentelekomcloud/data_source_opentelekomcloud_rds_versions_v3_test.go
@@ -1,0 +1,26 @@
+package opentelekomcloud
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestRDSVersionsV3_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testRDSVersionsV3_basic,
+				Check:  testAccCheckRdsFlavorV3DataSourceID("data.opentelekomcloud_rds_versions_v3.versions"),
+			},
+		},
+	})
+}
+
+var testRDSVersionsV3_basic = `
+data "opentelekomcloud_rds_versions_v3" "versions" {
+  database_name = "mysql"
+}
+`

--- a/opentelekomcloud/data_source_opentelekomcloud_rds_versions_v3_test.go
+++ b/opentelekomcloud/data_source_opentelekomcloud_rds_versions_v3_test.go
@@ -13,14 +13,26 @@ func TestRDSVersionsV3_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testRDSVersionsV3_basic,
-				Check:  testAccCheckRdsFlavorV3DataSourceID("data.opentelekomcloud_rds_versions_v3.versions"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRdsFlavorV3DataSourceID("data.opentelekomcloud_rds_versions_v3.sqls_versions"),
+					testAccCheckRdsFlavorV3DataSourceID("data.opentelekomcloud_rds_versions_v3.mysql_versions"),
+					testAccCheckRdsFlavorV3DataSourceID("data.opentelekomcloud_rds_versions_v3.psql_versions"),
+				),
 			},
 		},
 	})
 }
 
 var testRDSVersionsV3_basic = `
-data "opentelekomcloud_rds_versions_v3" "versions" {
+data "opentelekomcloud_rds_versions_v3" "sqls_versions" {
+  database_name = "sqlserver"
+}
+
+data "opentelekomcloud_rds_versions_v3" "mysql_versions" {
   database_name = "mysql"
+}
+
+data "opentelekomcloud_rds_versions_v3" "psql_versions" {
+  database_name = "postgresql"
 }
 `

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -220,6 +220,7 @@ func Provider() terraform.ResourceProvider {
 			"opentelekomcloud_obs_bucket_object":             dataSourceObsBucketObject(),
 			"opentelekomcloud_rds_flavors_v1":                dataSourceRdsFlavorV1(),
 			"opentelekomcloud_rds_flavors_v3":                dataSourceRdsFlavorV3(),
+			"opentelekomcloud_rds_versions_v3":               dataSourceRdsVersionsV3(),
 			"opentelekomcloud_rts_software_deployment_v1":    dataSourceRtsSoftwareDeploymentV1(),
 			"opentelekomcloud_rts_software_config_v1":        dataSourceRtsSoftwareConfigV1(),
 			"opentelekomcloud_rts_stack_resource_v1":         dataSourceRTSStackResourcesV1(),

--- a/opentelekomcloud/utils.go
+++ b/opentelekomcloud/utils.go
@@ -7,7 +7,10 @@ import (
 	"log"
 	"reflect"
 	"regexp"
+	"sort"
 	"strings"
+
+	ver "github.com/hashicorp/go-version"
 )
 
 func jsonBytesEqual(b1, b2 []byte) bool {
@@ -70,4 +73,49 @@ func base64IfNot(src string) string {
 		return src
 	}
 	return base64.StdEncoding.EncodeToString([]byte(src))
+}
+
+type versionSlice []*ver.Version
+
+func (v versionSlice) Len() int {
+	return len(v)
+}
+
+func (v versionSlice) Swap(i, j int) {
+	v[i], v[j] = v[j], v[i]
+}
+
+func (v versionSlice) Less(i, j int) bool {
+	return v[i].LessThan(v[j])
+}
+
+func (v versionSlice) ToStringSlice() []string {
+	res := make([]string, len(v))
+	for i, version := range v {
+		res[i] = version.String()
+	}
+	return res
+}
+
+func sortAsStringSlice(src []string) []string {
+	res := make([]string, len(src))
+	copy(res, src)
+	sort.Sort(sort.Reverse(sort.StringSlice(res)))
+	return res
+}
+
+// SortVersions sorts versions from newer to older.
+// If non-version-like string will be found in the slice,
+// slice will be sorted as string slice in reversed order (z-a)
+func SortVersions(src []string) []string {
+	verSlice := make(versionSlice, len(src))
+	for i, v := range src {
+		val, err := ver.NewVersion(v)
+		if err != nil {
+			return sortAsStringSlice(src) // in case it's not version-like
+		}
+		verSlice[i] = val
+	}
+	sort.Sort(sort.Reverse(verSlice))
+	return verSlice.ToStringSlice()
 }

--- a/opentelekomcloud/utils.go
+++ b/opentelekomcloud/utils.go
@@ -92,7 +92,7 @@ func (v versionSlice) Less(i, j int) bool {
 func (v versionSlice) ToStringSlice() []string {
 	res := make([]string, len(v))
 	for i, version := range v {
-		res[i] = version.String()
+		res[i] = version.Original()
 	}
 	return res
 }


### PR DESCRIPTION
## Summary of the Pull Request
Implement `data_source/opentelekomcloud_rds_versions_v3` for listing database engine versions.

Resolve #790

## PR Checklist

* [x] Refers to: #790
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
=== RUN   TestRDSVersionsV3_basic
--- PASS: TestRDSVersionsV3_basic (7.99s)
PASS

Process finished with exit code 0
```
