### PR TITLE
[CCE]  Fix crash on empty `basic` addon values

### DIFF
--- a/opentelekomcloud/resource_opentelekomcloud_cce_addon_v3.go
+++ b/opentelekomcloud/resource_opentelekomcloud_cce_addon_v3.go
@@ -132,22 +132,13 @@ func resourceCCEAddonV3Read(d *schema.ResourceData, meta interface{}) error {
 }
 
 func getAddonValues(d *schema.ResourceData) (basic, custom map[string]interface{}, err error) {
-	values := d.Get("values").([]interface{})
-	if len(values) == 0 {
-		err = fmt.Errorf("no values are set for CCE addon") // should be impossible, as Required: true
+	valLength := d.Get("values.#").(int)
+	if valLength == 0 {
+		err = fmt.Errorf("no values are set for CCE addon")
 		return
 	}
-	valuesMap := values[0].(map[string]interface{})
-
-	basicRaw, ok := valuesMap["basic"]
-	if !ok {
-		err = fmt.Errorf("no basic values are set for CCE addon") // should be impossible, as Required: true
-		return
-	}
-	if customRaw, ok := valuesMap["custom"]; ok {
-		custom = customRaw.(map[string]interface{})
-	}
-	basic = basicRaw.(map[string]interface{})
+	basic = d.Get("values.0.basic").(map[string]interface{})
+	custom = d.Get("values.0.custom").(map[string]interface{})
 	return
 }
 

--- a/opentelekomcloud/resource_opentelekomcloud_cce_addon_v3_test.go
+++ b/opentelekomcloud/resource_opentelekomcloud_cce_addon_v3_test.go
@@ -22,6 +22,19 @@ func TestAccCCEAddonV3_basic(t *testing.T) {
 	})
 }
 
+func TestAccCCEAddonV3_emptyBasic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCCEAddonV3Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCCEAddonV3_emptyBasic,
+			},
+		},
+	})
+}
+
 func testAccCheckCCEAddonV3Destroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 	cceClient, err := config.cceV3Client(OS_REGION_NAME)
@@ -43,7 +56,8 @@ func testAccCheckCCEAddonV3Destroy(s *terraform.State) error {
 	return nil
 }
 
-var testAccCCEAddonV3_basic = fmt.Sprintf(`
+var (
+	testAccCCEAddonV3_basic = fmt.Sprintf(`
 resource opentelekomcloud_cce_cluster_v3 cluster_1 {
   name                    = "%s"
   cluster_type            = "VirtualMachine"
@@ -69,3 +83,25 @@ resource opentelekomcloud_cce_addon_v3 addon {
   }
 }
 `, clusterName, OS_VPC_ID, OS_NETWORK_ID)
+
+	testAccCCEAddonV3_emptyBasic = fmt.Sprintf(`
+resource opentelekomcloud_cce_cluster_v3 cluster {
+  name                    = "%s"
+  cluster_type            = "VirtualMachine"
+  flavor_id               = "cce.s1.small"
+  vpc_id                  = "%s"
+  subnet_id               = "%s"
+  container_network_type  = "overlay_l2"
+  kubernetes_svc_ip_range = "10.247.0.0/16"
+}
+
+resource "opentelekomcloud_cce_addon_v3" "cluster_autoscaler" {
+  template_name    = "autoscaler"
+  template_version = "1.17.2"
+  cluster_id       = opentelekomcloud_cce_cluster_v3.cluster.id
+  values {
+    basic = {}
+  }
+}
+`, clusterName, OS_VPC_ID, OS_NETWORK_ID)
+)


### PR DESCRIPTION
## Summary of the Pull Request
Improve handling of addon values (both `basic` and `custom`)
Fix #834

Depends-on: https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/838

## PR Checklist

* [x] Refers to: #834
* [x] Tests added/passed.

## Acceptance Steps Performed

```
=== RUN   TestAccCCEAddonV3_basic
--- PASS: TestAccCCEAddonV3_basic (503.35s)
=== RUN   TestAccCCEAddonV3_emptyBasic
--- PASS: TestAccCCEAddonV3_emptyBasic (419.24s)
PASS

Process finished with exit code 0
```
