### PR TITLE
[DOC] `ecs_instance_v1`: Make nics required

### DIFF
--- a/docs/resources/ecs_instance_v1.md
+++ b/docs/resources/ecs_instance_v1.md
@@ -185,7 +185,7 @@ The following arguments are supported:
 
 * `vpc_id` - (Required) The ID of the desired VPC for the server. Changing this creates a new server.
 
-* `nics` - (Optional) An array of one or more networks to attach to the
+* `nics` - (Required) An array of one or more networks to attach to the
   instance. The nics object structure is documented below. Changing this
   creates a new server.
 


### PR DESCRIPTION
## Summary of the Pull Request
Make `nics` a required argument in opentelekomcloud_ecs_instance_v1 documentation.

Fix #950

## PR Checklist

* [x] Refers to: #950 
* [ ] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.