### PR TITLE
Make DNS resources diff ignore ending dot in name

### DIFF
--- a/opentelekomcloud/acceptance/resource_opentelekomcloud_dns_ptrrecord_v2_test.go
+++ b/opentelekomcloud/acceptance/resource_opentelekomcloud_dns_ptrrecord_v2_test.go
@@ -2,6 +2,7 @@ package acceptance
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
@@ -40,6 +41,21 @@ func TestAccDNSV2PtrRecord_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"opentelekomcloud_dns_ptrrecord_v2.ptr_1", "tags.muh", "value-update"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccDNSV2PtrRecord_undotted(t *testing.T) {
+	zoneName := randomZoneName()
+	zoneName = strings.TrimSuffix(zoneName, ".")
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDNSV2PtrRecordDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDNSV2PtrRecord_basic(zoneName),
 			},
 		},
 	})

--- a/opentelekomcloud/acceptance/resource_opentelekomcloud_dns_recordset_v2_test.go
+++ b/opentelekomcloud/acceptance/resource_opentelekomcloud_dns_recordset_v2_test.go
@@ -3,6 +3,7 @@ package acceptance
 import (
 	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
@@ -56,6 +57,21 @@ func TestAccDNSV2RecordSet_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"opentelekomcloud_dns_recordset_v2.recordset_1", "description", "an updated record set"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccDNSV2RecordSet_undotted(t *testing.T) {
+	zoneName := randomZoneName()
+	zoneName = strings.TrimSuffix(zoneName, ".")
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDNSV2RecordSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDNSV2RecordSet_basic(zoneName),
 			},
 		},
 	})
@@ -216,7 +232,7 @@ func testAccCheckDNSV2RecordSetExists(n string, recordset *recordsets.RecordSet)
 func testAccDNSV2RecordSet_basic(zoneName string) string {
 	return fmt.Sprintf(`
 resource "opentelekomcloud_dns_zone_v2" "zone_1" {
-  name        = "%s"
+  name        = "%[1]s"
   email       = "email2@example.com"
   description = "a zone"
   ttl         = 6000
@@ -224,7 +240,7 @@ resource "opentelekomcloud_dns_zone_v2" "zone_1" {
 
 resource "opentelekomcloud_dns_recordset_v2" "recordset_1" {
   zone_id     = opentelekomcloud_dns_zone_v2.zone_1.id
-  name        = "%s"
+  name        = "%[1]s"
   type        = "A"
   description = "a record set"
   ttl         = 3000
@@ -235,7 +251,7 @@ resource "opentelekomcloud_dns_recordset_v2" "recordset_1" {
     key = "value"
   }
 }
-`, zoneName, zoneName)
+`, zoneName)
 }
 
 func testAccDNSV2RecordSet_update(zoneName string) string {
@@ -266,7 +282,7 @@ resource "opentelekomcloud_dns_recordset_v2" "recordset_1" {
 func testAccDNSV2RecordSet_readTTL(zoneName string) string {
 	return fmt.Sprintf(`
 resource "opentelekomcloud_dns_zone_v2" "zone_1" {
-  name        = "%s"
+  name        = "%[1]s"
   email       = "email2@example.com"
   description = "an updated zone"
   ttl         = 6000
@@ -274,17 +290,17 @@ resource "opentelekomcloud_dns_zone_v2" "zone_1" {
 
 resource "opentelekomcloud_dns_recordset_v2" "recordset_1" {
   zone_id = opentelekomcloud_dns_zone_v2.zone_1.id
-  name    = "%s"
+  name    = "%[1]s"
   type    = "A"
   records = ["10.1.0.2"]
 }
-`, zoneName, zoneName)
+`, zoneName)
 }
 
 func testAccDNSV2RecordSet_timeout(zoneName string) string {
 	return fmt.Sprintf(`
 resource "opentelekomcloud_dns_zone_v2" "zone_1" {
-  name        = "%s"
+  name        = "%[1]s"
   email       = "email2@example.com"
   description = "an updated zone"
   ttl         = 6000
@@ -292,7 +308,7 @@ resource "opentelekomcloud_dns_zone_v2" "zone_1" {
 
 resource "opentelekomcloud_dns_recordset_v2" "recordset_1" {
   zone_id = opentelekomcloud_dns_zone_v2.zone_1.id
-  name    = "%s"
+  name    = "%[1]s"
   type    = "A"
   ttl     = 3000
   records = ["10.1.0.3", "10.1.0.2"]
@@ -303,7 +319,7 @@ resource "opentelekomcloud_dns_recordset_v2" "recordset_1" {
     delete = "5m"
   }
 }
-`, zoneName, zoneName)
+`, zoneName)
 }
 
 func testAccDNSV2RecordSet_reuse(zoneName string) string {

--- a/opentelekomcloud/acceptance/resource_opentelekomcloud_dns_zone_v2_test.go
+++ b/opentelekomcloud/acceptance/resource_opentelekomcloud_dns_zone_v2_test.go
@@ -3,6 +3,7 @@ package acceptance
 import (
 	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
@@ -49,6 +50,21 @@ func TestAccDNSV2Zone_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"opentelekomcloud_dns_zone_v2.zone_1", "tags.key", "value_updated"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccDNSV2Zone_undotted(t *testing.T) {
+	zoneName := randomZoneName()
+	zoneName = strings.TrimSuffix(zoneName, ".")
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDNSV2ZoneDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDNSV2Zone_basic(zoneName),
 			},
 		},
 	})

--- a/opentelekomcloud/common/diff_suppress_funcs.go
+++ b/opentelekomcloud/common/diff_suppress_funcs.go
@@ -82,3 +82,9 @@ func SuppressSmartVersionDiff(_, old, new string, _ *schema.ResourceData) bool {
 func SuppressCaseInsensitive(_, old, new string, _ *schema.ResourceData) bool {
 	return strings.ToLower(old) == strings.ToLower(new)
 }
+
+func SuppressEqualZoneNames(_, old, new string, _ *schema.ResourceData) bool {
+	oldShort := strings.TrimSuffix(old, ".")
+	newShort := strings.TrimSuffix(new, ".")
+	return oldShort == newShort
+}

--- a/opentelekomcloud/services/dns/resource_opentelekomcloud_dns_ptrrecord_v2.go
+++ b/opentelekomcloud/services/dns/resource_opentelekomcloud_dns_ptrrecord_v2.go
@@ -37,8 +37,9 @@ func ResourceDNSPtrRecordV2() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:             schema.TypeString,
+				Required:         true,
+				DiffSuppressFunc: common.SuppressEqualZoneNames,
 			},
 			"description": {
 				Type:     schema.TypeString,

--- a/opentelekomcloud/services/dns/resource_opentelekomcloud_dns_recordset_v2.go
+++ b/opentelekomcloud/services/dns/resource_opentelekomcloud_dns_recordset_v2.go
@@ -49,9 +49,10 @@ func ResourceDNSRecordSetV2() *schema.Resource {
 				ForceNew: true,
 			},
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				DiffSuppressFunc: common.SuppressEqualZoneNames,
 			},
 			"description": {
 				Type:     schema.TypeString,
@@ -416,8 +417,12 @@ func getExistingRecordSetID(d cfg.SchemaOrDiff, meta interface{}) (id string, er
 	if len(sets) == 0 {
 		return
 	}
+	expectedName := createOpts.Name
+	if !strings.HasSuffix(expectedName, ".") {
+		expectedName = fmt.Sprintf("%s.", expectedName)
+	}
 	for _, set := range sets {
-		if set.Name == createOpts.Name {
+		if set.Name == expectedName {
 			id = set.ID
 			return
 		}

--- a/opentelekomcloud/services/dns/resource_opentelekomcloud_dns_zone_v2.go
+++ b/opentelekomcloud/services/dns/resource_opentelekomcloud_dns_zone_v2.go
@@ -46,9 +46,10 @@ func ResourceDNSZoneV2() *schema.Resource {
 				ForceNew: true,
 			},
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				DiffSuppressFunc: common.SuppressEqualZoneNames,
 			},
 			"email": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
## Summary of the Pull Request
Add `DiffSuppressFunc: common.SuppressEqualZoneNames` to all DNS resources
Fix #849 

## PR Checklist

* [x] Refers to: #xxx
* [x] Tests added/passed.
* [x] Schema updated.

## Acceptance Steps Performed
### `resource_opentelekomcloud_dns_zone_v2_test`
```
=== RUN   TestAccDNSV2Zone_basic
--- PASS: TestAccDNSV2Zone_basic (33.61s)
=== RUN   TestAccDNSV2Zone_undotted
--- PASS: TestAccDNSV2Zone_undotted (19.61s)
=== RUN   TestAccDNSV2Zone_private
--- PASS: TestAccDNSV2Zone_private (19.91s)
=== RUN   TestAccDNSV2Zone_readTTL
--- PASS: TestAccDNSV2Zone_readTTL (19.38s)
=== RUN   TestAccDNSV2Zone_timeout
--- PASS: TestAccDNSV2Zone_timeout (21.49s)
PASS

Process finished with exit code 0
```
### `resource_opentelekomcloud_dns_ptrrecord_v2_test`
```
=== RUN   TestAccDNSV2PtrRecord_basic
--- PASS: TestAccDNSV2PtrRecord_basic (55.20s)
=== RUN   TestAccDNSV2PtrRecord_undotted
--- PASS: TestAccDNSV2PtrRecord_undotted (39.04s)
PASS

Process finished with exit code 0
```

### `resource_opentelekomcloud_dns_recordset_v2_test`
```
=== RUN   TestAccDNSV2RecordSet_basic
--- PASS: TestAccDNSV2RecordSet_basic (57.54s)
=== RUN   TestAccDNSV2RecordSet_undotted
--- PASS: TestAccDNSV2RecordSet_undotted (35.32s)
=== RUN   TestAccDNSV2RecordSet_childFirst
--- PASS: TestAccDNSV2RecordSet_childFirst (52.46s)
=== RUN   TestAccDNSV2RecordSet_readTTL
--- PASS: TestAccDNSV2RecordSet_readTTL (36.88s)
=== RUN   TestAccDNSV2RecordSet_timeout
--- PASS: TestAccDNSV2RecordSet_timeout (34.54s)
=== RUN   TestAccDNSV2RecordSet_shared
--- PASS: TestAccDNSV2RecordSet_shared (55.35s)
PASS

Process finished with exit code 0

```