### PR TITLE
Fix broken read of `OS_IMAGE_ID` env variable

### DIFF
--- a/opentelekomcloud/acceptance/resource_opentelekomcloud_compute_instance_v2_test.go
+++ b/opentelekomcloud/acceptance/resource_opentelekomcloud_compute_instance_v2_test.go
@@ -566,9 +566,8 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   network {
     uuid = "%s"
   }
-  image_id = "%s"
 }
-`, OS_AVAILABILITY_ZONE, OS_NETWORK_ID, OS_IMAGE_ID)
+`, OS_AVAILABILITY_ZONE, OS_NETWORK_ID)
 
 var testAccComputeV2Instance_withoutTags = fmt.Sprintf(`
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
@@ -581,9 +580,8 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   network {
     uuid = "%s"
   }
-  image_id = "%s"
 }
-`, OS_AVAILABILITY_ZONE, OS_NETWORK_ID, OS_IMAGE_ID)
+`, OS_AVAILABILITY_ZONE, OS_NETWORK_ID)
 
 var testAccComputeV2Instance_withTags = fmt.Sprintf(`
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
@@ -596,13 +594,12 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   network {
     uuid = "%s"
   }
-  image_id = "%s"
   tags = {
     foo = "bar"
     key = "value"
   }
 }
-`, OS_AVAILABILITY_ZONE, OS_NETWORK_ID, OS_IMAGE_ID)
+`, OS_AVAILABILITY_ZONE, OS_NETWORK_ID)
 
 var testAccComputeV2Instance_updateTags = fmt.Sprintf(`
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
@@ -615,13 +612,12 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   network {
     uuid = "%s"
   }
-  image_id = "%s"
   tags = {
     foo2 = "bar2"
     key  = "value2"
   }
 }
-`, OS_AVAILABILITY_ZONE, OS_NETWORK_ID, OS_IMAGE_ID)
+`, OS_AVAILABILITY_ZONE, OS_NETWORK_ID)
 
 var testAccComputeV2Instance_tag = fmt.Sprintf(`
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
@@ -634,13 +630,12 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   network {
     uuid = "%s"
   }
-  image_id = "%s"
   tag = {
     foo = "bar"
     key = "value"
   }
 }
-`, OS_AVAILABILITY_ZONE, OS_NETWORK_ID, OS_IMAGE_ID)
+`, OS_AVAILABILITY_ZONE, OS_NETWORK_ID)
 
 var testAccComputeV2Instance_updateTag = fmt.Sprintf(`
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
@@ -653,13 +648,12 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   network {
     uuid = "%s"
   }
-  image_id = "%s"
   tag = {
     foo  = "bar2"
     key1 = "value"
   }
 }
-`, OS_AVAILABILITY_ZONE, OS_NETWORK_ID, OS_IMAGE_ID)
+`, OS_AVAILABILITY_ZONE, OS_NETWORK_ID)
 
 var testAccComputeV2Instance_multiSecgroup = fmt.Sprintf(`
 resource "opentelekomcloud_compute_secgroup_v2" "secgroup_1" {
@@ -690,9 +684,8 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   network {
     uuid = "%s"
   }
-  image_id = "%s"
 }
-`, OS_NETWORK_ID, OS_IMAGE_ID)
+`, OS_NETWORK_ID)
 
 var testAccComputeV2Instance_multiSecgroupUpdate = fmt.Sprintf(`
 resource "opentelekomcloud_compute_secgroup_v2" "secgroup_1" {
@@ -727,9 +720,8 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   network {
     uuid = "%s"
   }
-  image_id = "%s"
 }
-`, OS_NETWORK_ID, OS_IMAGE_ID)
+`, OS_NETWORK_ID)
 
 var testAccComputeV2Instance_bootFromVolumeImage = fmt.Sprintf(`
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
@@ -817,9 +809,8 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
     uuid        = "%s"
     fixed_ip_v4 = "192.168.0.24"
   }
-  image_id = "%s"
 }
-`, OS_NETWORK_ID, OS_IMAGE_ID)
+`, OS_NETWORK_ID)
 
 var testAccComputeV2Instance_fixedIPUpdate = fmt.Sprintf(`
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
@@ -829,9 +820,8 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
     uuid        = "%s"
     fixed_ip_v4 = "192.168.0.25"
   }
-  image_id = "%s"
 }
-`, OS_NETWORK_ID, OS_IMAGE_ID)
+`, OS_NETWORK_ID)
 
 var testAccComputeV2Instance_stopBeforeDestroy = fmt.Sprintf(`
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
@@ -841,9 +831,8 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
     uuid = "%s"
   }
   stop_before_destroy = true
-  image_id            = "%s"
 }
-`, OS_NETWORK_ID, OS_IMAGE_ID)
+`, OS_NETWORK_ID)
 
 var testAccComputeV2Instance_metadata = fmt.Sprintf(`
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
@@ -856,9 +845,8 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
     foo = "bar"
     abc = "def"
   }
-  image_id = "%s"
 }
-`, OS_NETWORK_ID, OS_IMAGE_ID)
+`, OS_NETWORK_ID)
 
 var testAccComputeV2Instance_metadataUpdate = fmt.Sprintf(`
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
@@ -871,9 +859,8 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
     foo = "bar"
     ghi = "jkl"
   }
-  image_id = "%s"
 }
-`, OS_NETWORK_ID, OS_IMAGE_ID)
+`, OS_NETWORK_ID)
 
 var testAccComputeV2Instance_timeout = fmt.Sprintf(`
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
@@ -886,10 +873,8 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   timeouts {
     create = "10m"
   }
-
-  image_id = "%s"
 }
-`, OS_NETWORK_ID, OS_IMAGE_ID)
+`, OS_NETWORK_ID)
 
 var testAccComputeV2Instance_autoRecovery = fmt.Sprintf(`
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
@@ -902,10 +887,9 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   network {
     uuid = "%s"
   }
-  image_id      = "%s"
   auto_recovery = false
 }
-`, OS_AVAILABILITY_ZONE, OS_NETWORK_ID, OS_IMAGE_ID)
+`, OS_AVAILABILITY_ZONE, OS_NETWORK_ID)
 
 var testAccComputeV2Instance_crazyNICs = fmt.Sprintf(`
 resource "opentelekomcloud_networking_network_v2" "network_1" {
@@ -978,7 +962,6 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   network {
     uuid = "%s"
   }
-  image_id = "%s"
   network {
     uuid        = opentelekomcloud_networking_network_v2.network_1.id
     fixed_ip_v4 = "192.168.1.100"
@@ -1008,4 +991,4 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
     port = opentelekomcloud_networking_port_v2.port_4.id
   }
 }
-`, OS_NETWORK_ID, OS_IMAGE_ID)
+`, OS_NETWORK_ID)

--- a/opentelekomcloud/services/ecs/resource_opentelekomcloud_compute_instance_v2.go
+++ b/opentelekomcloud/services/ecs/resource_opentelekomcloud_compute_instance_v2.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log"
-	"os"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
@@ -54,16 +53,18 @@ func ResourceComputeInstanceV2() *schema.Resource {
 				ForceNew: false,
 			},
 			"image_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Computed:    true,
+				DefaultFunc: schema.EnvDefaultFunc("OS_IMAGE_ID", nil),
 			},
 			"image_name": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Computed:    true,
+				DefaultFunc: schema.EnvDefaultFunc("OS_IMAGE_NAME", nil),
 			},
 			"flavor_id": {
 				Type:        schema.TypeString,
@@ -1014,22 +1015,9 @@ func getImageIDFromConfig(client *golangsdk.ServiceClient, d *schema.ResourceDat
 
 	if imageId := d.Get("image_id").(string); imageId != "" {
 		return imageId, nil
-	} else {
-		// try the helpers.OS_IMAGE_ID environment variable
-		if v := os.Getenv("helpers.OS_IMAGE_ID"); v != "" {
-			return v, nil
-		}
 	}
 
-	imageName := d.Get("image_name").(string)
-	if imageName == "" {
-		// try the OS_IMAGE_NAME environment variable
-		if v := os.Getenv("OS_IMAGE_NAME"); v != "" {
-			imageName = v
-		}
-	}
-
-	if imageName != "" {
+	if imageName := d.Get("image_name").(string); imageName != "" {
 		imageId, err := images.IDFromName(client, imageName)
 		if err != nil {
 			return "", err


### PR DESCRIPTION
## Summary of the Pull Request
Fix #863 (both for ECS and BMS)

Simplify env vars usage for setting default values: use `EnvDefaultFunc`

## PR Checklist

* [x] Refers to: #863
* [x] Tests added/passed.
* [x] Schema updated.

## Acceptance Steps Performed

```
=== RUN   TestAccComputeV2Instance_basic
--- PASS: TestAccComputeV2Instance_basic (48.62s)
=== RUN   TestAccComputeV2Instance_tags
--- PASS: TestAccComputeV2Instance_tags (119.29s)
=== RUN   TestAccComputeV2Instance_tag
--- PASS: TestAccComputeV2Instance_tag (120.09s)
=== RUN   TestAccComputeV2Instance_multiSecgroup
--- PASS: TestAccComputeV2Instance_multiSecgroup (88.92s)
=== RUN   TestAccComputeV2Instance_bootFromVolumeImage
--- PASS: TestAccComputeV2Instance_bootFromVolumeImage (47.03s)
=== RUN   TestAccComputeV2Instance_bootFromVolumeVolume
--- PASS: TestAccComputeV2Instance_bootFromVolumeVolume (67.04s)
=== RUN   TestAccComputeV2Instance_bootFromVolumeForceNew
--- PASS: TestAccComputeV2Instance_bootFromVolumeForceNew (93.80s)
=== RUN   TestAccComputeV2Instance_changeFixedIP
--- PASS: TestAccComputeV2Instance_changeFixedIP (96.36s)
=== RUN   TestAccComputeV2Instance_stopBeforeDestroy
--- PASS: TestAccComputeV2Instance_stopBeforeDestroy (59.50s)
=== RUN   TestAccComputeV2Instance_metadata
--- PASS: TestAccComputeV2Instance_metadata (69.70s)
=== RUN   TestAccComputeV2Instance_timeout
--- PASS: TestAccComputeV2Instance_timeout (53.79s)
=== RUN   TestAccComputeV2Instance_autoRecovery
--- PASS: TestAccComputeV2Instance_autoRecovery (75.14s)
=== RUN   TestAccComputeV2Instance_crazyNICs
--- PASS: TestAccComputeV2Instance_crazyNICs (175.94s)
PASS

Process finished with exit code 0
```
