### PR TITLE
Add provider credentials validation

### DIFF
--- a/opentelekomcloud/config_test.go
+++ b/opentelekomcloud/config_test.go
@@ -186,7 +186,7 @@ func testRequestRetry(t *testing.T, count int) {
 	})
 
 	cfg := &Config{MaxRetries: retryCount}
-	_, err := genClient(cfg, golangsdk.AuthOptions{
+	_, err := cfg.genClient(golangsdk.AuthOptions{
 		IdentityEndpoint: fmt.Sprintf("%s/route", th.Endpoint()),
 	})
 	_, ok := err.(golangsdk.ErrDefault500)

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -64,7 +64,7 @@ func Provider() terraform.ResourceProvider {
 			},
 			"tenant_name": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
 					"OS_TENANT_NAME",
 					"OS_PROJECT_NAME",


### PR DESCRIPTION
## Summary of the Pull Request
Fix #801

Add provider validation tests

Minor refactoring

## PR Checklist

* [x] Refers to: #801
* [x] Tests added/passed.
* [x] Schema updated.

## Acceptance Steps Performed

To make sure everything is still working:
```
=== RUN   TestAccObsBucket_basic
--- PASS: TestAccObsBucket_basic (19.80s)

=== RUN   TestAccOTCVpcV1_basic
--- PASS: TestAccOTCVpcV1_basic (30.49s)
PASS
```

With built binary:
```
$ OS_CLOUD=terraform tf apply
Warning: Provider development overrides are in effect

The following provider development overrides are set in the CLI configuration:
 - opentelekomcloud/opentelekomcloud in /home/akachuri/go/bin

The behavior may therefore not match any released version of the provider and
applying changes may cause the state to become incompatible with published
releases.


An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # opentelekomcloud_obs_bucket.bucket_test will be created
  + resource "opentelekomcloud_obs_bucket" "bucket_test" {
      + acl                = "private"
      + bucket             = "obs-akachuri-test"
      + bucket_domain_name = (known after apply)
      + force_destroy      = false
      + id                 = (known after apply)
      + region             = (known after apply)
      + storage_class      = "STANDARD"
      + versioning         = false
    }

  # opentelekomcloud_vpc_v1.vpc will be created
  + resource "opentelekomcloud_vpc_v1" "vpc" {
      + cidr   = "192.168.0.0/16"
      + id     = (known after apply)
      + name   = "vpc-akachuri"
      + region = (known after apply)
      + shared = (known after apply)
      + status = (known after apply)
    }

Plan: 2 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

opentelekomcloud_vpc_v1.vpc: Creating...
opentelekomcloud_obs_bucket.bucket_test: Creating...
opentelekomcloud_obs_bucket.bucket_test: Creation complete after 1s [id=obs-akachuri-test]
opentelekomcloud_vpc_v1.vpc: Creation complete after 8s [id=e7de5051-8165-4a25-a5bc-f172847d09c8]

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
```
With binary and project ID/Name not set:
```
$ tf plan

Error: no project name/id or delegated project is provided

  on versions.tf line 11, in provider "opentelekomcloud":
  11: provider opentelekomcloud {


```

CLI config:
```hcl
provider_installation {
  dev_overrides {
    "opentelekomcloud/opentelekomcloud" = "/home/akachuri/go/bin"
  }
  direct {}
}
```