### PR TITLE
Remove vendoring modules in `fmtcheck`

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -29,7 +29,6 @@ fmt:
 	gofmt -w $(GOFMT_FILES)
 
 fmtcheck:
-	@go mod vendor
 	@sh -c "'$(CURDIR)/scripts/gofmtcheck.sh'"
 
 errcheck:


### PR DESCRIPTION
## Summary of the Pull Request
Remove `go mod vendor` from `fmtcheck` make target (included in `test` target)
