### PR TITLE
Add `power_state` to `compute_instance_v2`

### DIFF
--- a/docs/resources/compute_instance_v2.md
+++ b/docs/resources/compute_instance_v2.md
@@ -336,6 +336,12 @@ otherwise it will return an error.
 * `auto_recovery` - (Optional) Configures or deletes automatic recovery of an instance.
   Defaults to true.
 
+* `power_state` - (Optional) Provide the VM state. Only `active` and `shutoff` are supported values.
+
+  ->
+  If the initial `power_state` is the `shutoff` the VM will be stopped immediately after build,
+  and the provisioners like remote-exec or files are not supported.
+
 The `network` block supports:
 
 * `uuid` - (Required unless `port`  or `name` is provided) The network UUID to


### PR DESCRIPTION
## Summary of the Pull Request
Backport `openstack_compute_instance_v2` `power_state` feature

Resolve #949 

## PR Checklist

* [x] Refers to: #949
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
=== RUN   TestAccComputeV2Instance_initialStateActive
--- PASS: TestAccComputeV2Instance_initialStateActive (137.06s)
=== RUN   TestAccComputeV2Instance_initialStateShutoff
--- PASS: TestAccComputeV2Instance_initialStateShutoff (157.33s)
PASS

Process finished with exit code 0
```
