### PR TITLE
[VPC] Add `network_id` attribute to `vpc_subnet`

### DIFF
--- a/docs/data-sources/vpc_subnet_v1.md
+++ b/docs/data-sources/vpc_subnet_v1.md
@@ -57,6 +57,6 @@ the selected subnet.
 
 * `dhcp_enable` - DHCP function for the subnet.
 
-* `subnet_id` - Specifies the OpenStack Neutron Subnet ID.
+* `subnet_id` - Specifies the OpenStack subnet ID.
 
-* `network_id` - Specifies the OpenStack Neutron Network ID.
+* `network_id` - Specifies the OpenStack network ID.

--- a/docs/data-sources/vpc_subnet_v1.md
+++ b/docs/data-sources/vpc_subnet_v1.md
@@ -48,7 +48,7 @@ subnet whose data will be exported as attributes.
 
 ## Attributes Reference
 
-All of the argument attributes are also exported as result attributes.
+All the argument attributes are also exported as result attributes.
 This data source will complete the data by populating
 any fields that are not included in the configuration with the data for
 the selected subnet.
@@ -57,4 +57,6 @@ the selected subnet.
 
 * `dhcp_enable` - DHCP function for the subnet.
 
-* `subnet_id` - Specifies the subnet (Native OpenStack API) ID.
+* `subnet_id` - Specifies the OpenStack Neutron Subnet ID.
+
+* `network_id` - Specifies the OpenStack Neutron Network ID.

--- a/docs/resources/vpc_subnet_v1.md
+++ b/docs/resources/vpc_subnet_v1.md
@@ -76,7 +76,6 @@ The following arguments are supported:
 ~>
   Please note that primary DNS should be set to OTC-internal for managed services (e.g. CCE, CSS) to work.
 
-* `availability_zone` - (Optional) Identifies the availability zone (AZ) to which the subnet belongs. The value must be an existing AZ in the system. Changing this creates a new Subnet.
 * `availability_zone` - (Optional) Identifies the availability zone (AZ) to which the subnet belongs.
   The value must be an existing AZ in the system. Changing this creates a new Subnet.
 
@@ -92,9 +91,6 @@ All the argument attributes are also exported as result attributes:
 * `id` - Specifies a resource ID in UUID format. Same as OpenStack Neutron Network ID (`OS_NETWORK_ID`).
 
 * `status` - Specifies the status of the subnet. The value can be `ACTIVE`, `DOWN`, `UNKNOWN`, or `ERROR`.
-* `id` - Specifies a resource ID in UUID format. Same as OpenStack network ID (`OS_NETWORK_ID`).
-
-* `status` - Specifies the status of the subnet. The value can be ACTIVE, DOWN, UNKNOWN, or ERROR.
 
 * `subnet_id` - Specifies the OpenStack Neutron Subnet ID.
 

--- a/docs/resources/vpc_subnet_v1.md
+++ b/docs/resources/vpc_subnet_v1.md
@@ -48,28 +48,37 @@ resource "opentelekomcloud_vpc_subnet_v1" "subnet_with_tags" {
 
 The following arguments are supported:
 
-* `name` - (Required) The subnet name. The value is a string of 1 to 64 characters that can contain letters, digits, underscores (_), and hyphens (-).
+* `name` - (Required) The subnet name. The value is a string of 1 to 64 characters that can contain letters,
+  digits, underscores (_), and hyphens (-).
 
-* `cidr` - (Required) Specifies the network segment on which the subnet resides. The value must be in CIDR format. The value must be within the CIDR block of the VPC. The subnet mask cannot be greater than 28. Changing this creates a new Subnet.
+* `cidr` - (Required) Specifies the network segment on which the subnet resides. The value must be in CIDR format.
+  The value must be within the CIDR block of the VPC. The subnet mask cannot be greater than 28.
+  Changing this creates a new Subnet.
 
-* `gateway_ip` - (Required) Specifies the gateway of the subnet. The value must be a valid IP address. The value must be an IP address in the subnet segment. Changing this creates a new Subnet.
+* `gateway_ip` - (Required) Specifies the gateway of the subnet. The value must be a valid IP address.
+  The value must be an IP address in the subnet segment. Changing this creates a new Subnet.
 
 * `vpc_id` - (Required) Specifies the ID of the VPC to which the subnet belongs. Changing this creates a new Subnet.
 
-* `dhcp_enable` - (Optional) Specifies whether the DHCP function is enabled for the subnet. The value can be true or false. If this parameter is left blank, it is set to true by default.
+* `dhcp_enable` - (Optional) Specifies whether the DHCP function is enabled for the subnet. The value can
+  be `true` or `false`. If this parameter is left blank, it is set to `true` by default.
 
-* `primary_dns` - (Optional) Specifies the IP address of DNS server 1 on the subnet. The value must be a valid IP address.
-  Default is `100.125.4.25`, OpenTelekomCloud internal DNS server.
+* `primary_dns` - (Optional) Specifies the IP address of DNS server 1 on the subnet. The value must be a
+  valid IP address. Default is `100.125.4.25`, OpenTelekomCloud internal DNS server.
 
-* `secondary_dns` - (Optional) Specifies the IP address of DNS server 2 on the subnet. The value must be a valid IP address.
-  Default is `1.1.1.1`, `Cloudflare`/`APNIC` public DNS server.
+* `secondary_dns` - (Optional) Specifies the IP address of DNS server 2 on the subnet. The value must be a
+  valid IP address. Default is `1.1.1.1`, `Cloudflare`/`APNIC` public DNS server.
 
-* `dns_list` - (Optional) Specifies the DNS server address list of a subnet. This field is required if you need to use more than two DNS servers. This parameter value is the superset of both DNS server address 1 and DNS server address 2.
+* `dns_list` - (Optional) Specifies the DNS server address list of a subnet. This field is required if you
+  need to use more than two DNS servers. This parameter value is the superset of both DNS server address
+  1 and DNS server address 2.
 
 ~>
   Please note that primary DNS should be set to OTC-internal for managed services (e.g. CCE, CSS) to work.
 
 * `availability_zone` - (Optional) Identifies the availability zone (AZ) to which the subnet belongs. The value must be an existing AZ in the system. Changing this creates a new Subnet.
+* `availability_zone` - (Optional) Identifies the availability zone (AZ) to which the subnet belongs.
+  The value must be an existing AZ in the system. Changing this creates a new Subnet.
 
 * `ntp_addresses` - (Optional) Specifies the NTP server address configured for the subnet.
 
@@ -78,18 +87,23 @@ The following arguments are supported:
 
 ## Attributes Reference
 
-All of the argument attributes are also exported as result attributes:
+All the argument attributes are also exported as result attributes:
 
+* `id` - Specifies a resource ID in UUID format. Same as OpenStack Neutron Network ID (`OS_NETWORK_ID`).
+
+* `status` - Specifies the status of the subnet. The value can be `ACTIVE`, `DOWN`, `UNKNOWN`, or `ERROR`.
 * `id` - Specifies a resource ID in UUID format. Same as OpenStack network ID (`OS_NETWORK_ID`).
 
 * `status` - Specifies the status of the subnet. The value can be ACTIVE, DOWN, UNKNOWN, or ERROR.
 
-* `subnet_id` - Specifies the OpenStack subnet ID.
+* `subnet_id` - Specifies the OpenStack Neutron Subnet ID.
+
+* `network_id` - Specifies the OpenStack Neutron Network ID.
 
 ## Import
 
 Subnets can be imported using the `subnet id`, e.g.
 
-```sh
+```shell
 terraform import opentelekomcloud_vpc_subnet_v1 4779ab1c-7c1a-44b1-a02e-93dfc361b32d
 ```

--- a/docs/resources/vpc_subnet_v1.md
+++ b/docs/resources/vpc_subnet_v1.md
@@ -88,13 +88,13 @@ The following arguments are supported:
 
 All the argument attributes are also exported as result attributes:
 
-* `id` - Specifies a resource ID in UUID format. Same as OpenStack Neutron Network ID (`OS_NETWORK_ID`).
+* `id` - Specifies a resource ID in UUID format. Same as OpenStack network ID (`OS_NETWORK_ID`).
 
 * `status` - Specifies the status of the subnet. The value can be `ACTIVE`, `DOWN`, `UNKNOWN`, or `ERROR`.
 
-* `subnet_id` - Specifies the OpenStack Neutron Subnet ID.
+* `subnet_id` - Specifies the OpenStack subnet ID.
 
-* `network_id` - Specifies the OpenStack Neutron Network ID.
+* `network_id` - Specifies the OpenStack network ID.
 
 ## Import
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/jinzhu/copier v0.2.3
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.3.1
+	github.com/opentelekomcloud/gophertelekomcloud v0.3.2
 	github.com/unknwon/com v1.0.1
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/jinzhu/copier v0.2.3
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.3.1-0.20210423114009-617905b03bb3
+	github.com/opentelekomcloud/gophertelekomcloud v0.3.1
 	github.com/unknwon/com v1.0.1
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -276,8 +276,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWb
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.3.1 h1:/QQh5jxT4YudFLssA1Yvg084DjQlLqX/9yB7lXXPDXA=
-github.com/opentelekomcloud/gophertelekomcloud v0.3.1/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
+github.com/opentelekomcloud/gophertelekomcloud v0.3.2 h1:WIBpammLUjxO44YIWmNusIUNVXUNovd05i4NJNl2FQw=
+github.com/opentelekomcloud/gophertelekomcloud v0.3.2/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/go.sum
+++ b/go.sum
@@ -276,8 +276,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWb
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.3.1-0.20210423114009-617905b03bb3 h1:KqKE+zFqJCmV9rWN3pqHvm5PU8ggZHpCzp28yBaC5CU=
-github.com/opentelekomcloud/gophertelekomcloud v0.3.1-0.20210423114009-617905b03bb3/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
+github.com/opentelekomcloud/gophertelekomcloud v0.3.1 h1:/QQh5jxT4YudFLssA1Yvg084DjQlLqX/9yB7lXXPDXA=
+github.com/opentelekomcloud/gophertelekomcloud v0.3.1/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/opentelekomcloud/acceptance/vpc/data_source_opentelekomcloud_vpc_subnet_v1_test.go
+++ b/opentelekomcloud/acceptance/vpc/data_source_opentelekomcloud_vpc_subnet_v1_test.go
@@ -10,34 +10,36 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
 )
 
-func TestAccOTCVpcSubnetV1DataSource_basic(t *testing.T) {
+func TestAccVpcSubnetV1DataSource_basic(t *testing.T) {
+	dataSourceNameByID := "data.opentelekomcloud_vpc_subnet_v1.by_id"
+	dataSourceNameByCIDR := "data.opentelekomcloud_vpc_subnet_v1.by_cidr"
+	dataSourceNameByName := "data.opentelekomcloud_vpc_subnet_v1.by_name"
+	dataSourceNameByVPC := "data.opentelekomcloud_vpc_subnet_v1.by_vpc_id"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { common.TestAccPreCheck(t) },
 		Providers: common.TestAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceOTCVpcSubnetV1Config,
+				Config: testAccDataSourceVpcSubnetV1Config,
 				Check: resource.ComposeTestCheckFunc(
-					testAccDataSourceOTCVpcSubnetV1Check("data.opentelekomcloud_vpc_subnet_v1.by_id", "opentelekomcloud_subnet", "192.168.0.0/16",
-						"192.168.0.1", "eu-de-02"),
-					testAccDataSourceOTCVpcSubnetV1Check("data.opentelekomcloud_vpc_subnet_v1.by_cidr", "opentelekomcloud_subnet", "192.168.0.0/16",
-						"192.168.0.1", "eu-de-02"),
-					testAccDataSourceOTCVpcSubnetV1Check("data.opentelekomcloud_vpc_subnet_v1.by_name", "opentelekomcloud_subnet", "192.168.0.0/16",
-						"192.168.0.1", "eu-de-02"),
-					testAccDataSourceOTCVpcSubnetV1Check("data.opentelekomcloud_vpc_subnet_v1.by_vpc_id", "opentelekomcloud_subnet", "192.168.0.0/16",
-						"192.168.0.1", "eu-de-02"),
-					resource.TestCheckResourceAttr(
-						"data.opentelekomcloud_vpc_subnet_v1.by_id", "status", "ACTIVE"),
-					resource.TestCheckResourceAttr(
-						"data.opentelekomcloud_vpc_subnet_v1.by_id", "dhcp_enable", "true"),
+					testAccDataSourceVpcSubnetV1Check(dataSourceNameByID, "test_subnet", "10.0.0.0/24",
+						"10.0.0.1", "eu-de-02"),
+					testAccDataSourceVpcSubnetV1Check(dataSourceNameByCIDR, "test_subnet", "10.0.0.0/24",
+						"10.0.0.1", "eu-de-02"),
+					testAccDataSourceVpcSubnetV1Check(dataSourceNameByName, "test_subnet", "10.0.0.0/24",
+						"10.0.0.1", "eu-de-02"),
+					testAccDataSourceVpcSubnetV1Check(dataSourceNameByVPC, "test_subnet", "10.0.0.0/24",
+						"10.0.0.1", "eu-de-02"),
+					resource.TestCheckResourceAttr(dataSourceNameByID, "status", "ACTIVE"),
+					resource.TestCheckResourceAttr(dataSourceNameByID, "dhcp_enable", "true"),
 				),
 			},
 		},
 	})
 }
 
-func testAccDataSourceOTCVpcSubnetV1Check(n, name, cidr, gateway_ip, availability_zone string) resource.TestCheckFunc {
+func testAccDataSourceVpcSubnetV1Check(n, name, cidr, gatewayIP, availabilityZone string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -52,11 +54,7 @@ func testAccDataSourceOTCVpcSubnetV1Check(n, name, cidr, gateway_ip, availabilit
 		attr := rs.Primary.Attributes
 
 		if attr["id"] != subnetRs.Primary.Attributes["id"] {
-			return fmt.Errorf(
-				"id is %s; want %s",
-				attr["id"],
-				subnetRs.Primary.Attributes["id"],
-			)
+			return fmt.Errorf("bad id %s", attr["id"])
 		}
 
 		if attr["cidr"] != cidr {
@@ -65,10 +63,10 @@ func testAccDataSourceOTCVpcSubnetV1Check(n, name, cidr, gateway_ip, availabilit
 		if attr["name"] != name {
 			return fmt.Errorf("bad subnet name %s", attr["name"])
 		}
-		if attr["gateway_ip"] != gateway_ip {
+		if attr["gateway_ip"] != gatewayIP {
 			return fmt.Errorf("bad subnet gateway_ip %s", attr["gateway_ip"])
 		}
-		if attr["availability_zone"] != availability_zone {
+		if attr["availability_zone"] != availabilityZone {
 			return fmt.Errorf("bad subnet availability_zone %s", attr["availability_zone"])
 		}
 
@@ -76,19 +74,19 @@ func testAccDataSourceOTCVpcSubnetV1Check(n, name, cidr, gateway_ip, availabilit
 	}
 }
 
-const testAccDataSourceOTCVpcSubnetV1Config = `
+const testAccDataSourceVpcSubnetV1Config = `
 resource "opentelekomcloud_vpc_v1" "vpc_1" {
-	name = "test_vpc"
-	cidr= "192.168.0.0/16"
+  name = "test_vpc"
+  cidr= "10.0.0.0/24"
 }
 
 resource "opentelekomcloud_vpc_subnet_v1" "subnet_1" {
-  name = "opentelekomcloud_subnet"
-  cidr = "192.168.0.0/16"
-  gateway_ip = "192.168.0.1"
-  vpc_id = opentelekomcloud_vpc_v1.vpc_1.id
+  name              = "test_subnet"
+  cidr              = "10.0.0.0/24"
+  gateway_ip        = "10.0.0.1"
+  vpc_id            = opentelekomcloud_vpc_v1.vpc_1.id
   availability_zone = "eu-de-02"
- }
+}
 
 data "opentelekomcloud_vpc_subnet_v1" "by_id" {
   id = opentelekomcloud_vpc_subnet_v1.subnet_1.id
@@ -99,10 +97,10 @@ data "opentelekomcloud_vpc_subnet_v1" "by_cidr" {
 }
 
 data "opentelekomcloud_vpc_subnet_v1" "by_name" {
-	name = opentelekomcloud_vpc_subnet_v1.subnet_1.name
+  name = opentelekomcloud_vpc_subnet_v1.subnet_1.name
 }
 
 data "opentelekomcloud_vpc_subnet_v1" "by_vpc_id" {
-	vpc_id = opentelekomcloud_vpc_subnet_v1.subnet_1.vpc_id
+  vpc_id = opentelekomcloud_vpc_subnet_v1.subnet_1.vpc_id
 }
 `

--- a/opentelekomcloud/acceptance/vpc/import_opentelekomcloud_vpc_subnet_v1_test.go
+++ b/opentelekomcloud/acceptance/vpc/import_opentelekomcloud_vpc_subnet_v1_test.go
@@ -8,18 +8,17 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
 )
 
-func TestAccOTCVpcSubnetV1_importBasic(t *testing.T) {
+func TestAccVpcSubnetV1_importBasic(t *testing.T) {
 	resourceName := "opentelekomcloud_vpc_subnet_v1.subnet_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { common.TestAccPreCheck(t) },
 		Providers:    common.TestAccProviders,
-		CheckDestroy: testAccCheckOTCVpcSubnetV1Destroy,
+		CheckDestroy: testAccCheckVpcSubnetV1Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccOTCVpcSubnetV1Basic,
+				Config: testAccVpcSubnetV1Basic,
 			},
-
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_vpc_subnet_v1_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_vpc_subnet_v1_test.go
@@ -14,90 +14,83 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 )
 
-func TestAccOTCVpcSubnetV1Basic(t *testing.T) {
+func TestAccVpcSubnetV1Basic(t *testing.T) {
 	var subnet subnets.Subnet
+	resourceName := "opentelekomcloud_vpc_subnet_v1.subnet_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { common.TestAccPreCheck(t) },
 		Providers:    common.TestAccProviders,
-		CheckDestroy: testAccCheckOTCVpcSubnetV1Destroy,
+		CheckDestroy: testAccCheckVpcSubnetV1Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccOTCVpcSubnetV1Basic,
+				Config: testAccVpcSubnetV1Basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckOTCVpcSubnetV1Exists("opentelekomcloud_vpc_subnet_v1.subnet_1", &subnet),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_vpc_subnet_v1.subnet_1", "name", "opentelekomcloud_subnet"),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_vpc_subnet_v1.subnet_1", "cidr", "192.168.0.0/16"),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_vpc_subnet_v1.subnet_1", "gateway_ip", "192.168.0.1"),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_vpc_subnet_v1.subnet_1", "availability_zone", "eu-de-02"),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_vpc_subnet_v1.subnet_1", "ntp_addresses", "10.100.0.33,10.100.0.34"),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_vpc_subnet_v1.subnet_1", "tags.foo", "bar"),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_vpc_subnet_v1.subnet_1", "tags.key", "value"),
+					testAccCheckVpcSubnetV1Exists(resourceName, &subnet),
+					resource.TestCheckResourceAttr(resourceName, "name", "opentelekomcloud_subnet"),
+					resource.TestCheckResourceAttr(resourceName, "cidr", "192.168.0.0/16"),
+					resource.TestCheckResourceAttr(resourceName, "gateway_ip", "192.168.0.1"),
+					resource.TestCheckResourceAttr(resourceName, "availability_zone", "eu-de-02"),
+					resource.TestCheckResourceAttr(resourceName, "ntp_addresses", "10.100.0.33,10.100.0.34"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
 				),
 			},
 			{
-				Config: testAccOTCVpcSubnetV1Update,
+				Config: testAccVpcSubnetV1Update,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_vpc_subnet_v1.subnet_1", "name", "opentelekomcloud_subnet_1"),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_vpc_subnet_v1.subnet_1", "ntp_addresses", "10.100.0.35,10.100.0.36"),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_vpc_subnet_v1.subnet_1", "tags.key", "value_update"),
+					resource.TestCheckResourceAttr(resourceName, "name", "opentelekomcloud_subnet_1"),
+					resource.TestCheckResourceAttr(resourceName, "ntp_addresses", "10.100.0.35,10.100.0.36"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value_update"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccOTCVpcSubnetV1Timeout(t *testing.T) {
+func TestAccVpcSubnetV1Timeout(t *testing.T) {
 	var subnet subnets.Subnet
+	resourceName := "opentelekomcloud_vpc_subnet_v1.subnet_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { common.TestAccPreCheck(t) },
 		Providers:    common.TestAccProviders,
-		CheckDestroy: testAccCheckOTCVpcSubnetV1Destroy,
+		CheckDestroy: testAccCheckVpcSubnetV1Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccOTCVpcSubnetV1Timeout,
+				Config: testAccVpcSubnetV1Timeout,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckOTCVpcSubnetV1Exists("opentelekomcloud_vpc_subnet_v1.subnet_1", &subnet),
+					testAccCheckVpcSubnetV1Exists(resourceName, &subnet),
 				),
 			},
 		},
 	})
 }
 
-func TestAccOTCVpcSubnetV1DnsList(t *testing.T) {
+func TestAccVpcSubnetV1DnsList(t *testing.T) {
 	var subnet subnets.Subnet
+	resourceName := "opentelekomcloud_vpc_subnet_v1.subnet_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { common.TestAccPreCheck(t) },
 		Providers:    common.TestAccProviders,
-		CheckDestroy: testAccCheckOTCVpcSubnetV1Destroy,
+		CheckDestroy: testAccCheckVpcSubnetV1Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccOTCVpcSubnetV1DnsList,
+				Config: testAccVpcSubnetV1DnsList,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckOTCVpcSubnetV1Exists("opentelekomcloud_vpc_subnet_v1.subnet_1", &subnet),
+					testAccCheckVpcSubnetV1Exists(resourceName, &subnet),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckOTCVpcSubnetV1Destroy(s *terraform.State) error {
+func testAccCheckVpcSubnetV1Destroy(s *terraform.State) error {
 	config := common.TestAccProvider.Meta().(*cfg.Config)
-	subnetClient, err := config.NetworkingV1Client(env.OS_REGION_NAME)
+	client, err := config.NetworkingV1Client(env.OS_REGION_NAME)
 	if err != nil {
-		return fmt.Errorf("Error creating OpenTelekomCloud vpc client: %s", err)
+		return fmt.Errorf("error creating OpenTelekomCloud NetworkingV1 client: %w", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -105,38 +98,38 @@ func testAccCheckOTCVpcSubnetV1Destroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := subnets.Get(subnetClient, rs.Primary.ID).Extract()
+		_, err := subnets.Get(client, rs.Primary.ID).Extract()
 		if err == nil {
-			return fmt.Errorf("Subnet still exists")
+			return fmt.Errorf("subnet still exists")
 		}
 	}
 
 	return nil
 }
-func testAccCheckOTCVpcSubnetV1Exists(n string, subnet *subnets.Subnet) resource.TestCheckFunc {
+func testAccCheckVpcSubnetV1Exists(n string, subnet *subnets.Subnet) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return fmt.Errorf("not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
+			return fmt.Errorf("no ID is set")
 		}
 
 		config := common.TestAccProvider.Meta().(*cfg.Config)
-		subnetClient, err := config.NetworkingV1Client(env.OS_REGION_NAME)
+		client, err := config.NetworkingV1Client(env.OS_REGION_NAME)
 		if err != nil {
-			return fmt.Errorf("Error creating OpenTelekomCloud Vpc client: %s", err)
+			return fmt.Errorf("error creating OpenTelekomCloud NetworkingV1 client: %w", err)
 		}
 
-		found, err := subnets.Get(subnetClient, rs.Primary.ID).Extract()
+		found, err := subnets.Get(client, rs.Primary.ID).Extract()
 		if err != nil {
 			return err
 		}
 
 		if found.ID != rs.Primary.ID {
-			return fmt.Errorf("Subnet not found")
+			return fmt.Errorf("subnet not found")
 		}
 
 		*subnet = *found
@@ -146,19 +139,19 @@ func testAccCheckOTCVpcSubnetV1Exists(n string, subnet *subnets.Subnet) resource
 }
 
 const (
-	testAccOTCVpcSubnetV1Basic = `
+	testAccVpcSubnetV1Basic = `
 resource "opentelekomcloud_vpc_v1" "vpc_1" {
   name = "vpc_test"
   cidr = "192.168.0.0/16"
 }
 
 resource "opentelekomcloud_vpc_subnet_v1" "subnet_1" {
-  name = "opentelekomcloud_subnet"
-  cidr = "192.168.0.0/16"
-  gateway_ip = "192.168.0.1"
-  vpc_id = opentelekomcloud_vpc_v1.vpc_1.id
+  name              = "opentelekomcloud_subnet"
+  cidr              = "192.168.0.0/16"
+  gateway_ip        = "192.168.0.1"
+  vpc_id            = opentelekomcloud_vpc_v1.vpc_1.id
   availability_zone = "eu-de-02"
-  ntp_addresses = "10.100.0.33,10.100.0.34"
+  ntp_addresses     = "10.100.0.33,10.100.0.34"
 
   tags = {
     foo = "bar"
@@ -166,19 +159,19 @@ resource "opentelekomcloud_vpc_subnet_v1" "subnet_1" {
   }
 }
 `
-	testAccOTCVpcSubnetV1Update = `
+	testAccVpcSubnetV1Update = `
 resource "opentelekomcloud_vpc_v1" "vpc_1" {
   name = "vpc_test"
   cidr = "192.168.0.0/16"
 }
 
 resource "opentelekomcloud_vpc_subnet_v1" "subnet_1" {
-  name = "opentelekomcloud_subnet_1"
-  cidr = "192.168.0.0/16"
-  gateway_ip = "192.168.0.1"
-  vpc_id = opentelekomcloud_vpc_v1.vpc_1.id
+  name              = "opentelekomcloud_subnet_1"
+  cidr              = "192.168.0.0/16"
+  gateway_ip        = "192.168.0.1"
+  vpc_id            = opentelekomcloud_vpc_v1.vpc_1.id
   availability_zone = "eu-de-02"
-  ntp_addresses = "10.100.0.35,10.100.0.36"
+  ntp_addresses     = "10.100.0.35,10.100.0.36"
 
   tags = {
     foo = "bar"
@@ -187,17 +180,17 @@ resource "opentelekomcloud_vpc_subnet_v1" "subnet_1" {
 }
 `
 
-	testAccOTCVpcSubnetV1Timeout = `
+	testAccVpcSubnetV1Timeout = `
 resource "opentelekomcloud_vpc_v1" "vpc_1" {
   name = "vpc_test"
   cidr = "192.168.0.0/16"
 }
 
 resource "opentelekomcloud_vpc_subnet_v1" "subnet_1" {
-  name = "opentelekomcloud_subnet"
-  cidr = "192.168.0.0/16"
-  gateway_ip = "192.168.0.1"
-  vpc_id = opentelekomcloud_vpc_v1.vpc_1.id
+  name              = "opentelekomcloud_subnet"
+  cidr              = "192.168.0.0/16"
+  gateway_ip        = "192.168.0.1"
+  vpc_id            = opentelekomcloud_vpc_v1.vpc_1.id
   availability_zone = "eu-de-02"
 
   timeouts {
@@ -207,18 +200,18 @@ resource "opentelekomcloud_vpc_subnet_v1" "subnet_1" {
 }
 `
 
-	testAccOTCVpcSubnetV1DnsList = `
+	testAccVpcSubnetV1DnsList = `
 resource "opentelekomcloud_vpc_v1" "vpc" {
-  name       = "vpc_name"
-  cidr       = "192.168.0.0/16"
+  name = "vpc_name"
+  cidr = "192.168.0.0/16"
 }
 
 resource "opentelekomcloud_vpc_subnet_v1" "subnet_1" {
-  name          = "subnet_name"
-  vpc_id        = opentelekomcloud_vpc_v1.vpc.id
-  cidr          = cidrsubnet(opentelekomcloud_vpc_v1.vpc.cidr, 8, 0)
-  gateway_ip    = cidrhost(cidrsubnet(opentelekomcloud_vpc_v1.vpc.cidr, 8, 0), 1)
-  dns_list = ["100.125.4.25", "8.8.8.8"]
+  name       = "subnet_name"
+  vpc_id     = opentelekomcloud_vpc_v1.vpc.id
+  cidr       = cidrsubnet(opentelekomcloud_vpc_v1.vpc.cidr, 8, 0)
+  gateway_ip = cidrhost(cidrsubnet(opentelekomcloud_vpc_v1.vpc.cidr, 8, 0), 1)
+  dns_list   = ["100.125.4.25", "8.8.8.8"]
 }
 `
 )

--- a/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_instance_v3.go
+++ b/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_instance_v3.go
@@ -493,7 +493,7 @@ func getSubnetSubnetID(d *schema.ResourceData, config *cfg.Config) (id string, e
 	if err != nil {
 		return
 	}
-	id = sn.SubnetId
+	id = sn.SubnetID
 	return
 }
 

--- a/opentelekomcloud/services/vpc/data_source_opentelekomcloud_vpc_subnet_ids_v1.go
+++ b/opentelekomcloud/services/vpc/data_source_opentelekomcloud_vpc_subnet_ids_v1.go
@@ -39,34 +39,35 @@ func DataSourceVpcSubnetIdsV1() *schema.Resource {
 
 func dataSourceVpcSubnetIdsV1Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*cfg.Config)
-	subnetClient, err := config.NetworkingV1Client(config.GetRegion(d))
+	client, err := config.NetworkingV1Client(config.GetRegion(d))
 	if err != nil {
-		return err
+		return fmt.Errorf("error creating OpenTelekomCloud NetworkingV1 client: %w", err)
 	}
 
+	vpcID := d.Get("vpc_id").(string)
 	listOpts := subnets.ListOpts{
-		VPC_ID: d.Get("vpc_id").(string),
+		VpcID: vpcID,
 	}
 
-	refinedSubnets, err := subnets.List(subnetClient, listOpts)
+	refinedSubnets, err := subnets.List(client, listOpts)
 	if err != nil {
-		return fmt.Errorf("Unable to retrieve subnets: %s", err)
+		return fmt.Errorf("unable to retrieve subnets: %w", err)
 	}
 
 	if len(refinedSubnets) == 0 {
-		return fmt.Errorf("no matching subnet found for vpc with id %s", d.Get("vpc_id").(string))
+		return fmt.Errorf("no matching subnet found for vpc with id %s", vpcID)
 	}
 
 	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
 	if err != nil {
-		return fmt.Errorf("Error creating OpenTelekomCloud networking client: %s", err)
+		return fmt.Errorf("error creating OpenTelekomCloud NetworkingV2 client: %w", err)
 	}
 
 	sortedSubnets := make([]SubnetIP, 0)
 	for _, subnet := range refinedSubnets {
 		net, err := networkipavailabilities.Get(networkingClient, subnet.ID).Extract()
 		if err != nil {
-			return fmt.Errorf("Error retrieving network ip availabilities: %s", err)
+			return fmt.Errorf("error retrieving NetworkIP availabilities: %w", err)
 		}
 		subnetIPAvail := net.SubnetIPAvailabilities[0]
 		newSubnet := SubnetIP{
@@ -78,15 +79,19 @@ func dataSourceVpcSubnetIdsV1Read(d *schema.ResourceData, meta interface{}) erro
 
 	// Returns the Subnet contains most available IPs out of a slice of subnets.
 	sort.Sort(sort.Reverse(subnetSort(sortedSubnets)))
-	Subnets := make([]string, 0)
+	subnetIDs := make([]string, 0)
 	for _, subnet := range sortedSubnets {
-		Subnets = append(Subnets, subnet.ID)
+		subnetIDs = append(subnetIDs, subnet.ID)
 	}
 
-	d.SetId(d.Get("vpc_id").(string))
-	d.Set("ids", Subnets)
+	d.SetId(vpcID)
+	if err := d.Set("ids", subnetIDs); err != nil {
+		return err
+	}
 
-	d.Set("region", config.GetRegion(d))
+	if err := d.Set("region", config.GetRegion(d)); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/opentelekomcloud/services/vpc/data_source_opentelekomcloud_vpc_subnet_ids_v1.go
+++ b/opentelekomcloud/services/vpc/data_source_opentelekomcloud_vpc_subnet_ids_v1.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v1/subnets"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/networkipavailabilities"
 
@@ -85,12 +86,13 @@ func dataSourceVpcSubnetIdsV1Read(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	d.SetId(vpcID)
-	if err := d.Set("ids", subnetIDs); err != nil {
-		return err
-	}
+	mErr := multierror.Append(
+		d.Set("ids", subnetIDs),
+		d.Set("region", config.GetRegion(d)),
+	)
 
-	if err := d.Set("region", config.GetRegion(d)); err != nil {
-		return err
+	if mErr.ErrorOrNil() != nil {
+		return mErr
 	}
 
 	return nil

--- a/opentelekomcloud/services/vpc/resource_opentelekomcloud_vpc_subnet_v1.go
+++ b/opentelekomcloud/services/vpc/resource_opentelekomcloud_vpc_subnet_v1.go
@@ -16,15 +16,6 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 )
 
-func resourceSubnetDNSListV1(d *schema.ResourceData) []string {
-	rawDNS := d.Get("dns_list").([]interface{})
-	dns := make([]string, len(rawDNS))
-	for i, raw := range rawDNS {
-		dns[i] = raw.(string)
-	}
-	return dns
-}
-
 func ResourceVpcSubnetV1() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceVpcSubnetV1Create,
@@ -50,7 +41,6 @@ func ResourceVpcSubnetV1() *schema.Resource {
 			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ForceNew:     false,
 				ValidateFunc: common.ValidateName,
 			},
 			"cidr": {
@@ -78,30 +68,29 @@ func ResourceVpcSubnetV1() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  true,
-				ForceNew: false,
 			},
 			"primary_dns": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: common.ValidateIP,
 				Computed:     true,
+				ValidateFunc: common.ValidateIP,
 			},
 			"secondary_dns": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: common.ValidateIP,
 				Computed:     true,
+				ValidateFunc: common.ValidateIP,
 			},
 			"availability_zone": {
 				Type:     schema.TypeString,
-				ForceNew: true,
 				Optional: true,
 				Computed: true,
+				ForceNew: true,
 			},
 			"vpc_id": {
 				Type:     schema.TypeString,
-				ForceNew: true,
 				Required: true,
+				ForceNew: true,
 			},
 			"tags": common.TagsSchema(),
 			"ntp_addresses": {
@@ -112,16 +101,28 @@ func ResourceVpcSubnetV1() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"network_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
 
+func resourceSubnetDNSListV1(d *schema.ResourceData) []string {
+	rawDNS := d.Get("dns_list").([]interface{})
+	dns := make([]string, len(rawDNS))
+	for i, raw := range rawDNS {
+		dns[i] = raw.(string)
+	}
+	return dns
+}
+
 func resourceVpcSubnetV1Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*cfg.Config)
-	subnetClient, err := config.NetworkingV1Client(config.GetRegion(d))
-
+	client, err := config.NetworkingV1Client(config.GetRegion(d))
 	if err != nil {
-		return fmt.Errorf("error creating OpenTelekomCloud networking client: %s", err)
+		return fmt.Errorf("error creating OpenTelekomCloud NetworkingV1 client: %w", err)
 	}
 
 	primaryDNS := d.Get("primary_dns").(string)
@@ -132,65 +133,63 @@ func resourceVpcSubnetV1Create(d *schema.ResourceData, meta interface{}) error {
 		secondaryDNS = defaultDNS[1]
 	}
 
+	enableDHCP := d.Get("dhcp_enable").(bool)
 	createOpts := subnets.CreateOpts{
 		Name:             d.Get("name").(string),
 		CIDR:             d.Get("cidr").(string),
 		AvailabilityZone: d.Get("availability_zone").(string),
 		GatewayIP:        d.Get("gateway_ip").(string),
-		EnableDHCP:       d.Get("dhcp_enable").(bool),
-		VPC_ID:           d.Get("vpc_id").(string),
-		PRIMARY_DNS:      primaryDNS,
-		SECONDARY_DNS:    secondaryDNS,
-		DnsList:          dnsList,
+		EnableDHCP:       &enableDHCP,
+		VpcID:            d.Get("vpc_id").(string),
+		PrimaryDNS:       primaryDNS,
+		SecondaryDNS:     secondaryDNS,
+		DNSList:          dnsList,
 	}
 
 	if common.HasFilledOpt(d, "ntp_addresses") {
-		var extraDhcpRequests []subnets.ExtraDhcpOpt
-		extraDhcpReq := subnets.ExtraDhcpOpt{
+		var extraDhcpRequests []subnets.ExtraDHCPOpt
+		extraDhcpReq := subnets.ExtraDHCPOpt{
 			OptName:  "ntp",
 			OptValue: d.Get("ntp_addresses").(string),
 		}
 		extraDhcpRequests = append(extraDhcpRequests, extraDhcpReq)
-		createOpts.ExtraDhcpOpts = extraDhcpRequests
+		createOpts.ExtraDHCPOpts = extraDhcpRequests
 	}
 
-	n, err := subnets.Create(subnetClient, createOpts).Extract()
+	subnet, err := subnets.Create(client, createOpts).Extract()
 	if err != nil {
-		return fmt.Errorf("error creating OpenTelekomCloud VPC subnet: %s", err)
+		return fmt.Errorf("error creating OpenTelekomCloud VPC subnet: %w", err)
 	}
-
-	d.SetId(n.ID)
-	log.Printf("[INFO] Vpc Subnet ID: %s", n.ID)
 
 	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"CREATING"},
+		Pending:    []string{"UNKNOWN"},
 		Target:     []string{"ACTIVE"},
-		Refresh:    waitForVpcSubnetActive(subnetClient, n.ID),
+		Refresh:    waitForVpcSubnetActive(client, subnet.ID),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
 		Delay:      5 * time.Second,
 		MinTimeout: 3 * time.Second,
 	}
 
-	_, stateErr := stateConf.WaitForState()
-	if stateErr != nil {
-		return fmt.Errorf(
-			"error waiting for Subnet (%s) to become ACTIVE: %s",
-			n.ID, stateErr)
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("error waiting for Subnet (%s) to become ACTIVE: %w", subnet.ID, err)
 	}
 
 	// set tags
 	tagRaw := d.Get("tags").(map[string]interface{})
 	if len(tagRaw) > 0 {
-		vpcSubnetV2Client, err := config.NetworkingV2Client(config.GetRegion(d))
+		networkingV2Client, err := config.NetworkingV2Client(config.GetRegion(d))
 		if err != nil {
-			return fmt.Errorf("error creating OpenTelekomCloud networking client: %s", err)
+			return fmt.Errorf("error creating OpenTelekomCloud NetworkingV2 client: %w", err)
 		}
 
-		taglist := common.ExpandResourceTags(tagRaw)
-		if tagErr := tags.Create(vpcSubnetV2Client, "subnets", n.ID, taglist).ExtractErr(); tagErr != nil {
-			return fmt.Errorf("error setting tags of VpcSubnet %s: %s", n.ID, tagErr)
+		tagList := common.ExpandResourceTags(tagRaw)
+		if err := tags.Create(networkingV2Client, "subnets", subnet.ID, tagList).ExtractErr(); err != nil {
+			return fmt.Errorf("error setting tags of VPC subnet %s: %w", subnet.ID, err)
 		}
 	}
+
+	d.SetId(subnet.ID)
 
 	return resourceVpcSubnetV1Read(d, config)
 
@@ -198,36 +197,37 @@ func resourceVpcSubnetV1Create(d *schema.ResourceData, meta interface{}) error {
 
 func resourceVpcSubnetV1Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*cfg.Config)
-	subnetClient, err := config.NetworkingV1Client(config.GetRegion(d))
+	client, err := config.NetworkingV1Client(config.GetRegion(d))
 	if err != nil {
-		return fmt.Errorf("error creating OpenTelekomCloud networking client: %s", err)
+		return fmt.Errorf("error creating OpenTelekomCloud NetworkingV1 client: %w", err)
 	}
 
-	n, err := subnets.Get(subnetClient, d.Id()).Extract()
+	subnet, err := subnets.Get(client, d.Id()).Extract()
 	if err != nil {
 		if _, ok := err.(golangsdk.ErrDefault404); ok {
 			d.SetId("")
 			return nil
 		}
 
-		return fmt.Errorf("error retrieving OpenTelekomCloud Subnets: %s", err)
+		return fmt.Errorf("error retrieving OpenTelekomCloud Subnet: %w", err)
 	}
 
 	mErr := multierror.Append(
-		d.Set("name", n.Name),
-		d.Set("cidr", n.CIDR),
-		d.Set("dns_list", n.DnsList),
-		d.Set("gateway_ip", n.GatewayIP),
-		d.Set("dhcp_enable", n.EnableDHCP),
-		d.Set("primary_dns", n.PRIMARY_DNS),
-		d.Set("secondary_dns", n.SECONDARY_DNS),
-		d.Set("availability_zone", n.AvailabilityZone),
-		d.Set("vpc_id", n.VPC_ID),
-		d.Set("subnet_id", n.SubnetId),
+		d.Set("name", subnet.Name),
+		d.Set("cidr", subnet.CIDR),
+		d.Set("dns_list", subnet.DNSList),
+		d.Set("gateway_ip", subnet.GatewayIP),
+		d.Set("dhcp_enable", subnet.EnableDHCP),
+		d.Set("primary_dns", subnet.PrimaryDNS),
+		d.Set("secondary_dns", subnet.SecondaryDNS),
+		d.Set("availability_zone", subnet.AvailabilityZone),
+		d.Set("vpc_id", subnet.VpcID),
+		d.Set("subnet_id", subnet.SubnetID),
+		d.Set("network_id", subnet.NetworkID),
 		d.Set("region", config.GetRegion(d)),
 	)
 
-	for _, opt := range n.ExtraDhcpOpts {
+	for _, opt := range subnet.ExtraDHCPOpts {
 		if opt.OptName == "ntp" {
 			mErr = multierror.Append(mErr, d.Set("ntp_addresses", opt.OptValue))
 			break
@@ -239,19 +239,19 @@ func resourceVpcSubnetV1Read(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// save VpcSubnet tags
-	vpcSubnetV2Client, err := config.NetworkingV2Client(config.GetRegion(d))
+	networkingV2Client, err := config.NetworkingV2Client(config.GetRegion(d))
 	if err != nil {
-		return fmt.Errorf("error creating OpenTelekomCloud networking client: %s", err)
+		return fmt.Errorf("error creating OpenTelekomCloud NetworkingV2 client: %w", err)
 	}
 
-	resourceTags, err := tags.Get(vpcSubnetV2Client, "subnets", d.Id()).Extract()
+	resourceTags, err := tags.Get(networkingV2Client, "subnets", d.Id()).Extract()
 	if err != nil {
-		return fmt.Errorf("error fetching OpenTelekomCloud VpcSubnet tags: %s", err)
+		return fmt.Errorf("error fetching OpenTelekomCloud VPC Subnet tags: %s", err)
 	}
 
-	tagmap := common.TagsToMap(resourceTags)
-	if err := d.Set("tags", tagmap); err != nil {
-		return fmt.Errorf("error saving tags for OpenTelekomCloud VpcSubnet %s: %s", d.Id(), err)
+	tagMap := common.TagsToMap(resourceTags)
+	if err := d.Set("tags", tagMap); err != nil {
+		return fmt.Errorf("error saving tags for OpenTelekomCloud VPC Subnet %s: %w", d.Id(), err)
 	}
 
 	return nil
@@ -259,9 +259,9 @@ func resourceVpcSubnetV1Read(d *schema.ResourceData, meta interface{}) error {
 
 func resourceVpcSubnetV1Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*cfg.Config)
-	subnetClient, err := config.NetworkingV1Client(config.GetRegion(d))
+	client, err := config.NetworkingV1Client(config.GetRegion(d))
 	if err != nil {
-		return fmt.Errorf("error creating OpenTelekomCloud networking client: %s", err)
+		return fmt.Errorf("error creating OpenTelekomCloud networking client: %w", err)
 	}
 
 	var updateOpts subnets.UpdateOpts
@@ -270,23 +270,21 @@ func resourceVpcSubnetV1Update(d *schema.ResourceData, meta interface{}) error {
 	updateOpts.Name = d.Get("name").(string)
 
 	if d.HasChange("primary_dns") {
-		updateOpts.PRIMARY_DNS = d.Get("primary_dns").(string)
+		updateOpts.PrimaryDNS = d.Get("primary_dns").(string)
 	}
 	if d.HasChange("secondary_dns") {
-		updateOpts.SECONDARY_DNS = d.Get("secondary_dns").(string)
+		updateOpts.SecondaryDNS = d.Get("secondary_dns").(string)
 	}
 	if d.HasChange("dns_list") {
-		updateOpts.DnsList = resourceSubnetDNSListV1(d)
+		updateOpts.DNSList = resourceSubnetDNSListV1(d)
 	}
 	if d.HasChange("dhcp_enable") {
-		updateOpts.EnableDHCP = d.Get("dhcp_enable").(bool)
-
-	} else if d.Get("dhcp_enable").(bool) { // maintaining dhcp to be true if it was true earlier as default update option for dhcp bool is always going to be false in golangsdk
-		updateOpts.EnableDHCP = true
+		enableDHCP := d.Get("dhcp_enable").(bool)
+		updateOpts.EnableDHCP = &enableDHCP
 	}
 	if d.HasChange("ntp_addresses") {
-		var extraDhcpRequests []subnets.ExtraDhcpOpt
-		extraDhcpReq := subnets.ExtraDhcpOpt{
+		var extraDhcpRequests []subnets.ExtraDHCPOpt
+		extraDhcpReq := subnets.ExtraDHCPOpt{
 			OptName:  "ntp",
 			OptValue: d.Get("ntp_addresses").(string),
 		}
@@ -294,23 +292,22 @@ func resourceVpcSubnetV1Update(d *schema.ResourceData, meta interface{}) error {
 		updateOpts.ExtraDhcpOpts = extraDhcpRequests
 	}
 
-	vpc_id := d.Get("vpc_id").(string)
+	vpcID := d.Get("vpc_id").(string)
 
-	_, err = subnets.Update(subnetClient, vpc_id, d.Id(), updateOpts).Extract()
+	_, err = subnets.Update(client, vpcID, d.Id(), updateOpts).Extract()
 	if err != nil {
-		return fmt.Errorf("error updating OpenTelekomCloud VPC Subnet: %s", err)
+		return fmt.Errorf("error updating OpenTelekomCloud VPC Subnet: %w", err)
 	}
 
 	// update tags
 	if d.HasChange("tags") {
-		vpcSubnetV2Client, err := config.NetworkingV2Client(config.GetRegion(d))
+		networkingV2Client, err := config.NetworkingV2Client(config.GetRegion(d))
 		if err != nil {
-			return fmt.Errorf("error creating OpenTelekomCloud networking client: %s", err)
+			return fmt.Errorf("error creating OpenTelekomCloud NetworkingV2 client: %s", err)
 		}
 
-		tagErr := common.UpdateResourceTags(vpcSubnetV2Client, d, "subnets", d.Id())
-		if tagErr != nil {
-			return fmt.Errorf("error updating tags of VPC subnet %s: %s", d.Id(), tagErr)
+		if err := common.UpdateResourceTags(networkingV2Client, d, "subnets", d.Id()); err != nil {
+			return fmt.Errorf("error updating tags of VPC subnet %s: %w", d.Id(), err)
 		}
 	}
 
@@ -318,18 +315,17 @@ func resourceVpcSubnetV1Update(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceVpcSubnetV1Delete(d *schema.ResourceData, meta interface{}) error {
-
 	config := meta.(*cfg.Config)
-	subnetClient, err := config.NetworkingV1Client(config.GetRegion(d))
+	client, err := config.NetworkingV1Client(config.GetRegion(d))
 	if err != nil {
-		return fmt.Errorf("error creating OpenTelekomCloud networking client: %s", err)
+		return fmt.Errorf("error creating OpenTelekomCloud NetworkingV1 client: %w", err)
 	}
-	vpc_id := d.Get("vpc_id").(string)
+	vpcID := d.Get("vpc_id").(string)
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"ACTIVE"},
 		Target:     []string{"DELETED"},
-		Refresh:    waitForVpcSubnetDelete(subnetClient, vpc_id, d.Id()),
+		Refresh:    waitForVpcSubnetDelete(client, vpcID, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
 		Delay:      5 * time.Second,
 		MinTimeout: 3 * time.Second,
@@ -337,64 +333,61 @@ func resourceVpcSubnetV1Delete(d *schema.ResourceData, meta interface{}) error {
 
 	_, err = stateConf.WaitForState()
 	if err != nil {
-		return fmt.Errorf("error deleting OpenTelekomCloud Subnet: %s", err)
+		return fmt.Errorf("error deleting OpenTelekomCloud Subnet: %w", err)
 	}
 
 	d.SetId("")
 	return nil
 }
 
-func waitForVpcSubnetActive(subnetClient *golangsdk.ServiceClient, vpcId string) resource.StateRefreshFunc {
+func waitForVpcSubnetActive(client *golangsdk.ServiceClient, subnetID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		n, err := subnets.Get(subnetClient, vpcId).Extract()
+		subnet, err := subnets.Get(client, subnetID).Extract()
 		if err != nil {
 			return nil, "", err
 		}
 
-		if n.Status == "ACTIVE" {
-			return n, "ACTIVE", nil
+		if subnet.Status == "ACTIVE" {
+			return subnet, "ACTIVE", nil
 		}
 
 		// If subnet status is other than Active, send error
-		if n.Status == "DOWN" || n.Status == "error" {
-			return nil, "", fmt.Errorf("Subnet status: '%s'", n.Status)
+		if subnet.Status == "DOWN" || subnet.Status == "error" {
+			return nil, "", fmt.Errorf("subnet status: %s", subnet.Status)
 		}
 
-		return n, "CREATING", nil
+		return subnet, "CREATING", nil
 	}
 }
 
-func waitForVpcSubnetDelete(subnetClient *golangsdk.ServiceClient, vpcId string, subnetId string) resource.StateRefreshFunc {
+func waitForVpcSubnetDelete(client *golangsdk.ServiceClient, vpcID string, subnetID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-
-		r, err := subnets.Get(subnetClient, subnetId).Extract()
-
+		subnet, err := subnets.Get(client, subnetID).Extract()
 		if err != nil {
 			if _, ok := err.(golangsdk.ErrDefault404); ok {
-				log.Printf("[INFO] Successfully deleted OpenTelekomCloud subnet %s", subnetId)
-				return r, "DELETED", nil
+				log.Printf("[INFO] Successfully deleted OpenTelekomCloud subnet %s", subnetID)
+				return subnet, "DELETED", nil
 			}
-			return r, "ACTIVE", err
+			return subnet, "ACTIVE", err
 		}
-		err = subnets.Delete(subnetClient, vpcId, subnetId).ExtractErr()
 
-		if err != nil {
+		if err := subnets.Delete(client, vpcID, subnetID).ExtractErr(); err != nil {
 			if _, ok := err.(golangsdk.ErrDefault404); ok {
-				log.Printf("[INFO] Successfully deleted OpenTelekomCloud subnet %s", subnetId)
-				return r, "DELETED", nil
+				log.Printf("[INFO] Successfully deleted OpenTelekomCloud subnet %s", subnetID)
+				return subnet, "DELETED", nil
 			}
 			if _, ok := err.(golangsdk.ErrDefault400); ok {
-				log.Printf("[INFO] Successfully deleted OpenTelekomCloud subnet %s", subnetId)
-				return r, "DELETED", nil
+				log.Printf("[INFO] Successfully deleted OpenTelekomCloud subnet %s", subnetID)
+				return subnet, "DELETED", nil
 			}
 			if errCode, ok := err.(golangsdk.ErrUnexpectedResponseCode); ok {
 				if errCode.Actual == 409 || errCode.Actual == 500 {
-					return r, "ACTIVE", nil
+					return subnet, "ACTIVE", nil
 				}
 			}
-			return r, "ACTIVE", err
+			return subnet, "ACTIVE", err
 		}
 
-		return r, "ACTIVE", nil
+		return subnet, "ACTIVE", nil
 	}
 }

--- a/opentelekomcloud/services/vpc/resource_opentelekomcloud_vpc_subnet_v1.go
+++ b/opentelekomcloud/services/vpc/resource_opentelekomcloud_vpc_subnet_v1.go
@@ -162,7 +162,7 @@ func resourceVpcSubnetV1Create(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"UNKNOWN"},
+		Pending:    []string{"CREATING"},
 		Target:     []string{"ACTIVE"},
 		Refresh:    waitForVpcSubnetActive(client, subnet.ID),
 		Timeout:    d.Timeout(schema.TimeoutCreate),


### PR DESCRIPTION
## Summary of the Pull Request
Update `gophertelekomcloud` dep
Add possibility to read `network_id` in `resource/opentelekomcloud_vpc_subnet_v1`
Add possibility to read `network_id` in `data-source/opentelekomcloud_vpc_subnet_v1`
Small refactoring

Fixes: #1014

## PR Checklist

* [x] Refers to: #1014
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

### Data Source `vpc_subnet_v1`
```
=== RUN   TestAccVpcSubnetV1DataSource_basic
--- PASS: TestAccVpcSubnetV1DataSource_basic (63.92s)
PASS

Process finished with the exit code 0
```

### Import `vpc_subnet_v1`
```
=== RUN   TestAccVpcSubnetV1_importBasic
--- PASS: TestAccVpcSubnetV1_importBasic (61.33s)
PASS

Process finished with the exit code 0
```

### Resource `vpc_subnet_v1`
```
=== RUN   TestAccVpcSubnetV1Basic
--- PASS: TestAccVpcSubnetV1Basic (81.59s)
=== RUN   TestAccVpcSubnetV1Timeout
--- PASS: TestAccVpcSubnetV1Timeout (60.30s)
=== RUN   TestAccVpcSubnetV1DnsList
--- PASS: TestAccVpcSubnetV1DnsList (61.57s)
PASS

Process finished with the exit code 0
```

### Data Source`vpc_subnet_ids_v1`
```
=== RUN   TestAccOTCVpcSubnetIdsV2DataSource_basic
--- PASS: TestAccOTCVpcSubnetIdsV2DataSource_basic (88.29s)
PASS

Process finished with the exit code 0
```
