### PR TITLE
Get rid of acc test workaround for `lb_listener`

### DIFF
--- a/opentelekomcloud/acceptance/lb/resource_opentelekomcloud_lb_listener_v2_test.go
+++ b/opentelekomcloud/acceptance/lb/resource_opentelekomcloud_lb_listener_v2_test.go
@@ -393,10 +393,6 @@ resource "opentelekomcloud_lb_listener_v2" "listener_tls" {
   # which blocks final destruction of certificates
   depends_on = [opentelekomcloud_lb_certificate_v2.certificate_tls, opentelekomcloud_lb_certificate_v2.certificate_ca]
 
-  lifecycle {
-	ignore_changes = [client_ca_tls_container_ref, default_tls_container_ref]
-  }
-
   timeouts {
     create = "5m"
     update = "5m"

--- a/opentelekomcloud/services/elb/resource_opentelekomcloud_lb_listener_v2.go
+++ b/opentelekomcloud/services/elb/resource_opentelekomcloud_lb_listener_v2.go
@@ -89,14 +89,16 @@ func ResourceListenerV2() *schema.Resource {
 			"default_tls_container_ref": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			// new feature 2020 to handle Client certificates
 			"client_ca_tls_container_ref": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"sni_container_refs": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
@@ -128,7 +130,7 @@ func resourceListenerV2Create(d *schema.ResourceData, meta interface{}) error {
 	adminStateUp := d.Get("admin_state_up").(bool)
 	var sniContainerRefs []string
 	if raw, ok := d.GetOk("sni_container_refs"); ok {
-		for _, v := range raw.([]interface{}) {
+		for _, v := range raw.(*schema.Set).List() {
 			sniContainerRefs = append(sniContainerRefs, v.(string))
 		}
 	}


### PR DESCRIPTION
## Summary of the Pull Request
Make `default_tls_container_ref` and `client_ca_tls_container_ref` computed

Change type of `sni_container_refs` to `TypeSet`

Part of #981

## PR Checklist

* [x] Refers to: #981 #944
* [x] Tests added/passed.
* [x] Schema updated.

## Acceptance Steps Performed

```
=== RUN   TestAccLBV2Listener_basic
--- PASS: TestAccLBV2Listener_basic (86.02s)
=== RUN   TestAccLBV2Listener_tls
--- PASS: TestAccLBV2Listener_tls (83.56s)
PASS

Process finished with the exit code 0
```
