### PR TITLE
[ECS] Fix issue with multiple networks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/jinzhu/copier v0.2.3
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.3.3-0.20210504154301-ea895669e707
+	github.com/opentelekomcloud/gophertelekomcloud v0.3.3-0.20210513155845-aa4509827820
 	github.com/unknwon/com v1.0.1
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -276,8 +276,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWb
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.3.3-0.20210504154301-ea895669e707 h1:V1YQglGVFvt2l2anaTQO4sRlhnhajQZSbg6fRPPsrsI=
-github.com/opentelekomcloud/gophertelekomcloud v0.3.3-0.20210504154301-ea895669e707/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
+github.com/opentelekomcloud/gophertelekomcloud v0.3.3-0.20210513155845-aa4509827820 h1:FV3zLfaCqsN07tJZu/AMKtv71XX5v1593VXZFKnqrLI=
+github.com/opentelekomcloud/gophertelekomcloud v0.3.3-0.20210513155845-aa4509827820/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_instance_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_instance_v2_test.go
@@ -767,6 +767,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   ]
   name            = "instance_1"
   security_groups = ["default"]
+
   network {
     uuid = "%s"
   }

--- a/opentelekomcloud/services/ecs/compute_instance_v2_networking.go
+++ b/opentelekomcloud/services/ecs/compute_instance_v2_networking.go
@@ -397,6 +397,11 @@ func FlattenInstanceNetworks(
 		return nil, common.CheckDeleted(d, err, "server")
 	}
 
+	serverNICs, err := servers.GetNICs(computeClient, server.ID).Extract()
+	if err != nil {
+		return nil, err
+	}
+
 	allInstanceAddresses := getInstanceAddresses(server.Addresses)
 	allInstanceNetworks, err := getAllInstanceNetworks(d, meta)
 	if err != nil {
@@ -420,10 +425,6 @@ func FlattenInstanceNetworks(
 					"mac":         instanceNIC.MAC,
 				}
 
-				serverNICs, err := servers.GetNICs(computeClient, server.ID).Extract()
-				if err != nil {
-					return nil, err
-				}
 				for _, nicObj := range serverNICs {
 					if nicObj.MACAddress == instanceNIC.MAC {
 						v["uuid"] = nicObj.NetID

--- a/opentelekomcloud/services/ecs/compute_instance_v2_networking.go
+++ b/opentelekomcloud/services/ecs/compute_instance_v2_networking.go
@@ -7,6 +7,7 @@
 //
 // The end result, from the user's point of view, is a structured set of
 // understandable network information within the instance resource.
+
 package ecs
 
 import (
@@ -74,16 +75,15 @@ type InstanceNetwork struct {
 func getAllInstanceNetworks(d *schema.ResourceData, meta interface{}) ([]InstanceNetwork, error) {
 	var instanceNetworks []InstanceNetwork
 
-	networks := d.Get("network").([]interface{})
-	for _, v := range networks {
+	networksRaw := d.Get("network").([]interface{})
+	for _, v := range networksRaw {
 		network := v.(map[string]interface{})
 		networkID := network["uuid"].(string)
 		networkName := network["name"].(string)
 		portID := network["port"].(string)
 
 		if networkID == "" && networkName == "" && portID == "" {
-			return nil, fmt.Errorf(
-				"At least one of network.uuid, network.name, or network.port must be set.")
+			return nil, fmt.Errorf("at least one of network.uuid, network.name, or network.port must be set")
 		}
 
 		// If a user specified both an ID and name, that makes things easy
@@ -162,7 +162,7 @@ func GetInstanceNetworkInfo(
 		if err == nil {
 			networkInfo, err := getInstanceNetworkInfoNeutron(networkClient, queryType, queryTerm)
 			if err != nil {
-				return nil, fmt.Errorf("Error trying to get network information from the Network API: %s", err)
+				return nil, fmt.Errorf("error trying to get network information from the Network API: %w", err)
 			}
 
 			return networkInfo, nil
@@ -173,12 +173,12 @@ func GetInstanceNetworkInfo(
 
 	computeClient, err := config.ComputeV2Client(config.GetRegion(d))
 	if err != nil {
-		return nil, fmt.Errorf("Error creating OpenTelekomCloud compute client: %s", err)
+		return nil, fmt.Errorf("error creating OpenTelekomCloud compute client: %w", err)
 	}
 
 	networkInfo, err := getInstanceNetworkInfoNovaNet(computeClient, queryType, queryTerm)
 	if err != nil {
-		return nil, fmt.Errorf("Error trying to get network information from the Nova API: %s", err)
+		return nil, fmt.Errorf("error trying to get network information from the Nova API: %w", err)
 	}
 
 	return networkInfo, nil
@@ -191,20 +191,17 @@ func getInstanceNetworkInfoNovaNet(
 
 	// If somehow a port ended up here, we should just error out.
 	if queryType == "port" {
-		return nil, fmt.Errorf(
-			"Unable to query a port (%s) using the Nova API", queryTerm)
+		return nil, fmt.Errorf("unable to query a port (%s) using the Nova API", queryTerm)
 	}
 
 	allPages, err := tenantnetworks.List(client).AllPages()
 	if err != nil {
-		return nil, fmt.Errorf(
-			"An error occurred while querying the Nova API for network information: %s", err)
+		return nil, fmt.Errorf("an error occurred while querying the Nova API for network information: %w", err)
 	}
 
 	networkList, err := tenantnetworks.ExtractNetworks(allPages)
 	if err != nil {
-		return nil, fmt.Errorf(
-			"An error occurred while querying the Nova API for network information: %s", err)
+		return nil, fmt.Errorf("an error occurred while querying the Nova API for network information: %w", err)
 	}
 
 	var networkFound bool
@@ -234,7 +231,7 @@ func getInstanceNetworkInfoNovaNet(
 		return v, nil
 	}
 
-	return nil, fmt.Errorf("Could not find any matching network for %s %s", queryType, queryTerm)
+	return nil, fmt.Errorf("could not find any matching network for %s %s", queryType, queryTerm)
 }
 
 // getInstanceNetworkInfoNeutron will query the neutron API for the network
@@ -250,22 +247,22 @@ func getInstanceNetworkInfoNeutron(
 		}
 		allPages, err := ports.List(client, listOpts).AllPages()
 		if err != nil {
-			return nil, fmt.Errorf("Unable to retrieve networks from the Network API: %s", err)
+			return nil, fmt.Errorf("unable to retrieve networks from the Network API: %w", err)
 		}
 
 		allPorts, err := ports.ExtractPorts(allPages)
 		if err != nil {
-			return nil, fmt.Errorf("Unable to retrieve networks from the Network API: %s", err)
+			return nil, fmt.Errorf("unable to retrieve networks from the Network API: %w", err)
 		}
 
 		var port ports.Port
 		switch len(allPorts) {
 		case 0:
-			return nil, fmt.Errorf("Could not find any matching port for %s %s", queryType, queryTerm)
+			return nil, fmt.Errorf("could not find any matching port for %s %s", queryType, queryTerm)
 		case 1:
 			port = allPorts[0]
 		default:
-			return nil, fmt.Errorf("More than one port found for %s %s", queryType, queryTerm)
+			return nil, fmt.Errorf("more than one port found for %s %s", queryType, queryTerm)
 		}
 
 		queryType = "id"
@@ -285,22 +282,22 @@ func getInstanceNetworkInfoNeutron(
 
 	allPages, err := networks.List(client, listOpts).AllPages()
 	if err != nil {
-		return nil, fmt.Errorf("Unable to retrieve networks from the Network API: %s", err)
+		return nil, fmt.Errorf("unable to retrieve networks from the Network API: %w", err)
 	}
 
 	allNetworks, err := networks.ExtractNetworks(allPages)
 	if err != nil {
-		return nil, fmt.Errorf("Unable to retrieve networks from the Network API: %s", err)
+		return nil, fmt.Errorf("unable to retrieve networks from the Network API: %w", err)
 	}
 
 	var network networks.Network
 	switch len(allNetworks) {
 	case 0:
-		return nil, fmt.Errorf("Could not find any matching network for %s %s", queryType, queryTerm)
+		return nil, fmt.Errorf("could not find any matching network for %s %s", queryType, queryTerm)
 	case 1:
 		network = allNetworks[0]
 	default:
-		return nil, fmt.Errorf("More than one network found for %s %s", queryType, queryTerm)
+		return nil, fmt.Errorf("more than one network found for %s %s", queryType, queryTerm)
 	}
 
 	v := map[string]interface{}{
@@ -371,17 +368,17 @@ func getInstanceAddresses(addresses map[string]interface{}) []InstanceAddresses 
 // expandInstanceNetworks takes network information found in []InstanceNetwork
 // and builds a golangsdk []servers.Network for use in creating an Instance.
 func expandInstanceNetworks(allInstanceNetworks []InstanceNetwork) []servers.Network {
-	var networks []servers.Network
+	var networkList []servers.Network
 	for _, v := range allInstanceNetworks {
 		n := servers.Network{
 			UUID:    v.UUID,
 			Port:    v.Port,
 			FixedIP: v.FixedIP,
 		}
-		networks = append(networks, n)
+		networkList = append(networkList, n)
 	}
 
-	return networks
+	return networkList
 }
 
 // FlattenInstanceNetworks collects instance network information from different
@@ -392,7 +389,7 @@ func FlattenInstanceNetworks(
 	config := meta.(*cfg.Config)
 	computeClient, err := config.ComputeV2Client(config.GetRegion(d))
 	if err != nil {
-		return nil, fmt.Errorf("Error creating OpenTelekomCloud compute client: %s", err)
+		return nil, fmt.Errorf("error creating OpenTelekomCloud compute client: %w", err)
 	}
 
 	server, err := servers.Get(computeClient, d.Id()).Extract()
@@ -406,7 +403,7 @@ func FlattenInstanceNetworks(
 		return nil, err
 	}
 
-	networks := []map[string]interface{}{}
+	var networkList []map[string]interface{}
 
 	// If there were no instance networks returned, this means that there
 	// was not a network specified in the Terraform configuration. When this
@@ -423,24 +420,25 @@ func FlattenInstanceNetworks(
 					"mac":         instanceNIC.MAC,
 				}
 
-				// Use the same method as getAllInstanceNetworks to get the network uuid
-				networkInfo, err := GetInstanceNetworkInfo(d, meta, "name", instanceAddresses.NetworkName)
+				serverNICs, err := servers.GetNICs(computeClient, server.ID).Extract()
 				if err != nil {
-					log.Printf("[WARN] Error getting default network uuid: %s", err)
-				} else {
-					if v["uuid"] != nil {
-						v["uuid"] = networkInfo["uuid"].(string)
-					} else {
-						log.Printf("[WARN] Could not get default network uuid")
+					return nil, err
+				}
+				for _, nicObj := range serverNICs {
+					if nicObj.MACAddress == instanceNIC.MAC {
+						v["uuid"] = nicObj.NetID
 					}
 				}
+				if v["uuid"] == "" {
+					log.Printf("[WARN] Could not get default network uuid")
+				}
 
-				networks = append(networks, v)
+				networkList = append(networkList, v)
 			}
 		}
 
-		log.Printf("[DEBUG] flattenInstanceNetworks: %#v", networks)
-		return networks, nil
+		log.Printf("[DEBUG] flattenInstanceNetworks: %#v", networkList)
+		return networkList, nil
 	}
 
 	// Loop through all networks and addresses, merge relevant address details.
@@ -465,22 +463,20 @@ func FlattenInstanceNetworks(
 					"port":           instanceNetwork.Port,
 					"access_network": instanceNetwork.AccessNetwork,
 				}
-				networks = append(networks, v)
+				networkList = append(networkList, v)
 			}
 		}
 	}
 
-	log.Printf("[DEBUG] flattenInstanceNetworks: %#v", networks)
-	return networks, nil
+	log.Printf("[DEBUG] flattenInstanceNetworks: %#v", networkList)
+	return networkList, nil
 }
 
 // GetInstanceAccessAddresses determines the best IP address to communicate
 // with the instance. It does this by looping through all networks and looking
 // for a valid IP address. Priority is given to a network that was flagged as
 // an access_network.
-func GetInstanceAccessAddresses(
-	d *schema.ResourceData, networks []map[string]interface{}) (string, string) {
-
+func GetInstanceAccessAddresses(d *schema.ResourceData, networks []map[string]interface{}) (string, string) {
 	var hostv4, hostv6 string
 
 	// Loop through all networks

--- a/opentelekomcloud/services/ecs/resource_opentelekomcloud_compute_instance_v2.go
+++ b/opentelekomcloud/services/ecs/resource_opentelekomcloud_compute_instance_v2.go
@@ -347,7 +347,7 @@ func resourceComputeInstanceV2Create(d *schema.ResourceData, meta interface{}) e
 	config := meta.(*cfg.Config)
 	client, err := config.ComputeV2Client(config.GetRegion(d))
 	if err != nil {
-		return fmt.Errorf("error creating OpenTelekomCloud ComputeV2 client: %s", err)
+		return fmt.Errorf("error creating OpenTelekomCloud ComputeV2 client: %w", err)
 	}
 
 	var createOpts servers.CreateOptsBuilder
@@ -438,7 +438,7 @@ func resourceComputeInstanceV2Create(d *schema.ResourceData, meta interface{}) e
 	}
 
 	if err != nil {
-		return fmt.Errorf("error creating OpenTelekomCloud server: %s", err)
+		return fmt.Errorf("error creating OpenTelekomCloud server: %w", err)
 	}
 	log.Printf("[INFO] Instance ID: %s", server.ID)
 
@@ -467,7 +467,7 @@ func resourceComputeInstanceV2Create(d *schema.ResourceData, meta interface{}) e
 	if strings.ToLower(vmState) == "shutoff" {
 		err = startstop.Stop(client, d.Id()).ExtractErr()
 		if err != nil {
-			return fmt.Errorf("error stopping server instance: %s", err)
+			return fmt.Errorf("error stopping server instance: %w", err)
 		}
 		stopStateConf := &resource.StateChangeConf{
 			Target:     []string{"SHUTOFF"},
@@ -498,11 +498,11 @@ func resourceComputeInstanceV2Create(d *schema.ResourceData, meta interface{}) e
 	if len(tagRaw) > 0 {
 		computeClient, err := config.ComputeV1Client(config.GetRegion(d))
 		if err != nil {
-			return fmt.Errorf("error creating OpenTelekomCloud ComputeV1 client: %s", err)
+			return fmt.Errorf("error creating OpenTelekomCloud ComputeV1 client: %w", err)
 		}
 		tagList := common.ExpandResourceTags(tagRaw)
 		if err := tags.Create(computeClient, "cloudservers", server.ID, tagList).ExtractErr(); err != nil {
-			return fmt.Errorf("error setting tags of CloudServer: %s", err)
+			return fmt.Errorf("error setting tags of CloudServer: %w", err)
 		}
 	}
 
@@ -513,7 +513,7 @@ func resourceComputeInstanceV2Read(d *schema.ResourceData, meta interface{}) err
 	config := meta.(*cfg.Config)
 	client, err := config.ComputeV2Client(config.GetRegion(d))
 	if err != nil {
-		return fmt.Errorf("error creating OpenTelekomCloud ComputeV2 client: %s", err)
+		return fmt.Errorf("error creating OpenTelekomCloud ComputeV2 client: %w", err)
 	}
 
 	server, err := servers.Get(client, d.Id()).Extract()
@@ -548,17 +548,17 @@ func resourceComputeInstanceV2Read(d *schema.ResourceData, meta interface{}) err
 
 	mErr = multierror.Append(mErr,
 		d.Set("network", networks),
-		d.Set("access_ip_v4", server.AccessIPv4),
-		d.Set("access_ip_v6", server.AccessIPv6),
+		d.Set("access_ip_v4", hostv4),
+		d.Set("access_ip_v6", hostv6),
 	)
 
 	// Determine the best IP address to use for SSH connectivity.
 	// Prefer IPv4 over IPv6.
 	var preferredSSHAddress string
-	if server.AccessIPv4 != "" {
-		preferredSSHAddress = server.AccessIPv4
-	} else if server.AccessIPv6 != "" {
-		preferredSSHAddress = server.AccessIPv6
+	if hostv4 != "" {
+		preferredSSHAddress = hostv4
+	} else if hostv6 != "" {
+		preferredSSHAddress = hostv6
 	}
 
 	if preferredSSHAddress != "" {
@@ -644,18 +644,18 @@ func resourceComputeInstanceV2Read(d *schema.ResourceData, meta interface{}) err
 
 	ar, err := resourceECSAutoRecoveryV1Read(d, meta, d.Id())
 	if err != nil && !common.IsResourceNotFound(err) {
-		return fmt.Errorf("error reading auto recovery of instance: %s", err)
+		return fmt.Errorf("error reading auto recovery of instance: %w", err)
 	}
 	mErr = multierror.Append(mErr, d.Set("auto_recovery", ar))
 
 	computeClient, err := config.ComputeV1Client(config.GetRegion(d))
 	if err != nil {
-		return fmt.Errorf("error creating OpenTelekomCloud ComputeV1 client: %s", err)
+		return fmt.Errorf("error creating OpenTelekomCloud ComputeV1 client: %w", err)
 	}
 	// save tags
 	resourceTags, err := tags.Get(computeClient, "cloudservers", d.Id()).Extract()
 	if err != nil {
-		return fmt.Errorf("error fetching OpenTelekomCloud CloudServers tags: %s", err)
+		return fmt.Errorf("error fetching OpenTelekomCloud CloudServers tags: %w", err)
 	}
 	tagMap := common.TagsToMap(resourceTags)
 	mErr = multierror.Append(mErr, d.Set("tags", tagMap))
@@ -671,7 +671,7 @@ func resourceComputeInstanceV2Update(d *schema.ResourceData, meta interface{}) e
 	config := meta.(*cfg.Config)
 	client, err := config.ComputeV2Client(config.GetRegion(d))
 	if err != nil {
-		return fmt.Errorf("error creating OpenTelekomCloud ComputeV2 client: %s", err)
+		return fmt.Errorf("error creating OpenTelekomCloud ComputeV2 client: %w", err)
 	}
 
 	var updateOpts servers.UpdateOpts
@@ -682,7 +682,7 @@ func resourceComputeInstanceV2Update(d *schema.ResourceData, meta interface{}) e
 	if updateOpts != (servers.UpdateOpts{}) {
 		_, err := servers.Update(client, d.Id(), updateOpts).Extract()
 		if err != nil {
-			return fmt.Errorf("error updating OpenTelekomCloud server: %s", err)
+			return fmt.Errorf("error updating OpenTelekomCloud server: %w", err)
 		}
 	}
 
@@ -691,7 +691,7 @@ func resourceComputeInstanceV2Update(d *schema.ResourceData, meta interface{}) e
 		if strings.ToLower(powerStateNew) == "shutoff" {
 			err = startstop.Stop(client, d.Id()).ExtractErr()
 			if err != nil {
-				return fmt.Errorf("error stopping compute instance: %s", err)
+				return fmt.Errorf("error stopping compute instance: %w", err)
 			}
 			stopStateConf := &resource.StateChangeConf{
 				Target:     []string{"SHUTOFF"},
@@ -710,7 +710,7 @@ func resourceComputeInstanceV2Update(d *schema.ResourceData, meta interface{}) e
 		if strings.ToLower(powerStateNew) == "active" {
 			err = startstop.Start(client, d.Id()).ExtractErr()
 			if err != nil {
-				return fmt.Errorf("error starting compute instance: %s", err)
+				return fmt.Errorf("error starting compute instance: %w", err)
 			}
 			startStateConf := &resource.StateChangeConf{
 				Target:     []string{"ACTIVE"},
@@ -827,7 +827,7 @@ func resourceComputeInstanceV2Update(d *schema.ResourceData, meta interface{}) e
 		log.Printf("[DEBUG] Resize configuration: %#v", resizeOpts)
 		err = servers.Resize(client, d.Id(), resizeOpts).ExtractErr()
 		if err != nil {
-			return fmt.Errorf("error resizing OpenTelekomCloud server: %s", err)
+			return fmt.Errorf("error resizing OpenTelekomCloud server: %w", err)
 		}
 
 		// Wait for the instance to finish resizing.
@@ -851,7 +851,7 @@ func resourceComputeInstanceV2Update(d *schema.ResourceData, meta interface{}) e
 		log.Printf("[DEBUG] Confirming resize")
 		err = servers.ConfirmResize(client, d.Id()).ExtractErr()
 		if err != nil {
-			return fmt.Errorf("error confirming resize of OpenTelekomCloud server: %s", err)
+			return fmt.Errorf("error confirming resize of OpenTelekomCloud server: %w", err)
 		}
 
 		stateConf = &resource.StateChangeConf{
@@ -873,7 +873,7 @@ func resourceComputeInstanceV2Update(d *schema.ResourceData, meta interface{}) e
 	if d.HasChange("tags") {
 		computeClient, err := config.ComputeV1Client(config.GetRegion(d))
 		if err != nil {
-			return fmt.Errorf("error creating OpenTelekomCloud ComputeV1 client: %s", err)
+			return fmt.Errorf("error creating OpenTelekomCloud ComputeV1 client: %w", err)
 		}
 		if err := common.UpdateResourceTags(computeClient, d, "cloudservers", d.Id()); err != nil {
 			return fmt.Errorf("error updating tags of CloudServer %s: %s", d.Id(), err)
@@ -885,7 +885,7 @@ func resourceComputeInstanceV2Update(d *schema.ResourceData, meta interface{}) e
 		log.Printf("[DEBUG] Update auto recovery of instance to %t", ar)
 		err = setAutoRecoveryForInstance(d, meta, d.Id(), ar)
 		if err != nil {
-			return fmt.Errorf("error updating auto recovery of instance: %s", err)
+			return fmt.Errorf("error updating auto recovery of instance: %w", err)
 		}
 	}
 
@@ -896,7 +896,7 @@ func resourceComputeInstanceV2Delete(d *schema.ResourceData, meta interface{}) e
 	config := meta.(*cfg.Config)
 	client, err := config.ComputeV2Client(config.GetRegion(d))
 	if err != nil {
-		return fmt.Errorf("error creating OpenTelekomCloud ComputeV2 client: %s", err)
+		return fmt.Errorf("error creating OpenTelekomCloud ComputeV2 client: %w", err)
 	}
 
 	if d.Get("stop_before_destroy").(bool) {
@@ -907,7 +907,7 @@ func resourceComputeInstanceV2Delete(d *schema.ResourceData, meta interface{}) e
 
 	log.Printf("[DEBUG] Deleting OpenTelekomCloud Instance %s", d.Id())
 	if err := servers.Delete(client, d.Id()).ExtractErr(); err != nil {
-		return fmt.Errorf("error deleting OpenTelekomCloud server: %s", err)
+		return fmt.Errorf("error deleting OpenTelekomCloud server: %w", err)
 	}
 
 	// Wait for the instance to delete before moving on.
@@ -1182,7 +1182,7 @@ func resourceComputeInstanceV2ImportState(d *schema.ResourceData, meta interface
 	config := meta.(*cfg.Config)
 	computeClient, err := config.ComputeV2Client(config.GetRegion(d))
 	if err != nil {
-		return nil, fmt.Errorf("error creating compute v2 client: %s", err)
+		return nil, fmt.Errorf("error creating ComputeV2 client: %w", err)
 	}
 
 	results := make([]*schema.ResourceData, 1)
@@ -1208,7 +1208,7 @@ func setBlockDevice(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*cfg.Config)
 	computeClient, err := config.ComputeV2Client(config.GetRegion(d))
 	if err != nil {
-		return fmt.Errorf("error creating compute v2 client: %s", err)
+		return fmt.Errorf("error creating compute v2 client: %w", err)
 	}
 
 	raw := servers.Get(computeClient, d.Id())
@@ -1230,7 +1230,7 @@ func setBlockDevice(d *schema.ResourceData, meta interface{}) error {
 	if len(serverWithAttachments.VolumesAttached) > 0 {
 		blockStorageClient, err := config.BlockStorageV2Client(config.GetRegion(d))
 		if err != nil {
-			return fmt.Errorf("error creating volume v2 client: %s", err)
+			return fmt.Errorf("error creating volume v2 client: %w", err)
 		}
 
 		var volMetaData = struct {

--- a/opentelekomcloud/services/ecs/resource_opentelekomcloud_compute_instance_v2.go
+++ b/opentelekomcloud/services/ecs/resource_opentelekomcloud_compute_instance_v2.go
@@ -528,25 +528,26 @@ func resourceComputeInstanceV2Read(d *schema.ResourceData, meta interface{}) err
 	mErr = multierror.Append(mErr, d.Set("name", server.Name))
 
 	// Get the instance network and address information
-	var networkList []map[string]interface{}
-	networkNICs, err := servers.GetNICs(client, server.ID).Extract()
+	networks, err := FlattenInstanceNetworks(d, meta)
 	if err != nil {
-		return fmt.Errorf("error getting ECSv2 NICs: %w", err)
+		return err
 	}
 
-	for _, nicObj := range networkNICs {
-		nic := make(map[string]interface{})
-		nic["uuid"] = nicObj.NetID
-		nic["port"] = nicObj.PortID
-		nic["mac"] = nicObj.MACAddress
-		if len(nicObj.FixedIPs) > 0 {
-			nic["fixed_ip_v4"] = nicObj.FixedIPs[0].IPAddress
-		}
-		networkList = append(networkList, nic)
+	// Determine the best IPv4 and IPv6 addresses to access the instance with
+	hostv4, hostv6 := GetInstanceAccessAddresses(d, networks)
+
+	// AccessIPv4/v6 isn't standard in OpenTelekomCloud, but there have been reports
+	// of them being used in some environments.
+	if server.AccessIPv4 != "" && hostv4 == "" {
+		hostv4 = server.AccessIPv4
+	}
+
+	if server.AccessIPv6 != "" && hostv6 == "" {
+		hostv6 = server.AccessIPv6
 	}
 
 	mErr = multierror.Append(mErr,
-		d.Set("network", networkList),
+		d.Set("network", networks),
 		d.Set("access_ip_v4", server.AccessIPv4),
 		d.Set("access_ip_v6", server.AccessIPv6),
 	)


### PR DESCRIPTION
## Summary of the Pull Request
Fix issue with reading networks in `resource/opentelekomcloud_compute_instance_v2`
Fixes: #1039

## PR Checklist

* [x] Refers to: #1039
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
=== RUN   TestAccComputeV2Instance_basic
--- PASS: TestAccComputeV2Instance_basic (140.33s)
=== RUN   TestAccComputeV2Instance_multiSecgroup
--- PASS: TestAccComputeV2Instance_multiSecgroup (149.64s)
=== RUN   TestAccComputeV2Instance_bootFromImage
--- PASS: TestAccComputeV2Instance_bootFromImage (79.78s)
=== RUN   TestAccComputeV2Instance_bootFromVolume
--- PASS: TestAccComputeV2Instance_bootFromVolume (78.77s)
=== RUN   TestAccComputeV2Instance_changeFixedIP
--- PASS: TestAccComputeV2Instance_changeFixedIP (80.90s)
=== RUN   TestAccComputeV2Instance_bootFromVolumeVolume
--- PASS: TestAccComputeV2Instance_bootFromVolumeVolume (100.41s)
=== RUN   TestAccComputeV2Instance_stopBeforeDestroy
--- PASS: TestAccComputeV2Instance_stopBeforeDestroy (126.18s)
=== RUN   TestAccComputeV2Instance_metadata
--- PASS: TestAccComputeV2Instance_metadata (137.88s)
=== RUN   TestAccComputeV2Instance_timeout
--- PASS: TestAccComputeV2Instance_timeout (87.94s)
=== RUN   TestAccComputeV2Instance_autoRecovery
--- PASS: TestAccComputeV2Instance_autoRecovery (127.58s)
=== RUN   TestAccComputeV2Instance_crazyNICs
--- PASS: TestAccComputeV2Instance_crazyNICs (231.48s)
=== RUN   TestAccComputeV2Instance_initialStateActive
--- PASS: TestAccComputeV2Instance_initialStateActive (215.49s)
=== RUN   TestAccComputeV2Instance_initialStateShutoff
--- PASS: TestAccComputeV2Instance_initialStateShutoff (287.69s)
PASS

Process finished with the exit code 0
```
