### PR TITLE
Make goreleaser-build jobs non-voting

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -5,12 +5,14 @@
       jobs:
         - golang-make-test
         - golang-make-vet
-        - goreleaser-build
+        - goreleaser-build:
+            voting: false
     gate:
       jobs:
         - golang-make-test
         - golang-make-vet
-        - goreleaser-build
+        - goreleaser-build:
+            voting: false
     tag:
       jobs:
         - release-goreleaser


### PR DESCRIPTION
## Summary of the Pull Request
Make `goreleaser-build` jobs non-voting

Reason: `goreleaser-build` on openshift fails for some reason. 
