### PR TITLE
Fix raising error on changing existing public key

### DIFF
--- a/opentelekomcloud/acceptance/resource_opentelekomcloud_compute_keypair_v2_test.go
+++ b/opentelekomcloud/acceptance/resource_opentelekomcloud_compute_keypair_v2_test.go
@@ -131,20 +131,3 @@ resource "opentelekomcloud_compute_keypair_v2" "kp_2" {
   depends_on = [opentelekomcloud_compute_keypair_v2.kp_1]
 }
 `
-const testAccComputeV2Keypair_sharedInvalid = `
-locals {
-  public_name = "kp_1"
-  public_key  = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDAjpC1hwiOCCmKEWxJ4qzTTsJbKzndLo1BCz5PcwtUnflmU+gHJtWMZKpuEGVi29h0A/+ydKek1O18k10Ff+4tyFjiHDQAT9+OfgWf7+b1yK+qDip3X1C0UPMbwHlTfSGWLGZquwhvEFx9k3h/M+VtMvwR1lJ9LUyTAImnNjWG7TAIPmui30HvM2UiFEmqkr4ijq45MyX2+fLIePLRIFuu1p4whjHAQYufqyno3BS48icQb4p6iVEZPo4AE2o9oIyQvj2mx4dk5Y8CgSETOZTYDOR3rU2fZTRDRgPJDH9FWvQjF5tA0p3d9CoWWd2s6GKKbfoUIi8R/Db1BSPJwkqB jrp-hp-pc"
-}
-
-resource "opentelekomcloud_compute_keypair_v2" "kp_1" {
-  name       = local.public_name
-  public_key = local.public_key
-}
-
-resource "opentelekomcloud_compute_keypair_v2" "kp_2" {
-  name       = local.public_name
-
-  depends_on = [opentelekomcloud_compute_keypair_v2.kp_1]
-}
-`

--- a/opentelekomcloud/services/ecs/resource_opentelekomcloud_compute_keypair_v2.go
+++ b/opentelekomcloud/services/ecs/resource_opentelekomcloud_compute_keypair_v2.go
@@ -165,5 +165,5 @@ func keyPairExist(client *golangsdk.ServiceClient, name, publicKey string) (exis
 	if kp.PublicKey == publicKey {
 		return true, nil
 	}
-	return true, fmt.Errorf("key %s already exist with different public key", name)
+	return false, nil
 }


### PR DESCRIPTION
## Summary of the Pull Request
Make key pair considered to be not `shared` instead of error raising in case public keys differ for the same key pair name

## PR Checklist

* [x] Refers to: #885
* [x] Tests added/passed.

## Acceptance Steps Performed
```
=== RUN   TestAccComputeV2Keypair_basic
--- PASS: TestAccComputeV2Keypair_basic (9.38s)
=== RUN   TestAccComputeV2Keypair_shared
--- PASS: TestAccComputeV2Keypair_shared (18.05s)
PASS

Process finished with exit code 0

```
Additionally, the case from the `usage` section was used:

## Usage
The following workflow should be followed for managing such keys:
```
$ terraform import opentelekomcloud_compute_keypair_v2.kp akachuri-test-1
opentelekomcloud_compute_keypair_v2.kp: Importing from ID "akachuri-test-1"...
opentelekomcloud_compute_keypair_v2.kp: Import prepared!
  Prepared opentelekomcloud_compute_keypair_v2 for import
opentelekomcloud_compute_keypair_v2.kp: Refreshing state... [id=akachuri-test-1]

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.

$ terraform plan                                                         
opentelekomcloud_compute_keypair_v2.kp: Refreshing state... [id=akachuri-test-1]

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # opentelekomcloud_compute_keypair_v2.kp must be replaced
-/+ resource "opentelekomcloud_compute_keypair_v2" "kp" {
      ~ id         = "akachuri-test-1" -> (known after apply)
        name       = "akachuri-test-1"
      ~ public_key = <<-EOT # forces replacement
          - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC/NE0XV+Iqsg+B7GR6RwgZrwC0uaIztbVkBWgydG0ttqhxjKletpyhrnw9T7M518Ad8rlSFSOcd3Xx8MzcMoh+cKgRKQqXvS3E0RDhiEXBWxuHEWcmz5OFzQPb6w8wS4fNk05IiHO9VoJVxWi9cPjFtFd7YYav7OzhhRmTwD/msOIcP5liV9A7O4EjNHcswI10RqX9yFgkCPcBLelyp1SnlfmaZhdXe5l93nxk3mFAq1cHV2URCXDXPpNLJoqYVE6hk1jQvSZjIN/1F+r7y1qJ2EMu33wD20rcrGwblvdje9SBZ4r807AFUfwQhZV96IYtCaFVgFFAIOCyo93PxUIN Generated-by-Nova
          + ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMJQkCq4YWll7VjRnR0n2b+aybgcMdZvQnj9AxrMJkCq other@key
        EOT
      ~ region     = "eu-de" -> (known after apply)
        # (1 unchanged attribute hidden)
    }

Plan: 1 to add, 0 to change, 1 to destroy.

------------------------------------------------------------------------

Note: You didn't specify an "-out" parameter to save this plan, so Terraform
can't guarantee that exactly these actions will be performed if

```

For tests version build from the branch was used.
