### PR TITLE
Add possibility to import WAF certificate by name

### DIFF
--- a/docs/resources/waf_certificate_v1.md
+++ b/docs/resources/waf_certificate_v1.md
@@ -59,6 +59,12 @@ The following attributes are exported:
 
 Certificates can be imported using the `id`, e.g.
 
-```sh
+```shell
 terraform import opentelekomcloud_waf_certificate_v1.cert_1 7117d38e-4c8f-4624-a505-bd96b97d024c
+```
+
+Or using `name`, e.g.
+
+```shell
+terraform import opentelekomcloud_waf_certificate_v1.cert_1 cert_1
 ```

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/jinzhu/copier v0.2.3
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.4.2-0.20210610105657-237b4413e40c
+	github.com/opentelekomcloud/gophertelekomcloud v0.4.2-0.20210611075415-18454cd1ce33
 	github.com/unknwon/com v1.0.1
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -284,8 +284,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.4.2-0.20210610105657-237b4413e40c h1:YJkWZYQXdw3tsD0QfOZVC0oxwipHtLdL8TuZCww1oSY=
-github.com/opentelekomcloud/gophertelekomcloud v0.4.2-0.20210610105657-237b4413e40c/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
+github.com/opentelekomcloud/gophertelekomcloud v0.4.2-0.20210611075415-18454cd1ce33 h1:QE0X92ykmF1uwo7VlnzV8LlQVnF6Ui57+KRWM5M/3Sw=
+github.com/opentelekomcloud/gophertelekomcloud v0.4.2-0.20210611075415-18454cd1ce33/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/opentelekomcloud/acceptance/waf/import_opentelekomcloud_waf_certificate_v1_test.go
+++ b/opentelekomcloud/acceptance/waf/import_opentelekomcloud_waf_certificate_v1_test.go
@@ -22,6 +22,13 @@ func TestAccWafCertificateV1_import(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"content", "key"},
 			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateId:           "cert_1",
+				ImportStateVerifyIgnore: []string{"content", "key"},
+			},
 		},
 	})
 }


### PR DESCRIPTION
## Summary of the Pull Request
Use `importCertificateByIdOrName` for import function

Update gophertelekomcloud SDK to current `devel`

Resolve #1096 

## PR Checklist

* [x] Refers to: #1096
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
=== RUN   TestAccWafCertificateV1_import
--- PASS: TestAccWafCertificateV1_import (14.35s)
PASS

Process finished with the exit code 0
```
