### PR TITLE
[ECS] Unify `tags` workflow in `instance_v2`

### DIFF
--- a/docs/resources/compute_instance_v2.md
+++ b/docs/resources/compute_instance_v2.md
@@ -18,17 +18,16 @@ resource "opentelekomcloud_compute_instance_v2" "basic" {
   key_pair        = "my_key_pair_name"
   security_groups = ["default"]
 
-  tags = {
-    foo = "bar"
-    key = "value"
+  network {
+    name = "my_network"
   }
 
   metadata = {
     this = "that"
   }
 
-  network {
-    name = "my_network"
+  tags = {
+    muh = "kuh"
   }
 }
 ```
@@ -42,10 +41,10 @@ resource "opentelekomcloud_blockstorage_volume_v2" "myvol" {
 }
 
 resource "opentelekomcloud_compute_instance_v2" "myinstance" {
-  name            = "myinstance"
+  name            = "my_instance"
   image_id        = "ad091b52-742f-469e-8f3c-fd81cadf0743"
   flavor_id       = "3"
-  key_pair        = "my_key_pair_name"
+  key_pair        = "my_keypair"
   security_groups = ["default"]
 
   network {
@@ -262,9 +261,6 @@ function, or the `template_cloudinit_config` resource.
 
 ## Argument Reference
 
--> **Note:** The `tag` attribute has been deprecated and might
-be removed in future releases, please use `tags` instead.
-
 The following arguments are supported:
 
 * `name` - (Required) A unique name for the resource.
@@ -289,7 +285,8 @@ The following arguments are supported:
 * `security_groups` - (Optional) An array of one or more security group names
   to associate with the server. Changing this results in adding/removing
   security groups from the existing server.
--> **Note:** When attaching the instance to networks using Ports,
+
+-> When attaching the instance to networks using Ports,
   place the security groups on the Port and not the instance.
 
 * `availability_zone` - (Optional) The availability zone in which to create
@@ -325,14 +322,12 @@ The following arguments are supported:
 
 * `tags` -  (Optional) Tags key/value pairs to associate with the instance.
 
-* `tag` **DEPRECATED** - (Optional) Tags key/value pairs to associate with the instance.
-
 * `stop_before_destroy` - (Optional) Whether to try stop instance gracefully
   before destroying it, thus giving chance for guest OS daemons to stop correctly.
-  If instance doesn't stop within timeout, it will be destroyed anyway.
+  If instance doesn't stop within a timeout, it will be destroyed anyway.
 
 * `force_delete` - (Optional) Whether to force the OpenTelekomCloud instance to be
-  forcefully deleted. This is useful for environments that have reclaim / soft
+  forcefully deleted. This is useful for environments that have reclaim/soft
   deletion enabled.
 
 * `auto_recovery` - (Optional) Configures or deletes automatic recovery of an instance.
@@ -371,7 +366,8 @@ The `block_device` block supports:
   in the following combinations: source=image and destination=volume,
   and source=blank and destination=volume. Changing this creates a new server.
 
-* `volume_type` - (Optional) Currently, the value can be `SSD` (ultra-I/O disk type), `SAS` (high I/O disk type), or `SATA` (common I/O disk type)
+* `volume_type` - (Optional) Currently, the value can be `SSD` (ultra-I/O disk type),
+  `SAS` (high I/O disk type), or `SATA` (common I/O disk type)
   [OTC-API](https://docs.otc.t-systems.com/en-us/api/ecs/en-us_topic_0065817708.html)
 
 * `boot_index` - (Optional) The boot index of the volume. It defaults to 0.
@@ -461,7 +457,7 @@ equal to what the chosen flavor supports.
 The following example shows how to create an instance with multiple ephemeral
 disks:
 
-```
+```hcl
 resource "opentelekomcloud_compute_instance_v2" "foo" {
   name            = "terraform-test"
   security_groups = ["default"]

--- a/docs/resources/compute_instance_v2.md
+++ b/docs/resources/compute_instance_v2.md
@@ -41,10 +41,10 @@ resource "opentelekomcloud_blockstorage_volume_v2" "myvol" {
 }
 
 resource "opentelekomcloud_compute_instance_v2" "myinstance" {
-  name            = "my_instance"
+  name            = "myinstance"
   image_id        = "ad091b52-742f-469e-8f3c-fd81cadf0743"
   flavor_id       = "3"
-  key_pair        = "my_keypair"
+  key_pair        = "my_key_pair_name"
   security_groups = ["default"]
 
   network {

--- a/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_instance_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_instance_v2_test.go
@@ -81,7 +81,7 @@ func TestAccComputeV2Instance_multiSecgroup(t *testing.T) {
 	})
 }
 
-func TestAccComputeV2Instance_bootFromVolumeImage(t *testing.T) {
+func TestAccComputeV2Instance_bootFromImage(t *testing.T) {
 	var instance servers.Server
 	resourceName := "opentelekomcloud_compute_instance_v2.instance_1"
 
@@ -95,6 +95,44 @@ func TestAccComputeV2Instance_bootFromVolumeImage(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeV2InstanceExists(resourceName, &instance),
 					testAccCheckComputeV2InstanceBootVolumeAttachment(&instance),
+				),
+			},
+		},
+	})
+}
+
+func TestAccComputeV2Instance_bootFromVolume(t *testing.T) {
+	var instance servers.Server
+	resourceName := "opentelekomcloud_compute_instance_v2.instance_1"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { common.TestAccPreCheck(t) },
+		Providers:    common.TestAccProviders,
+		CheckDestroy: TestAccCheckComputeV2InstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeV2Instance_bootFromVolume,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeV2InstanceExists(resourceName, &instance),
+				),
+			},
+		},
+	})
+}
+
+func TestAccComputeV2Instance_changeFixedIP(t *testing.T) {
+	var instance servers.Server
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { common.TestAccPreCheck(t) },
+		Providers:    common.TestAccProviders,
+		CheckDestroy: TestAccCheckComputeV2InstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeV2Instance_fixedIP,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeV2InstanceExists(
+						"opentelekomcloud_compute_instance_v2.instance_1", &instance),
 				),
 			},
 		},
@@ -481,6 +519,35 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   }
 }
 `, env.OS_IMAGE_ID, env.OS_NETWORK_ID)
+
+var testAccComputeV2Instance_bootFromVolume = fmt.Sprintf(`
+resource "opentelekomcloud_compute_instance_v2" "instance_1" {
+  name            = "instance_1"
+  security_groups = ["default"]
+  network {
+    uuid = "%s"
+  }
+  block_device {
+    uuid                  = "%s"
+    source_type           = "image"
+    volume_size           = 50
+    boot_index            = 0
+    destination_type      = "volume"
+    delete_on_termination = true
+  }
+}
+`, env.OS_NETWORK_ID, env.OS_IMAGE_ID)
+
+var testAccComputeV2Instance_fixedIP = fmt.Sprintf(`
+resource "opentelekomcloud_compute_instance_v2" "instance_1" {
+  name            = "instance_1"
+  security_groups = ["default"]
+  network {
+    uuid        = "%s"
+    fixed_ip_v4 = "192.168.0.24"
+  }
+}
+`, env.OS_NETWORK_ID)
 
 var testAccComputeV2Instance_stopBeforeDestroy = fmt.Sprintf(`
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {

--- a/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_instance_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_instance_v2_test.go
@@ -482,64 +482,6 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
 }
 `, env.OS_IMAGE_ID, env.OS_NETWORK_ID)
 
-var testAccComputeV2Instance_bootFromVolume = fmt.Sprintf(`
-resource "opentelekomcloud_compute_instance_v2" "instance_1" {
-  name            = "instance_1"
-  security_groups = ["default"]
-  network {
-    uuid = "%s"
-  }
-  block_device {
-    uuid                  = "%s"
-    source_type           = "image"
-    volume_size           = 50
-    boot_index            = 0
-    destination_type      = "volume"
-    delete_on_termination = true
-  }
-}
-`, env.OS_NETWORK_ID, env.OS_IMAGE_ID)
-
-var testAccComputeV2Instance_bootFromVolumeUpdate = fmt.Sprintf(`
-resource "opentelekomcloud_compute_instance_v2" "instance_1" {
-  name            = "instance_1"
-  security_groups = ["default"]
-  network {
-    uuid = "%s"
-  }
-  block_device {
-    uuid                  = "%s"
-    source_type           = "image"
-    volume_size           = 51
-    boot_index            = 0
-    destination_type      = "volume"
-    delete_on_termination = true
-  }
-}
-`, env.OS_NETWORK_ID, env.OS_IMAGE_ID)
-
-var testAccComputeV2Instance_fixedIP = fmt.Sprintf(`
-resource "opentelekomcloud_compute_instance_v2" "instance_1" {
-  name            = "instance_1"
-  security_groups = ["default"]
-  network {
-    uuid        = "%s"
-    fixed_ip_v4 = "192.168.0.24"
-  }
-}
-`, env.OS_NETWORK_ID)
-
-var testAccComputeV2Instance_fixedIPUpdate = fmt.Sprintf(`
-resource "opentelekomcloud_compute_instance_v2" "instance_1" {
-  name            = "instance_1"
-  security_groups = ["default"]
-  network {
-    uuid        = "%s"
-    fixed_ip_v4 = "192.168.0.25"
-  }
-}
-`, env.OS_NETWORK_ID)
-
 var testAccComputeV2Instance_stopBeforeDestroy = fmt.Sprintf(`
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"


### PR DESCRIPTION
## Summary of the Pull Request
Unify usage of tags in `resource/opentelekomcloud_compute_instance_v2`

## PR Checklist

* [x] Refers to: #918
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
=== RUN   TestAccComputeV2Instance_basic
--- PASS: TestAccComputeV2Instance_basic (127.26s)
=== RUN   TestAccComputeV2Instance_multiSecgroup
--- PASS: TestAccComputeV2Instance_multiSecgroup (109.76s)
=== RUN   TestAccComputeV2Instance_bootFromImage
--- PASS: TestAccComputeV2Instance_bootFromImage (57.53s)
=== RUN   TestAccComputeV2Instance_bootFromVolume
--- PASS: TestAccComputeV2Instance_bootFromVolume (56.39s)
=== RUN   TestAccComputeV2Instance_changeFixedIP
--- PASS: TestAccComputeV2Instance_changeFixedIP (58.67s)
=== RUN   TestAccComputeV2Instance_bootFromVolumeVolume
--- PASS: TestAccComputeV2Instance_bootFromVolumeVolume (83.05s)
=== RUN   TestAccComputeV2Instance_stopBeforeDestroy
--- PASS: TestAccComputeV2Instance_stopBeforeDestroy (68.40s)
=== RUN   TestAccComputeV2Instance_metadata
--- PASS: TestAccComputeV2Instance_metadata (96.51s)
=== RUN   TestAccComputeV2Instance_timeout
--- PASS: TestAccComputeV2Instance_timeout (61.58s)
=== RUN   TestAccComputeV2Instance_autoRecovery
--- PASS: TestAccComputeV2Instance_autoRecovery (91.52s)
=== RUN   TestAccComputeV2Instance_crazyNICs
--- PASS: TestAccComputeV2Instance_crazyNICs (208.25s)
PASS

Process finished with exit code 0
```
