### PR TITLE
[RDS] Unify usage of `tags`

### DIFF
--- a/docs/resources/rds_instance_v3.md
+++ b/docs/resources/rds_instance_v3.md
@@ -42,7 +42,7 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
     keep_days  = 1
   }
 
-  tag = {
+  tags = {
     foo = "bar"
     key = "value"
   }
@@ -83,7 +83,7 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
     keep_days  = 1
   }
 
-  tag = {
+  tags = {
     foo = "bar"
     key = "value"
   }
@@ -125,10 +125,10 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
     start_time = "08:00-09:00"
     keep_days  = 1
   }
-  public_ips          = [
+  public_ips = [
     opentelekomcloud_compute_floatingip_v2.ip.address
   ]
-  tag                 = {
+  tags = {
     foo = "bar"
     key = "value"
   }
@@ -207,7 +207,7 @@ The following arguments are supported:
 * `ha_replication_mode` - (Optional) Specifies the replication mode for the standby DB instance. For MySQL, the value
   is async or semisync. For PostgreSQL, the value is async or sync. For Microsoft SQL Server, the value is sync.
 
--> **Note:** Async indicates the asynchronous replication mode. semisync indicates the
+-> Async indicates the asynchronous replication mode. `semisync` indicates the
   semi-synchronous replication mode. sync indicates the synchronous
   replication mode.  Changing this parameter will create a new resource.
 
@@ -216,12 +216,15 @@ The following arguments are supported:
 * `public_ips` - (Optional) Specifies floating IP to be assigned to the instance.
   This should be a list with single element only.
 
--> **Note:** Setting public IP is done with assigning floating IP to internally
+-> Setting public IP is done with assigning floating IP to internally
   created port. So RDS itself doesn't know about this assignment. This assignment
   won't show on the console.
   This argument will be ignored in future when RDSv3 API for EIP assignment will be implemented.
 
-* `tag` - (Optional) Tags key/value pairs to associate with the instance.
+* `tag` - (Optional) Tags key/value pairs to associate with the instance. Deprecated, please use
+  the `tags` instead.
+
+* `tags` - (Optional) Tags key/value pairs to associate with the instance.
 
 The `db` block supports:
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/jinzhu/copier v0.2.3
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.3.3-0.20210520125253-0c9c45749beb
+	github.com/opentelekomcloud/gophertelekomcloud v0.3.3-0.20210527085944-98979da2af29
 	github.com/unknwon/com v1.0.1
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -276,8 +276,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWb
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.3.3-0.20210520125253-0c9c45749beb h1:Eeoy8stoOH7M9kXnam2JMB2yGevjEeVE576M9R2aCBc=
-github.com/opentelekomcloud/gophertelekomcloud v0.3.3-0.20210520125253-0c9c45749beb/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
+github.com/opentelekomcloud/gophertelekomcloud v0.3.3-0.20210527085944-98979da2af29 h1:c9JB67YehSWLx4eDXFPC2D0bcbgqMwRVyyTbyNGruv0=
+github.com/opentelekomcloud/gophertelekomcloud v0.3.3-0.20210527085944-98979da2af29/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/opentelekomcloud/acceptance/rds/import_opentelekomcloud_rds_instance_v3_test.go
+++ b/opentelekomcloud/acceptance/rds/import_opentelekomcloud_rds_instance_v3_test.go
@@ -18,7 +18,7 @@ func TestAccRdsInstanceV3_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckRdsInstanceV3Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRdsInstanceV3_basic(acctest.RandString(10)),
+				Config: testAccRdsInstanceV3Basic(acctest.RandString(10)),
 			},
 
 			{

--- a/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
+++ b/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
@@ -48,7 +48,7 @@ func TestAccRdsInstanceV3Basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "flavor", "rds.pg.c2.large"),
 					resource.TestCheckResourceAttr(resourceName, "volume.0.size", "100"),
-					resource.TestCheckResourceAttr(resourceName, "muh.muh", "value-update"),
+					resource.TestCheckResourceAttr(resourceName, "tags.muh", "value-update"),
 				),
 			},
 		},

--- a/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
+++ b/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
@@ -18,7 +18,9 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/services/rds"
 )
 
-func TestAccRdsInstanceV3_basic(t *testing.T) {
+const resourceName = "opentelekomcloud_rds_instance_v3.instance"
+
+func TestAccRdsInstanceV3Basic(t *testing.T) {
 	postfix := acctest.RandString(3)
 	var rdsInstance instances.RdsInstanceResponse
 
@@ -28,29 +30,32 @@ func TestAccRdsInstanceV3_basic(t *testing.T) {
 		CheckDestroy: testAccCheckRdsInstanceV3Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRdsInstanceV3_basic(postfix),
+				Config: testAccRdsInstanceV3Basic(postfix),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRdsInstanceV3Exists("opentelekomcloud_rds_instance_v3.instance", &rdsInstance),
-					resource.TestCheckResourceAttr("opentelekomcloud_rds_instance_v3.instance", "flavor", "rds.pg.c2.medium"),
-					resource.TestCheckResourceAttr("opentelekomcloud_rds_instance_v3.instance", "db.0.port", "8635"),
-					resource.TestCheckResourceAttr("opentelekomcloud_rds_instance_v3.instance", "name", "tf_rds_instance_"+postfix),
-					resource.TestCheckResourceAttr("opentelekomcloud_rds_instance_v3.instance", "db.0.type", "PostgreSQL"),
-					resource.TestCheckResourceAttr("opentelekomcloud_rds_instance_v3.instance", "volume.0.size", "40"),
-					resource.TestCheckResourceAttr("opentelekomcloud_rds_instance_v3.instance", "backup_strategy.0.keep_days", "1"),
+					testAccCheckRdsInstanceV3Exists(resourceName, &rdsInstance),
+					resource.TestCheckResourceAttr(resourceName, "flavor", "rds.pg.c2.medium"),
+					resource.TestCheckResourceAttr(resourceName, "db.0.port", "8635"),
+					resource.TestCheckResourceAttr(resourceName, "name", "tf_rds_instance_"+postfix),
+					resource.TestCheckResourceAttr(resourceName, "db.0.type", "PostgreSQL"),
+					resource.TestCheckResourceAttr(resourceName, "volume.0.size", "40"),
+					resource.TestCheckResourceAttr(resourceName, "backup_strategy.0.keep_days", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.muh", "value-create"),
+					resource.TestCheckResourceAttr(resourceName, "tags.kuh", "value-create"),
 				),
 			},
 			{
-				Config: testAccRdsInstanceV3_update(postfix),
+				Config: testAccRdsInstanceV3Update(postfix),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("opentelekomcloud_rds_instance_v3.instance", "flavor", "rds.pg.c2.large"),
-					resource.TestCheckResourceAttr("opentelekomcloud_rds_instance_v3.instance", "volume.0.size", "100"),
+					resource.TestCheckResourceAttr(resourceName, "flavor", "rds.pg.c2.large"),
+					resource.TestCheckResourceAttr(resourceName, "volume.0.size", "100"),
+					resource.TestCheckResourceAttr(resourceName, "muh.muh", "value-update"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccRdsInstanceV3_ip(t *testing.T) {
+func TestAccRdsInstanceV3ElasticIP(t *testing.T) {
 	postfix := acctest.RandString(3)
 	var rdsInstance instances.RdsInstanceResponse
 
@@ -60,26 +65,26 @@ func TestAccRdsInstanceV3_ip(t *testing.T) {
 		CheckDestroy: testAccCheckRdsInstanceV3Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRdsInstanceV3_eip(postfix),
+				Config: testAccRdsInstanceV3ElasticIP(postfix),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRdsInstanceV3Exists("opentelekomcloud_rds_instance_v3.instance", &rdsInstance),
-					resource.TestCheckResourceAttr("opentelekomcloud_rds_instance_v3.instance", "name", "tf_rds_instance_"+postfix),
-					resource.TestCheckResourceAttr("opentelekomcloud_rds_instance_v3.instance", "db.0.version", "10"),
-					resource.TestCheckResourceAttr("opentelekomcloud_rds_instance_v3.instance", "public_ips.#", "1"),
+					testAccCheckRdsInstanceV3Exists(resourceName, &rdsInstance),
+					resource.TestCheckResourceAttr(resourceName, "name", "tf_rds_instance_"+postfix),
+					resource.TestCheckResourceAttr(resourceName, "db.0.version", "10"),
+					resource.TestCheckResourceAttr(resourceName, "public_ips.#", "1"),
 				),
 			},
 			{
-				Config: testAccRdsInstanceV3_basic(postfix),
+				Config: testAccRdsInstanceV3Basic(postfix),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("opentelekomcloud_rds_instance_v3.instance", "db.0.version", "10"),
-					resource.TestCheckResourceAttr("opentelekomcloud_rds_instance_v3.instance", "public_ips.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "db.0.version", "10"),
+					resource.TestCheckResourceAttr(resourceName, "public_ips.#", "0"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccRdsInstanceV3_ha(t *testing.T) {
+func TestAccRdsInstanceV3HA(t *testing.T) {
 	postfix := acctest.RandString(3)
 	var rdsInstance instances.RdsInstanceResponse
 
@@ -94,20 +99,20 @@ func TestAccRdsInstanceV3_ha(t *testing.T) {
 		CheckDestroy: testAccCheckRdsInstanceV3Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRdsInstanceV3_ha(postfix, availabilityZone2),
+				Config: testAccRdsInstanceV3HA(postfix, availabilityZone2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRdsInstanceV3Exists("opentelekomcloud_rds_instance_v3.instance", &rdsInstance),
-					resource.TestCheckResourceAttr("opentelekomcloud_rds_instance_v3.instance", "name", "tf_rds_instance_"+postfix),
-					resource.TestCheckResourceAttr("opentelekomcloud_rds_instance_v3.instance", "ha_replication_mode", "semisync"),
-					resource.TestCheckResourceAttr("opentelekomcloud_rds_instance_v3.instance", "volume.0.type", "ULTRAHIGH"),
-					resource.TestCheckResourceAttr("opentelekomcloud_rds_instance_v3.instance", "db.0.type", "MySQL"),
+					testAccCheckRdsInstanceV3Exists(resourceName, &rdsInstance),
+					resource.TestCheckResourceAttr(resourceName, "name", "tf_rds_instance_"+postfix),
+					resource.TestCheckResourceAttr(resourceName, "ha_replication_mode", "semisync"),
+					resource.TestCheckResourceAttr(resourceName, "volume.0.type", "ULTRAHIGH"),
+					resource.TestCheckResourceAttr(resourceName, "db.0.type", "MySQL"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccRdsInstanceV3_optionalParams(t *testing.T) {
+func TestAccRdsInstanceV3OptionalParams(t *testing.T) {
 	postfix := acctest.RandString(3)
 	var rdsInstance instances.RdsInstanceResponse
 
@@ -117,17 +122,17 @@ func TestAccRdsInstanceV3_optionalParams(t *testing.T) {
 		CheckDestroy: testAccCheckRdsInstanceV3Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRdsInstanceV3_optionalParams(postfix),
+				Config: testAccRdsInstanceV3OptionalParams(postfix),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRdsInstanceV3Exists("opentelekomcloud_rds_instance_v3.instance", &rdsInstance),
-					resource.TestCheckResourceAttr("opentelekomcloud_rds_instance_v3.instance", "name", "tf_rds_instance_"+postfix),
+					testAccCheckRdsInstanceV3Exists(resourceName, &rdsInstance),
+					resource.TestCheckResourceAttr(resourceName, "name", "tf_rds_instance_"+postfix),
 				),
 			},
 		},
 	})
 }
 
-func TestAccRdsInstanceV3_backupCheck(t *testing.T) {
+func TestAccRdsInstanceV3Backup(t *testing.T) {
 	postfix := acctest.RandString(3)
 	var rdsInstance instances.RdsInstanceResponse
 
@@ -137,17 +142,17 @@ func TestAccRdsInstanceV3_backupCheck(t *testing.T) {
 		CheckDestroy: testAccCheckRdsInstanceV3Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRdsInstanceV3_backupCheck(postfix),
+				Config: testAccRdsInstanceV3Backup(postfix),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRdsInstanceV3Exists("opentelekomcloud_rds_instance_v3.instance", &rdsInstance),
-					resource.TestCheckResourceAttr("opentelekomcloud_rds_instance_v3.instance", "name", "tf_rds_instance_"+postfix),
+					testAccCheckRdsInstanceV3Exists(resourceName, &rdsInstance),
+					resource.TestCheckResourceAttr(resourceName, "name", "tf_rds_instance_"+postfix),
 				),
 			},
 		},
 	})
 }
 
-func TestAccRdsInstanceV3_templateConfigCheck(t *testing.T) {
+func TestAccRdsInstanceV3TemplateConfig(t *testing.T) {
 	postfix := acctest.RandString(3)
 	var rdsInstance instances.RdsInstanceResponse
 
@@ -157,24 +162,24 @@ func TestAccRdsInstanceV3_templateConfigCheck(t *testing.T) {
 		CheckDestroy: testAccCheckRdsInstanceV3Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRdsInstanceV3_configTemplateBasic(postfix),
+				Config: testAccRdsInstanceV3ConfigTemplateBasic(postfix),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRdsInstanceV3Exists("opentelekomcloud_rds_instance_v3.instance", &rdsInstance),
-					resource.TestCheckResourceAttr("opentelekomcloud_rds_instance_v3.instance", "name", "tf_rds_instance_"+postfix),
+					testAccCheckRdsInstanceV3Exists(resourceName, &rdsInstance),
+					resource.TestCheckResourceAttr(resourceName, "name", "tf_rds_instance_"+postfix),
 				),
 			},
 			{
-				Config: testAccRdsInstanceV3_configTemplateChange(postfix),
+				Config: testAccRdsInstanceV3ConfigTemplateUpdate(postfix),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRdsInstanceV3Exists("opentelekomcloud_rds_instance_v3.instance", &rdsInstance),
-					resource.TestCheckResourceAttr("opentelekomcloud_rds_instance_v3.instance", "name", "tf_rds_instance_"+postfix),
+					testAccCheckRdsInstanceV3Exists(resourceName, &rdsInstance),
+					resource.TestCheckResourceAttr(resourceName, "name", "tf_rds_instance_"+postfix),
 				),
 			},
 		},
 	})
 }
 
-func TestAccRdsInstanceV3_invalidDbVersion(t *testing.T) {
+func TestAccRdsInstanceV3InvalidDBVersion(t *testing.T) {
 	postfix := acctest.RandString(3)
 
 	resource.Test(t, resource.TestCase{
@@ -183,7 +188,7 @@ func TestAccRdsInstanceV3_invalidDbVersion(t *testing.T) {
 		CheckDestroy: testAccCheckRdsInstanceV3Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccRdsInstanceV3_invalidDbVersion(postfix),
+				Config:      testAccRdsInstanceV3InvalidDBVersion(postfix),
 				PlanOnly:    true,
 				ExpectError: regexp.MustCompile(`can't find version.+`),
 			},
@@ -232,7 +237,7 @@ func testAccCheckRdsInstanceV3Exists(n string, rdsInstance *instances.RdsInstanc
 			return err
 		}
 		if found.Id != rs.Primary.ID {
-			return fmt.Errorf("rdsv3 instance not found")
+			return fmt.Errorf("RDSv3 instance not found")
 		}
 
 		*rdsInstance = *found
@@ -241,7 +246,7 @@ func testAccCheckRdsInstanceV3Exists(n string, rdsInstance *instances.RdsInstanc
 	}
 }
 
-func testAccRdsInstanceV3_basic(postfix string) string {
+func testAccRdsInstanceV3Basic(postfix string) string {
 	return fmt.Sprintf(`
 resource "opentelekomcloud_networking_secgroup_v2" "sg" {
   name = "sg-rds-test"
@@ -268,15 +273,15 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
     start_time = "08:00-09:00"
     keep_days  = 1
   }
-  tag = {
-    foo = "bar"
-    key = "value"
+  tags = {
+    muh = "value-create"
+    kuh = "value-create"
   }
 }
 `, postfix, env.OS_AVAILABILITY_ZONE, env.OS_NETWORK_ID, env.OS_VPC_ID)
 }
 
-func testAccRdsInstanceV3_update(postfix string) string {
+func testAccRdsInstanceV3Update(postfix string) string {
 	return fmt.Sprintf(`
 resource opentelekomcloud_networking_secgroup_v2 sg {
   name = "sg-rds-test"
@@ -303,15 +308,14 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
     start_time = "08:00-09:00"
     keep_days  = 1
   }
-  tag = {
-    foo = "bar1"
-    value = "key"
+  tags = {
+    muh = "value-update"
   }
 }
 `, postfix, env.OS_AVAILABILITY_ZONE, env.OS_NETWORK_ID, env.OS_VPC_ID)
 }
 
-func testAccRdsInstanceV3_eip(postfix string) string {
+func testAccRdsInstanceV3ElasticIP(postfix string) string {
 	return fmt.Sprintf(`
 resource "opentelekomcloud_networking_floatingip_v2" "fip_1" {}
 
@@ -346,7 +350,7 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
 `, postfix, env.OS_AVAILABILITY_ZONE, env.OS_NETWORK_ID, env.OS_VPC_ID)
 }
 
-func testAccRdsInstanceV3_ha(postfix string, az2 string) string {
+func testAccRdsInstanceV3HA(postfix string, az2 string) string {
 	return fmt.Sprintf(`
 resource "opentelekomcloud_networking_secgroup_v2" "sg" {
   name = "sg-rds-test"
@@ -378,7 +382,7 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
 `, postfix, env.OS_AVAILABILITY_ZONE, az2, env.OS_NETWORK_ID, env.OS_VPC_ID)
 }
 
-func testAccRdsInstanceV3_optionalParams(postfix string) string {
+func testAccRdsInstanceV3OptionalParams(postfix string) string {
 	return fmt.Sprintf(`
 resource "opentelekomcloud_networking_secgroup_v2" "sg" {
   name = "sg-rds-test"
@@ -404,7 +408,7 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
 `, postfix, env.OS_AVAILABILITY_ZONE, env.OS_NETWORK_ID, env.OS_VPC_ID)
 }
 
-func testAccRdsInstanceV3_backupCheck(postfix string) string {
+func testAccRdsInstanceV3Backup(postfix string) string {
 	return fmt.Sprintf(`
 resource "opentelekomcloud_networking_secgroup_v2" "sg" {
   name = "sg-rds-test"
@@ -435,7 +439,7 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
 `, postfix, env.OS_AVAILABILITY_ZONE, env.OS_NETWORK_ID, env.OS_VPC_ID)
 }
 
-func testAccRdsInstanceV3_configTemplateBasic(postfix string) string {
+func testAccRdsInstanceV3ConfigTemplateBasic(postfix string) string {
 	return fmt.Sprintf(`
 resource "opentelekomcloud_rds_parametergroup_v3" "pg" {
 	name = "pg-rds-test"
@@ -486,7 +490,7 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
 `, postfix, env.OS_AVAILABILITY_ZONE, env.OS_NETWORK_ID, env.OS_VPC_ID)
 }
 
-func testAccRdsInstanceV3_configTemplateChange(postfix string) string {
+func testAccRdsInstanceV3ConfigTemplateUpdate(postfix string) string {
 	return fmt.Sprintf(`
 resource "opentelekomcloud_rds_parametergroup_v3" "pg" {
 	name = "pg-rds-test"
@@ -537,7 +541,7 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
 `, postfix, env.OS_AVAILABILITY_ZONE, env.OS_NETWORK_ID, env.OS_VPC_ID)
 }
 
-func testAccRdsInstanceV3_invalidDbVersion(postfix string) string {
+func testAccRdsInstanceV3InvalidDBVersion(postfix string) string {
 	return fmt.Sprintf(`
 resource "opentelekomcloud_networking_secgroup_v2" "sg" {
   name = "sg-rds-test"

--- a/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_instance_v3.go
+++ b/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_instance_v3.go
@@ -10,10 +10,11 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/tags"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v1/subnets"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/layer3/floatingips"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/ports"
-	"github.com/opentelekomcloud/gophertelekomcloud/openstack/rds/v1/tags"
+	tag "github.com/opentelekomcloud/gophertelekomcloud/openstack/rds/v1/tags"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/rds/v3/backups"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/rds/v3/configurations"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/rds/v3/flavors"
@@ -166,9 +167,17 @@ func ResourceRdsInstanceV3() *schema.Resource {
 				ForceNew: true,
 			},
 			"tag": {
-				Type:         schema.TypeMap,
-				Optional:     true,
-				ValidateFunc: common.ValidateTags,
+				Type:          schema.TypeMap,
+				Optional:      true,
+				ValidateFunc:  common.ValidateTags,
+				Deprecated:    "Please use `tags` instead",
+				ConflictsWith: []string{"tags"},
+			},
+			"tags": {
+				Type:          schema.TypeMap,
+				Optional:      true,
+				ValidateFunc:  common.ValidateTags,
+				ConflictsWith: []string{"tag"},
 			},
 			"param_group_id": {
 				Type:     schema.TypeString,
@@ -361,13 +370,23 @@ func resourceRdsInstanceV3Create(d *schema.ResourceData, meta interface{}) error
 		tagMap := d.Get("tag").(map[string]interface{})
 		log.Printf("[DEBUG] Setting tag(key/value): %v", tagMap)
 		for key, val := range tagMap {
-			tagOpts := tags.CreateOpts{
+			tagOpts := tag.CreateOpts{
 				Key:   key,
 				Value: val.(string),
 			}
-			err = tags.Create(tagClient, nodeID, tagOpts).ExtractErr()
+			err = tag.Create(tagClient, nodeID, tagOpts).ExtractErr()
 			if err != nil {
 				log.Printf("[WARN] Error setting tag(key/value) of instance %s, err: %s", r.Instance.Id, err)
+			}
+		}
+	}
+
+	if common.HasFilledOpt(d, "tags") {
+		tagRaw := d.Get("tags").(map[string]interface{})
+		if len(tagRaw) > 0 {
+			tagList := common.ExpandResourceTags(tagRaw)
+			if err := tags.Create(client, "instances", r.Instance.Id, tagList).ExtractErr(); err != nil {
+				return fmt.Errorf("error setting tags of RDSv3 instance: %w", err)
 			}
 		}
 	}
@@ -549,7 +568,7 @@ func resourceRdsInstanceV3Update(d *schema.ResourceData, meta interface{}) error
 
 		if len(remove) > 0 {
 			for _, opts := range remove {
-				err = tags.Delete(tagClient, nodeID, opts).ExtractErr()
+				err = tag.Delete(tagClient, nodeID, opts).ExtractErr()
 				if err != nil {
 					log.Printf("[WARN] Error deleting tag(key/value) of instance: %s, err: %s", d.Id(), err)
 				}
@@ -557,11 +576,16 @@ func resourceRdsInstanceV3Update(d *schema.ResourceData, meta interface{}) error
 		}
 		if len(create) > 0 {
 			for _, opts := range create {
-				err = tags.Create(tagClient, nodeID, opts).ExtractErr()
+				err = tag.Create(tagClient, nodeID, opts).ExtractErr()
 				if err != nil {
 					log.Printf("[WARN] Error setting tag(key/value) of instance: %s, err: %s", d.Id(), err)
 				}
 			}
+		}
+	}
+	if d.HasChange("tags") {
+		if err := common.UpdateResourceTags(client, d, "instances", d.Id()); err != nil {
+			return fmt.Errorf("error updating tags of RDSv3 instance %s: %s", d.Id(), err)
 		}
 	}
 
@@ -807,14 +831,14 @@ func resourceRdsInstanceV3Read(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if nodeID == "" {
-		log.Printf("[WARN] Error fetching node id of instance:%s", d.Id())
+		log.Printf("[WARN] Error fetching node id of instance: %s", d.Id())
 		return nil
 	}
 	tagClient, err := config.RdsTagV1Client(config.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating OpenTelekomCloud rds tag client: %#v", err)
 	}
-	tagList, err := tags.Get(tagClient, nodeID).Extract()
+	tagList, err := tag.Get(tagClient, nodeID).Extract()
 	if err != nil {
 		return fmt.Errorf("error fetching OpenTelekomCloud rds instance tags: %s", err)
 	}
@@ -824,6 +848,16 @@ func resourceRdsInstanceV3Read(d *schema.ResourceData, meta interface{}) error {
 	}
 	if err := d.Set("tag", tagMap); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving tag to state for OpenTelekomCloud rds instance (%s): %s", d.Id(), err)
+	}
+
+	// save tags
+	resourceTags, err := tags.Get(client, "instances", d.Id()).Extract()
+	if err != nil {
+		return fmt.Errorf("error fetching OpenTelekomCloud RDSv3 instance tags: %s", err)
+	}
+	tagsMap := common.TagsToMap(resourceTags)
+	if err := d.Set("tags", tagsMap); err != nil {
+		return fmt.Errorf("error saving tags for OpenTelekomCloud RDSv3 instance: %s", err)
 	}
 
 	return nil


### PR DESCRIPTION
## Summary of the Pull Request

Unify usage of `tags` in `resource/opentelekomcloud_rds_instance_v3`

Closes: #918

## PR Checklist

* [x] Refers to: #918
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
=== RUN   TestAccRdsInstanceV3Basic
--- PASS: TestAccRdsInstanceV3Basic (1183.81s)
=== RUN   TestAccRdsInstanceV3ElasticIP
--- PASS: TestAccRdsInstanceV3ElasticIP (705.28s)
=== RUN   TestAccRdsInstanceV3OptionalParams
--- PASS: TestAccRdsInstanceV3OptionalParams (649.11s)
=== RUN   TestAccRdsInstanceV3Backup
--- PASS: TestAccRdsInstanceV3Backup (688.16s)
=== RUN   TestAccRdsInstanceV3TemplateConfig
--- PASS: TestAccRdsInstanceV3TemplateConfig (723.68s)
=== RUN   TestAccRdsInstanceV3InvalidDBVersion
--- PASS: TestAccRdsInstanceV3InvalidDBVersion (3.67s)
PASS

Process finished with the exit code 0
```
