### PR TITLE
[ELB] Add possibility to set `domain_name`

### DIFF
--- a/docs/resources/lb_monitor_v2.md
+++ b/docs/resources/lb_monitor_v2.md
@@ -43,23 +43,26 @@ The following arguments are supported:
 * `max_retries` - (Required) Number of permissible ping failures before
   changing the member's status to INACTIVE. Must be a number between 1 and 10.
 
+* `domain_name` - (Optional) The `domain_name` of the HTTP request during the health check.
+  This parameter is valid when the value of `type` is set to `HTTP`.
+
 * `admin_state_up` - (Optional) The administrative state of the monitor.
-  A valid value is true (UP) or false (DOWN).
+  A valid value is `true` (`UP`) or `false` (`DOWN`).
 
 * `http_method` - (Optional) Required for HTTP types. The HTTP method used
   for requests by the monitor. If this attribute is not specified, it
   defaults to `GET`. The value can be `GET`, `HEAD`, `POST`, `PUT`, `DELETE`,
   `TRACE`, `OPTIONS`, `CONNECT`, and `PATCH`.
 
--> **Note:** These parameters `url_path`, `expected_codes` and `monitor_port`
-  are valid when the value of `type` is set to `HTTP`
+-> These parameters `url_path`, `expected_codes` and `monitor_port`
+  are valid when the value of `type` is set to `HTTP`.
 
 * `url_path` - (Optional) Required for HTTP types. URI path that will be
   accessed if monitor type is `HTTP`.
 
-* `expected_codes` - (Optional) Required for HTTP types. Expected HTTP codes
+* `expected_codes` - (Optional) Required for `HTTP` types. Expected HTTP codes
   for a passing HTTP monitor. You can either specify a single status like
-  "200", or a list like "200,202".
+  `"200"`, or a list like `"200,202"`.
 
 * `monitor_port` - (Optional) Specifies the health check port. The port number
   ranges from 1 to 65535. The value is left blank by default, indicating that
@@ -83,6 +86,8 @@ The following attributes are exported:
 * `max_retries` - See Argument Reference above.
 
 * `url_path` - See Argument Reference above.
+
+* `domain_name` - See Argument Reference above.
 
 * `http_method` - See Argument Reference above.
 

--- a/docs/resources/lb_monitor_v2.md
+++ b/docs/resources/lb_monitor_v2.md
@@ -43,9 +43,6 @@ The following arguments are supported:
 * `max_retries` - (Required) Number of permissible ping failures before
   changing the member's status to INACTIVE. Must be a number between 1 and 10.
 
-* `domain_name` - (Optional) The `domain_name` of the HTTP request during the health check.
-  This parameter is valid when the value of `type` is set to `HTTP`.
-
 * `admin_state_up` - (Optional) The administrative state of the monitor.
   A valid value is `true` (`UP`) or `false` (`DOWN`).
 
@@ -54,8 +51,11 @@ The following arguments are supported:
   defaults to `GET`. The value can be `GET`, `HEAD`, `POST`, `PUT`, `DELETE`,
   `TRACE`, `OPTIONS`, `CONNECT`, and `PATCH`.
 
--> These parameters `url_path`, `expected_codes` and `monitor_port`
+-> These parameters `domain_name`, `url_path`, `expected_codes` and `monitor_port`
   are valid when the value of `type` is set to `HTTP`.
+
+* `domain_name` - (Optional) The `domain_name` of the HTTP request during the health check.
+  This parameter is valid when the value of `type` is set to `HTTP`.
 
 * `url_path` - (Optional) Required for HTTP types. URI path that will be
   accessed if monitor type is `HTTP`.

--- a/docs/resources/lb_monitor_v2.md
+++ b/docs/resources/lb_monitor_v2.md
@@ -55,7 +55,6 @@ The following arguments are supported:
   are valid when the value of `type` is set to `HTTP`.
 
 * `domain_name` - (Optional) The `domain_name` of the HTTP request during the health check.
-  This parameter is valid when the value of `type` is set to `HTTP`.
 
 * `url_path` - (Optional) Required for HTTP types. URI path that will be
   accessed if monitor type is `HTTP`.

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/jinzhu/copier v0.2.3
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.2.7-0.20210319160506-316fc19ae099
+	github.com/opentelekomcloud/gophertelekomcloud v0.2.7-0.20210322104213-15020aa64f3b
 	github.com/unknwon/com v1.0.1
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -276,8 +276,6 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWb
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.2.7-0.20210317130019-8526a9584142 h1:Z3GXIhdiWk0PQdxF9w2bARJWCX4rUAitymnX2NziX14=
-github.com/opentelekomcloud/gophertelekomcloud v0.2.7-0.20210317130019-8526a9584142/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
 github.com/opentelekomcloud/gophertelekomcloud v0.2.7-0.20210322104213-15020aa64f3b h1:Fnu9bpaZC8Ftn4AsxaEbvGNFVsHXZC6ltfrqj10NyD8=
 github.com/opentelekomcloud/gophertelekomcloud v0.2.7-0.20210322104213-15020aa64f3b/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=

--- a/go.sum
+++ b/go.sum
@@ -276,8 +276,10 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWb
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.2.7-0.20210319160506-316fc19ae099 h1:jAp6XZZVRoMQ9FER9SuLpgLUOPwRGO+HPW+E6TpZDyk=
-github.com/opentelekomcloud/gophertelekomcloud v0.2.7-0.20210319160506-316fc19ae099/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
+github.com/opentelekomcloud/gophertelekomcloud v0.2.7-0.20210317130019-8526a9584142 h1:Z3GXIhdiWk0PQdxF9w2bARJWCX4rUAitymnX2NziX14=
+github.com/opentelekomcloud/gophertelekomcloud v0.2.7-0.20210317130019-8526a9584142/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
+github.com/opentelekomcloud/gophertelekomcloud v0.2.7-0.20210322104213-15020aa64f3b h1:Fnu9bpaZC8Ftn4AsxaEbvGNFVsHXZC6ltfrqj10NyD8=
+github.com/opentelekomcloud/gophertelekomcloud v0.2.7-0.20210322104213-15020aa64f3b/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/opentelekomcloud/acceptance/lb/resource_opentelekomcloud_lb_monitor_v2_test.go
+++ b/opentelekomcloud/acceptance/lb/resource_opentelekomcloud_lb_monitor_v2_test.go
@@ -15,6 +15,7 @@ import (
 
 func TestAccLBV2Monitor_basic(t *testing.T) {
 	var monitor monitors.Monitor
+	resourceName := "opentelekomcloud_lb_monitor_v2.monitor_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { common.TestAccPreCheck(t) },
@@ -24,19 +25,21 @@ func TestAccLBV2Monitor_basic(t *testing.T) {
 			{
 				Config: TestAccLBV2MonitorConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLBV2MonitorExists("opentelekomcloud_lb_monitor_v2.monitor_1", &monitor),
-					resource.TestCheckResourceAttr("opentelekomcloud_lb_monitor_v2.monitor_1", "monitor_port", "112"),
-					resource.TestCheckResourceAttr("opentelekomcloud_lb_monitor_v2.monitor_1", "delay", "20"),
-					resource.TestCheckResourceAttr("opentelekomcloud_lb_monitor_v2.monitor_1", "timeout", "10"),
+					testAccCheckLBV2MonitorExists(resourceName, &monitor),
+					resource.TestCheckResourceAttr(resourceName, "monitor_port", "112"),
+					resource.TestCheckResourceAttr(resourceName, "delay", "20"),
+					resource.TestCheckResourceAttr(resourceName, "timeout", "10"),
+					resource.TestCheckResourceAttr(resourceName, "domain_name", ""),
 				),
 			},
 			{
 				Config: TestAccLBV2MonitorConfig_update,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("opentelekomcloud_lb_monitor_v2.monitor_1", "name", "monitor_1_updated"),
-					resource.TestCheckResourceAttr("opentelekomcloud_lb_monitor_v2.monitor_1", "delay", "30"),
-					resource.TestCheckResourceAttr("opentelekomcloud_lb_monitor_v2.monitor_1", "timeout", "15"),
-					resource.TestCheckResourceAttr("opentelekomcloud_lb_monitor_v2.monitor_1", "monitor_port", "120"),
+					resource.TestCheckResourceAttr(resourceName, "name", "monitor_1_updated"),
+					resource.TestCheckResourceAttr(resourceName, "delay", "30"),
+					resource.TestCheckResourceAttr(resourceName, "timeout", "15"),
+					resource.TestCheckResourceAttr(resourceName, "monitor_port", "120"),
+					resource.TestCheckResourceAttr(resourceName, "domain_name", "www.test.com"),
 				),
 			},
 		},
@@ -45,6 +48,7 @@ func TestAccLBV2Monitor_basic(t *testing.T) {
 
 func TestAccLBV2Monitor_minConfig(t *testing.T) {
 	var monitor monitors.Monitor
+	resourceName := "opentelekomcloud_lb_monitor_v2.monitor_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { common.TestAccPreCheck(t) },
@@ -54,16 +58,16 @@ func TestAccLBV2Monitor_minConfig(t *testing.T) {
 			{
 				Config: TestAccLBV2MonitorConfig_minConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLBV2MonitorExists("opentelekomcloud_lb_monitor_v2.monitor_1", &monitor),
-					resource.TestCheckResourceAttr("opentelekomcloud_lb_monitor_v2.monitor_1", "delay", "20"),
-					resource.TestCheckResourceAttr("opentelekomcloud_lb_monitor_v2.monitor_1", "timeout", "10"),
+					testAccCheckLBV2MonitorExists(resourceName, &monitor),
+					resource.TestCheckResourceAttr(resourceName, "delay", "20"),
+					resource.TestCheckResourceAttr(resourceName, "timeout", "10"),
 				),
 			},
 			{
 				Config: TestAccLBV2MonitorConfig_update,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("opentelekomcloud_lb_monitor_v2.monitor_1", "name", "monitor_1_updated"),
-					resource.TestCheckResourceAttr("opentelekomcloud_lb_monitor_v2.monitor_1", "monitor_port", "120"),
+					resource.TestCheckResourceAttr(resourceName, "name", "monitor_1_updated"),
+					resource.TestCheckResourceAttr(resourceName, "monitor_port", "120"),
 				),
 			},
 		},
@@ -72,7 +76,7 @@ func TestAccLBV2Monitor_minConfig(t *testing.T) {
 
 func testAccCheckLBV2MonitorDestroy(s *terraform.State) error {
 	config := common.TestAccProvider.Meta().(*cfg.Config)
-	networkingClient, err := config.NetworkingV2Client(env.OS_REGION_NAME)
+	client, err := config.NetworkingV2Client(env.OS_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("error creating OpenTelekomCloud networking client: %s", err)
 	}
@@ -82,7 +86,7 @@ func testAccCheckLBV2MonitorDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := monitors.Get(networkingClient, rs.Primary.ID).Extract()
+		_, err := monitors.Get(client, rs.Primary.ID).Extract()
 		if err == nil {
 			return fmt.Errorf("monitor still exists: %s", rs.Primary.ID)
 		}
@@ -103,12 +107,12 @@ func testAccCheckLBV2MonitorExists(n string, monitor *monitors.Monitor) resource
 		}
 
 		config := common.TestAccProvider.Meta().(*cfg.Config)
-		networkingClient, err := config.NetworkingV2Client(env.OS_REGION_NAME)
+		client, err := config.NetworkingV2Client(env.OS_REGION_NAME)
 		if err != nil {
-			return fmt.Errorf("error creating OpenTelekomCloud networking client: %s", err)
+			return fmt.Errorf("error creating OpenTelekomCloud NetworkingV2 client: %s", err)
 		}
 
-		found, err := monitors.Get(networkingClient, rs.Primary.ID).Extract()
+		found, err := monitors.Get(client, rs.Primary.ID).Extract()
 		if err != nil {
 			return err
 		}
@@ -189,6 +193,7 @@ resource "opentelekomcloud_lb_monitor_v2" "monitor_1" {
   admin_state_up = "true"
   pool_id        = opentelekomcloud_lb_pool_v2.pool_1.id
   monitor_port   = 120
+  domain_name    = "www.test.com"
 
   timeouts {
     create = "5m"

--- a/opentelekomcloud/acceptance/lb/resource_opentelekomcloud_lb_monitor_v2_test.go
+++ b/opentelekomcloud/acceptance/lb/resource_opentelekomcloud_lb_monitor_v2_test.go
@@ -29,7 +29,6 @@ func TestAccLBV2Monitor_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "monitor_port", "112"),
 					resource.TestCheckResourceAttr(resourceName, "delay", "20"),
 					resource.TestCheckResourceAttr(resourceName, "timeout", "10"),
-					resource.TestCheckResourceAttr(resourceName, "domain_name", ""),
 				),
 			},
 			{


### PR DESCRIPTION
## Summary of the Pull Request
Add possibility to set `domain_name` in `resource/opentelekomcloud_lb_monitor_v2`
Resolves: #920 

## PR Checklist

* [x] Refers to: #920
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
=== RUN   TestAccLBV2Monitor_basic
--- PASS: TestAccLBV2Monitor_basic (155.63s)
=== RUN   TestAccLBV2Monitor_minConfig
--- PASS: TestAccLBV2Monitor_minConfig (154.95s)
PASS

Process finished with exit code 0
```
