### PR TITLE
[CCE] Fix bug with `privateIp` setting in `CreateOpts`

### DIFF
--- a/docs/resources/cce_node_v3.md
+++ b/docs/resources/cce_node_v3.md
@@ -96,7 +96,7 @@ The following arguments are supported:
 
 * `public_key` - (Optional) The Public key. Changing this parameter will create a new cluster resource.
 
-* `private_ip` - (Optional) Private IP of the CCE node.  Changing this parameter will create a new resource.
+* `private_ip` - (Optional) Private IP of the CCE node. Changing this parameter will create a new resource.
 
 * `preinstall` - (Optional) Script required before installation. The input value can be a Base64 encoded string or not.
   Changing this parameter will create a new resource.

--- a/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_v3.go
+++ b/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_v3.go
@@ -405,13 +405,6 @@ func resourceCCENodeV3Create(d *schema.ResourceData, meta interface{}) error {
 			},
 			BillingMode: d.Get("billing_mode").(int),
 			Count:       1,
-			NodeNicSpec: nodes.NodeNicSpec{
-				PrimaryNic: nodes.PrimaryNic{
-					FixedIPs: []string{
-						d.Get("private_ip").(string),
-					},
-				},
-			},
 			ExtendParam: nodes.ExtendParam{
 				ChargingMode:       d.Get("extend_param_charging_mode").(int),
 				EcsPerformanceType: d.Get("ecs_performance_type").(string),


### PR DESCRIPTION
## Summary of the Pull Request
Fix issue with setting empty `privateIp` field in `createOpts`

Make `privateIp` set in `createOpts` only if it is not empty.

Resolves: #972

## PR Checklist

* [x] Refers to: #972
* [x] Tests added/passed

## Acceptance Steps Performed

```
=== RUN   TestAccCCENodesV3_basic
--- PASS: TestAccCCENodesV3_basic (805.29s)
=== RUN   TestAccCCENodesV3_timeout
--- PASS: TestAccCCENodesV3_timeout (661.99s)
=== RUN   TestAccCCENodesV3_os
--- PASS: TestAccCCENodesV3_os (716.49s)
=== RUN   TestAccCCENodesV3_bandWidthResize
--- PASS: TestAccCCENodesV3_bandWidthResize (721.61s)
=== RUN   TestAccCCENodesV3_eipIds
--- PASS: TestAccCCENodesV3_eipIds (753.98s)
=== RUN   TestAccCCENodesV3_ipSetNull
--- PASS: TestAccCCENodesV3_ipSetNull (678.53s)
=== RUN   TestAccCCENodesV3_ipCreate
--- PASS: TestAccCCENodesV3_ipCreate (685.42s)
=== RUN   TestAccCCENodesV3_ipWithExtendedParameters
--- PASS: TestAccCCENodesV3_ipWithExtendedParameters (694.92s)
=== RUN   TestAccCCENodesV3_ipNulls
--- PASS: TestAccCCENodesV3_ipNulls (682.76s)
PASS

Process finished with the exit code 0
```
