### PR TITLE
Fix client in `identity_provider` operations

### DIFF
--- a/opentelekomcloud/services/iam/resource_opentelekomcloud_identity_provider.go
+++ b/opentelekomcloud/services/iam/resource_opentelekomcloud_identity_provider.go
@@ -6,8 +6,9 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/opentelekomcloud/gophertelekomcloud"
-	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/identity/v3/federation/providers"
+
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 )
 
 func ResourceIdentityProviderV3() *schema.Resource {
@@ -53,7 +54,8 @@ func ResourceIdentityProviderV3() *schema.Resource {
 }
 
 func resourceIdentityProviderV3Create(d *schema.ResourceData, meta interface{}) error {
-	client, err := clients.NewIdentityV3Client()
+	config := meta.(*cfg.Config)
+	client, err := config.IdentityV3Client(config.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf(clientCreationFail, err)
 	}
@@ -75,7 +77,8 @@ func resourceIdentityProviderV3Create(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceIdentityProviderV3Read(d *schema.ResourceData, meta interface{}) error {
-	client, err := clients.NewIdentityV3Client()
+	config := meta.(*cfg.Config)
+	client, err := config.IdentityV3Client(config.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf(clientCreationFail, err)
 	}
@@ -105,7 +108,8 @@ func resourceIdentityProviderV3Read(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceIdentityProviderV3Update(d *schema.ResourceData, meta interface{}) error {
-	client, err := clients.NewIdentityV3Client()
+	config := meta.(*cfg.Config)
+	client, err := config.IdentityV3Client(config.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf(clientCreationFail, err)
 	}
@@ -130,7 +134,8 @@ func resourceIdentityProviderV3Update(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceIdentityProviderV3Delete(d *schema.ResourceData, meta interface{}) error {
-	client, err := clients.NewIdentityV3Client()
+	config := meta.(*cfg.Config)
+	client, err := config.IdentityV3Client(config.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf(clientCreationFail, err)
 	}


### PR DESCRIPTION
## Summary of the Pull Request
Replace acceptance tests client with a standard one

Resolves #1046

## PR Checklist

* [x] Refers to: #1046
* [x] Tests added/passed.

## Acceptance Steps Performed
_This PR is checked together with DevStack_


### Import
```
=== RUN   TestAccIdentityV3ProviderImport
--- PASS: TestAccIdentityV3ProviderImport (9.72s)
PASS

Process finished with the exit code 0

```

### Resource
```
=== RUN   TestAccIdentityV3ProviderBasic
--- PASS: TestAccIdentityV3ProviderBasic (15.61s)
PASS

Process finished with the exit code 0
```


### Manual
```~/GolandProjects/terraform-provider-opentelekomcloud/_sandbox on  devel! ⌚ 15:27:30
$ tf apply --auto-approve
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - opentelekomcloud/opentelekomcloud in /home/akachurin/go/bin
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
opentelekomcloud_identity_provider_v3.prov: Creating...
opentelekomcloud_identity_provider_v3.prov: Creation complete after 1s [id=my-little-prov]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

~/GolandProjects/terraform-provider-opentelekomcloud/_sandbox on  devel! ⌚ 15:28:01
$ tf destroy --auto-approve
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - opentelekomcloud/opentelekomcloud in /home/akachurin/go/bin
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
opentelekomcloud_identity_provider_v3.prov: Refreshing state... [id=my-little-prov]
opentelekomcloud_identity_provider_v3.prov: Destroying... [id=my-little-prov]
opentelekomcloud_identity_provider_v3.prov: Destruction complete after 0s

Destroy complete! Resources: 1 destroyed.

```
