### PR TITLE
[OBS] Don't store malformed policy in the state file

### DIFF
--- a/opentelekomcloud/services/obs/resource_opentelekomcloud_obs_bucket_policy.go
+++ b/opentelekomcloud/services/obs/resource_opentelekomcloud_obs_bucket_policy.go
@@ -13,10 +13,6 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 )
 
-const (
-	version = "2008-10-17"
-)
-
 func ResourceObsBucketPolicy() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceObsBucketPolicyPut,

--- a/opentelekomcloud/services/obs/resource_opentelekomcloud_obs_bucket_policy.go
+++ b/opentelekomcloud/services/obs/resource_opentelekomcloud_obs_bucket_policy.go
@@ -49,7 +49,6 @@ func resourceObsBucketPolicyPut(d *schema.ResourceData, meta interface{}) error 
 
 	policy := d.Get("policy").(string)
 	bucket := d.Get("bucket").(string)
-	d.SetId(bucket)
 
 	log.Printf("[DEBUG] OBS bucket: %s, put policy: %s", bucket, policy)
 
@@ -73,6 +72,8 @@ func resourceObsBucketPolicyPut(d *schema.ResourceData, meta interface{}) error 
 	if err != nil {
 		return fmt.Errorf("error putting OBS policy: %s", err)
 	}
+
+	d.SetId(bucket)
 
 	return nil
 }


### PR DESCRIPTION
## Summary of the Pull Request
Move setting bucket policy ID after it's created
Fixes: #1005 

## PR Checklist

* [x] Refers to: #1005
* [x] Tests added/passed.

## Acceptance Steps Performed

```
=== RUN   TestAccObsBucketPolicyBasic
--- PASS: TestAccObsBucketPolicyBasic (39.21s)
=== RUN   TestAccObsBucketPolicyUpdate
--- PASS: TestAccObsBucketPolicyUpdate (69.03s)
=== RUN   TestAccObsBucketPolicyMalformed
--- PASS: TestAccObsBucketPolicyMalformed (81.69s)
PASS

Process finished with the exit code 0
```
