### PR TITLE
Docu: Fix cce_addon_v3 example

### DIFF
--- a/docs/resources/cce_addon_v3.md
+++ b/docs/resources/cce_addon_v3.md
@@ -30,7 +30,7 @@ resource "opentelekomcloud_cce_addon_v3" "addon" {
 
   values {
     basic = {
-      euleros_version = "2.5"
+      euleros_version = "2.2.5"
       swr_addr        = "100.125.7.25:20202"
       swr_user        = "hwofficial"
     }


### PR DESCRIPTION
The euleros version should be 2.2.5 as correctly mentioned here https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/blob/devel/opentelekomcloud/services/cce/addon-templates.md#metrics-server

## Summary of the Pull Request


## PR Checklist

* [ ] Refers to: #xxx
* [ ] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.