### PR TITLE
Fix config pollution with temporary AK/SK

### DIFF
--- a/opentelekomcloud/common/cfg/config.go
+++ b/opentelekomcloud/common/cfg/config.go
@@ -591,30 +591,28 @@ func setUpOBSLogging() {
 	}
 }
 
-// setupTemporaryCredentials creates temporary AK/SK, which can be used to auth in OBS when AK/SK is not provided
-func (c *Config) setupTemporaryCredentials() error {
+// issueTemporaryCredentials creates temporary AK/SK, which can be used to auth in OBS when AK/SK is not provided
+func (c *Config) issueTemporaryCredentials() (*credentials.TemporaryCredential, error) {
 	if c.SecurityToken != "" || (c.AccessKey != "" && c.SecretKey != "") {
-		return nil
+		return nil, nil
 	}
 	client, err := c.IdentityV3Client()
 	if err != nil {
-		return fmt.Errorf("error creating identity v3 domain client: %s", err)
+		return nil, fmt.Errorf("error creating identity v3 domain client: %s", err)
 	}
 	credential, err := credentials.CreateTemporary(client, credentials.CreateTemporaryOpts{
 		Methods: []string{"token"},
 		Token:   client.Token(),
 	}).Extract()
 	if err != nil {
-		return fmt.Errorf("error creating temporary AK/SK: %s", err)
+		return nil, fmt.Errorf("error creating temporary AK/SK: %s", err)
 	}
-	c.AccessKey = credential.AccessKey
-	c.SecretKey = credential.SecretKey
-	c.SecurityToken = credential.SecurityToken
-	return nil
+	return credential, nil
 }
 
 func (c *Config) NewObjectStorageClient(region string) (*obs.ObsClient, error) {
-	if err := c.setupTemporaryCredentials(); err != nil {
+	cred, err := c.issueTemporaryCredentials()
+	if err != nil {
 		return nil, fmt.Errorf("failed to construct OBS client without AK/SK: %s", err)
 	}
 
@@ -628,7 +626,7 @@ func (c *Config) NewObjectStorageClient(region string) (*obs.ObsClient, error) {
 
 	setUpOBSLogging()
 
-	return obs.New(c.AccessKey, c.SecretKey, client.Endpoint, obs.WithSecurityToken(c.SecurityToken))
+	return obs.New(cred.AccessKey, cred.SecretKey, client.Endpoint, obs.WithSecurityToken(cred.SecurityToken))
 }
 
 func (c *Config) blockStorageV1Client(region string) (*golangsdk.ServiceClient, error) {

--- a/opentelekomcloud/common/cfg/config.go
+++ b/opentelekomcloud/common/cfg/config.go
@@ -593,8 +593,12 @@ func setUpOBSLogging() {
 
 // issueTemporaryCredentials creates temporary AK/SK, which can be used to auth in OBS when AK/SK is not provided
 func (c *Config) issueTemporaryCredentials() (*credentials.TemporaryCredential, error) {
-	if c.SecurityToken != "" || (c.AccessKey != "" && c.SecretKey != "") {
-		return nil, nil
+	if c.AccessKey != "" && c.SecretKey != "" {
+		return &credentials.TemporaryCredential{
+			AccessKey:     c.AccessKey,
+			SecretKey:     c.SecretKey,
+			SecurityToken: c.SecurityToken,
+		}, nil
 	}
 	client, err := c.IdentityV3Client()
 	if err != nil {


### PR DESCRIPTION
## Summary of the Pull Request
Stop saving temporary AK/SK to the configuration

Using OBS potentially breaks other resources
(and temporary AK/SK is applicable to OBS only)

## PR Checklist

* [x] Refers to: #1122
* [x] Tests added/passed.

## Acceptance Steps Performed

### Username/password
```
=== RUN   TestAccObsBucket_basic
--- PASS: TestAccObsBucket_basic (39.19s)
PASS

Process finished with the exit code 0
```

### AK/SK
```
2021/06/18 16:24:34 [INFO] Building Swift S3 auth structure
2021/06/18 16:24:34 [INFO] Setting AWS metadata API timeout to 100ms
2021/06/18 16:24:36 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2021/06/18 16:24:36 [INFO] Swift S3 Auth provider used: "StaticProvider"
=== RUN   TestAccObsBucket_basic
--- PASS: TestAccObsBucket_basic (90.04s)
PASS

Process finished with the exit code 0

```
