### PR TITLE
Make goreleaser build matrix more strict

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,6 +28,21 @@ builds:
     ignore:
       - goos: darwin
         goarch: '386'
+      # Linux only:
+      # arm 8
+      - goos: darwin  # Requires Go 1.16: https://golang.org/doc/go1.16#darwin
+        goarch: arm64
+      - goos: freebsd
+        goarch: arm64
+      - goos: windows
+        goarch: arm64
+      # arm 6
+      - goos: darwin
+        goarch: arm
+      - goos: freebsd
+        goarch: arm
+      - goos: windows
+        goarch: arm
     binary: '{{ .ProjectName }}_v{{ .Version }}'  # this `v` is absolutely required - in CI `v` is stripped for some reason
 archives:
   - format: zip
@@ -44,7 +59,6 @@ signs:
       - "${artifact}"
 release:
   # Visit your project's GitHub Releases page to publish this release.
-  draft: true
   github:
     owner: opentelekomcloud
     name: terraform-provider-opentelekomcloud


### PR DESCRIPTION
## Summary of the Pull Request
Make builds for arm versions 6 and 8 Linux-only

Make release not draft

Using OS/arch combinations based on https://www.terraform.io/docs/registry/providers/os-arch.html

## PR Checklist

* [x] Refers to: #856 

