### PR TITLE
[AS] Update description of `as_group`

### DIFF
--- a/docs/resources/as_group_v1.md
+++ b/docs/resources/as_group_v1.md
@@ -140,8 +140,8 @@ The following arguments are supported:
   The system supports up to five networks. The networks object structure
   is documented below.
 
-* `security_groups` - (Required) An array of one or more security group IDs
-  to associate with the group. The security_groups object structure is
+* `security_groups` - (Required) An array of one security group ID
+  to associate with the group. The `security_groups` object structure is
   documented below.
 
 * `vpc_id` - (Required) The VPC ID. Changing this creates a new group.

--- a/docs/resources/as_group_v1.md
+++ b/docs/resources/as_group_v1.md
@@ -140,8 +140,8 @@ The following arguments are supported:
   The system supports up to five networks. The networks object structure
   is documented below.
 
-* `security_groups` - (Required) An array of one security group ID
-  to associate with the group. The `security_groups` object structure is
+* `security_groups` - (Required) An array of security group IDs to associate with the group.
+  A maximum of one security group can be selected. The `security_groups` object structure is
   documented below.
 
 * `vpc_id` - (Required) The VPC ID. Changing this creates a new group.

--- a/opentelekomcloud/services/as/resource_opentelekomcloud_as_group_v1.go
+++ b/opentelekomcloud/services/as/resource_opentelekomcloud_as_group_v1.go
@@ -117,6 +117,7 @@ func ResourceASGroup() *schema.Resource {
 			"security_groups": {
 				Type:     schema.TypeList,
 				Required: true,
+				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"id": {


### PR DESCRIPTION
## Summary of the Pull Request
Clarify description of `security_groups` field in `resource/opentelekomcloud_as_group_v1`
Resolves: #898 

## PR Checklist

* [x] Refers to: #898 
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
=== RUN   TestAccASV1Group_basic
--- PASS: TestAccASV1Group_basic (125.55s)
=== RUN   TestAccASV1Group_RemoveWithSetMinNumber
--- PASS: TestAccASV1Group_RemoveWithSetMinNumber (183.89s)
PASS

Process finished with exit code 0
```
