### PR TITLE
[IMS] Add possibility to search images via regex

### DIFF
--- a/docs/data-sources/images_image_v2.md
+++ b/docs/data-sources/images_image_v2.md
@@ -8,14 +8,20 @@ Use this data source to get the ID of an available OpenTelekomCloud image.
 
 ## Example Usage
 
+### Get Ubuntu_20.04 latest
+
 ```hcl
 data "opentelekomcloud_images_image_v2" "ubuntu" {
-  name = "Ubuntu 16.04"
-  most_recent = true
+  name = "Standard_Ubuntu_20.04_latest"
+}
+```
 
-  properties = {
-    key = "value"
-  }
+### Get most recent Debian
+
+```hcl
+data "opentelekomcloud_images_image_v2" "latest-debian" {
+  name        = "^Standard_Debian.?"
+  most_resent = true
 }
 ```
 
@@ -24,6 +30,10 @@ data "opentelekomcloud_images_image_v2" "ubuntu" {
 * `most_recent` - (Optional) If more than one result is returned, use the most recent image.
 
 * `name` - (Optional) The name of the image.
+
+* `name_regex` - (Optional) A regex string to apply to the images list.
+  This allows more advanced filtering not supported from the OpenTelekomCloud API.
+  This filtering is done locally on what OpenTelekomCloud returns.
 
 * `owner` - (Optional) The owner (UUID) of the image.
 
@@ -41,8 +51,11 @@ data "opentelekomcloud_images_image_v2" "ubuntu" {
 * `tag` - (Optional) Search for images with a specific tag.
 
 * `visibility` - (Optional) The visibility of the image. Must be one of
-   "public", "private", "community", or "shared". Defaults to "private".
+   `public`, `private`, `community`, or `shared`. Defaults to `private`.
 
+-> If more or less than a single match is returned by the search, Terraform will fail.
+Ensure that your search is specific enough to return a single IMS ID only, or use `most_recent`
+to choose the most recent one.
 
 ## Attributes Reference
 
@@ -57,7 +70,7 @@ data "opentelekomcloud_images_image_v2" "ubuntu" {
 * `disk_format`: The format of the image's disk.
 
 * `file` - the trailing path after the glance endpoint that represent the
-  location of the image or the path to retrieve it.
+  location of the image, or the path to retrieve it.
 
 * `metadata` - The metadata associated with the image.
   Image metadata allow for meaningfully define the image properties
@@ -69,7 +82,7 @@ data "opentelekomcloud_images_image_v2" "ubuntu" {
 
 * `properties` - Freeform information about the image.
 
-* `protected` - Whether or not the image is protected.
+* `protected` - Whether the image is protected.
 
 * `schema` - The path to the JSON-schema that represent the image or image
 

--- a/opentelekomcloud/acceptance/ims/data_source_opentelekomcloud_images_image_v2_test.go
+++ b/opentelekomcloud/acceptance/ims/data_source_opentelekomcloud_images_image_v2_test.go
@@ -10,62 +10,79 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
 )
 
-func TestAccOpenTelekomCloudImagesV2ImageDataSource_basic(t *testing.T) {
+func TestAccImagesV2ImageDataSource_basic(t *testing.T) {
+	dataSourceName := "data.opentelekomcloud_images_image_v2.image_1"
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { common.TestAccPreCheck(t) },
 		Providers: common.TestAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccOpenTelekomCloudImagesV2ImageDataSource_cirros,
+				Config: testAccImagesV2ImageDataSource_cirros,
 			},
 			{
-				Config: testAccOpenTelekomCloudImagesV2ImageDataSource_basic,
+				Config: testAccImagesV2ImageDataSource_basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckImagesV2DataSourceID("data.opentelekomcloud_images_image_v2.image_1"),
-					resource.TestCheckResourceAttr(
-						"data.opentelekomcloud_images_image_v2.image_1", "name", "CirrOS-tf"),
-					resource.TestCheckResourceAttr(
-						"data.opentelekomcloud_images_image_v2.image_1", "container_format", "bare"),
-					resource.TestCheckResourceAttr(
-						"data.opentelekomcloud_images_image_v2.image_1", "min_ram_mb", "0"),
-					resource.TestCheckResourceAttr(
-						"data.opentelekomcloud_images_image_v2.image_1", "protected", "false"),
-					resource.TestCheckResourceAttr(
-						"data.opentelekomcloud_images_image_v2.image_1", "visibility", "private"),
+					testAccCheckImagesV2DataSourceID(dataSourceName),
+					resource.TestCheckResourceAttr(dataSourceName, "name", "CirrOS-tf"),
+					resource.TestCheckResourceAttr(dataSourceName, "container_format", "bare"),
+					resource.TestCheckResourceAttr(dataSourceName, "min_ram_mb", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "protected", "false"),
+					resource.TestCheckResourceAttr(dataSourceName, "visibility", "private"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccOpenTelekomCloudImagesV2ImageDataSource_testQueries(t *testing.T) {
+func TestAccImagesV2ImageDataSource_testQueries(t *testing.T) {
+	dataSourceName := "data.opentelekomcloud_images_image_v2.image_1"
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { common.TestAccPreCheck(t) },
 		Providers: common.TestAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccOpenTelekomCloudImagesV2ImageDataSource_cirros,
+				Config: testAccImagesV2ImageDataSource_cirros,
 			},
 			{
-				Config: testAccOpenTelekomCloudImagesV2ImageDataSource_queryTag,
+				Config: testAccImagesV2ImageDataSource_queryTag,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckImagesV2DataSourceID("data.opentelekomcloud_images_image_v2.image_1"),
+					testAccCheckImagesV2DataSourceID(dataSourceName),
 				),
 			},
 			{
-				Config: testAccOpenTelekomCloudImagesV2ImageDataSource_querySizeMin,
+				Config: testAccImagesV2ImageDataSource_querySizeMin,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckImagesV2DataSourceID("data.opentelekomcloud_images_image_v2.image_1"),
+					testAccCheckImagesV2DataSourceID(dataSourceName),
 				),
 			},
 			{
-				Config: testAccOpenTelekomCloudImagesV2ImageDataSource_querySizeMax,
+				Config: testAccImagesV2ImageDataSource_querySizeMax,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckImagesV2DataSourceID("data.opentelekomcloud_images_image_v2.image_1"),
+					testAccCheckImagesV2DataSourceID(dataSourceName),
 				),
 			},
 			{
-				Config: testAccOpenTelekomCloudImagesV2ImageDataSource_cirros,
+				Config: testAccImagesV2ImageDataSource_cirros,
+			},
+		},
+	})
+}
+
+func TestAccImagesV2ImageDataSource_regex(t *testing.T) {
+	dataSourceName := "data.opentelekomcloud_images_image_v2.image_1"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { common.TestAccPreCheck(t) },
+		Providers: common.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccImagesV2ImageDataSource_regex,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckImagesV2DataSourceID(dataSourceName),
+					resource.TestCheckResourceAttr(dataSourceName, "visibility", "public"),
+				),
 			},
 		},
 	})
@@ -75,11 +92,11 @@ func testAccCheckImagesV2DataSourceID(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Can't find image data source: %s", n)
+			return fmt.Errorf("can't find image data source: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("Image data source ID not set")
+			return fmt.Errorf("image data source ID not set")
 		}
 
 		return nil
@@ -87,51 +104,59 @@ func testAccCheckImagesV2DataSourceID(n string) resource.TestCheckFunc {
 }
 
 // Standard CirrOS image
-const testAccOpenTelekomCloudImagesV2ImageDataSource_cirros = `
+const testAccImagesV2ImageDataSource_cirros = `
 resource "opentelekomcloud_images_image_v2" "image_1" {
-	name = "CirrOS-tf"
-	container_format = "bare"
-	disk_format = "qcow2"
-	image_source_url = "http://download.cirros-cloud.net/0.3.5/cirros-0.3.5-x86_64-disk.img"
-	tags = ["cirros-tf"]
+  name             = "CirrOS-tf"
+  container_format = "bare"
+  disk_format      = "qcow2"
+  image_source_url = "https://download.cirros-cloud.net/0.3.5/cirros-0.3.5-x86_64-disk.img"
+  tags             = ["cirros-tf"]
 }
 `
 
-var testAccOpenTelekomCloudImagesV2ImageDataSource_basic = fmt.Sprintf(`
+var testAccImagesV2ImageDataSource_basic = fmt.Sprintf(`
 %s
 
 data "opentelekomcloud_images_image_v2" "image_1" {
 	most_recent = true
-	name = opentelekomcloud_images_image_v2.image_1.name
+	name        = opentelekomcloud_images_image_v2.image_1.name
 }
-`, testAccOpenTelekomCloudImagesV2ImageDataSource_cirros)
+`, testAccImagesV2ImageDataSource_cirros)
 
-var testAccOpenTelekomCloudImagesV2ImageDataSource_queryTag = fmt.Sprintf(`
+var testAccImagesV2ImageDataSource_queryTag = fmt.Sprintf(`
 %s
 
 data "opentelekomcloud_images_image_v2" "image_1" {
-	most_recent = true
-	visibility = "private"
-	tag = "cirros-tf"
+  most_recent = true
+  visibility  = "private"
+  tag         = "cirros-tf"
 }
-`, testAccOpenTelekomCloudImagesV2ImageDataSource_cirros)
+`, testAccImagesV2ImageDataSource_cirros)
 
-var testAccOpenTelekomCloudImagesV2ImageDataSource_querySizeMin = fmt.Sprintf(`
+var testAccImagesV2ImageDataSource_querySizeMin = fmt.Sprintf(`
 %s
 
 data "opentelekomcloud_images_image_v2" "image_1" {
-	most_recent = true
-	visibility = "private"
-	size_min = "13000000"
+  most_recent = true
+  visibility  = "private"
+  size_min    = "13000000"
 }
-`, testAccOpenTelekomCloudImagesV2ImageDataSource_cirros)
+`, testAccImagesV2ImageDataSource_cirros)
 
-var testAccOpenTelekomCloudImagesV2ImageDataSource_querySizeMax = fmt.Sprintf(`
+var testAccImagesV2ImageDataSource_querySizeMax = fmt.Sprintf(`
 %s
 
 data "opentelekomcloud_images_image_v2" "image_1" {
-	most_recent = true
-	visibility = "private"
-	size_max = "23000000"
+  most_recent = true
+  visibility  = "private"
+  size_max    = "23000000"
 }
-`, testAccOpenTelekomCloudImagesV2ImageDataSource_cirros)
+`, testAccImagesV2ImageDataSource_cirros)
+
+var testAccImagesV2ImageDataSource_regex = `
+data "opentelekomcloud_images_image_v2" "image_1" {
+  name_regex  = "^Standard_Debian.+"
+  most_recent = true
+  visibility  = "public"
+}
+`

--- a/opentelekomcloud/services/bms/data_source_opentelekomcloud_compute_bms_flavor_v2.go
+++ b/opentelekomcloud/services/bms/data_source_opentelekomcloud_compute_bms_flavor_v2.go
@@ -5,10 +5,10 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/bms/v2/flavors"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
-	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/services/ims"
 )
 
 func DataSourceBMSFlavorV2() *schema.Resource {
@@ -75,10 +75,12 @@ func DataSourceBMSFlavorV2() *schema.Resource {
 			},
 
 			"sort_dir": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Default:      "asc",
-				ValidateFunc: ims.DataSourceImagesImageV2SortDirection,
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "asc",
+				ValidateFunc: validation.StringInSlice([]string{
+					"asc", "desc",
+				}, false),
 			},
 		},
 	}

--- a/opentelekomcloud/services/ims/data_source_opentelekomcloud_images_image_v2.go
+++ b/opentelekomcloud/services/ims/data_source_opentelekomcloud_images_image_v2.go
@@ -145,7 +145,6 @@ func DataSourceImagesImageV2() *schema.Resource {
 	}
 }
 
-// dataSourceImagesImageV2Read performs the image lookup.
 func dataSourceImagesImageV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*cfg.Config)
 	client, err := config.ImageV2Client(config.GetRegion(d))


### PR DESCRIPTION
## Summary of the Pull Request
Add `name_regex` param for searching with regular expressions in `datasource/opentelekomcloud_images_image_v2`

Resolves: #964

## PR Checklist

* [x] Refers to: #964
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
=== RUN   TestAccImagesV2ImageDataSource_basic
--- PASS: TestAccImagesV2ImageDataSource_basic (302.04s)
=== RUN   TestAccImagesV2ImageDataSource_testQueries
--- PASS: TestAccImagesV2ImageDataSource_testQueries (321.28s)
=== RUN   TestAccImagesV2ImageDataSource_regex
--- PASS: TestAccImagesV2ImageDataSource_regex (51.30s)
PASS

Process finished with the exit code 0
```
