### PR TITLE
Allow creating CCE cluster without addons

### DIFF
--- a/docs/resources/cce_cluster_v3.md
+++ b/docs/resources/cce_cluster_v3.md
@@ -132,6 +132,8 @@ The following arguments are supported:
 * `kubernetes_svc_ip_range` - (Optional) Service CIDR block, or the IP address range which the kubernetes
   clusterIp must fall within. This parameter is available only for clusters of v1.11.7 and later.
 
+* `no_addons` - (Optional) Remove addons installed by the default after the cluster creation.
+
 ## Attributes Reference
 
 All above argument parameters can be exported as attribute parameters along with attribute reference.
@@ -158,7 +160,7 @@ All above argument parameters can be exported as attribute parameters along with
 
 * `certificate_users/client_key_data` - The client key data.
 
-* `kube_proxy_mode` - (Optional) Service forwarding mode. Two modes are available:
+* `kube_proxy_mode` - Service forwarding mode. Two modes are available:
   * `iptables`: Traditional kube-proxy uses iptables rules to implement service load balancing.
   In this mode, too many iptables rules will be generated when many services are deployed.
   In addition, non-incremental updates will cause a latency and even obvious performance issues
@@ -166,6 +168,8 @@ All above argument parameters can be exported as attribute parameters along with
   * `ipvs`: Optimized kube-proxy mode with higher throughput and faster speed.
   This mode supports incremental updates and can keep connections uninterrupted during service updates.
   It is suitable for large-sized clusters.
+
+* `installed_addons` - List of installed addon IDs.
 
 ## Timeouts
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/jinzhu/copier v0.2.3
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.3.3-0.20210527085944-98979da2af29
+	github.com/opentelekomcloud/gophertelekomcloud v0.3.3-0.20210527110744-19f8fbb87916
 	github.com/unknwon/com v1.0.1
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -276,8 +276,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWb
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.3.3-0.20210527085944-98979da2af29 h1:c9JB67YehSWLx4eDXFPC2D0bcbgqMwRVyyTbyNGruv0=
-github.com/opentelekomcloud/gophertelekomcloud v0.3.3-0.20210527085944-98979da2af29/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
+github.com/opentelekomcloud/gophertelekomcloud v0.3.3-0.20210527110744-19f8fbb87916 h1:yG/FvcdDKxb3lCtNnKBfXA8OKovGHHxCwwq80y43qls=
+github.com/opentelekomcloud/gophertelekomcloud v0.3.3-0.20210527110744-19f8fbb87916/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/opentelekomcloud/acceptance/cce/import_opentelekomcloud_cce_cluster_test.go
+++ b/opentelekomcloud/acceptance/cce/import_opentelekomcloud_cce_cluster_test.go
@@ -17,7 +17,7 @@ func TestAccCCEClusterV3_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckCCEClusterV3Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCCEClusterV3_basic,
+				Config: testAccCCEClusterV3Basic,
 			},
 
 			{

--- a/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_cluster_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_cluster_v3_test.go
@@ -237,7 +237,6 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   name                   = "%s"
   cluster_type           = "VirtualMachine"
   flavor_id              = "cce.s2.small"
-  cluster_version        = "v1.9.2-r2"
   vpc_id                 = "%s"
   subnet_id              = "%s"
   eip                    = opentelekomcloud_networking_floatingip_v2.fip_1.address


### PR DESCRIPTION
## Summary of the Pull Request

Add `no_addons` argument to remove addons after cluster creation

Add `installed_addons` attribute to store installed addons

Update SDK to latest `devel`

Resolve #1056 

## PR Checklist

* [x] Refers to: #1056
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed
### Resource;
```
=== RUN   TestAccCCEClusterV3_basic
--- PASS: TestAccCCEClusterV3_basic (1405.59s)
=== RUN   TestAccCCEClusterV3NoAddons
--- PASS: TestAccCCEClusterV3NoAddons (396.93s)
PASS

Process finished with the exit code 0
```
### Import:
```
=== RUN   TestAccCCEClusterV3_importBasic
--- PASS: TestAccCCEClusterV3_importBasic (426.96s)
PASS

Process finished with the exit code 0
```