### PR TITLE
Get rid of infinite retrial in Node Pool creation

### DIFF
--- a/opentelekomcloud/services/cce/common.go
+++ b/opentelekomcloud/services/cce/common.go
@@ -1,0 +1,5 @@
+package cce
+
+const (
+	cceClientError = "error creating Open Telekom Cloud CCE client: %w"
+)


### PR DESCRIPTION
## Summary of the Pull Request
Retry 403 only once

Refactor `cce_node_pool` resource

Fix #1065 

## PR Checklist

* [x] Refers to: #1065 
* [x] Tests added/passed.

## Acceptance Steps Performed

```
=== RUN   TestAccCCENodePoolsV3_basic
--- PASS: TestAccCCENodePoolsV3_basic (799.02s)
=== RUN   TestAccCCENodePoolsV3_randomAZ
--- PASS: TestAccCCENodePoolsV3_randomAZ (732.14s)
PASS

Process finished with the exit code 0
```
