### PR TITLE
[SWR] Add `opentelekomcloud_swr_domain_v2` resource

### DIFF
--- a/docs/resources/swr_domain_v2.md
+++ b/docs/resources/swr_domain_v2.md
@@ -1,0 +1,67 @@
+---
+subcategory: "Software Repository for Container (SWR)"
+---
+
+# opentelekomcloud_swr_domain_v2
+
+Manages SWRv2 image sharing domain.
+
+## Example Usage
+
+```hcl
+variable "access_domain" { }
+
+resource opentelekomcloud_swr_organization_v2 org_1 {
+  name = "organization_1"
+}
+
+resource opentelekomcloud_swr_repository_v2 repo_1 {
+  organization = opentelekomcloud_swr_organization_v2.org_1.name
+  name         = "repository_1"
+  description  = "Test repository"
+  category     = "linux"
+  is_public    = false
+}
+
+resource opentelekomcloud_swr_domain_v2 domain_1 {
+  organization  = opentelekomcloud_swr_organization_v2.org_1.name
+  repository    = opentelekomcloud_swr_organization_v2.repo_1.name
+  access_domain = var.access_domain
+  permission    = "read"
+  deadline      = "forever"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `organization` - (Required) The name of the repository organization.
+
+* `repository` - (Required) The name of the repository.
+
+* `access_domain` - (Required) The name of the domain for image sharing.
+
+* `permission` - (Required) Permission to be granted. Currently, only the `read` permission is supported.
+
+* `deadline` - (Required) End date of image sharing (UTC). When the value is set to `forever`,
+  the image will be permanently available for the domain. The validity period is calculated by day.
+  The shared images expire at `00:00:00` on the day after the end date.
+
+* `description` - (Optional) Specifies SWR domain description.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `name` - See Argument Reference above.
+
+* `creater_id` - Username ID of the domain creator.
+
+* `creator_name` - Username of the domain creator.
+
+* `created` - Indicates the creation time.
+
+* `updated` - Indicates the domain when was last updated.
+
+* `status` - Indicates the domain is valid or expired.

--- a/docs/resources/swr_domain_v2.md
+++ b/docs/resources/swr_domain_v2.md
@@ -64,4 +64,4 @@ In addition to all arguments above, the following attributes are exported:
 
 * `updated` - Indicates the domain when was last updated.
 
-* `status` - Indicates the domain is valid or expired.
+* `status` - Indicates the domain is valid (`true`) or expired (`false`).

--- a/docs/resources/swr_domain_v2.md
+++ b/docs/resources/swr_domain_v2.md
@@ -42,6 +42,8 @@ The following arguments are supported:
 
 * `access_domain` - (Required) The name of the domain for image sharing.
 
+-> `access_domain` should be an existing OTC domain.
+
 * `permission` - (Required) Permission to be granted. Currently, only the `read` permission is supported.
 
 * `deadline` - (Required) End date of image sharing (UTC). When the value is set to `forever`,
@@ -52,11 +54,9 @@ The following arguments are supported:
 
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to all arguments above, the following attributes are exported:
 
-* `name` - See Argument Reference above.
-
-* `creater_id` - Username ID of the domain creator.
+* `creator_id` - Username ID of the domain creator.
 
 * `creator_name` - Username of the domain creator.
 

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/jinzhu/copier v0.2.3
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.4.2-0.20210616121349-01a3ddf617a5
+	github.com/opentelekomcloud/gophertelekomcloud v0.4.2-0.20210616155545-6a7dbf4df6c7
 	github.com/unknwon/com v1.0.1
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -284,10 +284,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.4.2-0.20210611075415-18454cd1ce33 h1:QE0X92ykmF1uwo7VlnzV8LlQVnF6Ui57+KRWM5M/3Sw=
-github.com/opentelekomcloud/gophertelekomcloud v0.4.2-0.20210611075415-18454cd1ce33/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
-github.com/opentelekomcloud/gophertelekomcloud v0.4.2-0.20210616121349-01a3ddf617a5 h1:84Y4EUrqJ9ZC6/f1bjAhZn0MrsHTP9j2uPhMYZcYDWQ=
-github.com/opentelekomcloud/gophertelekomcloud v0.4.2-0.20210616121349-01a3ddf617a5/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
+github.com/opentelekomcloud/gophertelekomcloud v0.4.2-0.20210616155545-6a7dbf4df6c7 h1:oZoXK2xiw/uiEzUdpVOGa9bX2Zx8CFcv6+ypV6bNg0g=
+github.com/opentelekomcloud/gophertelekomcloud v0.4.2-0.20210616155545-6a7dbf4df6c7/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/opentelekomcloud/acceptance/swr/resource_opentelekomcloud_swr_domain_v2_test.go
+++ b/opentelekomcloud/acceptance/swr/resource_opentelekomcloud_swr_domain_v2_test.go
@@ -1,0 +1,86 @@
+package swr
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/swr/v2/domains"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/services/swr"
+)
+
+func TestSwrDomainV2Basic(t *testing.T) {
+	domainToShare := os.Getenv("OS_DOMAIN_NAME_2")
+	if domainToShare == "" {
+		t.Skip("OS_DOMAIN_NAME_2 is empty")
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testSwrDomainV2Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testSwrDomainV2Basic(name, domainToShare),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceDomainName, "permission", "read"),
+					resource.TestCheckResourceAttr(resourceDomainName, "access_domain", domainToShare),
+				),
+			},
+		},
+	})
+}
+
+func testSwrDomainV2Destroy(s *terraform.State) error {
+	config := common.TestAccProvider.Meta().(*cfg.Config)
+	client, err := config.SwrV2Client(env.OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf(swr.SwrClientError, err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "opentelekomcloud_swr_domain_v2" {
+			continue
+		}
+
+		_, err := domains.Get(client, rs.Primary.Attributes["organization"], rs.Primary.Attributes["repository"], rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("SWR domain still exists")
+		}
+	}
+
+	return nil
+}
+
+const (
+	resourceDomainName = "opentelekomcloud_swr_domain_v2.domain_1"
+)
+
+func testSwrDomainV2Basic(name, domainToShare string) string {
+	return fmt.Sprintf(`
+resource opentelekomcloud_swr_organization_v2 org_1 {
+  name = "%[1]s"
+}
+
+resource opentelekomcloud_swr_repository_v2 repo_1 {
+  organization = opentelekomcloud_swr_organization_v2.org_1.name
+  name         = "%[1]s"
+  description  = "Test repository"
+  category     = "linux"
+  is_public    = false
+}
+
+resource opentelekomcloud_swr_domain_v2 domain_1 {
+  organization  = opentelekomcloud_swr_organization_v2.org_1.name
+  repository    = opentelekomcloud_swr_repository_v2.name
+  access_domain = "%[2]s"
+  permission    = "read"
+  deadline      = "forever"
+}
+`, name, domainToShare)
+}

--- a/opentelekomcloud/acceptance/swr/resource_opentelekomcloud_swr_domain_v2_test.go
+++ b/opentelekomcloud/acceptance/swr/resource_opentelekomcloud_swr_domain_v2_test.go
@@ -77,7 +77,7 @@ resource opentelekomcloud_swr_repository_v2 repo_1 {
 
 resource opentelekomcloud_swr_domain_v2 domain_1 {
   organization  = opentelekomcloud_swr_organization_v2.org_1.name
-  repository    = opentelekomcloud_swr_repository_v2.name
+  repository    = opentelekomcloud_swr_repository_v2.repo_1.name
   access_domain = "%[2]s"
   permission    = "read"
   deadline      = "forever"

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -391,6 +391,7 @@ func Provider() *schema.Provider {
 			"opentelekomcloud_sfs_turbo_share_v1":                 sfs.ResourceSFSTurboShareV1(),
 			"opentelekomcloud_smn_topic_v2":                       smn.ResourceTopic(),
 			"opentelekomcloud_smn_subscription_v2":                smn.ResourceSubscription(),
+			"opentelekomcloud_swr_domain_v2":                      swr.ResourceSwrDomainV2(),
 			"opentelekomcloud_swr_organization_v2":                swr.ResourceSwrOrganizationV2(),
 			"opentelekomcloud_swr_repository_v2":                  swr.ResourceSwrRepositoryV2(),
 			"opentelekomcloud_vpc_eip_v1":                         vpc.ResourceVpcEIPV1(),

--- a/opentelekomcloud/services/swr/resource_opentelekomcloud_swr_domain_v2.go
+++ b/opentelekomcloud/services/swr/resource_opentelekomcloud_swr_domain_v2.go
@@ -1,0 +1,169 @@
+package swr
+
+import (
+	"context"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/swr/v2/domains"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
+)
+
+func ResourceSwrDomainV2() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceSwrDomainCreate,
+		ReadContext:   resourceSwrDomainRead,
+		UpdateContext: resourceSwrDomainUpdate,
+		DeleteContext: resourceSwrDomainDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Default: schema.DefaultTimeout(2 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"namespace": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"repository": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"access_domain": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"permission": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"deadline": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"creator_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"creator_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func repository(d *schema.ResourceData) string {
+	return d.Get("repository").(string)
+}
+
+func resourceSwrDomainCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := config.SwrV2Client(config.GetRegion(d))
+	if err != nil {
+		return fmterr.Errorf(SwrClientError, err)
+	}
+
+	opts := domains.CreateOpts{
+		AccessDomain: d.Get("access_domain").(string),
+		Permit:       d.Get("permission").(string),
+		Deadline:     d.Get("deadline").(string),
+		Description:  d.Get("description").(string),
+	}
+
+	err = domains.Create(client, organization(d), repository(d), opts).ExtractErr()
+	if err != nil {
+		return fmterr.Errorf("error creating domain: %w", err)
+	}
+	d.SetId(opts.AccessDomain)
+
+	return resourceRepositoryRead(ctx, d, meta)
+}
+
+func resourceSwrDomainRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := config.SwrV2Client(config.GetRegion(d))
+	if err != nil {
+		return fmterr.Errorf(SwrClientError, err)
+	}
+
+	domain, err := domains.Get(client, organization(d), repository(d), d.Id()).Extract()
+	if err != nil {
+		return fmterr.Errorf("error reading repository: %w", err)
+	}
+
+	mErr := multierror.Append(
+		d.Set("access_domain", domain.AccessDomain),
+		d.Set("repository", domain.Repository),
+		d.Set("organization", domain.Organization),
+		d.Set("description", domain.Description),
+		d.Set("status", domain.Status),
+		d.Set("permission", domain.Permit),
+		d.Set("created", domain.Created),
+		d.Set("updated", domain.Updated),
+		d.Set("creator_id", domain.CreatorID),
+		d.Set("creator_name", domain.CreatorName),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return fmterr.Errorf("error setting resource fields: %w", err)
+	}
+
+	return nil
+}
+
+func resourceSwrDomainUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := config.SwrV2Client(config.GetRegion(d))
+	if err != nil {
+		return fmterr.Errorf(SwrClientError, err)
+	}
+
+	opts := domains.UpdateOpts{
+		Permit:      d.Get("permission").(string),
+		Deadline:    d.Get("deadline").(string),
+		Description: d.Get("description").(string),
+	}
+	err = domains.Update(client, organization(d), repository(d), d.Id(), opts).ExtractErr()
+	if err != nil {
+		return fmterr.Errorf("error updating domain: %w", err)
+	}
+
+	return resourceRepositoryRead(ctx, d, meta)
+}
+
+func resourceSwrDomainDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := config.SwrV2Client(config.GetRegion(d))
+	if err != nil {
+		return fmterr.Errorf(SwrClientError, err)
+	}
+
+	err = domains.Delete(client, organization(d), repository(d), d.Id()).ExtractErr()
+	if err != nil {
+		fmterr.Errorf("error deleting domain: %w", err)
+	}
+
+	return nil
+}

--- a/opentelekomcloud/services/swr/resource_opentelekomcloud_swr_domain_v2.go
+++ b/opentelekomcloud/services/swr/resource_opentelekomcloud_swr_domain_v2.go
@@ -2,6 +2,7 @@ package swr
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -115,7 +116,7 @@ func resourceSwrDomainRead(_ context.Context, d *schema.ResourceData, meta inter
 	}
 
 	mErr := multierror.Append(
-		d.Set("access_domain", domain.AccessDomain),
+		d.Set("access_domain", strings.ToUpper(domain.AccessDomain)),
 		d.Set("repository", domain.Repository),
 		d.Set("organization", domain.Organization),
 		d.Set("description", domain.Description),

--- a/opentelekomcloud/services/swr/resource_opentelekomcloud_swr_domain_v2.go
+++ b/opentelekomcloud/services/swr/resource_opentelekomcloud_swr_domain_v2.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/swr/v2/domains"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
@@ -43,6 +44,9 @@ func ResourceSwrDomainV2() *schema.Resource {
 			"permission": {
 				Type:     schema.TypeString,
 				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"read",
+				}, false),
 			},
 			"deadline": {
 				Type:     schema.TypeString,

--- a/opentelekomcloud/services/swr/resource_opentelekomcloud_swr_domain_v2.go
+++ b/opentelekomcloud/services/swr/resource_opentelekomcloud_swr_domain_v2.go
@@ -25,7 +25,7 @@ func ResourceSwrDomainV2() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"namespace": {
+			"organization": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
@@ -39,6 +39,9 @@ func ResourceSwrDomainV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				StateFunc: func(v interface{}) string {
+					return strings.ToUpper(v.(string))
+				},
 			},
 			"permission": {
 				Type:     schema.TypeString,
@@ -116,7 +119,7 @@ func resourceSwrDomainRead(_ context.Context, d *schema.ResourceData, meta inter
 	}
 
 	mErr := multierror.Append(
-		d.Set("access_domain", strings.ToUpper(domain.AccessDomain)),
+		d.Set("access_domain", domain.AccessDomain),
 		d.Set("repository", domain.Repository),
 		d.Set("organization", domain.Organization),
 		d.Set("description", domain.Description),


### PR DESCRIPTION
## Summary of the Pull Request
Implement `opentelekomcloud_swr_domain_v2` resource
Part of: #623

## PR Checklist

* [x] Refers to: #623
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
=== RUN   TestSwrDomainV2Basic
--- PASS: TestSwrDomainV2Basic (50.09s)
PASS

Process finished with the exit code 0
```
