### PR TITLE
[CCE] Add possibility to import nodepools

### DIFF
--- a/docs/resources/cce_node_pool_v3.md
+++ b/docs/resources/cce_node_pool_v3.md
@@ -120,3 +120,11 @@ This resource provides the following timeouts configuration options:
   - `create` - Default is 30 minutes.
   - `update` - Default is 30 minutes.
   - `delete` - Default is 30 minutes.
+
+## Import
+
+CCE NodePool can be imported using the `cluster_id/node_pool_id`, e.g.
+
+```sh
+terraform import opentelekomcloud_cce_node_pool_v3.pool_1 14a80bc7-c12c-4fe0-a38a-cb77eeac9bd6/89c60255-9bd6-460c-822a-e2b959ede9d2
+```

--- a/opentelekomcloud/acceptance/cce/import_opentelekomcloud_cce_node_pool_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/import_opentelekomcloud_cce_node_pool_v3_test.go
@@ -1,0 +1,50 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+)
+
+func TestAccCCENodePoolV3ImportBasic(t *testing.T) {
+	resourceName := "opentelekomcloud_cce_node_pool_v3.node_pool"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { common.TestAccPreCheck(t) },
+		Providers:    common.TestAccProviders,
+		CheckDestroy: testAccCheckCCENodePoolV3Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCCENodePoolV3_basic,
+			},
+
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccCCENodePoolV3ImportStateIdFunc(),
+			},
+		},
+	})
+}
+
+func testAccCCENodePoolV3ImportStateIdFunc() resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		var clusterID string
+		var nodePoolID string
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type == "opentelekomcloud_cce_cluster_v3" {
+				clusterID = rs.Primary.ID
+			} else if rs.Type == "opentelekomcloud_cce_node_pool_v3" {
+				nodePoolID = rs.Primary.ID
+			}
+		}
+		if clusterID == "" || nodePoolID == "" {
+			return "", fmt.Errorf("resource not found: %s/%s", clusterID, nodePoolID)
+		}
+		return fmt.Sprintf("%s/%s", clusterID, nodePoolID), nil
+	}
+}

--- a/opentelekomcloud/acceptance/cce/import_opentelekomcloud_cce_node_pool_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/import_opentelekomcloud_cce_node_pool_v3_test.go
@@ -26,6 +26,9 @@ func TestAccCCENodePoolV3ImportBasic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateIdFunc: testAccCCENodePoolV3ImportStateIdFunc(),
+				ImportStateVerifyIgnore: []string{
+					"max_node_count", "min_node_count", "priority", "scale_down_cooldown_time",
+				},
 			},
 		},
 	})


### PR DESCRIPTION
## Summary of the Pull Request
Add possibility to import `resource/opentelekomcloud_cce_node_pool_v3`
Closes: #1040

## PR Checklist

* [x] Refers to: #1040
* [x] Tests added/passed.
* [x] Documentation updated.

## Acceptance Steps Performed

### Basic

```
=== RUN   TestAccCCENodePoolsV3_basic
--- PASS: TestAccCCENodePoolsV3_basic (832.48s)
=== RUN   TestAccCCENodePoolsV3_randomAZ
--- PASS: TestAccCCENodePoolsV3_randomAZ (694.29s)
PASS

Process finished with the exit code 0
```

### Import

```
=== RUN   TestAccCCENodePoolV3ImportBasic
--- PASS: TestAccCCENodePoolV3ImportBasic (696.66s)
PASS

Process finished with the exit code 0
```