### PR TITLE
[AS] Make `security_groups` in `as_group_v1` optional

### DIFF
--- a/docs/resources/as_group_v1.md
+++ b/docs/resources/as_group_v1.md
@@ -140,7 +140,7 @@ The following arguments are supported:
   The system supports up to five networks. The networks object structure
   is documented below.
 
-* `security_groups` - (Required) An array of security group IDs to associate with the group.
+* `security_groups` - (Optional) An array of security group IDs to associate with the group.
   A maximum of one security group can be selected. The `security_groups` object structure is
   documented below.
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/jinzhu/copier v0.2.3
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.3.1-0.20210407140234-cbf4acabe5dc
+	github.com/opentelekomcloud/gophertelekomcloud v0.3.1-0.20210416135709-bc13c4fba692
 	github.com/unknwon/com v1.0.1
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/jinzhu/copier v0.2.3
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.3.1-0.20210416135709-bc13c4fba692
+	github.com/opentelekomcloud/gophertelekomcloud v0.3.1-0.20210419101943-0e6c9f47b3d3
 	github.com/unknwon/com v1.0.1
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -276,8 +276,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWb
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.3.1-0.20210407140234-cbf4acabe5dc h1:ONWyACkD6FTcvYFBwEgx6IlurkuP9fsPniEfFp3tm0Y=
-github.com/opentelekomcloud/gophertelekomcloud v0.3.1-0.20210407140234-cbf4acabe5dc/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
+github.com/opentelekomcloud/gophertelekomcloud v0.3.1-0.20210416135709-bc13c4fba692 h1:KyKTUW81CINLYZjVWpaFIrpP/4Myfvvv0DqVB4Ea+Rk=
+github.com/opentelekomcloud/gophertelekomcloud v0.3.1-0.20210416135709-bc13c4fba692/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/go.sum
+++ b/go.sum
@@ -276,8 +276,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWb
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.3.1-0.20210416135709-bc13c4fba692 h1:KyKTUW81CINLYZjVWpaFIrpP/4Myfvvv0DqVB4Ea+Rk=
-github.com/opentelekomcloud/gophertelekomcloud v0.3.1-0.20210416135709-bc13c4fba692/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
+github.com/opentelekomcloud/gophertelekomcloud v0.3.1-0.20210419101943-0e6c9f47b3d3 h1:JR2/Ef2hPvFB5uw7Xy3cd1NcTxLF+6UsU6WA2RWJbkk=
+github.com/opentelekomcloud/gophertelekomcloud v0.3.1-0.20210419101943-0e6c9f47b3d3/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/opentelekomcloud/acceptance/as/resource_opentelekomcloud_as_group_v1_test.go
+++ b/opentelekomcloud/acceptance/as/resource_opentelekomcloud_as_group_v1_test.go
@@ -104,12 +104,12 @@ func testAccCheckASV1GroupExists(n string, group *groups.Group) resource.TestChe
 		}
 
 		config := common.TestAccProvider.Meta().(*cfg.Config)
-		asClient, err := config.AutoscalingV1Client(env.OS_REGION_NAME)
+		client, err := config.AutoscalingV1Client(env.OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("error creating opentelekomcloud autoscaling client: %s", err)
 		}
 
-		found, err := groups.Get(asClient, rs.Primary.ID).Extract()
+		found, err := groups.Get(client, rs.Primary.ID).Extract()
 		if err != nil {
 			return err
 		}
@@ -118,7 +118,7 @@ func testAccCheckASV1GroupExists(n string, group *groups.Group) resource.TestChe
 			return fmt.Errorf("autoscaling Group not found")
 		}
 		log.Printf("[DEBUG] test found is: %#v", found)
-		group = &found
+		group = found
 
 		return nil
 	}

--- a/opentelekomcloud/services/as/resource_opentelekomcloud_as_configuration_v1.go
+++ b/opentelekomcloud/services/as/resource_opentelekomcloud_as_configuration_v1.go
@@ -396,11 +396,11 @@ func getASGroupsByConfiguration(client *golangsdk.ServiceClient, configID string
 	listOpts := groups.ListOpts{
 		ConfigurationID: configID,
 	}
-	page, err := groups.List(client, listOpts).AllPages()
+	allPages, err := groups.List(client, listOpts).AllPages()
 	if err != nil {
 		return asGroups, fmt.Errorf("error getting ASGroups by configuration %q: %s", configID, err)
 	}
-	asGroups, err = page.(groups.GroupPage).Extract()
+	asGroups, err = groups.ExtractGroups(allPages)
 	return asGroups, err
 }
 

--- a/opentelekomcloud/services/as/resource_opentelekomcloud_as_group_v1.go
+++ b/opentelekomcloud/services/as/resource_opentelekomcloud_as_group_v1.go
@@ -116,7 +116,7 @@ func ResourceASGroup() *schema.Resource {
 			},
 			"security_groups": {
 				Type:     schema.TypeList,
-				Required: true,
+				Optional: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -355,6 +355,7 @@ func resourceASGroupCreate(d *schema.ResourceData, meta interface{}) error {
 	networks := getAllNetworks(d)
 	secGroups := getAllSecurityGroups(d)
 	asgLBaaSListeners := getAllLBaaSListeners(d)
+	isDeletePublicIp := d.Get("delete_publicip").(bool)
 
 	log.Printf("[DEBUG] available_zones: %#v", d.Get("available_zones"))
 	createOpts := groups.CreateOpts{
@@ -375,7 +376,7 @@ func resourceASGroupCreate(d *schema.ResourceData, meta interface{}) error {
 		HealthPeriodicAuditGrace:  d.Get("health_periodic_audit_grace_period").(int),
 		InstanceTerminatePolicy:   d.Get("instance_terminate_policy").(string),
 		Notifications:             getAllNotifications(d),
-		IsDeletePublicip:          d.Get("delete_publicip").(bool),
+		IsDeletePublicip:          &isDeletePublicIp,
 	}
 
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)
@@ -454,7 +455,7 @@ func resourceASGroupRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("health_periodic_audit_grace_period", asGroup.HealthPeriodicAuditGrace),
 		d.Set("instance_terminate_policy", asGroup.InstanceTerminatePolicy),
 		d.Set("scaling_configuration_id", asGroup.ConfigurationID),
-		d.Set("delete_publicip", asGroup.DeletePublicip),
+		d.Set("delete_publicip", asGroup.DeletePublicIP),
 		d.Set("region", config.GetRegion(d)),
 	)
 	if len(asGroup.Notifications) >= 1 {
@@ -525,6 +526,7 @@ func resourceASGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	networks := getAllNetworks(d)
 	secGroups := getAllSecurityGroups(d)
+	isDeletePublicIp := d.Get("delete_publicip").(bool)
 
 	asgLBaaSListeners := getAllLBaaSListeners(d)
 	updateOpts := groups.UpdateOpts{
@@ -544,7 +546,7 @@ func resourceASGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 		HealthPeriodicAuditGrace:  d.Get("health_periodic_audit_grace_period").(int),
 		InstanceTerminatePolicy:   d.Get("instance_terminate_policy").(string),
 		Notifications:             getAllNotifications(d),
-		IsDeletePublicip:          d.Get("delete_publicip").(bool),
+		IsDeletePublicip:          &isDeletePublicIp,
 	}
 	asGroupID, err := groups.Update(client, d.Id(), updateOpts).Extract()
 	if err != nil {


### PR DESCRIPTION
## Summary of the Pull Request
Make `security_groups` optional in `resource/opentelekomcloud_as_group_v1`
Fixes: #982

## PR Checklist

* [x] Refers to: #982
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
=== RUN   TestAccASV1Group_basic
--- PASS: TestAccASV1Group_basic (128.09s)
=== RUN   TestAccASV1Group_RemoveWithSetMinNumber
--- PASS: TestAccASV1Group_RemoveWithSetMinNumber (191.39s)
=== RUN   TestAccASV1Group_WithoutSecurityGroups
--- PASS: TestAccASV1Group_WithoutSecurityGroups (156.53s)
PASS

Process finished with the exit code 0
```
