### PR TITLE
[compute_instance_v2] Deprecate personality field

### DIFF
--- a/docs/resources/compute_instance_v2.md
+++ b/docs/resources/compute_instance_v2.md
@@ -186,9 +186,7 @@ resource "opentelekomcloud_compute_instance_v2" "multi-net" {
   image_id        = "ad091b52-742f-469e-8f3c-fd81cadf0743"
   flavor_id       = "3"
   key_pair        = "my_key_pair_name"
-  security_groups = [
-    "default"
-  ]
+  security_groups = ["default"]
 
   network {
     name = "my_first_network"

--- a/opentelekomcloud/resource_opentelekomcloud_compute_instance_v2.go
+++ b/opentelekomcloud/resource_opentelekomcloud_compute_instance_v2.go
@@ -343,7 +343,7 @@ func resourceComputeInstanceV2() *schema.Resource {
 					},
 				},
 				Set:        resourceComputeInstancePersonalityHash,
-				Deprecated: "This block will be removed in future releases. It doesn't work. Don't use it",
+				Deprecated: "Open Telekom Cloud API doesn't accept `personality`, please use `user_data` instead",
 			},
 			"stop_before_destroy": {
 				Type:     schema.TypeBool,

--- a/opentelekomcloud/resource_opentelekomcloud_compute_instance_v2.go
+++ b/opentelekomcloud/resource_opentelekomcloud_compute_instance_v2.go
@@ -326,6 +326,24 @@ func resourceComputeInstanceV2() *schema.Resource {
 				},
 				Set: resourceComputeSchedulerHintsHash,
 			},
+			"personality": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"file": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"content": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+				Deprecated: "This block will be removed in future releases, please don't use it",
+			},
 			"stop_before_destroy": {
 				Type:     schema.TypeBool,
 				Optional: true,

--- a/opentelekomcloud/resource_opentelekomcloud_compute_instance_v2.go
+++ b/opentelekomcloud/resource_opentelekomcloud_compute_instance_v2.go
@@ -342,6 +342,7 @@ func resourceComputeInstanceV2() *schema.Resource {
 						},
 					},
 				},
+				Set:        resourceComputeInstancePersonalityHash,
 				Deprecated: "This block will be removed in future releases, please don't use it",
 			},
 			"stop_before_destroy": {
@@ -1125,6 +1126,14 @@ func setImageInformation(computeClient *golangsdk.ServiceClient, server *servers
 	}
 
 	return nil
+}
+
+func resourceComputeInstancePersonalityHash(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+	buf.WriteString(fmt.Sprintf("%s-", m["file"].(string)))
+
+	return hashcode.String(buf.String())
 }
 
 func getFlavorID(client *golangsdk.ServiceClient, d *schema.ResourceData) (string, error) {

--- a/opentelekomcloud/resource_opentelekomcloud_compute_instance_v2.go
+++ b/opentelekomcloud/resource_opentelekomcloud_compute_instance_v2.go
@@ -343,7 +343,7 @@ func resourceComputeInstanceV2() *schema.Resource {
 					},
 				},
 				Set:        resourceComputeInstancePersonalityHash,
-				Deprecated: "This block will be removed in future releases, please don't use it",
+				Deprecated: "This block will be removed in future releases. It doesn't work. Don't use it",
 			},
 			"stop_before_destroy": {
 				Type:     schema.TypeBool,

--- a/opentelekomcloud/resource_opentelekomcloud_compute_instance_v2_test.go
+++ b/opentelekomcloud/resource_opentelekomcloud_compute_instance_v2_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 
-	"github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/compute/v2/extensions/secgroups"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/compute/v2/extensions/volumeattach"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/compute/v2/servers"
@@ -48,7 +47,7 @@ func TestAccComputeV2Instance_tags(t *testing.T) {
 		CheckDestroy: testAccCheckComputeV2InstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeV2Instance_tags,
+				Config: testAccComputeV2Instance_withTags,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeV2InstanceExists("opentelekomcloud_compute_instance_v2.instance_1", &instance),
 					testAccCheckComputeV2InstanceTagsV1(&instance, "foo", "bar"),
@@ -56,7 +55,7 @@ func TestAccComputeV2Instance_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccComputeV2Instance_tags2,
+				Config: testAccComputeV2Instance_updateTags,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeV2InstanceExists("opentelekomcloud_compute_instance_v2.instance_1", &instance),
 					testAccCheckComputeV2InstanceTagsV1(&instance, "foo2", "bar2"),
@@ -64,14 +63,14 @@ func TestAccComputeV2Instance_tags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccComputeV2Instance_notags,
+				Config: testAccComputeV2Instance_withoutTags,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeV2InstanceExists("opentelekomcloud_compute_instance_v2.instance_1", &instance),
 					testAccCheckComputeV2InstanceNoTagV1(&instance),
 				),
 			},
 			{
-				Config: testAccComputeV2Instance_tags,
+				Config: testAccComputeV2Instance_withTags,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeV2InstanceExists("opentelekomcloud_compute_instance_v2.instance_1", &instance),
 					testAccCheckComputeV2InstanceTagsV1(&instance, "foo", "bar"),
@@ -99,7 +98,7 @@ func TestAccComputeV2Instance_tag(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccComputeV2Instance_tag2,
+				Config: testAccComputeV2Instance_updateTag,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeV2InstanceExists("opentelekomcloud_compute_instance_v2.instance_1", &instance),
 					testAccCheckComputeV2InstanceTagsV1(&instance, "foo", "bar2"),
@@ -107,7 +106,7 @@ func TestAccComputeV2Instance_tag(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccComputeV2Instance_notags,
+				Config: testAccComputeV2Instance_withoutTags,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeV2InstanceExists("opentelekomcloud_compute_instance_v2.instance_1", &instance),
 					testAccCheckComputeV2InstanceNoTagV1(&instance),
@@ -125,9 +124,9 @@ func TestAccComputeV2Instance_tag(t *testing.T) {
 	})
 }
 
-func TestAccComputeV2Instance_secgroupMulti(t *testing.T) {
-	var instance_1 servers.Server
-	var secgroup_1 secgroups.SecurityGroup
+func TestAccComputeV2Instance_multiSecgroup(t *testing.T) {
+	var instance servers.Server
+	var firstSecGroup, secondSecGroup secgroups.SecurityGroup
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -135,47 +134,25 @@ func TestAccComputeV2Instance_secgroupMulti(t *testing.T) {
 		CheckDestroy: testAccCheckComputeV2InstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeV2Instance_secgroupMulti,
+				Config: testAccComputeV2Instance_multiSecgroup,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeV2SecGroupExists(
-						"opentelekomcloud_compute_secgroup_v2.secgroup_1", &secgroup_1),
-					testAccCheckComputeV2InstanceExists(
-						"opentelekomcloud_compute_instance_v2.instance_1", &instance_1),
-				),
-			},
-		},
-	})
-}
-
-func TestAccComputeV2Instance_secgroupMultiUpdate(t *testing.T) {
-	var instance_1 servers.Server
-	var secgroup_1, secgroup_2 secgroups.SecurityGroup
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckComputeV2InstanceDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccComputeV2Instance_secgroupMultiUpdate_1,
-				Check: resource.ComposeTestCheckFunc(
+						"opentelekomcloud_compute_secgroup_v2.secgroup_1", &firstSecGroup),
 					testAccCheckComputeV2SecGroupExists(
-						"opentelekomcloud_compute_secgroup_v2.secgroup_1", &secgroup_1),
-					testAccCheckComputeV2SecGroupExists(
-						"opentelekomcloud_compute_secgroup_v2.secgroup_2", &secgroup_2),
+						"opentelekomcloud_compute_secgroup_v2.secgroup_2", &secondSecGroup),
 					testAccCheckComputeV2InstanceExists(
-						"opentelekomcloud_compute_instance_v2.instance_1", &instance_1),
+						"opentelekomcloud_compute_instance_v2.instance_1", &instance),
 				),
 			},
 			{
-				Config: testAccComputeV2Instance_secgroupMultiUpdate_2,
+				Config: testAccComputeV2Instance_multiSecgroupUpdate,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeV2SecGroupExists(
-						"opentelekomcloud_compute_secgroup_v2.secgroup_1", &secgroup_1),
+						"opentelekomcloud_compute_secgroup_v2.secgroup_1", &firstSecGroup),
 					testAccCheckComputeV2SecGroupExists(
-						"opentelekomcloud_compute_secgroup_v2.secgroup_2", &secgroup_2),
+						"opentelekomcloud_compute_secgroup_v2.secgroup_2", &secondSecGroup),
 					testAccCheckComputeV2InstanceExists(
-						"opentelekomcloud_compute_instance_v2.instance_1", &instance_1),
+						"opentelekomcloud_compute_instance_v2.instance_1", &instance),
 				),
 			},
 		},
@@ -221,36 +198,8 @@ func TestAccComputeV2Instance_bootFromVolumeVolume(t *testing.T) {
 }
 
 func TestAccComputeV2Instance_bootFromVolumeForceNew(t *testing.T) {
-	var instance1_1 servers.Server
-	var instance1_2 servers.Server
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckComputeV2InstanceDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccComputeV2Instance_bootFromVolumeForceNew_1,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2InstanceExists(
-						"opentelekomcloud_compute_instance_v2.instance_1", &instance1_1),
-				),
-			},
-			{
-				Config: testAccComputeV2Instance_bootFromVolumeForceNew_2,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2InstanceExists(
-						"opentelekomcloud_compute_instance_v2.instance_1", &instance1_2),
-					testAccCheckComputeV2InstanceInstanceIDsDoNotMatch(&instance1_1, &instance1_2),
-				),
-			},
-		},
-	})
-}
-
-// TODO: verify the personality really exists on the instance.
-func TestAccComputeV2Instance_personality(t *testing.T) {
 	var instance servers.Server
+	var newInstance servers.Server
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -258,9 +207,18 @@ func TestAccComputeV2Instance_personality(t *testing.T) {
 		CheckDestroy: testAccCheckComputeV2InstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeV2Instance_personality,
+				Config: testAccComputeV2Instance_bootFromVolume,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2InstanceExists("opentelekomcloud_compute_instance_v2.instance_1", &instance),
+					testAccCheckComputeV2InstanceExists(
+						"opentelekomcloud_compute_instance_v2.instance_1", &instance),
+				),
+			},
+			{
+				Config: testAccComputeV2Instance_bootFromVolumeUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeV2InstanceExists(
+						"opentelekomcloud_compute_instance_v2.instance_1", &newInstance),
+					testAccCheckComputeV2InstanceInstanceIDsDoNotMatch(&instance, &newInstance),
 				),
 			},
 		},
@@ -268,8 +226,8 @@ func TestAccComputeV2Instance_personality(t *testing.T) {
 }
 
 func TestAccComputeV2Instance_changeFixedIP(t *testing.T) {
-	var instance1_1 servers.Server
-	var instance1_2 servers.Server
+	var instance servers.Server
+	var newInstance servers.Server
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -277,18 +235,18 @@ func TestAccComputeV2Instance_changeFixedIP(t *testing.T) {
 		CheckDestroy: testAccCheckComputeV2InstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeV2Instance_changeFixedIP_1,
+				Config: testAccComputeV2Instance_fixedIP,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeV2InstanceExists(
-						"opentelekomcloud_compute_instance_v2.instance_1", &instance1_1),
+						"opentelekomcloud_compute_instance_v2.instance_1", &instance),
 				),
 			},
 			{
-				Config: testAccComputeV2Instance_changeFixedIP_2,
+				Config: testAccComputeV2Instance_fixedIPUpdate,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeV2InstanceExists(
-						"opentelekomcloud_compute_instance_v2.instance_1", &instance1_2),
-					testAccCheckComputeV2InstanceInstanceIDsDoNotMatch(&instance1_1, &instance1_2),
+						"opentelekomcloud_compute_instance_v2.instance_1", &newInstance),
+					testAccCheckComputeV2InstanceInstanceIDsDoNotMatch(&instance, &newInstance),
 				),
 			},
 		},
@@ -297,6 +255,7 @@ func TestAccComputeV2Instance_changeFixedIP(t *testing.T) {
 
 func TestAccComputeV2Instance_stopBeforeDestroy(t *testing.T) {
 	var instance servers.Server
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -312,7 +271,7 @@ func TestAccComputeV2Instance_stopBeforeDestroy(t *testing.T) {
 	})
 }
 
-func TestAccComputeV2Instance_metadataRemove(t *testing.T) {
+func TestAccComputeV2Instance_metadata(t *testing.T) {
 	var instance servers.Server
 
 	resource.Test(t, resource.TestCase{
@@ -321,7 +280,7 @@ func TestAccComputeV2Instance_metadataRemove(t *testing.T) {
 		CheckDestroy: testAccCheckComputeV2InstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeV2Instance_metadataRemove_1,
+				Config: testAccComputeV2Instance_metadata,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeV2InstanceExists("opentelekomcloud_compute_instance_v2.instance_1", &instance),
 					testAccCheckComputeV2InstanceMetadata(&instance, "foo", "bar"),
@@ -333,7 +292,7 @@ func TestAccComputeV2Instance_metadataRemove(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccComputeV2Instance_metadataRemove_2,
+				Config: testAccComputeV2Instance_metadataUpdate,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeV2InstanceExists("opentelekomcloud_compute_instance_v2.instance_1", &instance),
 					testAccCheckComputeV2InstanceMetadata(&instance, "foo", "bar"),
@@ -366,7 +325,7 @@ func TestAccComputeV2Instance_timeout(t *testing.T) {
 	})
 }
 
-func TestAccComputeV2Instance_auto_recovery(t *testing.T) {
+func TestAccComputeV2Instance_autoRecovery(t *testing.T) {
 	var instance servers.Server
 
 	resource.Test(t, resource.TestCase{
@@ -383,7 +342,7 @@ func TestAccComputeV2Instance_auto_recovery(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccComputeV2Instance_auto_recovery,
+				Config: testAccComputeV2Instance_autoRecovery,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeV2InstanceExists("opentelekomcloud_compute_instance_v2.instance_1", &instance),
 					resource.TestCheckResourceAttr(
@@ -398,7 +357,7 @@ func testAccCheckComputeV2InstanceDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 	computeClient, err := config.computeV2Client(OS_REGION_NAME)
 	if err != nil {
-		return fmt.Errorf("Error creating OpenTelekomCloud compute client: %s", err)
+		return fmt.Errorf("error creating OpenTelekomCloud ComputeV2 client: %s", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -409,7 +368,7 @@ func testAccCheckComputeV2InstanceDestroy(s *terraform.State) error {
 		server, err := servers.Get(computeClient, rs.Primary.ID).Extract()
 		if err == nil {
 			if server.Status != "SOFT_DELETED" {
-				return fmt.Errorf("Instance still exists")
+				return fmt.Errorf("instance still exists")
 			}
 		}
 	}
@@ -421,17 +380,17 @@ func testAccCheckComputeV2InstanceExists(n string, instance *servers.Server) res
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return fmt.Errorf("not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
+			return fmt.Errorf("no ID is set")
 		}
 
 		config := testAccProvider.Meta().(*Config)
 		computeClient, err := config.computeV2Client(OS_REGION_NAME)
 		if err != nil {
-			return fmt.Errorf("Error creating OpenTelekomCloud compute client: %s", err)
+			return fmt.Errorf("error creating OpenTelekomCloud ComputeV2 client: %s", err)
 		}
 
 		found, err := servers.Get(computeClient, rs.Primary.ID).Extract()
@@ -440,7 +399,7 @@ func testAccCheckComputeV2InstanceExists(n string, instance *servers.Server) res
 		}
 
 		if found.ID != rs.Primary.ID {
-			return fmt.Errorf("Instance not found")
+			return fmt.Errorf("instance not found")
 		}
 
 		*instance = *found
@@ -449,45 +408,23 @@ func testAccCheckComputeV2InstanceExists(n string, instance *servers.Server) res
 	}
 }
 
-func testAccCheckComputeV2InstanceDoesNotExist(n string, instance *servers.Server) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(*Config)
-		computeClient, err := config.computeV2Client(OS_REGION_NAME)
-		if err != nil {
-			return fmt.Errorf("Error creating OpenTelekomCloud compute client: %s", err)
-		}
-
-		_, err = servers.Get(computeClient, instance.ID).Extract()
-		if err != nil {
-			if _, ok := err.(golangsdk.ErrDefault404); ok {
-				return nil
-			}
-			return err
-		}
-
-		return fmt.Errorf("Instance still exists")
-	}
-}
-
 func testAccCheckComputeV2InstanceMetadata(instance *servers.Server, k string, v string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if instance.Metadata == nil {
-			return fmt.Errorf("No metadata")
+			return fmt.Errorf("no metadata")
 		}
-
 		for key, value := range instance.Metadata {
 			if k != key {
 				continue
 			}
-
 			if v == value {
 				return nil
 			}
 
-			return fmt.Errorf("Bad value for %s: %s", k, value)
+			return fmt.Errorf("bad value for %s: %s", k, value)
 		}
 
-		return fmt.Errorf("Metadata not found: %s", k)
+		return fmt.Errorf("metadata not found: %s", k)
 	}
 }
 
@@ -499,7 +436,7 @@ func testAccCheckComputeV2InstanceNoMetadataKey(instance *servers.Server, k stri
 
 		for key := range instance.Metadata {
 			if k == key {
-				return fmt.Errorf("Metadata found: %s", k)
+				return fmt.Errorf("metadata found: %s", k)
 			}
 		}
 
@@ -512,23 +449,25 @@ func testAccCheckComputeV2InstanceTagsV1(instance *servers.Server, k, v string) 
 		config := testAccProvider.Meta().(*Config)
 		client, err := config.computeV1Client(OS_REGION_NAME)
 		if err != nil {
-			return fmt.Errorf("Error creating OpenTelekomCloud compute v1 client: %s", err)
+			return fmt.Errorf("error creating OpenTelekomCloud ComputeV1 client: %s", err)
 		}
 
 		tagsList, err := tags.Get(client, instance.ID).Extract()
+		if err != nil {
+			return err
+		}
 		for _, val := range tagsList.Tags {
 			if k != val.Key {
 				continue
 			}
-
 			if v == val.Value {
 				return nil
 			}
 
-			return fmt.Errorf("Bad value for %s: %s", k, val.Value)
+			return fmt.Errorf("bad value for %s: %s", k, val.Value)
 		}
 
-		return fmt.Errorf("Tag not found: %s", k)
+		return fmt.Errorf("tag not found: %s", k)
 	}
 }
 
@@ -537,10 +476,13 @@ func testAccCheckComputeV2InstanceNoTagV1(instance *servers.Server) resource.Tes
 		config := testAccProvider.Meta().(*Config)
 		client, err := config.computeV1Client(OS_REGION_NAME)
 		if err != nil {
-			return fmt.Errorf("Error creating OpenTelekomCloud compute v1 client: %s", err)
+			return fmt.Errorf("error creating OpenTelekomCloud ComputeV1 client: %s", err)
 		}
 
 		tagList, err := tags.Get(client, instance.ID).Extract()
+		if err != nil {
+			return err
+		}
 
 		if tagList.Tags == nil {
 			return nil
@@ -549,7 +491,7 @@ func testAccCheckComputeV2InstanceNoTagV1(instance *servers.Server) resource.Tes
 			return nil
 		}
 
-		return fmt.Errorf("Expected no tags, but found %v", tagList.Tags)
+		return fmt.Errorf("expected no tags, but found %v", tagList.Tags)
 	}
 }
 
@@ -568,7 +510,7 @@ func testAccCheckComputeV2InstanceBootVolumeAttachment(instance *servers.Server)
 
 				actual, err := volumeattach.ExtractVolumeAttachments(page)
 				if err != nil {
-					return false, fmt.Errorf("Unable to lookup attachment: %s", err)
+					return false, fmt.Errorf("unable to lookup attachment: %s", err)
 				}
 
 				attachments = actual
@@ -579,14 +521,14 @@ func testAccCheckComputeV2InstanceBootVolumeAttachment(instance *servers.Server)
 			return nil
 		}
 
-		return fmt.Errorf("No attached volume found.")
+		return fmt.Errorf("no attached volume found")
 	}
 }
 
 func testAccCheckComputeV2InstanceInstanceIDsDoNotMatch(instance1, instance2 *servers.Server) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if instance1.ID == instance2.ID {
-			return fmt.Errorf("Instance was not recreated.")
+			return fmt.Errorf("instance was not recreated")
 		}
 
 		return nil
@@ -607,7 +549,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
 }
 `, OS_AVAILABILITY_ZONE, OS_NETWORK_ID)
 
-var testAccComputeV2Instance_notags = fmt.Sprintf(`
+var testAccComputeV2Instance_withoutTags = fmt.Sprintf(`
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name = "instance_1"
   security_groups = ["default"]
@@ -621,7 +563,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
 }
 `, OS_AVAILABILITY_ZONE, OS_NETWORK_ID)
 
-var testAccComputeV2Instance_tags = fmt.Sprintf(`
+var testAccComputeV2Instance_withTags = fmt.Sprintf(`
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name = "instance_1"
   security_groups = ["default"]
@@ -639,7 +581,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
 }
 `, OS_AVAILABILITY_ZONE, OS_NETWORK_ID)
 
-var testAccComputeV2Instance_tags2 = fmt.Sprintf(`
+var testAccComputeV2Instance_updateTags = fmt.Sprintf(`
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name = "instance_1"
   security_groups = ["default"]
@@ -675,7 +617,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
 }
 `, OS_AVAILABILITY_ZONE, OS_NETWORK_ID)
 
-var testAccComputeV2Instance_tag2 = fmt.Sprintf(`
+var testAccComputeV2Instance_updateTag = fmt.Sprintf(`
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name = "instance_1"
   security_groups = ["default"]
@@ -693,28 +635,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
 }
 `, OS_AVAILABILITY_ZONE, OS_NETWORK_ID)
 
-var testAccComputeV2Instance_secgroupMulti = fmt.Sprintf(`
-resource "opentelekomcloud_compute_secgroup_v2" "secgroup_1" {
-  name = "secgroup_1"
-  description = "a security group"
-  rule {
-    from_port = 22
-    to_port = 22
-    ip_protocol = "tcp"
-    cidr = "0.0.0.0/0"
-  }
-}
-
-resource "opentelekomcloud_compute_instance_v2" "instance_1" {
-  name = "instance_1"
-  security_groups = ["default", opentelekomcloud_compute_secgroup_v2.secgroup_1.name]
-  network {
-    uuid = "%s"
-  }
-}
-`, OS_NETWORK_ID)
-
-var testAccComputeV2Instance_secgroupMultiUpdate_1 = fmt.Sprintf(`
+var testAccComputeV2Instance_multiSecgroup = fmt.Sprintf(`
 resource "opentelekomcloud_compute_secgroup_v2" "secgroup_1" {
   name = "secgroup_1"
   description = "a security group"
@@ -746,7 +667,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
 }
 `, OS_NETWORK_ID)
 
-var testAccComputeV2Instance_secgroupMultiUpdate_2 = fmt.Sprintf(`
+var testAccComputeV2Instance_multiSecgroupUpdate = fmt.Sprintf(`
 resource "opentelekomcloud_compute_secgroup_v2" "secgroup_1" {
   name = "secgroup_1"
   description = "a security group"
@@ -820,7 +741,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
 }
 `, OS_IMAGE_ID, OS_NETWORK_ID)
 
-var testAccComputeV2Instance_bootFromVolumeForceNew_1 = fmt.Sprintf(`
+var testAccComputeV2Instance_bootFromVolume = fmt.Sprintf(`
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name = "instance_1"
   security_groups = ["default"]
@@ -838,7 +759,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
 }
 `, OS_NETWORK_ID, OS_IMAGE_ID)
 
-var testAccComputeV2Instance_bootFromVolumeForceNew_2 = fmt.Sprintf(`
+var testAccComputeV2Instance_bootFromVolumeUpdate = fmt.Sprintf(`
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name = "instance_1"
   security_groups = ["default"]
@@ -856,141 +777,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
 }
 `, OS_NETWORK_ID, OS_IMAGE_ID)
 
-var testAccComputeV2Instance_blockDeviceNewVolume = fmt.Sprintf(`
-resource "opentelekomcloud_compute_instance_v2" "instance_1" {
-  name = "instance_1"
-  security_groups = ["default"]
-  network {
-    uuid = "%s"
-  }
-  block_device {
-    uuid = "%s"
-    source_type = "image"
-    destination_type = "local"
-    boot_index = 0
-    delete_on_termination = true
-  }
-  block_device {
-    source_type = "blank"
-    destination_type = "volume"
-    volume_size = 1
-    boot_index = 1
-    delete_on_termination = true
-  }
-}
-`, OS_NETWORK_ID, OS_IMAGE_ID)
-
-var testAccComputeV2Instance_blockDeviceExistingVolume = fmt.Sprintf(`
-resource "opentelekomcloud_blockstorage_volume_v2" "volume_1" {
-  name = "volume_1"
-  size = 1
-}
-
-resource "opentelekomcloud_compute_instance_v2" "instance_1" {
-  name = "instance_1"
-  security_groups = ["default"]
-  network {
-    uuid = "%s"
-  }
-  block_device {
-    uuid = "%s"
-    source_type = "image"
-    destination_type = "local"
-    boot_index = 0
-    delete_on_termination = true
-  }
-  block_device {
-    uuid = opentelekomcloud_blockstorage_volume_v2.volume_1.id
-    source_type = "volume"
-    destination_type = "volume"
-    boot_index = 1
-    delete_on_termination = true
-  }
-}
-`, OS_NETWORK_ID, OS_IMAGE_ID)
-
-var testAccComputeV2Instance_personality = fmt.Sprintf(`
-resource "opentelekomcloud_compute_instance_v2" "instance_1" {
-  name = "instance_1"
-  security_groups = ["default"]
-  network {
-    uuid = "%s"
-  }
-  personality {
-    file = "/tmp/foobar.txt"
-    content = "happy"
-  }
-  personality {
-    file = "/tmp/barfoo.txt"
-    content = "angry"
-  }
-}
-`, OS_NETWORK_ID)
-
-var testAccComputeV2Instance_multiEphemeral = fmt.Sprintf(`
-resource "opentelekomcloud_compute_instance_v2" "instance_1" {
-  name = "terraform-test"
-  security_groups = ["default"]
-  network {
-    uuid = "%s"
-  }
-  block_device {
-    boot_index = 0
-    delete_on_termination = true
-    destination_type = "local"
-    source_type = "image"
-    uuid = "%s"
-  }
-  block_device {
-    boot_index = -1
-    delete_on_termination = true
-    destination_type = "local"
-    source_type = "blank"
-    volume_size = 1
-  }
-  block_device {
-    boot_index = -1
-    delete_on_termination = true
-    destination_type = "local"
-    source_type = "blank"
-    volume_size = 1
-  }
-}
-`, OS_NETWORK_ID, OS_IMAGE_ID)
-
-var testAccComputeV2Instance_accessIPv4 = fmt.Sprintf(`
-resource "opentelekomcloud_networking_network_v2" "network_1" {
-  name = "network_1"
-}
-
-resource "opentelekomcloud_networking_subnet_v2" "subnet_1" {
-  name = "subnet_1"
-  network_id = opentelekomcloud_networking_network_v2.network_1.id
-  cidr = "192.168.1.0/24"
-  ip_version = 4
-  enable_dhcp = true
-  no_gateway = true
-}
-
-resource "opentelekomcloud_compute_instance_v2" "instance_1" {
-  depends_on = ["opentelekomcloud_networking_subnet_v2.subnet_1"]
-
-  name = "instance_1"
-  security_groups = ["default"]
-
-  network {
-    uuid = "%s"
-  }
-
-  network {
-    uuid = opentelekomcloud_networking_network_v2.network_1.id
-    fixed_ip_v4 = "192.168.1.100"
-    access_network = true
-  }
-}
-`, OS_NETWORK_ID)
-
-var testAccComputeV2Instance_changeFixedIP_1 = fmt.Sprintf(`
+var testAccComputeV2Instance_fixedIP = fmt.Sprintf(`
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name = "instance_1"
   security_groups = ["default"]
@@ -1001,7 +788,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
 }
 `, OS_NETWORK_ID)
 
-var testAccComputeV2Instance_changeFixedIP_2 = fmt.Sprintf(`
+var testAccComputeV2Instance_fixedIPUpdate = fmt.Sprintf(`
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name = "instance_1"
   security_groups = ["default"]
@@ -1023,7 +810,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
 }
 `, OS_NETWORK_ID)
 
-var testAccComputeV2Instance_metadataRemove_1 = fmt.Sprintf(`
+var testAccComputeV2Instance_metadata = fmt.Sprintf(`
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name = "instance_1"
   security_groups = ["default"]
@@ -1037,7 +824,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
 }
 `, OS_NETWORK_ID)
 
-var testAccComputeV2Instance_metadataRemove_2 = fmt.Sprintf(`
+var testAccComputeV2Instance_metadataUpdate = fmt.Sprintf(`
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name = "instance_1"
   security_groups = ["default"]
@@ -1050,19 +837,6 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   }
 }
 `, OS_NETWORK_ID)
-
-/*
-var testAccComputeV2Instance_forceDelete = fmt.Sprintf(`
-resource "opentelekomcloud_compute_instance_v2" "instance_1" {
-  name = "instance_1"
-  security_groups = ["default"]
-  network {
-    uuid = "%s"
-  }
-  force_delete = true
-}
-`, OS_NETWORK_ID)
-*/
 
 var testAccComputeV2Instance_timeout = fmt.Sprintf(`
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
@@ -1078,162 +852,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
 }
 `, OS_NETWORK_ID)
 
-var testAccComputeV2Instance_networkNameToID = fmt.Sprintf(`
-resource "opentelekomcloud_networking_network_v2" "network_1" {
-  name = "network_1"
-}
-
-resource "opentelekomcloud_networking_subnet_v2" "subnet_1" {
-  name = "subnet_1"
-  network_id = opentelekomcloud_networking_network_v2.network_1.id
-  cidr = "192.168.1.0/24"
-  ip_version = 4
-  enable_dhcp = true
-  no_gateway = true
-}
-
-resource "opentelekomcloud_compute_instance_v2" "instance_1" {
-  depends_on = ["opentelekomcloud_networking_subnet_v2.subnet_1"]
-
-  name = "instance_1"
-  security_groups = ["default"]
-
-  network {
-    uuid = "%s"
-  }
-
-  network {
-    name = opentelekomcloud_networking_network_v2.network_1.name
-  }
-
-}
-`, OS_NETWORK_ID)
-
-var testAccComputeV2Instance_crazyNICs = fmt.Sprintf(`
-resource "opentelekomcloud_networking_network_v2" "network_1" {
-  name = "network_1"
-}
-
-resource "opentelekomcloud_networking_subnet_v2" "subnet_1" {
-  name = "subnet_1"
-  network_id = opentelekomcloud_networking_network_v2.network_1.id
-  cidr = "192.168.1.0/24"
-  ip_version = 4
-  enable_dhcp = true
-  no_gateway = true
-}
-
-resource "opentelekomcloud_networking_network_v2" "network_2" {
-  name = "network_2"
-}
-
-resource "opentelekomcloud_networking_subnet_v2" "subnet_2" {
-  name = "subnet_2"
-  network_id = opentelekomcloud_networking_network_v2.network_2.id
-  cidr = "192.168.2.0/24"
-  ip_version = 4
-  enable_dhcp = true
-  no_gateway = true
-}
-
-resource "opentelekomcloud_networking_port_v2" "port_1" {
-  name = "port_1"
-  network_id = opentelekomcloud_networking_network_v2.network_1.id
-  admin_state_up = "true"
-
-  fixed_ip {
-    subnet_id = opentelekomcloud_networking_subnet_v2.subnet_1.id
-    ip_address = "192.168.1.103"
-  }
-}
-
-resource "opentelekomcloud_networking_port_v2" "port_2" {
-  name = "port_2"
-  network_id = opentelekomcloud_networking_network_v2.network_2.id
-  admin_state_up = "true"
-
-  fixed_ip {
-    subnet_id = opentelekomcloud_networking_subnet_v2.subnet_2.id
-    ip_address = "192.168.2.103"
-  }
-}
-
-resource "opentelekomcloud_networking_port_v2" "port_3" {
-  name = "port_3"
-  network_id = opentelekomcloud_networking_network_v2.network_1.id
-  admin_state_up = "true"
-
-  fixed_ip {
-    subnet_id = opentelekomcloud_networking_subnet_v2.subnet_1.id
-    ip_address = "192.168.1.104"
-  }
-}
-
-resource "opentelekomcloud_networking_port_v2" "port_4" {
-  name = "port_4"
-  network_id = opentelekomcloud_networking_network_v2.network_2.id
-  admin_state_up = "true"
-
-  fixed_ip {
-    subnet_id = opentelekomcloud_networking_subnet_v2.subnet_2.id
-    ip_address = "192.168.2.104"
-  }
-}
-
-resource "opentelekomcloud_compute_instance_v2" "instance_1" {
-  depends_on = [
-    "opentelekomcloud_networking_subnet_v2.subnet_1",
-    "opentelekomcloud_networking_subnet_v2.subnet_2",
-    "opentelekomcloud_networking_port_v2.port_1",
-    "opentelekomcloud_networking_port_v2.port_2",
-  ]
-
-  name = "instance_1"
-  security_groups = ["default"]
-
-  network {
-    uuid = "%s"
-  }
-
-  network {
-    uuid = opentelekomcloud_networking_network_v2.network_1.id
-    fixed_ip_v4 = "192.168.1.100"
-  }
-
-  network {
-    uuid = opentelekomcloud_networking_network_v2.network_2.id
-    fixed_ip_v4 = "192.168.2.100"
-  }
-
-  network {
-    uuid = opentelekomcloud_networking_network_v2.network_1.id
-    fixed_ip_v4 = "192.168.1.101"
-  }
-
-  network {
-    uuid = opentelekomcloud_networking_network_v2.network_2.id
-    fixed_ip_v4 = "192.168.2.101"
-  }
-
-  network {
-    port = opentelekomcloud_networking_port_v2.port_1.id
-  }
-
-  network {
-    port = opentelekomcloud_networking_port_v2.port_2.id
-  }
-
-  network {
-    port = opentelekomcloud_networking_port_v2.port_3.id
-  }
-
-  network {
-    port = opentelekomcloud_networking_port_v2.port_4.id
-  }
-}
-`, OS_NETWORK_ID)
-
-var testAccComputeV2Instance_auto_recovery = fmt.Sprintf(`
+var testAccComputeV2Instance_autoRecovery = fmt.Sprintf(`
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name = "instance_1"
   security_groups = ["default"]


### PR DESCRIPTION
## Summary of the Pull Request
Remove unused tests
Deprecate `personality` field

## PR Checklist

* [x] Refers to: #591
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
=== RUN   TestAccComputeV2Instance_basic
--- PASS: TestAccComputeV2Instance_basic (73.82s)
=== RUN   TestAccComputeV2Instance_tags
--- PASS: TestAccComputeV2Instance_tags (207.18s)
=== RUN   TestAccComputeV2Instance_tag
--- PASS: TestAccComputeV2Instance_tag (207.80s)
=== RUN   TestAccComputeV2Instance_multiSecgroup
--- PASS: TestAccComputeV2Instance_multiSecgroup (133.97s)
=== RUN   TestAccComputeV2Instance_bootFromVolumeImage
--- PASS: TestAccComputeV2Instance_bootFromVolumeImage (70.69s)
=== RUN   TestAccComputeV2Instance_bootFromVolumeVolume
--- PASS: TestAccComputeV2Instance_bootFromVolumeVolume (89.01s)
=== RUN   TestAccComputeV2Instance_bootFromVolumeForceNew
--- PASS: TestAccComputeV2Instance_bootFromVolumeForceNew (137.55s)
=== RUN   TestAccComputeV2Instance_changeFixedIP
--- PASS: TestAccComputeV2Instance_changeFixedIP (149.93s)
=== RUN   TestAccComputeV2Instance_stopBeforeDestroy
--- PASS: TestAccComputeV2Instance_stopBeforeDestroy (81.13s)
=== RUN   TestAccComputeV2Instance_metadata
--- PASS: TestAccComputeV2Instance_metadata (113.43s)
=== RUN   TestAccComputeV2Instance_timeout
--- PASS: TestAccComputeV2Instance_timeout (72.09s)
=== RUN   TestAccComputeV2Instance_autoRecovery
--- PASS: TestAccComputeV2Instance_autoRecovery (112.06s)
=== RUN   TestAccComputeV2Instance_crazyNICs
--- PASS: TestAccComputeV2Instance_crazyNICs (215.74s)
PASS

Process finished with exit code 0
```
