### PR TITLE
Remove `css.large.8` flavor from CSS

### DIFF
--- a/docs/resources/css_cluster_v1.md
+++ b/docs/resources/css_cluster_v1.md
@@ -73,7 +73,6 @@ The `node_config` block supports:
 
 * `flavor` - (Required) Instance flavor name.
   - Value range of flavor `css.medium.8`: 40 GB to 640 GB
-  - Value range of flavor `css.large.8`: 40 GB to 1280 GB
   - Value range of flavor `css.xlarge.8`: 40 GB to 2560 GB
   - Value range of flavor `css.2xlarge.8`: 80 GB to 5120 GB
   - Value range of flavor `css.4xlarge.8`: 160 GB to 10240 GB

--- a/opentelekomcloud/acceptance/css/resource_opentelekomcloud_css_cluster_v1_test.go
+++ b/opentelekomcloud/acceptance/css/resource_opentelekomcloud_css_cluster_v1_test.go
@@ -63,7 +63,7 @@ func TestAccCssClusterV1_validateDiskandFlavor(t *testing.T) {
 			},
 			{
 				Config:      testAccCssClusterV1FlavorName(name),
-				ExpectError: regexp.MustCompile(`can't find flavor matching.+`),
+				ExpectError: regexp.MustCompile(`can't find flavor with name: .+`),
 				PlanOnly:    true,
 			},
 			{
@@ -176,7 +176,7 @@ resource "opentelekomcloud_css_cluster_v1" "cluster" {
   expect_node_num = 1
   name            = "%[1]s"
   node_config {
-    flavor = "bla-bla-bla"
+    flavor = "css.large.8"
     network_info {
       security_group_id = data.opentelekomcloud_networking_secgroup_v2.secgroup.id
       network_id        = "%s"


### PR DESCRIPTION
## Summary of the Pull Request
Remove `css.large.8` flavor from the documentation

Add check that `css.large.8` is not allowed by the service

Resolve #980

## PR Checklist

* [x] Refers to: #980
* [x] Tests added/passed.

## Acceptance Steps Performed

```
=== RUN   TestAccCssClusterV1_validateDiskandFlavor
--- PASS: TestAccCssClusterV1_validateDiskandFlavor (20.12s)
PASS

Process finished with the exit code 0
```
