### PR TITLE
Fix DNS zone v2 basic acceptance test

### DIFF
--- a/opentelekomcloud/acceptance/data_source_opentelekomcloud_dns_zone_v2_test.go
+++ b/opentelekomcloud/acceptance/data_source_opentelekomcloud_dns_zone_v2_test.go
@@ -9,22 +9,24 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-var zoneName = fmt.Sprintf("acpttest%s.com.", acctest.RandString(5))
-
 func TestAccOpenStackDNSZoneV2DataSource_basic(t *testing.T) {
+	zone := randomZoneName()
+	randZoneTag := fmt.Sprintf("value-%s", acctest.RandString(5))
+
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheckRequiredEnvVars(t) },
-		Providers: testAccProviders,
+		PreCheck:     func() { testAccPreCheckRequiredEnvVars(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDNSV2ZoneDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccOpenStackDNSZoneV2DataSource_zone,
+				Config: testAccOpenStackDNSZoneV2DataSource_zone(zone, randZoneTag),
 			},
 			{
-				Config: testAccOpenStackDNSZoneV2DataSource_basic,
+				Config: testAccOpenStackDNSZoneV2DataSource_basic(zone, randZoneTag),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDNSZoneV2DataSourceID("data.opentelekomcloud_dns_zone_v2.z1"),
 					resource.TestCheckResourceAttr(
-						"data.opentelekomcloud_dns_zone_v2.z1", "name", zoneName),
+						"data.opentelekomcloud_dns_zone_v2.z1", "name", zone),
 					resource.TestCheckResourceAttr(
 						"data.opentelekomcloud_dns_zone_v2.z1", "ttl", "3000"),
 					resource.TestCheckResourceAttr(
@@ -32,13 +34,29 @@ func TestAccOpenStackDNSZoneV2DataSource_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccOpenStackDNSZoneV2DataSource_byTag,
+				Config: testAccOpenStackDNSZoneV2DataSource_zone(zone, randZoneTag),
+			},
+		},
+	})
+}
+
+func TestAccOpenStackDNSZoneV2DataSource_byTag(t *testing.T) {
+	zone := randomZoneName()
+	randZoneTag := fmt.Sprintf("value-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckRequiredEnvVars(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDNSV2ZoneDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOpenStackDNSZoneV2DataSource_zone(zone, randZoneTag),
+			},
+			{
+				Config: testAccOpenStackDNSZoneV2DataSource_byTag(zone, randZoneTag),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDNSZoneV2DataSourceID("data.opentelekomcloud_dns_zone_v2.z1"),
 				),
-			},
-			{
-				Config: testAccOpenStackDNSZoneV2DataSource_zone,
 			},
 		},
 	})
@@ -59,20 +77,42 @@ func testAccCheckDNSZoneV2DataSourceID(n string) resource.TestCheckFunc {
 	}
 }
 
-var testAccOpenStackDNSZoneV2DataSource_zone = testAccDNSV2Zone_basic(zoneName)
+const zoneTemplate = `
+resource "opentelekomcloud_dns_zone_v2" "zone_1" {
+  name        = "%s"
+  email       = "email1@example.com"
+  description = "a public zone"
+  ttl         = 3000
+  type        = "public"
 
-var testAccOpenStackDNSZoneV2DataSource_basic = fmt.Sprintf(`
+  tags = {
+    key = "%s"
+  }
+}
+`
+
+func testAccOpenStackDNSZoneV2DataSource_zone(zoneName, zoneTagValue string) string {
+	return fmt.Sprintf(zoneTemplate, zoneName, zoneTagValue)
+}
+
+func testAccOpenStackDNSZoneV2DataSource_basic(zoneName, zoneTagValue string) string {
+	base := testAccOpenStackDNSZoneV2DataSource_zone(zoneName, zoneTagValue)
+	return fmt.Sprintf(`
 %s
 data "opentelekomcloud_dns_zone_v2" "z1" {
-	name = "%s"
+  name = "%s"
 }
-`, testAccDNSV2Zone_basic(zoneName), zoneName)
+`, base, zoneName)
+}
 
-var testAccOpenStackDNSZoneV2DataSource_byTag = fmt.Sprintf(`
+func testAccOpenStackDNSZoneV2DataSource_byTag(zoneName, zoneTagValue string) string {
+	base := testAccOpenStackDNSZoneV2DataSource_zone(zoneName, zoneTagValue)
+	return fmt.Sprintf(`
 %s
 data "opentelekomcloud_dns_zone_v2" "z1" {
-	tags = {
-		key = "value"
-	}
+  tags = {
+    key = "%s"
+  }
 }
-`, testAccDNSV2Zone_basic(zoneName))
+`, base, zoneName)
+}


### PR DESCRIPTION
## Summary of the Pull Request
Separate basic and by tag tests

Test for search by tags is failing, service is returning all existing DNS zones instead of the searched one

## PR Checklist

* [x] Tests added/passed.

## Acceptance Steps Performed

```
=== RUN   TestAccOpenStackDNSZoneV2DataSource_basic
--- PASS: TestAccOpenStackDNSZoneV2DataSource_basic (32.37s)
=== RUN   TestAccOpenStackDNSZoneV2DataSource_byTag
    testing.go:705: Step 1 error: errors during refresh:
        
        Error: your query returned more than one result. Please try a more specific search criteria
        
          on /tmp/tf-test293400622/main.tf line 15:
          (source code not available)
        
        
--- FAIL: TestAccOpenStackDNSZoneV2DataSource_byTag (13.27s)

FAIL

Process finished with exit code 1


```
