### PR TITLE
Allow shared key pairs in `compute_keypair_v2`

### DIFF
--- a/docs/resources/compute_keypair_v2.md
+++ b/docs/resources/compute_keypair_v2.md
@@ -49,3 +49,5 @@ Keypairs can be imported using the `name`, e.g.
 ```sh
 terraform import opentelekomcloud_compute_keypair_v2.my-keypair test-keypair
 ```
+
+Imported key pairs are considered to be not shared.

--- a/docs/resources/compute_keypair_v2.md
+++ b/docs/resources/compute_keypair_v2.md
@@ -21,8 +21,12 @@ The following arguments are supported:
 
 * `name` - (Required) A unique name for the keypair. Changing this creates a new keypair.
 
-* `public_key` - (Required) A pregenerated OpenSSH-formatted public key.
+* `public_key` - (Required) A pre-generated OpenSSH-formatted public key.
   Changing this creates a new keypair.
+
+-> *Note:*
+  If both `name` and `public_key` duplicates existing keypair value, new keypair won't be managed
+  by the Terraform. Keypair resource will be marked as `shared.`
 
 * `value_specs` - (Optional) Map of additional options.
 
@@ -33,6 +37,10 @@ The following attributes are exported:
 * `name` - See Argument Reference above.
 
 * `public_key` - See Argument Reference above.
+
+* `value_specs` - See Argument Reference above.
+
+* `shared` - Indicates that keypair is shared (global) and not managed by Terraform.
 
 ## Import
 

--- a/docs/resources/compute_keypair_v2.md
+++ b/docs/resources/compute_keypair_v2.md
@@ -24,9 +24,9 @@ The following arguments are supported:
 * `public_key` - (Required) A pre-generated OpenSSH-formatted public key.
   Changing this creates a new keypair.
 
--> *Note:*
-  If both `name` and `public_key` duplicates existing keypair value, new keypair won't be managed
-  by the Terraform. Keypair resource will be marked as `shared.`
+->
+If both `name` and `public_key` duplicate the existing keypair value, the new keypair won't be
+managed by the Terraform. Keypair resource will be marked as `shared.`
 
 * `value_specs` - (Optional) Map of additional options.
 

--- a/opentelekomcloud/resource_opentelekomcloud_compute_keypair_v2.go
+++ b/opentelekomcloud/resource_opentelekomcloud_compute_keypair_v2.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/compute/v2/extensions/keypairs"
 )
 
@@ -17,6 +19,8 @@ func resourceComputeKeypairV2() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
+		CustomizeDiff: useSharedKeypair,
+
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:     schema.TypeString,
@@ -24,7 +28,6 @@ func resourceComputeKeypairV2() *schema.Resource {
 				Computed: true,
 				ForceNew: true,
 			},
-
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -40,6 +43,10 @@ func resourceComputeKeypairV2() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"shared": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -48,10 +55,10 @@ func resourceComputeKeypairV2Create(d *schema.ResourceData, meta interface{}) er
 	config := meta.(*Config)
 	computeClient, err := config.computeV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating OpenTelekomCloud compute client: %s", err)
+		return fmt.Errorf("error creating OpenTelekomCloud compute client: %s", err)
 	}
 
-	createOpts := KeyPairCreateOpts{
+	opts := KeyPairCreateOpts{
 		keypairs.CreateOpts{
 			Name:      d.Get("name").(string),
 			PublicKey: d.Get("public_key").(string),
@@ -59,13 +66,17 @@ func resourceComputeKeypairV2Create(d *schema.ResourceData, meta interface{}) er
 		MapValueSpecs(d),
 	}
 
-	log.Printf("[DEBUG] Create Options: %#v", createOpts)
-	kp, err := keypairs.Create(computeClient, createOpts).Extract()
-	if err != nil {
-		return fmt.Errorf("Error creating OpenTelekomCloud keypair: %s", err)
+	shared := d.Get("shared").(bool)
+	if !shared {
+		log.Printf("[DEBUG] Create Options: %#v", opts)
+		_, err := keypairs.Create(computeClient, opts).Extract()
+		if err != nil {
+			return fmt.Errorf("error creating OpenTelekomCloud keypair: %s", err)
+		}
+	} else {
+		log.Printf("[DEBUG] Using non-managed key pair, skipping creation")
 	}
-
-	d.SetId(kp.Name)
+	d.SetId(opts.Name)
 
 	return resourceComputeKeypairV2Read(d, meta)
 }
@@ -74,7 +85,7 @@ func resourceComputeKeypairV2Read(d *schema.ResourceData, meta interface{}) erro
 	config := meta.(*Config)
 	computeClient, err := config.computeV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating OpenTelekomCloud compute client: %s", err)
+		return fmt.Errorf("error creating OpenTelekomCloud compute client: %s", err)
 	}
 
 	kp, err := keypairs.Get(computeClient, d.Id()).Extract()
@@ -82,10 +93,14 @@ func resourceComputeKeypairV2Read(d *schema.ResourceData, meta interface{}) erro
 		return CheckDeleted(d, err, "keypair")
 	}
 
-	d.Set("name", kp.Name)
-	d.Set("public_key", kp.PublicKey)
-	d.Set("region", GetRegion(d, config))
-
+	mErr := multierror.Append(
+		d.Set("name", kp.Name),
+		d.Set("public_key", kp.PublicKey),
+		d.Set("region", GetRegion(d, config)),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -93,13 +108,55 @@ func resourceComputeKeypairV2Delete(d *schema.ResourceData, meta interface{}) er
 	config := meta.(*Config)
 	computeClient, err := config.computeV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating OpenTelekomCloud compute client: %s", err)
+		return fmt.Errorf("error creating OpenTelekomCloud compute client: %s", err)
 	}
 
-	err = keypairs.Delete(computeClient, d.Id()).ExtractErr()
-	if err != nil {
-		return fmt.Errorf("Error deleting OpenTelekomCloud keypair: %s", err)
+	shared := d.Get("shared").(bool)
+
+	if !shared {
+		err = keypairs.Delete(computeClient, d.Id()).ExtractErr()
+		if err != nil {
+			return fmt.Errorf("error deleting OpenTelekomCloud keypair: %s", err)
+		}
+	} else {
+		log.Printf("[DEBUG] Using non-managed key pair, skipping deletion")
 	}
+
 	d.SetId("")
 	return nil
+}
+
+func useSharedKeypair(d *schema.ResourceDiff, meta interface{}) error {
+	if d.Id() != "" { // skip if not new resource
+		return nil
+	}
+
+	config := meta.(*Config)
+	client, err := config.computeV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("error creating OpenTelekomCloud compute client: %s", err)
+	}
+	name := d.Get("name").(string)
+	publicKey := d.Get("public_key").(string)
+	exists, err := keyPairExist(client, name, publicKey)
+	if err != nil {
+		return err
+	}
+	_ = d.SetNew("shared", exists)
+	return nil
+}
+
+// Searches for keypair with the same name and public key
+func keyPairExist(client *golangsdk.ServiceClient, name, publicKey string) (exists bool, err error) {
+	kp, err := keypairs.Get(client, name).Extract()
+	if err != nil {
+		if _, ok := err.(golangsdk.ErrDefault404); ok {
+			return false, nil
+		}
+		return false, err
+	}
+	if kp.PublicKey == publicKey {
+		return true, nil
+	}
+	return true, fmt.Errorf("key %s already exist with different public key", name)
 }

--- a/opentelekomcloud/resource_opentelekomcloud_compute_keypair_v2_test.go
+++ b/opentelekomcloud/resource_opentelekomcloud_compute_keypair_v2_test.go
@@ -2,7 +2,6 @@ package opentelekomcloud
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -48,23 +47,6 @@ func TestAccComputeV2Keypair_shared(t *testing.T) {
 					resource.TestCheckResourceAttr("opentelekomcloud_compute_keypair_v2.kp_2", "shared", "true"),
 					resource.TestCheckResourceAttr("opentelekomcloud_compute_keypair_v2.kp_1", "shared", "false"),
 				),
-			},
-		},
-	})
-}
-
-func TestAccComputeV2Keypair_sharedInvalid(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckComputeV2KeypairDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccComputeV2Keypair_basic,
-			},
-			{
-				Config:      testAccComputeV2Keypair_sharedInvalid,
-				ExpectError: regexp.MustCompile(`.+already exist with different public key`),
 			},
 		},
 	})

--- a/opentelekomcloud/util.go
+++ b/opentelekomcloud/util.go
@@ -29,8 +29,7 @@ func BuildRequest(opts interface{}, parent string) (map[string]interface{}, erro
 // sets the resource ID to the empty string instead of throwing an error.
 func CheckDeleted(d *schema.ResourceData, err error, msg string) error {
 	_, ok := err.(golangsdk.ErrDefault404)
-	_, ok1 := err.(golangsdk.ErrDefault404)
-	if ok || ok1 {
+	if ok {
 		d.SetId("")
 		return nil
 	}


### PR DESCRIPTION
## Summary of the Pull Request
Make shared key pairs not managed by terraform
Part of #785

If `opentelekomcloud_compute_keypair_v2` has both name and public key
duplicating the existing one, no new keypair will be created or deleted.


## PR Checklist

* [x] Refers to: #785
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
=== RUN   TestAccComputeV2Keypair_basic
--- PASS: TestAccComputeV2Keypair_basic (9.02s)
=== RUN   TestAccComputeV2Keypair_shared
--- PASS: TestAccComputeV2Keypair_shared (16.55s)
PASS

Process finished with exit code 0

=== RUN   TestAccComputeV2Keypair_importBasic
--- PASS: TestAccComputeV2Keypair_importBasic (9.33s)
PASS

Process finished with exit code 0

```
