### PR TITLE
[ECS] Fix issue with `user_data`

### DIFF
--- a/opentelekomcloud/acceptance/as/resource_opentelekomcloud_as_configuration_v1_test.go
+++ b/opentelekomcloud/acceptance/as/resource_opentelekomcloud_as_configuration_v1_test.go
@@ -158,6 +158,7 @@ resource "opentelekomcloud_as_configuration_v1" "hth_as_config"{
       disk_type   = "DATA"
     }
     key_name = "%s"
+    user_data = "#! /bin/bash"
   }
 }
 `, env.OS_IMAGE_ID, env.OS_KEYPAIR_NAME)

--- a/opentelekomcloud/services/as/resource_opentelekomcloud_as_configuration_v1.go
+++ b/opentelekomcloud/services/as/resource_opentelekomcloud_as_configuration_v1.go
@@ -2,8 +2,6 @@ package as
 
 import (
 	"context"
-	"crypto/sha1"
-	"encoding/hex"
 	"fmt"
 	"log"
 
@@ -74,8 +72,7 @@ func ResourceASConfiguration() *schema.Resource {
 							StateFunc: func(v interface{}) string {
 								switch v.(type) {
 								case string:
-									hash := sha1.Sum([]byte(v.(string)))
-									return hex.EncodeToString(hash[:])
+									return common.InstallScriptHashSum(v.(string))
 								default:
 									return ""
 								}
@@ -346,7 +343,7 @@ func resourceASConfigurationRead(_ context.Context, d *schema.ResourceData, meta
 	instanceConfigInfo["flavor"] = asConfig.InstanceConfig.FlavorRef
 	instanceConfigInfo["image"] = asConfig.InstanceConfig.ImageRef
 	instanceConfigInfo["key_name"] = asConfig.InstanceConfig.SSHKey
-	instanceConfigInfo["user_data"] = asConfig.InstanceConfig.UserData
+	instanceConfigInfo["user_data"] = common.InstallScriptHashSum(asConfig.InstanceConfig.UserData)
 
 	var secGrpIDs []string
 	for _, sg := range asConfig.InstanceConfig.SecurityGroups {

--- a/opentelekomcloud/services/bms/resource_opentelekomcloud_compute_bms_server_v2.go
+++ b/opentelekomcloud/services/bms/resource_opentelekomcloud_compute_bms_server_v2.go
@@ -2,8 +2,6 @@ package bms
 
 import (
 	"context"
-	"crypto/sha1"
-	"encoding/hex"
 	"fmt"
 	"log"
 	"time"
@@ -92,8 +90,7 @@ func ResourceComputeBMSInstanceV2() *schema.Resource {
 				StateFunc: func(v interface{}) string {
 					switch v.(type) {
 					case string:
-						hash := sha1.Sum([]byte(v.(string)))
-						return hex.EncodeToString(hash[:])
+						return common.InstallScriptHashSum(v.(string))
 					default:
 						return ""
 					}

--- a/opentelekomcloud/services/ecs/resource_opentelekomcloud_compute_instance_v2.go
+++ b/opentelekomcloud/services/ecs/resource_opentelekomcloud_compute_instance_v2.go
@@ -3,8 +3,6 @@ package ecs
 import (
 	"bytes"
 	"context"
-	"crypto/sha1"
-	"encoding/hex"
 	"fmt"
 	"log"
 	"strings"
@@ -98,8 +96,7 @@ func ResourceComputeInstanceV2() *schema.Resource {
 				StateFunc: func(v interface{}) string {
 					switch v.(type) {
 					case string:
-						hash := sha1.Sum([]byte(v.(string)))
-						return hex.EncodeToString(hash[:])
+						return common.InstallScriptHashSum(v.(string))
 					default:
 						return ""
 					}

--- a/opentelekomcloud/services/ecs/resource_opentelekomcloud_ecs_instance_v1.go
+++ b/opentelekomcloud/services/ecs/resource_opentelekomcloud_ecs_instance_v1.go
@@ -2,8 +2,6 @@ package ecs
 
 import (
 	"context"
-	"crypto/sha1"
-	"encoding/hex"
 	"log"
 	"time"
 
@@ -69,8 +67,7 @@ func ResourceEcsInstanceV1() *schema.Resource {
 				StateFunc: func(v interface{}) string {
 					switch v.(type) {
 					case string:
-						hash := sha1.Sum([]byte(v.(string)))
-						return hex.EncodeToString(hash[:])
+						return common.InstallScriptHashSum(v.(string))
 					default:
 						return ""
 					}


### PR DESCRIPTION
## Summary of the Pull Request
Fix issue with `user_data` in `as_configuration_v1`, `compute_instance_v2`, `ecs_instance_v1`, `bms_server_v2`
Closes: #1124

## PR Checklist

* [x] Refers to: #1124
* [x] Tests added/passed.

## Acceptance Steps Performed

```
=== RUN   TestAccASV1Configuration_basic
--- PASS: TestAccASV1Configuration_basic (43.97s)
PASS

Process finished with the exit code 0
```
