### PR TITLE
[compute] Remove stale arguments from schema

### DIFF
--- a/opentelekomcloud/services/ecs/resource_opentelekomcloud_compute_instance_v2.go
+++ b/opentelekomcloud/services/ecs/resource_opentelekomcloud_compute_instance_v2.go
@@ -80,10 +80,10 @@ func ResourceComputeInstanceV2() *schema.Resource {
 				DefaultFunc: schema.EnvDefaultFunc("OS_FLAVOR_NAME", nil),
 			},
 			"floating_ip": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: false,
-				Removed:  "Use the opentelekomcloud_compute_floatingip_associate_v2 resource instead",
+				Type:       schema.TypeString,
+				Optional:   true,
+				ForceNew:   false,
+				Deprecated: "Use the opentelekomcloud_compute_floatingip_associate_v2 resource instead",
 			},
 			"user_data": {
 				Type:     schema.TypeString,
@@ -151,10 +151,10 @@ func ResourceComputeInstanceV2() *schema.Resource {
 							Computed: true,
 						},
 						"floating_ip": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
-							Removed:  "Use the opentelekomcloud_compute_floatingip_associate_v2 resource instead",
+							Type:       schema.TypeString,
+							Optional:   true,
+							Computed:   true,
+							Deprecated: "Use the opentelekomcloud_compute_floatingip_associate_v2 resource instead",
 						},
 						"mac": {
 							Type:     schema.TypeString,
@@ -255,9 +255,9 @@ func ResourceComputeInstanceV2() *schema.Resource {
 				},
 			},
 			"volume": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Removed:  "Use block_device or opentelekomcloud_compute_volume_attach_v2 instead",
+				Type:       schema.TypeSet,
+				Optional:   true,
+				Deprecated: "Use block_device or opentelekomcloud_compute_volume_attach_v2 instead",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"id": {
@@ -328,25 +328,6 @@ func ResourceComputeInstanceV2() *schema.Resource {
 					},
 				},
 				Set: resourceComputeSchedulerHintsHash,
-			},
-			"personality": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				ForceNew: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"file": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"content": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-					},
-				},
-				Set:        resourceComputeInstancePersonalityHash,
-				Deprecated: "Open Telekom Cloud API doesn't accept `personality`, please use `user_data` instead",
 			},
 			"stop_before_destroy": {
 				Type:     schema.TypeBool,
@@ -1129,14 +1110,6 @@ func setImageInformation(computeClient *golangsdk.ServiceClient, server *servers
 	}
 
 	return nil
-}
-
-func resourceComputeInstancePersonalityHash(v interface{}) int {
-	var buf bytes.Buffer
-	m := v.(map[string]interface{})
-	buf.WriteString(fmt.Sprintf("%s-", m["file"].(string)))
-
-	return hashcode.String(buf.String())
 }
 
 func getFlavorID(client *golangsdk.ServiceClient, d *schema.ResourceData) (string, error) {

--- a/opentelekomcloud/services/ecs/resource_opentelekomcloud_compute_instance_v2.go
+++ b/opentelekomcloud/services/ecs/resource_opentelekomcloud_compute_instance_v2.go
@@ -79,12 +79,6 @@ func ResourceComputeInstanceV2() *schema.Resource {
 				Computed:    true,
 				DefaultFunc: schema.EnvDefaultFunc("OS_FLAVOR_NAME", nil),
 			},
-			"floating_ip": {
-				Type:       schema.TypeString,
-				Optional:   true,
-				ForceNew:   false,
-				Deprecated: "Use the opentelekomcloud_compute_floatingip_associate_v2 resource instead",
-			},
 			"user_data": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -149,12 +143,6 @@ func ResourceComputeInstanceV2() *schema.Resource {
 							Optional: true,
 							ForceNew: true,
 							Computed: true,
-						},
-						"floating_ip": {
-							Type:       schema.TypeString,
-							Optional:   true,
-							Computed:   true,
-							Deprecated: "Use the opentelekomcloud_compute_floatingip_associate_v2 resource instead",
 						},
 						"mac": {
 							Type:     schema.TypeString,
@@ -250,29 +238,6 @@ func ResourceComputeInstanceV2() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 							ForceNew: true,
-						},
-					},
-				},
-			},
-			"volume": {
-				Type:       schema.TypeSet,
-				Optional:   true,
-				Deprecated: "Use block_device or opentelekomcloud_compute_volume_attach_v2 instead",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"id": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
-						},
-						"volume_id": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"device": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
 						},
 					},
 				},


### PR DESCRIPTION
## Summary of the Pull Request
Remove all fields which don't have api support in `resource/opentelekomcloud_compute_instance_v2`
Resolves: #591 

## PR Checklist

* [x] Refers to: #591
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
=== RUN   TestAccComputeV2Instance_basic
--- PASS: TestAccComputeV2Instance_basic (155.10s)
=== RUN   TestAccComputeV2Instance_tags
--- PASS: TestAccComputeV2Instance_tags (246.09s)
=== RUN   TestAccComputeV2Instance_tag
--- PASS: TestAccComputeV2Instance_tag (247.21s)
=== RUN   TestAccComputeV2Instance_multiSecgroup
--- PASS: TestAccComputeV2Instance_multiSecgroup (218.32s)
=== RUN   TestAccComputeV2Instance_bootFromVolumeImage
--- PASS: TestAccComputeV2Instance_bootFromVolumeImage (66.70s)
=== RUN   TestAccComputeV2Instance_bootFromVolumeVolume
--- PASS: TestAccComputeV2Instance_bootFromVolumeVolume (74.47s)
=== RUN   TestAccComputeV2Instance_bootFromVolumeForceNew
--- PASS: TestAccComputeV2Instance_bootFromVolumeForceNew (106.97s)
=== RUN   TestAccComputeV2Instance_changeFixedIP
--- PASS: TestAccComputeV2Instance_changeFixedIP (314.36s)
=== RUN   TestAccComputeV2Instance_stopBeforeDestroy
--- PASS: TestAccComputeV2Instance_stopBeforeDestroy (159.38s)
=== RUN   TestAccComputeV2Instance_metadata
--- PASS: TestAccComputeV2Instance_metadata (182.89s)
=== RUN   TestAccComputeV2Instance_timeout
--- PASS: TestAccComputeV2Instance_timeout (159.38s)
=== RUN   TestAccComputeV2Instance_autoRecovery
--- PASS: TestAccComputeV2Instance_autoRecovery (184.73s)
=== RUN   TestAccComputeV2Instance_crazyNICs
--- PASS: TestAccComputeV2Instance_crazyNICs (301.46s)
PASS

Process finished with exit code 0
```
