### PR TITLE
Remove deprecated `security_group_ids`

### DIFF
--- a/docs/resources/lb_loadbalancer_v2.md
+++ b/docs/resources/lb_loadbalancer_v2.md
@@ -75,10 +75,6 @@ The following arguments are supported:
 * `loadbalancer_provider` - (Optional) The name of the provider. Changing this
   creates a new loadbalancer.
 
-* `security_group_ids` **DEPRECATED** - (Optional) A list of security group IDs to apply to the
-  loadbalancer. The security groups must be specified by ID and not name (as
-  opposed to how they are configured with the Compute Instance).
-
 * `tags` - (Optional) Tags key/value pairs to associate with the loadbalancer.
 
 
@@ -99,8 +95,6 @@ The following attributes are exported:
 * `admin_state_up` - See Argument Reference above.
 
 * `loadbalancer_provider` - See Argument Reference above.
-
-* `security_group_ids` - See Argument Reference above.
 
 * `vip_port_id` - The Port ID of the Load Balancer IP.
 

--- a/opentelekomcloud/acceptance/elb/resource_opentelekomcloud_lb_loadbalancer_v2_test.go
+++ b/opentelekomcloud/acceptance/elb/resource_opentelekomcloud_lb_loadbalancer_v2_test.go
@@ -9,12 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/lbaas_v2/loadbalancers"
-	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/security/groups"
-	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/ports"
-
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
-	vpc "github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/vpc"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 )
 
@@ -38,53 +34,6 @@ func TestAccLBV2LoadBalancer_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", "loadbalancer_1_updated"),
 					resource.TestMatchResourceAttr(resourceName, "vip_port_id", regexp.MustCompile("^[a-f0-9-]+")),
-				),
-			},
-		},
-	})
-}
-
-func TestAccLBV2LoadBalancer_secGroup(t *testing.T) {
-	var lb loadbalancers.LoadBalancer
-	var sg1, sg2 groups.SecGroup
-	resourceName := "opentelekomcloud_lb_loadbalancer_v2.loadbalancer_1"
-	sgResource1Name := "opentelekomcloud_networking_secgroup_v2.secgroup_1"
-	sgResource2Name := "opentelekomcloud_networking_secgroup_v2.secgroup_2"
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { common.TestAccPreCheck(t) },
-		Providers:    common.TestAccProviders,
-		CheckDestroy: testAccCheckLBV2LoadBalancerDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccLBV2LoadBalancer_secGroup,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLBV2LoadBalancerExists(resourceName, &lb),
-					vpc.TestAccCheckNetworkingV2SecGroupExists(sgResource1Name, &sg1),
-					vpc.TestAccCheckNetworkingV2SecGroupExists(sgResource2Name, &sg2),
-					resource.TestCheckResourceAttr(resourceName, "security_group_ids.#", "1"),
-					testAccCheckLBV2LoadBalancerHasSecGroup(&lb, &sg1),
-				),
-			},
-			{
-				Config: testAccLBV2LoadBalancer_secGroup_update1,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLBV2LoadBalancerExists(resourceName, &lb),
-					vpc.TestAccCheckNetworkingV2SecGroupExists(sgResource1Name, &sg1),
-					vpc.TestAccCheckNetworkingV2SecGroupExists(sgResource2Name, &sg2),
-					resource.TestCheckResourceAttr(resourceName, "security_group_ids.#", "2"),
-					testAccCheckLBV2LoadBalancerHasSecGroup(&lb, &sg1),
-					testAccCheckLBV2LoadBalancerHasSecGroup(&lb, &sg2),
-				),
-			},
-			{
-				Config: testAccLBV2LoadBalancer_secGroup_update2,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLBV2LoadBalancerExists(resourceName, &lb),
-					vpc.TestAccCheckNetworkingV2SecGroupExists(sgResource1Name, &sg1),
-					vpc.TestAccCheckNetworkingV2SecGroupExists(sgResource2Name, &sg2),
-					resource.TestCheckResourceAttr(resourceName, "security_group_ids.#", "1"),
-					testAccCheckLBV2LoadBalancerHasSecGroup(&lb, &sg2),
 				),
 			},
 		},
@@ -144,29 +93,6 @@ func testAccCheckLBV2LoadBalancerExists(n string, lb *loadbalancers.LoadBalancer
 	}
 }
 
-func testAccCheckLBV2LoadBalancerHasSecGroup(lb *loadbalancers.LoadBalancer, sg *groups.SecGroup) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		config := common.TestAccProvider.Meta().(*cfg.Config)
-		client, err := config.NetworkingV2Client(env.OS_REGION_NAME)
-		if err != nil {
-			return fmt.Errorf("error creating OpenTelekomCloud NetworkingV2 client: %s", err)
-		}
-
-		port, err := ports.Get(client, lb.VipPortID).Extract()
-		if err != nil {
-			return err
-		}
-
-		for _, p := range port.SecurityGroups {
-			if p == sg.ID {
-				return nil
-			}
-		}
-
-		return fmt.Errorf("LoadBalancer does not have the security group")
-	}
-}
-
 var testAccLBV2LoadBalancerConfig_basic = fmt.Sprintf(`
 resource "opentelekomcloud_lb_loadbalancer_v2" "loadbalancer_1" {
   name          = "loadbalancer_1"
@@ -200,69 +126,5 @@ resource "opentelekomcloud_lb_loadbalancer_v2" "loadbalancer_1" {
     update = "5m"
     delete = "5m"
   }
-}
-`, env.OS_SUBNET_ID)
-
-var testAccLBV2LoadBalancer_secGroup = fmt.Sprintf(`
-resource "opentelekomcloud_networking_secgroup_v2" "secgroup_1" {
-  name        = "secgroup_1"
-  description = "secgroup_1"
-}
-
-resource "opentelekomcloud_networking_secgroup_v2" "secgroup_2" {
-  name        = "secgroup_2"
-  description = "secgroup_2"
-}
-
-resource "opentelekomcloud_lb_loadbalancer_v2" "loadbalancer_1" {
-  name               = "loadbalancer_1"
-  vip_subnet_id      = "%s"
-  security_group_ids = [
-    opentelekomcloud_networking_secgroup_v2.secgroup_1.id
-  ]
-}
-`, env.OS_SUBNET_ID)
-
-var testAccLBV2LoadBalancer_secGroup_update1 = fmt.Sprintf(`
-resource "opentelekomcloud_networking_secgroup_v2" "secgroup_1" {
-  name        = "secgroup_1"
-  description = "secgroup_1"
-}
-
-resource "opentelekomcloud_networking_secgroup_v2" "secgroup_2" {
-  name        = "secgroup_2"
-  description = "secgroup_2"
-}
-
-resource "opentelekomcloud_lb_loadbalancer_v2" "loadbalancer_1" {
-  name = "loadbalancer_1"
-  vip_subnet_id = "%s"
-  security_group_ids = [
-    opentelekomcloud_networking_secgroup_v2.secgroup_1.id,
-    opentelekomcloud_networking_secgroup_v2.secgroup_2.id
-  ]
-}
-`, env.OS_SUBNET_ID)
-
-var testAccLBV2LoadBalancer_secGroup_update2 = fmt.Sprintf(`
-resource "opentelekomcloud_networking_secgroup_v2" "secgroup_1" {
-  name        = "secgroup_1"
-  description = "secgroup_1"
-}
-
-resource "opentelekomcloud_networking_secgroup_v2" "secgroup_2" {
-  name        = "secgroup_2"
-  description = "secgroup_2"
-}
-
-resource "opentelekomcloud_lb_loadbalancer_v2" "loadbalancer_1" {
-  name               = "loadbalancer_1"
-  vip_subnet_id      = "%s"
-  security_group_ids = [
-    opentelekomcloud_networking_secgroup_v2.secgroup_2.id
-  ]
-  depends_on = [
-    opentelekomcloud_networking_secgroup_v2.secgroup_1
-  ]
 }
 `, env.OS_SUBNET_ID)


### PR DESCRIPTION
## Summary of the Pull Request

Get rid of previously deprecated `security_group_ids` in `lb_loadbalancer_v2`

Update `lb_loadbalancer_v2` documentation

Remove related acceptance tests

Fix #1061

## PR Checklist

* [x] Refers to: #1061
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

### Resource
```
=== RUN   TestAccLBV2LoadBalancer_basic
--- PASS: TestAccLBV2LoadBalancer_basic (53.89s)
PASS

Process finished with the exit code 0
```
