### PR TITLE
Set `timezone` required for `cbr_policy_v3`

### DIFF
--- a/docs/resources/cbr_policy_v3.md
+++ b/docs/resources/cbr_policy_v3.md
@@ -40,6 +40,13 @@ The following arguments are supported:
 
 * `operation_definition` - (Optional) Scheduling parameter. See reference below.
 
+* `operation_type` - (Required) Policy type. Enumeration values: `backup`, `replication`.
+
+* `trigger_pattern` - (Required) Scheduling rule. In the replication policy, you are advised
+  to set one time point for one day. A maximum of 24 rules can be configured. The scheduling
+  rule complies with iCalendar RFC 2445, but it supports only parameters `FREQ`, `BYDAY`, `BYHOUR`,
+  `BYMINUTE`, and `INTERVAL`. `FREQ` can be set only to `WEEKLY` and `DAILY`.
+
 The `operation_definition` block contains:
 
 * `day_backups` - (Optional) Specifies the number of retained daily backups. The latest
@@ -62,9 +69,7 @@ The `operation_definition` block contains:
   with the maximum number of retained backups specified by `max_backups`. The value ranges
   from `0` to `100`. If this parameter is configured, `timezone` is mandatory.
 
-* `timezone` - (Optional) Time zone where the user is located, for example, `UTC+00:00`.
-  Set this parameter only after you have configured any of the parameters `day_backups`,
-  `week_backups`, `month_backups`, `year_backups`.
+* `timezone` - (Required) Time zone where the user is located, for example, `UTC+00:00`.
 
 * `max_backups` - (Optional) Maximum number of retained backups. The value can be `-1` or ranges
   from `0` to `99999`. If the value is set to `-1`, the backups will not be cleared even though
@@ -75,13 +80,6 @@ The `operation_definition` block contains:
   The maximum value is `99999`. `-1` indicates that the backups will not be cleared based on
   the retention duration. If this parameter and `max_backups` are left blank at the same time,
   the backups will be retained permanently.
-
-* `operation_type` - (Required) Policy type. Enumeration values: `backup`, `replication`.
-
-* `trigger_pattern` - (Required) Scheduling rule. In the replication policy, you are advised
-  to set one time point for one day. A maximum of 24 rules can be configured. The scheduling
-  rule complies with iCalendar RFC 2445, but it supports only parameters `FREQ`, `BYDAY`, `BYHOUR`,
-  `BYMINUTE`, and `INTERVAL`. `FREQ` can be set only to `WEEKLY` and `DAILY`.
 
 ## Attributes Reference
 

--- a/opentelekomcloud/acceptance/resource_opentelekomcloud_cbr_policy_v3_test.go
+++ b/opentelekomcloud/acceptance/resource_opentelekomcloud_cbr_policy_v3_test.go
@@ -42,6 +42,7 @@ func TestAccCBRPolicyV3_basic(t *testing.T) {
 
 func TestAccCBRPolicyV3_minConfig(t *testing.T) {
 	var cbrPolicy policies.Policy
+	policyRes := "opentelekomcloud_cbr_policy_v3.policy"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccFlavorPreCheck(t) },
@@ -51,10 +52,16 @@ func TestAccCBRPolicyV3_minConfig(t *testing.T) {
 			{
 				Config: testCBRPolicyV3_minConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCBRPolicyV3Exists("opentelekomcloud_cbr_policy_v3.policy", &cbrPolicy),
-					resource.TestCheckResourceAttr("opentelekomcloud_cbr_policy_v3.policy", "name", "some-policy-min"),
-					resource.TestCheckResourceAttr("opentelekomcloud_cbr_policy_v3.policy", "operation_type", "backup"),
-					resource.TestCheckResourceAttr("opentelekomcloud_cbr_policy_v3.policy", "enabled", "true"),
+					testAccCheckCBRPolicyV3Exists(policyRes, &cbrPolicy),
+					resource.TestCheckResourceAttr(policyRes, "name", "some-policy-min"),
+					resource.TestCheckResourceAttr(policyRes, "operation_type", "backup"),
+					resource.TestCheckResourceAttr(policyRes, "enabled", "true"),
+				),
+			},
+			{
+				Config: testCBRPolicyV3_minOperationDef,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(policyRes, "operation_definition.0.timezone", "UTC+03:00"),
 				),
 			},
 		},
@@ -112,7 +119,8 @@ func testAccCheckCBRPolicyV3Exists(n string, group *policies.Policy) resource.Te
 	}
 }
 
-var testCBRPolicyV3_basic = fmt.Sprintf(`
+const (
+	testCBRPolicyV3_basic = `
 resource opentelekomcloud_cbr_policy_v3 policy {
   name                 = "test-policy"
   operation_type       = "backup"
@@ -127,9 +135,8 @@ resource opentelekomcloud_cbr_policy_v3 policy {
   }
   enabled = "true"
 }
-`)
-
-var testCBRPolicyV3_update = fmt.Sprintf(`
+`
+	testCBRPolicyV3_update = `
 resource opentelekomcloud_cbr_policy_v3 policy {
   name                 = "name2"
   operation_type       = "backup"
@@ -144,12 +151,25 @@ resource opentelekomcloud_cbr_policy_v3 policy {
   }
   enabled = "false"
 }
-`)
-
-var testCBRPolicyV3_minConfig = fmt.Sprintf(`
+`
+	testCBRPolicyV3_minConfig = `
 resource opentelekomcloud_cbr_policy_v3 policy {
   name            = "some-policy-min"
   operation_type  = "backup"
   trigger_pattern = ["FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR,SA,SU;BYHOUR=14;BYMINUTE=00"]
 }
-`)
+`
+
+	testCBRPolicyV3_minOperationDef = `
+resource opentelekomcloud_cbr_policy_v3 policy {
+  name            = "some-policy-min"
+  operation_type  = "backup"
+  trigger_pattern = ["FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR,SA,SU;BYHOUR=14;BYMINUTE=00"]
+
+
+  operation_definition {
+    timezone                = "UTC+03:00"
+  }
+}
+`
+)

--- a/opentelekomcloud/services/cbr/resource_opentelekomcloud_cbr_policy_v3.go
+++ b/opentelekomcloud/services/cbr/resource_opentelekomcloud_cbr_policy_v3.go
@@ -69,8 +69,7 @@ func ResourceCBRPolicyV3() *schema.Resource {
 						},
 						"timezone": {
 							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
+							Required: true,
 						},
 						"week_backups": {
 							Type:         schema.TypeInt,


### PR DESCRIPTION
## Summary of the Pull Request
Fix #881

API requires `timezone` to be defined if `operation_definition` is set.

Argument `timezone` marked as `Required` in the doc

Fix incorrect argument description in the documentation.

## PR Checklist

* [x] Refers to: #881
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
=== RUN   TestAccCBRPolicyV3_basic
--- PASS: TestAccCBRPolicyV3_basic (35.97s)
=== RUN   TestAccCBRPolicyV3_minConfig
--- PASS: TestAccCBRPolicyV3_minConfig (32.69s)
PASS

Process finished with exit code 0
```
