### PR TITLE
Add clarifcation that zone_type is required for private zones

### DIFF
--- a/docs/data-sources/dns_zone_v2.md
+++ b/docs/data-sources/dns_zone_v2.md
@@ -16,7 +16,7 @@ data "opentelekomcloud_dns_zone_v2" "zone_1" {
 
 ## Argument Reference
 
-* `zone_type` - (Optional) The type of the zone: `private` or `public`.
+* `zone_type` - (Optional) The type of the zone: `private` or `public`. This argument is required to match private zones.
 
 * `name` - (Optional) The name of the zone.
 


### PR DESCRIPTION
## Summary of the Pull Request
Added clarification to the docs for opentelekomcloud_dns_zone_v2 that private zones only match when the attribute zone_type is set to `private`

Resolves #869 

## PR Checklist
* [x] Refers to: #869 
* [ ] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

Only docs updated, so none.

