### PR TITLE
Update schema for `r/netowrking_port_v2`

### DIFF
--- a/docs/resources/networking_port_v2.md
+++ b/docs/resources/networking_port_v2.md
@@ -48,6 +48,11 @@ The following arguments are supported:
   port. The security groups must be specified by ID and not name (as opposed
   to how they are configured with the Compute Instance).
 
+* `no_security_groups` - (Optional) If set to `true`, then no security groups
+  are applied to the port. If set to `false` and no `security_group_ids` are specified,
+  then the port will yield to the default behavior of the Networking service,
+  which is to usually apply the `"default"` security group.
+
 * `device_id` - (Optional) The ID of the device attached to the port. Changing this
   creates a new port.
 
@@ -74,6 +79,13 @@ The `allowed_address_pairs` block supports:
 
 * `mac_address` - (Optional) The additional MAC address.
 
+* `port_security_enabled` - (Optional) Whether to explicitly enable or disable
+  port security on the port. Port Security is usually enabled by default, so
+  omitting argument will usually result in a value of `true`. Setting this
+  explicitly to `false` will disable port security. In order to disable port
+  security, the port must not have any security groups. Valid values are `true`
+  and `false`.
+
 ## Attributes Reference
 
 The following attributes are exported:
@@ -93,6 +105,8 @@ The following attributes are exported:
 * `fixed_ip` - See Argument Reference above.
 
 * `all fixed_ips` - The collection of Fixed IP addresses on the port in the order returned by the Network v2 API.
+
+* `port_security_enabled` - See Argument Reference above.
 
 ## Import
 

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_port_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_port_v2_test.go
@@ -453,7 +453,6 @@ resource "opentelekomcloud_networking_subnet_v2" "subnet_1" {
 resource "opentelekomcloud_networking_port_v2" "port_1" {
   name                  = "port_1"
   network_id            = opentelekomcloud_networking_network_v2.network_1.id
-  no_security_groups    = true
   port_security_enabled = false
   fixed_ip {
     subnet_id  = opentelekomcloud_networking_subnet_v2.subnet_1.id
@@ -476,7 +475,6 @@ resource "opentelekomcloud_networking_subnet_v2" "subnet_1" {
 resource "opentelekomcloud_networking_port_v2" "port_1" {
   name                  = "port_1"
   network_id            = opentelekomcloud_networking_network_v2.network_1.id
-  no_security_groups    = true
   port_security_enabled = true
   fixed_ip {
     subnet_id  = opentelekomcloud_networking_subnet_v2.subnet_1.id

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_port_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_port_v2_test.go
@@ -454,6 +454,7 @@ resource "opentelekomcloud_networking_port_v2" "port_1" {
   name                  = "port_1"
   network_id            = opentelekomcloud_networking_network_v2.network_1.id
   port_security_enabled = false
+  no_security_groups    = true
   fixed_ip {
     subnet_id  = opentelekomcloud_networking_subnet_v2.subnet_1.id
     ip_address = "192.168.199.23"
@@ -476,6 +477,7 @@ resource "opentelekomcloud_networking_port_v2" "port_1" {
   name                  = "port_1"
   network_id            = opentelekomcloud_networking_network_v2.network_1.id
   port_security_enabled = true
+  no_security_groups    = false
   fixed_ip {
     subnet_id  = opentelekomcloud_networking_subnet_v2.subnet_1.id
     ip_address = "192.168.199.23"

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_port_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_port_v2_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/portsecurity"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/networks"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/ports"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/subnets"
@@ -14,6 +15,11 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 )
+
+type testPortWithExtensions struct {
+	ports.Port
+	portsecurity.PortSecurityExt
+}
 
 func TestAccNetworkingV2Port_basic(t *testing.T) {
 	var network networks.Network
@@ -63,7 +69,7 @@ func TestAccNetworkingV2Port_noip(t *testing.T) {
 func TestAccNetworkingV2Port_allowedAddressPairs(t *testing.T) {
 	var network networks.Network
 	var subnet subnets.Subnet
-	var vrrp_port_1, vrrp_port_2, instance_port ports.Port
+	var vrrpPort1, vrrpPort2, instancePort ports.Port
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { common.TestAccPreCheck(t) },
@@ -75,9 +81,38 @@ func TestAccNetworkingV2Port_allowedAddressPairs(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					TestAccCheckNetworkingV2SubnetExists("opentelekomcloud_networking_subnet_v2.vrrp_subnet", &subnet),
 					TestAccCheckNetworkingV2NetworkExists("opentelekomcloud_networking_network_v2.vrrp_network", &network),
-					testAccCheckNetworkingV2PortExists("opentelekomcloud_networking_port_v2.vrrp_port_1", &vrrp_port_1),
-					testAccCheckNetworkingV2PortExists("opentelekomcloud_networking_port_v2.vrrp_port_2", &vrrp_port_2),
-					testAccCheckNetworkingV2PortExists("opentelekomcloud_networking_port_v2.instance_port", &instance_port),
+					testAccCheckNetworkingV2PortExists("opentelekomcloud_networking_port_v2.vrrp_port_1", &vrrpPort1),
+					testAccCheckNetworkingV2PortExists("opentelekomcloud_networking_port_v2.vrrp_port_2", &vrrpPort2),
+					testAccCheckNetworkingV2PortExists("opentelekomcloud_networking_port_v2.instance_port", &instancePort),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetworkingV2Port_portSecurity_enabled(t *testing.T) {
+	var port testPortWithExtensions
+	resourceName := "opentelekomcloud_networking_port_v2.port_1"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { common.TestAccPreCheck(t) },
+		Providers:    common.TestAccProviders,
+		CheckDestroy: testAccCheckNetworkingV2PortDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkingV2PortSecurityEnabled,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingV2PortWithExtensionsExists(resourceName, &port),
+					resource.TestCheckResourceAttr(resourceName, "port_security_enabled", "true"),
+					testAccCheckNetworkingV2PortPortSecurity(&port, true),
+				),
+			},
+			{
+				Config: testAccNetworkingV2PortSecurityDisabled,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingV2PortWithExtensionsExists(resourceName, &port),
+					resource.TestCheckResourceAttr(resourceName, "port_security_enabled", "false"),
+					testAccCheckNetworkingV2PortPortSecurity(&port, false),
 				),
 			},
 		},
@@ -108,9 +143,9 @@ func TestAccNetworkingV2Port_timeout(t *testing.T) {
 
 func testAccCheckNetworkingV2PortDestroy(s *terraform.State) error {
 	config := common.TestAccProvider.Meta().(*cfg.Config)
-	networkingClient, err := config.NetworkingV2Client(env.OS_REGION_NAME)
+	client, err := config.NetworkingV2Client(env.OS_REGION_NAME)
 	if err != nil {
-		return fmt.Errorf("Error creating OpenTelekomCloud networking client: %s", err)
+		return fmt.Errorf("error creating OpenTelekomCloud NetworkingV2 client: %w", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -118,9 +153,9 @@ func testAccCheckNetworkingV2PortDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := ports.Get(networkingClient, rs.Primary.ID).Extract()
+		_, err := ports.Get(client, rs.Primary.ID).Extract()
 		if err == nil {
-			return fmt.Errorf("Port still exists")
+			return fmt.Errorf("port still exists")
 		}
 	}
 
@@ -131,26 +166,26 @@ func testAccCheckNetworkingV2PortExists(n string, port *ports.Port) resource.Tes
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return fmt.Errorf("not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
+			return fmt.Errorf("no ID is set")
 		}
 
 		config := common.TestAccProvider.Meta().(*cfg.Config)
-		networkingClient, err := config.NetworkingV2Client(env.OS_REGION_NAME)
+		client, err := config.NetworkingV2Client(env.OS_REGION_NAME)
 		if err != nil {
-			return fmt.Errorf("Error creating OpenTelekomCloud networking client: %s", err)
+			return fmt.Errorf("error creating OpenTelekomCloud NetworkingV2 client: %w", err)
 		}
 
-		found, err := ports.Get(networkingClient, rs.Primary.ID).Extract()
+		found, err := ports.Get(client, rs.Primary.ID).Extract()
 		if err != nil {
 			return err
 		}
 
 		if found.ID != rs.Primary.ID {
-			return fmt.Errorf("Port not found")
+			return fmt.Errorf("port not found")
 		}
 
 		*port = *found
@@ -159,10 +194,43 @@ func testAccCheckNetworkingV2PortExists(n string, port *ports.Port) resource.Tes
 	}
 }
 
+func testAccCheckNetworkingV2PortWithExtensionsExists(n string, port *testPortWithExtensions) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		config := common.TestAccProvider.Meta().(*cfg.Config)
+		client, err := config.NetworkingV2Client(env.OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("error creating OpenTelekomCloud NetworkingV2 client: %s", err)
+		}
+
+		var found testPortWithExtensions
+		err = ports.Get(client, rs.Primary.ID).ExtractInto(&found)
+		if err != nil {
+			return err
+		}
+
+		if found.ID != rs.Primary.ID {
+			return fmt.Errorf("port not found")
+		}
+
+		*port = found
+
+		return nil
+	}
+}
+
 func testAccCheckNetworkingV2PortCountFixedIPs(port *ports.Port, expected int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if len(port.FixedIPs) != expected {
-			return fmt.Errorf("Expected %d Fixed IPs, got %d", expected, len(port.FixedIPs))
+			return fmt.Errorf("expected %d Fixed IPs, got %d", expected, len(port.FixedIPs))
 		}
 
 		return nil
@@ -172,7 +240,17 @@ func testAccCheckNetworkingV2PortCountFixedIPs(port *ports.Port, expected int) r
 func testAccCheckNetworkingV2PortCountSecurityGroups(port *ports.Port, expected int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if len(port.SecurityGroups) != expected {
-			return fmt.Errorf("Expected %d Security Groups, got %d", expected, len(port.SecurityGroups))
+			return fmt.Errorf("expected %d Security Groups, got %d", expected, len(port.SecurityGroups))
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckNetworkingV2PortPortSecurity(port *testPortWithExtensions, expected bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if port.PortSecurityEnabled != expected {
+			return fmt.Errorf("port has wrong port_security_enabled. Expected %t, got %t", expected, port.PortSecurityEnabled)
 		}
 
 		return nil
@@ -357,6 +435,52 @@ resource "opentelekomcloud_networking_port_v2" "port_1" {
   fixed_ip {
     subnet_id =  opentelekomcloud_networking_subnet_v2.subnet_1.id
     ip_address = "192.168.199.40"
+  }
+}
+`
+
+const testAccNetworkingV2PortSecurityDisabled = `
+resource "opentelekomcloud_networking_network_v2" "network_1" {
+  name = "network_1"
+}
+resource "opentelekomcloud_networking_subnet_v2" "subnet_1" {
+  name       = "subnet_1"
+  cidr       = "192.168.199.0/24"
+  ip_version = 4
+  network_id = opentelekomcloud_networking_network_v2.network_1.id
+}
+
+resource "opentelekomcloud_networking_port_v2" "port_1" {
+  name                  = "port_1"
+  network_id            = opentelekomcloud_networking_network_v2.network_1.id
+  no_security_groups    = true
+  port_security_enabled = false
+  fixed_ip {
+    subnet_id  = opentelekomcloud_networking_subnet_v2.subnet_1.id
+    ip_address = "192.168.199.23"
+  }
+}
+`
+
+const testAccNetworkingV2PortSecurityEnabled = `
+resource "opentelekomcloud_networking_network_v2" "network_1" {
+  name = "network_1"
+}
+resource "opentelekomcloud_networking_subnet_v2" "subnet_1" {
+  name       = "subnet_1"
+  cidr       = "192.168.199.0/24"
+  ip_version = 4
+  network_id = opentelekomcloud_networking_network_v2.network_1.id
+}
+
+resource "opentelekomcloud_networking_port_v2" "port_1" {
+  name                  = "port_1"
+  network_id            = opentelekomcloud_networking_network_v2.network_1.id
+  no_security_groups    = true
+  port_security_enabled = true
+  fixed_ip {
+    subnet_id  = opentelekomcloud_networking_subnet_v2.subnet_1.id
+    ip_address = "192.168.199.23"
   }
 }
 `

--- a/opentelekomcloud/services/vpc/resource_opentelekomcloud_networking_port_v2.go
+++ b/opentelekomcloud/services/vpc/resource_opentelekomcloud_networking_port_v2.go
@@ -231,7 +231,7 @@ func resourceNetworkingPortV2Create(d *schema.ResourceData, meta interface{}) er
 
 	_, err = stateConf.WaitForState()
 	if err != nil {
-		return fmt.Errorf("error creating OpenTelekomCloud Neutron Network: %w", err)
+		return fmt.Errorf("error creating OpenTelekomCloud Neutron port: %w", err)
 	}
 
 	d.SetId(p.ID)
@@ -324,7 +324,7 @@ func resourceNetworkingPortV2Update(d *schema.ResourceData, meta interface{}) er
 	if d.HasChange("no_security_groups") {
 		if noSecurityGroups {
 			hasChange = true
-			var v []string
+			v := []string{}
 			updateOpts.SecurityGroups = &v
 		}
 	}
@@ -367,6 +367,7 @@ func resourceNetworkingPortV2Update(d *schema.ResourceData, meta interface{}) er
 
 	var finalUpdateOpts ports.UpdateOptsBuilder
 	finalUpdateOpts = updateOpts
+
 	if d.HasChange("port_security_enabled") {
 		hasChange = true
 		portSecurityEnabled := d.Get("port_security_enabled").(bool)
@@ -381,7 +382,7 @@ func resourceNetworkingPortV2Update(d *schema.ResourceData, meta interface{}) er
 
 		_, err = ports.Update(client, d.Id(), finalUpdateOpts).Extract()
 		if err != nil {
-			return fmt.Errorf("error updating OpenTelekomCloud Neutron Network: %w", err)
+			return fmt.Errorf("error updating OpenTelekomCloud Neutron port: %w", err)
 		}
 	}
 	return resourceNetworkingPortV2Read(d, meta)
@@ -405,7 +406,7 @@ func resourceNetworkingPortV2Delete(d *schema.ResourceData, meta interface{}) er
 
 	_, err = stateConf.WaitForState()
 	if err != nil {
-		return fmt.Errorf("error deleting OpenTelekomCloud Neutron Network: %w", err)
+		return fmt.Errorf("error deleting OpenTelekomCloud Neutron port: %w", err)
 	}
 
 	d.SetId("")

--- a/opentelekomcloud/services/vpc/resource_opentelekomcloud_networking_port_v2.go
+++ b/opentelekomcloud/services/vpc/resource_opentelekomcloud_networking_port_v2.go
@@ -243,7 +243,7 @@ func resourceNetworkingPortV2Read(d *schema.ResourceData, meta interface{}) erro
 	config := meta.(*cfg.Config)
 	client, err := config.NetworkingV2Client(config.GetRegion(d))
 	if err != nil {
-		return fmt.Errorf("error creating OpenTelekomCloud networking client: %w", err)
+		return fmt.Errorf("error creating OpenTelekomCloud NetworkingV2 client: %w", err)
 	}
 
 	var port portWithPortSecurityExtensions
@@ -303,7 +303,7 @@ func resourceNetworkingPortV2Update(d *schema.ResourceData, meta interface{}) er
 	config := meta.(*cfg.Config)
 	client, err := config.NetworkingV2Client(config.GetRegion(d))
 	if err != nil {
-		return fmt.Errorf("error creating OpenTelekomCloud networking client: %w", err)
+		return fmt.Errorf("error creating OpenTelekomCloud NetworkingV2 client: %w", err)
 	}
 
 	noSecurityGroups := d.Get("no_security_groups").(bool)
@@ -391,7 +391,7 @@ func resourceNetworkingPortV2Delete(d *schema.ResourceData, meta interface{}) er
 	config := meta.(*cfg.Config)
 	client, err := config.NetworkingV2Client(config.GetRegion(d))
 	if err != nil {
-		return fmt.Errorf("error creating OpenTelekomCloud networking client: %w", err)
+		return fmt.Errorf("error creating OpenTelekomCloud NetworkingV2 client: %w", err)
 	}
 
 	stateConf := &resource.StateChangeConf{
@@ -472,9 +472,9 @@ func allowedAddressPairsHash(v interface{}) int {
 	return hashcode.String(buf.String())
 }
 
-func waitForNetworkPortActive(networkingClient *golangsdk.ServiceClient, portId string) resource.StateRefreshFunc {
+func waitForNetworkPortActive(client *golangsdk.ServiceClient, portId string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		p, err := ports.Get(networkingClient, portId).Extract()
+		p, err := ports.Get(client, portId).Extract()
 		if err != nil {
 			return nil, "", err
 		}
@@ -488,11 +488,11 @@ func waitForNetworkPortActive(networkingClient *golangsdk.ServiceClient, portId 
 	}
 }
 
-func waitForNetworkPortDelete(networkingClient *golangsdk.ServiceClient, portID string) resource.StateRefreshFunc {
+func waitForNetworkPortDelete(client *golangsdk.ServiceClient, portID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		log.Printf("[DEBUG] Attempting to delete OpenTelekomCloud Neutron Port %s", portID)
 
-		p, err := ports.Get(networkingClient, portID).Extract()
+		p, err := ports.Get(client, portID).Extract()
 		if err != nil {
 			if _, ok := err.(golangsdk.ErrDefault404); ok {
 				log.Printf("[DEBUG] Successfully deleted OpenTelekomCloud Port %s", portID)
@@ -501,7 +501,7 @@ func waitForNetworkPortDelete(networkingClient *golangsdk.ServiceClient, portID 
 			return p, "ACTIVE", err
 		}
 
-		err = ports.Delete(networkingClient, portID).ExtractErr()
+		err = ports.Delete(client, portID).ExtractErr()
 		if err != nil {
 			if _, ok := err.(golangsdk.ErrDefault404); ok {
 				log.Printf("[DEBUG] Successfully deleted OpenTelekomCloud Port %s", portID)

--- a/opentelekomcloud/services/vpc/resource_opentelekomcloud_networking_port_v2.go
+++ b/opentelekomcloud/services/vpc/resource_opentelekomcloud_networking_port_v2.go
@@ -215,7 +215,7 @@ func resourceNetworkingPortV2Create(d *schema.ResourceData, meta interface{}) er
 	log.Printf("[DEBUG] Create Options: %#v", finalCreateOpts)
 	p, err := ports.Create(client, finalCreateOpts).Extract()
 	if err != nil {
-		return fmt.Errorf("error creating OpenTelekomCloud Neutron network: %w", err)
+		return fmt.Errorf("error creating OpenTelekomCloud Neutron port: %w", err)
 	}
 	log.Printf("[INFO] Network ID: %s", p.ID)
 
@@ -247,7 +247,7 @@ func resourceNetworkingPortV2Read(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	var port portWithPortSecurityExtensions
-	err = ports.Get(client, d.Id()).ExtractInto(port)
+	err = ports.Get(client, d.Id()).ExtractInto(&port)
 	if err != nil {
 		return common.CheckDeleted(d, err, "port")
 	}


### PR DESCRIPTION
## Summary of the Pull Request
Add possibility to enable/disable `port_security_enabled`

Resolves: #1043
 
## PR Checklist

* [x] Refers to: #1043
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
=== RUN   TestAccNetworkingV2Port_basic
--- PASS: TestAccNetworkingV2Port_basic (70.27s)
=== RUN   TestAccNetworkingV2Port_noip
--- PASS: TestAccNetworkingV2Port_noip (69.81s)
=== RUN   TestAccNetworkingV2Port_allowedAddressPairs
--- PASS: TestAccNetworkingV2Port_allowedAddressPairs (92.12s)
=== RUN   TestAccNetworkingV2Port_portSecurity_enabled
--- PASS: TestAccNetworkingV2Port_portSecurity_enabled (82.48s)
=== RUN   TestAccNetworkingV2Port_timeout
--- PASS: TestAccNetworkingV2Port_timeout (70.40s)
PASS

Process finished with the exit code 0
```
