### PR TITLE
Fix `vpc_subnet` creation with `dns_list` defined

### DIFF
--- a/opentelekomcloud/acceptance/vpc/import_opentelekomcloud_vpc_subnet_v1_test.go
+++ b/opentelekomcloud/acceptance/vpc/import_opentelekomcloud_vpc_subnet_v1_test.go
@@ -17,7 +17,7 @@ func TestAccOTCVpcSubnetV1_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckOTCVpcSubnetV1Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccOTCVpcSubnetV1_basic,
+				Config: testAccOTCVpcSubnetV1Basic,
 			},
 
 			{

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_vpc_subnet_v1_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_vpc_subnet_v1_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 )
 
-func TestAccOTCVpcSubnetV1_basic(t *testing.T) {
+func TestAccOTCVpcSubnetV1Basic(t *testing.T) {
 	var subnet subnets.Subnet
 
 	resource.Test(t, resource.TestCase{
@@ -23,7 +23,7 @@ func TestAccOTCVpcSubnetV1_basic(t *testing.T) {
 		CheckDestroy: testAccCheckOTCVpcSubnetV1Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccOTCVpcSubnetV1_basic,
+				Config: testAccOTCVpcSubnetV1Basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckOTCVpcSubnetV1Exists("opentelekomcloud_vpc_subnet_v1.subnet_1", &subnet),
 					resource.TestCheckResourceAttr(
@@ -43,7 +43,7 @@ func TestAccOTCVpcSubnetV1_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccOTCVpcSubnetV1_update,
+				Config: testAccOTCVpcSubnetV1Update,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"opentelekomcloud_vpc_subnet_v1.subnet_1", "name", "opentelekomcloud_subnet_1"),
@@ -57,7 +57,7 @@ func TestAccOTCVpcSubnetV1_basic(t *testing.T) {
 	})
 }
 
-func TestAccOTCVpcSubnetV1_timeout(t *testing.T) {
+func TestAccOTCVpcSubnetV1Timeout(t *testing.T) {
 	var subnet subnets.Subnet
 
 	resource.Test(t, resource.TestCase{
@@ -66,7 +66,25 @@ func TestAccOTCVpcSubnetV1_timeout(t *testing.T) {
 		CheckDestroy: testAccCheckOTCVpcSubnetV1Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccOTCVpcSubnetV1_timeout,
+				Config: testAccOTCVpcSubnetV1Timeout,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOTCVpcSubnetV1Exists("opentelekomcloud_vpc_subnet_v1.subnet_1", &subnet),
+				),
+			},
+		},
+	})
+}
+
+func TestAccOTCVpcSubnetV1DnsList(t *testing.T) {
+	var subnet subnets.Subnet
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { common.TestAccPreCheck(t) },
+		Providers:    common.TestAccProviders,
+		CheckDestroy: testAccCheckOTCVpcSubnetV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOTCVpcSubnetV1DnsList,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckOTCVpcSubnetV1Exists("opentelekomcloud_vpc_subnet_v1.subnet_1", &subnet),
 				),
@@ -127,7 +145,8 @@ func testAccCheckOTCVpcSubnetV1Exists(n string, subnet *subnets.Subnet) resource
 	}
 }
 
-const testAccOTCVpcSubnetV1_basic = `
+const (
+	testAccOTCVpcSubnetV1Basic = `
 resource "opentelekomcloud_vpc_v1" "vpc_1" {
   name = "vpc_test"
   cidr = "192.168.0.0/16"
@@ -147,8 +166,7 @@ resource "opentelekomcloud_vpc_subnet_v1" "subnet_1" {
   }
 }
 `
-
-const testAccOTCVpcSubnetV1_update = `
+	testAccOTCVpcSubnetV1Update = `
 resource "opentelekomcloud_vpc_v1" "vpc_1" {
   name = "vpc_test"
   cidr = "192.168.0.0/16"
@@ -169,7 +187,7 @@ resource "opentelekomcloud_vpc_subnet_v1" "subnet_1" {
 }
 `
 
-const testAccOTCVpcSubnetV1_timeout = `
+	testAccOTCVpcSubnetV1Timeout = `
 resource "opentelekomcloud_vpc_v1" "vpc_1" {
   name = "vpc_test"
   cidr = "192.168.0.0/16"
@@ -188,3 +206,19 @@ resource "opentelekomcloud_vpc_subnet_v1" "subnet_1" {
   }
 }
 `
+
+	testAccOTCVpcSubnetV1DnsList = `
+resource "opentelekomcloud_vpc_v1" "vpc" {
+  name       = "vpc_name"
+  cidr       = "192.168.0.0/16"
+}
+
+resource "opentelekomcloud_vpc_subnet_v1" "subnet_1" {
+  name          = "subnet_name"
+  vpc_id        = opentelekomcloud_vpc_v1.vpc.id
+  cidr          = cidrsubnet(opentelekomcloud_vpc_v1.vpc.cidr, 8, 0)
+  gateway_ip    = cidrhost(cidrsubnet(opentelekomcloud_vpc_v1.vpc.cidr, 8, 0), 1)
+  dns_list = ["100.125.4.25", "8.8.8.8"]
+}
+`
+)


### PR DESCRIPTION
## Summary of the Pull Request
Revert `vpc_subnet_v1` schema changes done in #977

Set default primary and secondary DNS servers during subnet creation

Fix #994 

## PR Checklist

* [x] Refers to: #994
* [x] Tests added/passed.
* [x] Schema updated.

## Acceptance Steps Performed

### Resource
```
=== RUN   TestAccOTCVpcSubnetV1Basic
--- PASS: TestAccOTCVpcSubnetV1Basic (69.19s)
=== RUN   TestAccOTCVpcSubnetV1Timeout
--- PASS: TestAccOTCVpcSubnetV1Timeout (56.58s)
=== RUN   TestAccOTCVpcSubnetV1DnsList
--- PASS: TestAccOTCVpcSubnetV1DnsList (50.14s)
PASS

Process finished with the exit code 0
```

### Import
```
=== RUN   TestAccOTCVpcSubnetV1_importBasic
--- PASS: TestAccOTCVpcSubnetV1_importBasic (51.34s)
PASS

Process finished with the exit code 0
```
