### PR TITLE
Fix docs for importing vpc_subnet_v1

### DIFF
--- a/docs/resources/cce_addon_v3.md
+++ b/docs/resources/cce_addon_v3.md
@@ -21,6 +21,7 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   subnet_id               = var.subnet_id
   container_network_type  = "overlay_l2"
   kubernetes_svc_ip_range = "10.247.0.0/16"
+  cluster_version         = "v1.17.9-r0"
 }
 
 resource "opentelekomcloud_cce_addon_v3" "addon" {
@@ -34,6 +35,7 @@ resource "opentelekomcloud_cce_addon_v3" "addon" {
       swr_addr        = "100.125.7.25:20202"
       swr_user        = "hwofficial"
     }
+    custom = {}
   }
 }
 ```
@@ -52,7 +54,7 @@ The following arguments are supported:
 
     * `basic` - (Required) Basic add-on information.
 
-    * `custom` - (Optional) Custom parameters of the add-on.
+    * `custom` - (Required) Custom parameters of the add-on.
 
 Arguments which can be passed to the `basic` and `custom` addon parameters depends on the addon type and version.
 For more detailed description see [addons description](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/blob/devel/opentelekomcloud/services/cce/addon-templates.md).

--- a/docs/resources/dds_instance_v3.md
+++ b/docs/resources/dds_instance_v3.md
@@ -6,6 +6,37 @@ subcategory: "Document Database Service (DDS)"
 
 Manages DDS instance resource within OpenTelekomCloud
 
+## Example Usage: Creating a Replica Set
+```hcl
+variable "availability_zone" {}
+variable "vpc_id" {}
+variable "subnet_id" {}
+variable "security_group_id" {}
+
+resource "opentelekomcloud_dds_instance_v3" "instance" {
+  name = "dds-instance"
+  datastore {
+    type           = "DDS-Community"
+    version        = "3.4"
+    storage_engine = "wiredTiger"
+  }
+
+  availability_zone = var.availability_zone
+  vpc_id            = var.vpc_id
+  subnet_id         = var.subnet_id
+  security_group_id = var.security_group_id
+  password          = "5ecuredPa55w0rd@"
+  mode              = "ReplicaSet"
+  flavor {
+    type      = "replica"
+    num       = 1
+    storage   = "ULTRAHIGH"
+    size      = 30
+    spec_code = "dds.mongodb.s2.medium.4.repset"
+  }
+}
+```
+
 ## Example Usage: Creating a Cluster Community Edition
 
 ```hcl
@@ -50,37 +81,6 @@ resource "opentelekomcloud_dds_instance_v3" "instance" {
   backup_strategy {
     start_time = "08:00-09:00"
     keep_days  = "8"
-  }
-}
-```
-
-## Example Usage: Creating a Replica Set
-```hcl
-variable "availability_zone" {}
-variable "vpc_id" {}
-variable "subnet_id" {}
-variable "security_group_id" {}
-
-resource "opentelekomcloud_dds_instance_v3" "instance" {
-  name = "dds-instance"
-  datastore {
-    type           = "DDS-Community"
-    version        = "3.4"
-    storage_engine = "wiredTiger"
-  }
-
-  availability_zone = var.availability_zone
-  vpc_id            = var.vpc_id
-  subnet_id         = var.subnet_id
-  security_group_id = var.security_group_id
-  password          = "5ecuredPa55w0rd@"
-  mode              = "ReplicaSet"
-  flavor {
-    type      = "replica"
-    num       = 1
-    storage   = "ULTRAHIGH"
-    size      = 30
-    spec_code = "dds.mongodb.s2.medium.4.repset"
   }
 }
 ```

--- a/docs/resources/vpc_subnet_v1.md
+++ b/docs/resources/vpc_subnet_v1.md
@@ -98,7 +98,7 @@ All the argument attributes are also exported as result attributes:
 
 ## Import
 
-Subnets can be imported using the `subnet id`, e.g.
+Subnets can be imported using the `network id`, e.g.
 
 ```shell
 terraform import opentelekomcloud_vpc_subnet_v1 4779ab1c-7c1a-44b1-a02e-93dfc361b32d

--- a/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_addon_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_addon_v3_test.go
@@ -80,17 +80,17 @@ func testAccCheckCCEAddonV3Destroy(s *terraform.State) error {
 	config := common.TestAccProvider.Meta().(*cfg.Config)
 	cceClient, err := config.CceV3Client(env.OS_REGION_NAME)
 	if err != nil {
-		return fmt.Errorf("error creating opentelekomcloud CCE client: %s", err)
+		return fmt.Errorf("error creating opentelekomcloud CCE client: %w", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "opentelekomcloud_cce_cluster_v3" {
+		if rs.Type != "opentelekomcloud_cce_addon_v3" {
 			continue
 		}
 
 		_, err := addons.Get(cceClient, rs.Primary.ID, rs.Primary.Attributes["cluster_id"]).Extract()
 		if err == nil {
-			return fmt.Errorf("cluster still exists")
+			return fmt.Errorf("addon still exists")
 		}
 	}
 
@@ -111,7 +111,7 @@ resource opentelekomcloud_cce_cluster_v3 cluster_1 {
 
 resource "opentelekomcloud_cce_addon_v3" "autoscaler" {
   template_name    = "autoscaler"
-  template_version = "1.17.2"
+  template_version = "1.19.1"
   cluster_id       = opentelekomcloud_cce_cluster_v3.cluster_1.id
 
   values {
@@ -138,11 +138,12 @@ resource "opentelekomcloud_cce_addon_v3" "autoscaler" {
       "scaleUpMemUtilizationThreshold": 0.8,
       "scaleUpUnscheduledPodEnabled": true,
       "scaleUpUtilizationEnabled": true,
-      "unremovableNodeRecheckTimeout": 5
+      "unremovableNodeRecheckTimeout": 5,
+      "tenant_id": "%s"
     }
   }
 }
-`, clusterName, env.OS_VPC_ID, env.OS_NETWORK_ID)
+`, clusterName, env.OS_VPC_ID, env.OS_NETWORK_ID, env.OS_TENANT_ID)
 
 	testAccCCEAddonV3Updated = fmt.Sprintf(`
 resource opentelekomcloud_cce_cluster_v3 cluster_1 {
@@ -157,7 +158,7 @@ resource opentelekomcloud_cce_cluster_v3 cluster_1 {
 
 resource "opentelekomcloud_cce_addon_v3" "autoscaler" {
   template_name    = "autoscaler"
-  template_version = "1.17.2"
+  template_version = "1.19.1"
   cluster_id       = opentelekomcloud_cce_cluster_v3.cluster_1.id
 
   values {
@@ -184,11 +185,12 @@ resource "opentelekomcloud_cce_addon_v3" "autoscaler" {
       "scaleUpMemUtilizationThreshold": 0.8,
       "scaleUpUnscheduledPodEnabled": true,
       "scaleUpUtilizationEnabled": true,
-      "unremovableNodeRecheckTimeout": 5
+      "unremovableNodeRecheckTimeout": 5,
+      "tenant_id": "%s"
     }
   }
 }
-`, clusterName, env.OS_VPC_ID, env.OS_NETWORK_ID)
+`, clusterName, env.OS_VPC_ID, env.OS_NETWORK_ID, env.OS_TENANT_ID)
 
 	testAccCCEAddonV3EmptyBasic = fmt.Sprintf(`
 resource opentelekomcloud_cce_cluster_v3 cluster {
@@ -203,10 +205,11 @@ resource opentelekomcloud_cce_cluster_v3 cluster {
 
 resource "opentelekomcloud_cce_addon_v3" "cluster_autoscaler" {
   template_name    = "autoscaler"
-  template_version = "1.17.2"
+  template_version = "1.19.1"
   cluster_id       = opentelekomcloud_cce_cluster_v3.cluster.id
   values {
-    basic = {}
+    basic  = {}
+    custom = {}
   }
 }
 `, clusterName, env.OS_VPC_ID, env.OS_NETWORK_ID)
@@ -224,7 +227,7 @@ resource opentelekomcloud_cce_cluster_v3 cluster_1 {
 
 resource "opentelekomcloud_cce_addon_v3" "autoscaler" {
   template_name    = "autoscaler"
-  template_version = "1.17.2"
+  template_version = "1.19.1"
   cluster_id       = opentelekomcloud_cce_cluster_v3.cluster_1.id
 
   values {
@@ -251,11 +254,12 @@ resource "opentelekomcloud_cce_addon_v3" "autoscaler" {
       "scaleUpMemUtilizationThreshold": 0.8,
       "scaleUpUnscheduledPodEnabled": true,
       "scaleUpUtilizationEnabled": true,
-      "unremovableNodeRecheckTimeout": 5
+      "unremovableNodeRecheckTimeout": 5,
+      "tenant_id": "%s"
     }
   }
 }
-`, clusterName, env.OS_VPC_ID, env.OS_NETWORK_ID)
+`, clusterName, env.OS_VPC_ID, env.OS_NETWORK_ID, env.OS_TENANT_ID)
 )
 
 func checkScaleDownForAutoscaler(name string, enabled bool) resource.TestCheckFunc {
@@ -272,7 +276,7 @@ func checkScaleDownForAutoscaler(name string, enabled bool) resource.TestCheckFu
 		config := common.TestAccProvider.Meta().(*cfg.Config)
 		client, err := config.CceV3AddonClient(env.OS_REGION_NAME)
 		if err != nil {
-			return fmt.Errorf("error creating opentelekomcloud CCE client: %s", err)
+			return fmt.Errorf("error creating opentelekomcloud CCE client: %w", err)
 		}
 
 		found, err := addons.Get(client, rs.Primary.ID, rs.Primary.Attributes["cluster_id"]).Extract()
@@ -281,7 +285,7 @@ func checkScaleDownForAutoscaler(name string, enabled bool) resource.TestCheckFu
 		}
 
 		if found.Metadata.Id != rs.Primary.ID {
-			return fmt.Errorf("cluster not found")
+			return fmt.Errorf("addon not found")
 		}
 
 		if actual := found.Spec.Values.Advanced["scaleDownEnabled"]; actual != enabled {

--- a/opentelekomcloud/acceptance/env/vars.go
+++ b/opentelekomcloud/acceptance/env/vars.go
@@ -28,6 +28,7 @@ var (
 	OS_NIC_ID                 = os.Getenv("OS_NIC_ID")
 	OS_TO_TENANT_ID           = os.Getenv("OS_TO_TENANT_ID")
 	OS_TENANT_NAME            = GetTenantName()
+	OS_TENANT_ID              = os.Getenv("OS_TENANT_ID")
 )
 
 func GetTenantName() cfg.ProjectName {

--- a/opentelekomcloud/services/cce/addon-templates.md
+++ b/opentelekomcloud/services/cce/addon-templates.md
@@ -1,7 +1,7 @@
 # Addon Templates
 
 Addon support configuration input depending on addon type and version. This page contains description of addon arguments
-for the cluster with most recent available k8s version `v1.17.9`.
+for the cluster with available k8s version `v1.17.9`.
 
 Up to date reference of addon arguments for your cluster you can get using API for listing CCE addon templates
 at `https://<cluster_id>.cce.eu-de.otc.t-systems.com/api/v3/addontemplates`, where `<cluster_id>` is ID of the created

--- a/opentelekomcloud/services/cce/common.go
+++ b/opentelekomcloud/services/cce/common.go
@@ -1,0 +1,5 @@
+package cce
+
+const (
+	cceClientError = "error creating Open Telekom Cloud CCE client: %w"
+)

--- a/opentelekomcloud/services/dds/resource_opentelekomcloud_dds_instance_v3.go
+++ b/opentelekomcloud/services/dds/resource_opentelekomcloud_dds_instance_v3.go
@@ -278,7 +278,7 @@ func resourceDdsBackupStrategy(d *schema.ResourceData) instances.BackupStrategy 
 	return backupStrategy
 }
 
-func DdsInstanceStateRefreshFunc(client *golangsdk.ServiceClient, instanceID string) resource.StateRefreshFunc {
+func instanceStateRefreshFunc(client *golangsdk.ServiceClient, instanceID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		opts := instances.ListInstanceOpts{
 			Id: instanceID,
@@ -312,7 +312,7 @@ func resourceDdsInstanceV3Create(d *schema.ResourceData, meta interface{}) error
 	config := meta.(*cfg.Config)
 	client, err := config.DdsV3Client(config.GetRegion(d))
 	if err != nil {
-		return fmt.Errorf("error creating OpenTelekomCloud DDSv3 client: %s ", err)
+		return fmt.Errorf("error creating OpenTelekomCloud DDSv3 client: %w", err)
 	}
 
 	createOpts := instances.CreateOpts{
@@ -338,14 +338,16 @@ func resourceDdsInstanceV3Create(d *schema.ResourceData, meta interface{}) error
 
 	instance, err := instances.Create(client, createOpts).Extract()
 	if err != nil {
-		return fmt.Errorf("Error getting instance from result: %s ", err)
+		return fmt.Errorf("error getting instance from result: %w", err)
 	}
 	log.Printf("[DEBUG] Create instance %s: %#v", instance.Id, instance)
+
+	d.SetId(instance.Id)
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"creating", "updating"},
 		Target:     []string{"normal"},
-		Refresh:    DdsInstanceStateRefreshFunc(client, instance.Id),
+		Refresh:    instanceStateRefreshFunc(client, instance.Id),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
 		Delay:      20 * time.Second,
 		MinTimeout: 10 * time.Second,
@@ -353,10 +355,9 @@ func resourceDdsInstanceV3Create(d *schema.ResourceData, meta interface{}) error
 
 	_, err = stateConf.WaitForState()
 	if err != nil {
-		return fmt.Errorf("Error waiting for instance (%s) to become ready: %s ", instance.Id, err)
+		return fmt.Errorf("error waiting for instance (%s) to become ready: %w", instance.Id, err)
 	}
 
-	d.SetId(instance.Id)
 	return resourceDdsInstanceV3Read(d, meta)
 }
 
@@ -364,7 +365,7 @@ func resourceDdsInstanceV3Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*cfg.Config)
 	client, err := config.DdsV3Client(config.GetRegion(d))
 	if err != nil {
-		return fmt.Errorf("error creating OpenTelekomCloud DDSv3 client: %s", err)
+		return fmt.Errorf("error creating OpenTelekomCloud DDSv3 client: %w", err)
 	}
 
 	listOpts := instances.ListInstanceOpts{
@@ -372,11 +373,11 @@ func resourceDdsInstanceV3Read(d *schema.ResourceData, meta interface{}) error {
 	}
 	allPages, err := instances.List(client, listOpts).AllPages()
 	if err != nil {
-		return fmt.Errorf("error fetching DDS instance: %s", err)
+		return fmt.Errorf("error fetching DDS instance: %w", err)
 	}
 	instancesList, err := instances.ExtractInstances(allPages)
 	if err != nil {
-		return fmt.Errorf("error extracting DDS instance: %s", err)
+		return fmt.Errorf("error extracting DDS instance: %w", err)
 	}
 	if instancesList.TotalCount == 0 {
 		log.Printf("[WARN] DDS instance (%s) was not found", d.Id())
@@ -419,7 +420,7 @@ func resourceDdsInstanceV3Read(d *schema.ResourceData, meta interface{}) error {
 	}
 	datastoreList = append(datastoreList, datastore)
 	if err = d.Set("datastore", datastoreList); err != nil {
-		return fmt.Errorf("error setting DDSv3 datastore opts: %s", err)
+		return fmt.Errorf("error setting DDSv3 datastore opts: %w", err)
 	}
 
 	backupStrategyList := make([]map[string]interface{}, 0, 1)
@@ -429,13 +430,13 @@ func resourceDdsInstanceV3Read(d *schema.ResourceData, meta interface{}) error {
 	}
 	backupStrategyList = append(backupStrategyList, backupStrategy)
 	if err = d.Set("backup_strategy", backupStrategyList); err != nil {
-		return fmt.Errorf("error setting DDSv3 backup_strategy opts: %s", err)
+		return fmt.Errorf("error setting DDSv3 backup_strategy opts: %w", err)
 	}
 
 	// save nodes attribute
 	err = d.Set("nodes", flattenDdsInstanceV3Nodes(instance))
 	if err != nil {
-		return fmt.Errorf("error setting nodes of DDSv3 instance: %s", err)
+		return fmt.Errorf("error setting nodes of DDSv3 instance: %w", err)
 	}
 
 	return mErr.ErrorOrNil()
@@ -445,7 +446,7 @@ func resourceDdsInstanceV3Update(d *schema.ResourceData, meta interface{}) error
 	config := meta.(*cfg.Config)
 	client, err := config.DdsV3Client(config.GetRegion(d))
 	if err != nil {
-		return fmt.Errorf("error creating OpenTelekomCloud DDSv3 client: %s ", err)
+		return fmt.Errorf("error creating OpenTelekomCloud DDSv3 client: %w", err)
 	}
 
 	var opts []instances.UpdateOpt
@@ -495,13 +496,13 @@ func resourceDdsInstanceV3Update(d *schema.ResourceData, meta interface{}) error
 
 	r := instances.Update(client, d.Id(), opts)
 	if r.Err != nil {
-		return fmt.Errorf("error updating instance from result: %s ", r.Err)
+		return fmt.Errorf("error updating instance from result: %w", r.Err)
 	}
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"updating"},
 		Target:     []string{"normal"},
-		Refresh:    DdsInstanceStateRefreshFunc(client, d.Id()),
+		Refresh:    instanceStateRefreshFunc(client, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
 		Delay:      15 * time.Second,
 		MinTimeout: 10 * time.Second,
@@ -509,7 +510,7 @@ func resourceDdsInstanceV3Update(d *schema.ResourceData, meta interface{}) error
 
 	_, err = stateConf.WaitForState()
 	if err != nil {
-		return fmt.Errorf("Error waiting for instance (%s) to become ready: %s ", d.Id(), err)
+		return fmt.Errorf("error waiting for instance (%s) to become ready: %w", d.Id(), err)
 	}
 
 	return resourceDdsInstanceV3Read(d, meta)
@@ -519,7 +520,7 @@ func resourceDdsInstanceV3Delete(d *schema.ResourceData, meta interface{}) error
 	config := meta.(*cfg.Config)
 	client, err := config.DdsV3Client(config.GetRegion(d))
 	if err != nil {
-		return fmt.Errorf("error creating OpenTelekomCloud DDSv3 client: %s ", err)
+		return fmt.Errorf("error creating OpenTelekomCloud DDSv3 client: %w", err)
 	}
 
 	result := instances.Delete(client, d.Id())
@@ -529,7 +530,7 @@ func resourceDdsInstanceV3Delete(d *schema.ResourceData, meta interface{}) error
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"normal", "abnormal", "frozen", "createfail", "enlargefail", "data_disk_full"},
 		Target:     []string{"deleted"},
-		Refresh:    DdsInstanceStateRefreshFunc(client, d.Id()),
+		Refresh:    instanceStateRefreshFunc(client, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
 		Delay:      15 * time.Second,
 		MinTimeout: 10 * time.Second,
@@ -537,7 +538,7 @@ func resourceDdsInstanceV3Delete(d *schema.ResourceData, meta interface{}) error
 
 	_, err = stateConf.WaitForState()
 	if err != nil {
-		return fmt.Errorf("Error waiting for instance (%s) to be deleted: %s ", d.Id(), err)
+		return fmt.Errorf("error waiting for instance (%s) to be deleted: %w", d.Id(), err)
 	}
 	log.Printf("[DEBUG] Successfully deleted instance %s", d.Id())
 	return nil


### PR DESCRIPTION
## Summary of the Pull Request

This PR fixes an issue in the documentation for importing vpc_subnet_v1 resources.
It was mentioned that the subnet id should be used for importing the resource, which didn't work (failed silently). Checking via `terraform state list` didn't contain the imported resource.

The only hint I had was this warning shown with `TF_LOG=TRACE`:

```
2021-05-24T15:35:08.897+0200 [WARN]  Provider "registry.terraform.io/opentelekomcloud/opentelekomcloud" produced an unexpected new value for opentelekomcloud_vpc_subnet_v1.subnet["<RESOURCE INSTANCE NAME>"] during refresh.
      - Root resource was present, but now absent
```

So I tried using the network id of the subnet for the import, which worked.

## PR Checklist

* [ ] Refers to: #xxx
* [ ] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

