### PR TITLE
Add default values for subnet DNS servers

### DIFF
--- a/docs/resources/networking_subnet_v2.md
+++ b/docs/resources/networking_subnet_v2.md
@@ -57,7 +57,7 @@ The following arguments are supported:
 
 * `dns_nameservers` - (Optional) An array of DNS name server names used by hosts
   in this subnet. Changing this updates the DNS name servers for the existing
-  subnet.
+  subnet. Default value is `["100.125.4.25", "1.1.1.1"]`
 
 * `host_routes` - (Optional) An array of routes that should be used by devices
   with IPs from this subnet (not including local subnet route). The host_route

--- a/docs/resources/vpc_subnet_v1.md
+++ b/docs/resources/vpc_subnet_v1.md
@@ -59,8 +59,10 @@ The following arguments are supported:
 * `dhcp_enable` - (Optional) Specifies whether the DHCP function is enabled for the subnet. The value can be true or false. If this parameter is left blank, it is set to true by default.
 
 * `primary_dns` - (Optional) Specifies the IP address of DNS server 1 on the subnet. The value must be a valid IP address.
+  Default is `100.125.4.25`, OpenTelekomCloud internal DNS server.
 
 * `secondary_dns` - (Optional) Specifies the IP address of DNS server 2 on the subnet. The value must be a valid IP address.
+  Default is `1.1.1.1`, `Cloudflare`/`APNIC` public DNS server.
 
 * `dns_list` - (Optional) Specifies the DNS server address list of a subnet. This field is required if you need to use more than two DNS servers. This parameter value is the superset of both DNS server address 1 and DNS server address 2.
 
@@ -75,11 +77,11 @@ The following arguments are supported:
 
 All of the argument attributes are also exported as result attributes:
 
-* `id` - Specifies a resource ID in UUID format.
+* `id` - Specifies a resource ID in UUID format. Same as OpenStack network ID (`OS_NETWORK_ID`).
  
 * `status` - Specifies the status of the subnet. The value can be ACTIVE, DOWN, UNKNOWN, or ERROR.
 
-* `subnet_id` - Specifies the subnet (Native OpenStack API) ID.
+* `subnet_id` - Specifies the OpenStack subnet ID.
 
 ## Import
 

--- a/opentelekomcloud/services/vpc/utils.go
+++ b/opentelekomcloud/services/vpc/utils.go
@@ -4,3 +4,5 @@ import "github.com/hashicorp/terraform-plugin-sdk/helper/mutexkv"
 
 // This is a global MutexKV for use within this plugin.
 var osMutexKV = mutexkv.NewMutexKV()
+
+var defaultDNS = []string{"100.125.4.25", "1.1.1.1"}


### PR DESCRIPTION
## Summary of the Pull Request
Add `primary_dns` and `secondary_dns` defaults to `vpc_subnet_v1`

Add `dns_nameservers` default to `networking_subnet_v2`

Resolve #965

## PR Checklist

* [x] Refers to: #965, #967
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed
`resource_opentelekomcloud_networking_subnet_v2_test`:
```
=== RUN   TestAccNetworkingV2Subnet_basic
--- PASS: TestAccNetworkingV2Subnet_basic (51.14s)
=== RUN   TestAccNetworkingV2Subnet_enableDHCP
--- PASS: TestAccNetworkingV2Subnet_enableDHCP (43.29s)
=== RUN   TestAccNetworkingV2Subnet_noGateway
--- PASS: TestAccNetworkingV2Subnet_noGateway (42.94s)
=== RUN   TestAccNetworkingV2Subnet_impliedGateway
--- PASS: TestAccNetworkingV2Subnet_impliedGateway (44.04s)
=== RUN   TestAccNetworkingV2Subnet_timeout
--- PASS: TestAccNetworkingV2Subnet_timeout (42.88s)
PASS

Process finished with the exit code 0
```

`resource_opentelekomcloud_vpc_subnet_v1_test`
```
=== RUN   TestAccOTCVpcSubnetV1_basic
--- PASS: TestAccOTCVpcSubnetV1_basic (66.39s)
=== RUN   TestAccOTCVpcSubnetV1_timeout
--- PASS: TestAccOTCVpcSubnetV1_timeout (51.71s)
PASS
```

`import_opentelekomcloud_networking_subnet_v2_test`:
```
=== RUN   TestAccNetworkingV2Subnet_importBasic
--- PASS: TestAccNetworkingV2Subnet_importBasic (43.17s)
PASS

Process finished with the exit code 0

```

`import_opentelekomcloud_vpc_subnet_v1_test`:
```
=== RUN   TestAccOTCVpcSubnetV1_importBasic
--- PASS: TestAccOTCVpcSubnetV1_importBasic (54.51s)
PASS

Process finished with the exit code 0
```

