### PR TITLE
Add support of `compute_instance_v2` import

### DIFF
--- a/docs/resources/compute_instance_v2.md
+++ b/docs/resources/compute_instance_v2.md
@@ -265,154 +265,134 @@ The following arguments are supported:
 
 * `name` - (Required) A unique name for the resource.
 
-* `image_id` - (Optional; Required if `image_name` is empty and not booting
-  from a volume. Do not specify if booting from a volume.) The image ID of
-  the desired image for the server. Changing this creates a new server.
+* `image_id` - (Optional; Required if `image_name` is empty and not booting from a volume. Do not specify if booting
+  from a volume.) The image ID of the desired image for the server. Changing this creates a new server.
 
-* `image_name` - (Optional; Required if `image_id` is empty and not booting
-  from a volume. Do not specify if booting from a volume.) The name of the
-  desired image for the server. Changing this creates a new server.
+* `image_name` - (Optional; Required if `image_id` is empty and not booting from a volume. Do not specify if booting
+  from a volume.) The name of the desired image for the server. Changing this creates a new server.
 
-* `flavor_id` - (Optional; Required if `flavor_name` is empty) The flavor ID of
-  the desired flavor for the server. Changing this resizes the existing server.
+* `flavor_id` - (Optional; Required if `flavor_name` is empty) The flavor ID of the desired flavor for the server.
+  Changing this resizes the existing server.
 
-* `flavor_name` - (Optional; Required if `flavor_id` is empty) The name of the
-  desired flavor for the server. Changing this resizes the existing server.
+* `flavor_name` - (Optional; Required if `flavor_id` is empty) The name of the desired flavor for the server. Changing
+  this resizes the existing server.
 
-* `user_data` - (Optional) The user data to provide when launching the instance.
-  Changing this creates a new server.
+* `user_data` - (Optional) The user data to provide when launching the instance. Changing this creates a new server.
 
-* `security_groups` - (Optional) An array of one or more security group names
-  to associate with the server. Changing this results in adding/removing
-  security groups from the existing server.
+* `security_groups` - (Optional) An array of one or more security group names to associate with the server. Changing
+  this results in adding/removing security groups from the existing server.
 
-~> **Warning** Names should be used and not IDs. Security group names should be **unique**,
-otherwise it will return an error.
+~> **Warning** Names should be used and not IDs. Security group names should be **unique**, otherwise it will return an
+error.
 
--> When attaching the instance to networks using Ports,
-  place the security groups on the Port and not the instance.
+-> When attaching the instance to networks using Ports, place the security groups on the Port and not the instance.
 
-* `availability_zone` - (Optional) The availability zone in which to create
-  the server. Changing this creates a new server.
+* `availability_zone` - (Optional) The availability zone in which to create the server. Changing this creates a new
+  server.
 
-* `network` - (Optional) An array of one or more networks to attach to the
-  instance. Required when there are multiple networks defined for the tenant.
-  The network object structure is documented below. Changing this creates a
+* `network` - (Optional) An array of one or more networks to attach to the instance. Required when there are multiple
+  networks defined for the tenant. The network object structure is documented below. Changing this creates a new server.
+
+* `metadata` - (Optional) Metadata key/value pairs to make available from within the instance. Changing this updates the
+  existing server metadata.
+
+* `config_drive` - (Optional) Whether to use the config_drive feature to configure the instance. Changing this creates a
   new server.
 
-* `metadata` - (Optional) Metadata key/value pairs to make available from
-  within the instance. Changing this updates the existing server metadata.
+* `admin_pass` - (Optional) The administrative password to assign to the server. Changing this changes the root password
+  on the existing server.
 
-* `config_drive` - (Optional) Whether to use the config_drive feature to
-  configure the instance. Changing this creates a new server.
+* `key_pair` - (Optional) The name of a key pair to put on the server. The key pair must already be created and
+  associated with the tenant's account. Changing this creates a new server.
 
-* `admin_pass` - (Optional) The administrative password to assign to the server.
-  Changing this changes the root password on the existing server.
-
-* `key_pair` - (Optional) The name of a key pair to put on the server. The key
-  pair must already be created and associated with the tenant's account.
-  Changing this creates a new server.
-
-* `block_device` - (Optional) Configuration of block devices. The block_device
-  structure is documented below. Changing this creates a new server.
-  You can specify multiple block devices which will create an instance with
-  multiple disks. This configuration is very flexible, so please see the
+* `block_device` - (Optional) Configuration of block devices. The block_device structure is documented below. Changing
+  this creates a new server. You can specify multiple block devices which will create an instance with multiple disks.
+  This configuration is very flexible, so please see the
   following [reference](http://docs.openstack.org/developer/nova/block_device_mapping.html)
   for more information.
 
-* `scheduler_hints` - (Optional) Provide the Nova scheduler with hints on how
-  the instance should be launched. The available hints are described below.
+* `scheduler_hints` - (Optional) Provide the Nova scheduler with hints on how the instance should be launched. The
+  available hints are described below.
 
 * `tags` -  (Optional) Tags key/value pairs to associate with the instance.
 
-* `stop_before_destroy` - (Optional) Whether to try stop instance gracefully
-  before destroying it, thus giving chance for guest OS daemons to stop correctly.
-  If instance doesn't stop within a timeout, it will be destroyed anyway.
+* `stop_before_destroy` - (Optional) Whether to try stop instance gracefully before destroying it, thus giving chance
+  for guest OS daemons to stop correctly. If instance doesn't stop within a timeout, it will be destroyed anyway.
 
-* `force_delete` - (Optional) Whether to force the OpenTelekomCloud instance to be
-  forcefully deleted. This is useful for environments that have reclaim/soft
-  deletion enabled.
+* `force_delete` - (Optional) Whether to force the OpenTelekomCloud instance to be forcefully deleted. This is useful
+  for environments that have reclaim/soft deletion enabled.
 
-* `auto_recovery` - (Optional) Configures or deletes automatic recovery of an instance.
-  Defaults to true.
+* `auto_recovery` - (Optional) Configures or deletes automatic recovery of an instance. Defaults to true.
 
 * `power_state` - (Optional) Provide the VM state. Only `active` and `shutoff` are supported values.
 
   ->
-  If the initial `power_state` is the `shutoff` the VM will be stopped immediately after build,
-  and the provisioners like remote-exec or files are not supported.
+  If the initial `power_state` is the `shutoff` the VM will be stopped immediately after build, and the provisioners
+  like remote-exec or files are not supported.
 
 The `network` block supports:
 
-* `uuid` - (Required unless `port`  or `name` is provided) The network UUID to
-  attach to the server. Changing this creates a new server.
+* `uuid` - (Required unless `port`  or `name` is provided) The network UUID to attach to the server. Changing this
+  creates a new server.
 
-* `name` - (Required unless `uuid` or `port` is provided) The human-readable
-    name of the network. Changing this creates a new server.
+* `name` - (Required unless `uuid` or `port` is provided) The human-readable name of the network. Changing this creates
+  a new server.
 
-* `port` - (Required unless `uuid` or `name` is provided) The port UUID of a
-  network to attach to the server. Changing this creates a new server.
+* `port` - (Required unless `uuid` or `name` is provided) The port UUID of a network to attach to the server. Changing
+  this creates a new server.
 
-* `fixed_ip_v4` - (Optional) Specifies a fixed IPv4 address to be used on this
-  network. Changing this creates a new server.
+* `fixed_ip_v4` - (Optional) Specifies a fixed IPv4 address to be used on this network. Changing this creates a new
+  server.
 
-* `fixed_ip_v6` - (Optional) Specifies a fixed IPv6 address to be used on this
-  network. Changing this creates a new server.
+* `fixed_ip_v6` - (Optional) Specifies a fixed IPv6 address to be used on this network. Changing this creates a new
+  server.
 
-* `access_network` - (Optional) Specifies if this network should be used for
-  provisioning access. Accepts true or false. Defaults to false.
+* `access_network` - (Optional) Specifies if this network should be used for provisioning access. Accepts true or false.
+  Defaults to false.
 
 The `block_device` block supports:
 
-* `uuid` - (Required unless `source_type` is set to `"blank"` ) The UUID of
-  the image, volume, or snapshot. Changing this creates a new server.
+* `uuid` - (Required unless `source_type` is set to `"blank"` ) The UUID of the image, volume, or snapshot. Changing
+  this creates a new server.
 
 * `source_type` - (Required) The source type of the device. Must be one of
-  "blank", "image", "volume", or "snapshot". Changing this creates a new
-  server.
+  "blank", "image", "volume", or "snapshot". Changing this creates a new server.
 
-* `volume_size` - The size of the volume to create (in gigabytes). Required
-  in the following combinations: source=image and destination=volume,
-  and source=blank and destination=volume. Changing this creates a new server.
+* `volume_size` - The size of the volume to create (in gigabytes). Required in the following combinations: source=image
+  and destination=volume, and source=blank and destination=volume. Changing this creates a new server.
 
 * `volume_type` - (Optional) Currently, the value can be `SSD` (ultra-I/O disk type),
   `SAS` (high I/O disk type), or `SATA` (common I/O disk type)
   [OTC-API](https://docs.otc.t-systems.com/en-us/api/ecs/en-us_topic_0065817708.html)
 
-* `boot_index` - (Optional) The boot index of the volume. It defaults to 0.
-  Changing this creates a new server.
+* `boot_index` - (Optional) The boot index of the volume. It defaults to 0. Changing this creates a new server.
 
-* `destination_type` - (Optional) The type that gets created. Currently only
-  support "volume". Changing this creates a new server.
-
-* `delete_on_termination` - (Optional) Delete the volume / block device upon
-  termination of the instance. Defaults to false. Changing this creates a
+* `destination_type` - (Optional) The type that gets created. Currently only support "volume". Changing this creates a
   new server.
+
+* `delete_on_termination` - (Optional) Delete the volume / block device upon termination of the instance. Defaults to
+  false. Changing this creates a new server.
 
 The `scheduler_hints` block supports:
 
-* `group` - (Optional) A UUID of a Server Group. The instance will be placed
-  into that group.
+* `group` - (Optional) A UUID of a Server Group. The instance will be placed into that group.
 
-* `different_host` - (Optional) A list of instance UUIDs. The instance will
-  be scheduled on a different host than all other instances.
+* `different_host` - (Optional) A list of instance UUIDs. The instance will be scheduled on a different host than all
+  other instances.
 
-* `same_host` - (Optional) A list of instance UUIDs. The instance will be
-  scheduled on the same host of those specified.
+* `same_host` - (Optional) A list of instance UUIDs. The instance will be scheduled on the same host of those specified.
 
-* `query` - (Optional) A conditional query that a compute node must pass in
-  order to host an instance.
+* `query` - (Optional) A conditional query that a compute node must pass in order to host an instance.
 
 * `target_cell` - (Optional) The name of a cell to host the instance.
 
-* `build_near_host_ip` - (Optional) An IP Address in CIDR form. The instance
-  will be placed on a compute node that is in the same subnet.
+* `build_near_host_ip` - (Optional) An IP Address in CIDR form. The instance will be placed on a compute node that is in
+  the same subnet.
 
- * `tenancy` - (Optional) The tenancy specifies whether the ECS is to be created on a Dedicated Host
+* `tenancy` - (Optional) The tenancy specifies whether the ECS is to be created on a Dedicated Host
   (DeH) or in a shared pool.
 
- * `deh_id` - (Optional) The ID of DeH. This parameter takes effect only when the value
-  of tenancy is dedicated.
+* `deh_id` - (Optional) The ID of DeH. This parameter takes effect only when the value of tenancy is dedicated.
 
 ## Attributes Reference
 
@@ -420,8 +400,7 @@ The following attributes are exported:
 
 * `name` - See Argument Reference above.
 
-* `access_ip_v4` - The first detected Fixed IPv4 address _or_ the
-  Floating IP.
+* `access_ip_v4` - The first detected Fixed IPv4 address _or_ the Floating IP.
 
 * `access_ip_v6` - The first detected Fixed IPv6 address.
 
@@ -439,18 +418,15 @@ The following attributes are exported:
 
 * `network/port` - See Argument Reference above.
 
-* `network/fixed_ip_v4` - The Fixed IPv4 address of the Instance on that
-  network.
+* `network/fixed_ip_v4` - The Fixed IPv4 address of the Instance on that network.
 
-* `network/fixed_ip_v6` - The Fixed IPv6 address of the Instance on that
-  network.
+* `network/fixed_ip_v6` - The Fixed IPv6 address of the Instance on that network.
 
 * `network/mac` - The MAC address of the NIC on that network.
 
 * `volume_attached/id` - The volume id on that attachment.
 
-* `all_metadata` - Contains all instance metadata, even metadata not set
-  by Terraform.
+* `all_metadata` - Contains all instance metadata, even metadata not set by Terraform.
 
 * `auto_recovery` - See Argument Reference above.
 
@@ -458,25 +434,22 @@ The following attributes are exported:
 
 ### Multiple Ephemeral Disks
 
-It's possible to specify multiple `block_device` entries to create an instance
-with multiple ephemeral (local) disks. In order to create multiple ephemeral
-disks, the sum of the total amount of ephemeral space must be less than or
-equal to what the chosen flavor supports.
+It's possible to specify multiple `block_device` entries to create an instance with multiple ephemeral (local) disks. In
+order to create multiple ephemeral disks, the sum of the total amount of ephemeral space must be less than or equal to
+what the chosen flavor supports.
 
-The following example shows how to create an instance with multiple ephemeral
-disks:
+The following example shows how to create an instance with multiple ephemeral disks:
 
 ```hcl
 resource "opentelekomcloud_compute_instance_v2" "foo" {
   name            = "terraform-test"
-  security_groups = ["default"]
 
   block_device {
     boot_index            = 0
     delete_on_termination = true
     destination_type      = "volume"
     source_type           = "image"
-    uuid                  = "<image uuid>"
+    uuid                  = var.image_id
   }
 
   block_device {
@@ -499,21 +472,18 @@ resource "opentelekomcloud_compute_instance_v2" "foo" {
 
 ### Instances and Ports
 
-Neutron Ports are a great feature and provide a lot of functionality. However,
-there are some notes to be aware of when mixing Instances and Ports:
+Neutron Ports are a great feature and provide a lot of functionality. However, there are some notes to be aware of when
+mixing Instances and Ports:
 
-* When attaching an Instance to one or more networks using Ports, place the
-security groups on the Port and not the Instance. If you place the security
-groups on the Instance, the security groups will not be applied upon creation,
-but they will be applied upon a refresh. This is a known OpenTelekomCloud bug.
+* When attaching an Instance to one or more networks using Ports, place the security groups on the Port and not the
+  Instance. If you place the security groups on the Instance, the security groups will not be applied upon creation, but
+  they will be applied upon a refresh. This is a known OpenTelekomCloud bug.
 
-* Network IP information is not available within an instance for networks that
-are attached with Ports. This is mostly due to the flexibility Neutron Ports
-provide when it comes to IP addresses. For example, a Neutron Port can have
-multiple Fixed IP addresses associated with it. It's not possible to know which
-single IP address the user would want returned to the Instance's state
-information. Therefore, in order for a Provisioner to connect to an Instance
-via it's network Port, customize the `connection` information:
+* Network IP information is not available within an instance for networks that are attached with Ports. This is mostly
+  due to the flexibility Neutron Ports provide when it comes to IP addresses. For example, a Neutron Port can have
+  multiple Fixed IP addresses associated with it. It's not possible to know which single IP address the user would want
+  returned to the Instance's state information. Therefore, in order for a Provisioner to connect to an Instance via it's
+  network Port, customize the `connection` information:
 
 ```hcl
 resource "opentelekomcloud_networking_port_v2" "port_1" {
@@ -548,3 +518,122 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   }
 }
 ```
+
+## Importing instances
+
+Importing instances can be tricky, since the nova api does not offer all information provided at creation time for later
+retrieval. Network interface attachment order, and number and sizes of ephemeral disks are examples of this.
+
+### Importing basic instance
+
+Assume you want to import an instance with one ephemeral root disk, and one network interface.
+
+Your configuration would look like the following:
+
+```hcl
+resource "opentelekomcloud_compute_instance_v2" "basic_instance" {
+  name      = "basic"
+  flavor_id = var.flavor_id
+  key_pair  = var.key_pair
+  image_id  = var.image_id
+
+  network {
+    name = var.network_name
+  }
+}
+
+```
+
+Then you execute
+
+```
+terraform import opentelekomcloud_compute_instance_v2.basic_instance <instance_id>
+```
+
+### Importing instance with multiple network interfaces.
+
+Nova returns the network interfaces grouped by network, thus not in creation order. That means that if you have multiple
+network interfaces you must take care of the order of networks in your configuration.
+
+As example we want to import an instance with one ephemeral root disk, and 3 network interfaces.
+
+Examples
+
+```hcl
+resource "opentelekomcloud_compute_instance_v2" "boot-from-volume" {
+  name      = "boot-from-volume"
+  flavor_id = var.flavor_id
+  key_pair  = var.key_pair
+  image_id  = var.image_id
+
+  network {
+    name = var.network_1_name
+  }
+  network {
+    name = var.network_2_name
+  }
+  network {
+    name        = var.network_1_name
+    fixed_ip_v4 = "<fixed_ip_v4>"
+  }
+
+}
+```
+
+In the above configuration the networks are out of order compared to what nova and thus the import code returns, which
+means the plan will not be empty after import.
+
+So either with care check the plan and modify configuration, or read the network order in the state file after import
+and modify your configuration accordingly.
+
+* A note on ports. If you have created a neutron port independent of an instance, then the import code has no way to
+  detect that the port is created idenpendently, and therefore on deletion of imported instances you might have port
+  resources in your project, which you expected to be created by the instance and thus to also be deleted with the
+  instance.
+
+### Importing instances with multiple block storage volumes.
+
+We have an instance with two block storage volumes, one bootable and one non-bootable. Note that we only configure the
+bootable device as block_device. The other volumes can be specified as `opentelekomcloud_blockstorage_volume_v2`
+
+```hcl
+resource "opentelekomcloud_compute_instance_v2" "instance_2" {
+  name            = "instance_2"
+  image_id        = var.image_id
+  flavor_id       = var.flavor_id
+  key_pair        = var.key_pair
+
+  block_device {
+    uuid                  = var.image_id
+    source_type           = "image"
+    destination_type      = "volume"
+    boot_index            = 0
+    delete_on_termination = true
+  }
+
+  network {
+    name = var.network_name
+  }
+}
+resource "opentelekomcloud_blockstorage_volume_v2" "volume_1" {
+  size = 1
+  name = var.volume_name
+}
+resource "opentelekomcloud_compute_volume_attach_v2" "va_1" {
+  volume_id   = opentelekomcloud_blockstorage_volume_v2.volume_1.id
+  instance_id = opentelekomcloud_compute_instance_v2.instance_2.id
+}
+```
+
+To import the instance outlined in the above configuration do the following:
+
+```
+terraform import opentelekomcloud_compute_instance_v2.instance_2 <instance_id>
+import opentelekomcloud_blockstorage_volume_v2.volume_1 <volume_id>
+terraform import opentelekomcloud_compute_volume_attach_v2.va_1
+<instance_id>/<volume_id>
+```
+
+* A note on block storage volumes, the importer does not read delete_on_termination flag, and always assumes true. If
+  you import an instance created with delete_on_termination false, you end up with "orphaned" volumes after destruction
+  of instances.

--- a/opentelekomcloud/acceptance/ecs/import_opentelekomcloud_compute_instance_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/import_opentelekomcloud_compute_instance_v2_test.go
@@ -1,0 +1,57 @@
+package acceptance
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+)
+
+func TestAccComputeV2InstanceImportBasic(t *testing.T) {
+	resourceName := "opentelekomcloud_compute_instance_v2.instance_1"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { common.TestAccPreCheck(t) },
+		Providers:    common.TestAccProviders,
+		CheckDestroy: TestAccCheckComputeV2InstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeV2Instance_basic,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"stop_before_destroy",
+					"force_delete",
+				},
+			},
+		},
+	})
+}
+
+func TestAccComputeV2InstanceImportBootFromVolumeImage(t *testing.T) {
+	resourceName := "opentelekomcloud_compute_instance_v2.instance_1"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { common.TestAccPreCheck(t) },
+		Providers:    common.TestAccProviders,
+		CheckDestroy: TestAccCheckComputeV2InstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeV2Instance_bootFromVolumeImage,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"stop_before_destroy",
+					"force_delete",
+				},
+			},
+		},
+	})
+}

--- a/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_instance_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_instance_v2_test.go
@@ -461,7 +461,6 @@ func testAccCheckComputeV2InstanceBootVolumeAttachment(instance *servers.Server)
 var testAccComputeV2Instance_basic = fmt.Sprintf(`
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name              = "instance_1"
-  security_groups   = ["default"]
   availability_zone = "%s"
   metadata = {
     foo = "bar"


### PR DESCRIPTION
## Summary of the Pull Request
Backport terraform-provider-openstack/terraform-provider-openstack#768
Make `block_device` computed and populated during `Read`

Resolve #1023 

## PR Checklist

* [x] Refers to: #1023
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

Import:
```
=== RUN   TestAccComputeV2InstanceImportBasic
--- PASS: TestAccComputeV2InstanceImportBasic (96.95s)
=== RUN   TestAccComputeV2InstanceImportBootFromVolumeImage
--- PASS: TestAccComputeV2InstanceImportBootFromVolumeImage (67.16s)
PASS

Process finished with the exit code 0
```

Resource:
```
=== RUN   TestAccComputeV2Instance_basic
--- PASS: TestAccComputeV2Instance_basic (121.42s)
=== RUN   TestAccComputeV2Instance_multiSecgroup
--- PASS: TestAccComputeV2Instance_multiSecgroup (93.06s)
=== RUN   TestAccComputeV2Instance_bootFromImage
--- PASS: TestAccComputeV2Instance_bootFromImage (69.50s)
=== RUN   TestAccComputeV2Instance_bootFromVolume
--- PASS: TestAccComputeV2Instance_bootFromVolume (50.04s)
=== RUN   TestAccComputeV2Instance_changeFixedIP
--- PASS: TestAccComputeV2Instance_changeFixedIP (50.88s)
=== RUN   TestAccComputeV2Instance_bootFromVolumeVolume
--- PASS: TestAccComputeV2Instance_bootFromVolumeVolume (68.69s)
=== RUN   TestAccComputeV2Instance_stopBeforeDestroy
--- PASS: TestAccComputeV2Instance_stopBeforeDestroy (58.73s)
=== RUN   TestAccComputeV2Instance_metadata
--- PASS: TestAccComputeV2Instance_metadata (74.97s)
=== RUN   TestAccComputeV2Instance_timeout
--- PASS: TestAccComputeV2Instance_timeout (52.45s)
=== RUN   TestAccComputeV2Instance_autoRecovery
--- PASS: TestAccComputeV2Instance_autoRecovery (106.32s)
=== RUN   TestAccComputeV2Instance_crazyNICs
--- PASS: TestAccComputeV2Instance_crazyNICs (184.76s)
=== RUN   TestAccComputeV2Instance_initialStateActive
--- PASS: TestAccComputeV2Instance_initialStateActive (113.84s)
=== RUN   TestAccComputeV2Instance_initialStateShutoff
--- PASS: TestAccComputeV2Instance_initialStateShutoff (146.50s)
PASS

Process finished with the exit code 0
```
