### PR TITLE
[ECS] Add possibility to encrypt `data_volumes`

### DIFF
--- a/docs/resources/ecs_instance_v1.md
+++ b/docs/resources/ecs_instance_v1.md
@@ -238,13 +238,14 @@ The `data_disks` block supports:
 * `size` - (Required) The size of the data disk in GB. The value range is 10 to 32768.
   Changing this creates a new server.
 
+* `kms_id` - (Optional) The Encryption KMS ID of the data disk.
+
 * `snapshot_id` - (Optional) Specifies the snapshot ID or ID of the original data disk contained in the full-ECS image.
   Changing this creates a new server.
 
-
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the server.
 * `nics/mac_address` - The MAC address of the NIC on that network.

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/jinzhu/copier v0.2.3
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.4.2-0.20210617094609-0b0ef06baa36
+	github.com/opentelekomcloud/gophertelekomcloud v0.4.2-0.20210618152005-46781edf65ae
 	github.com/unknwon/com v1.0.1
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -284,8 +284,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.4.2-0.20210617094609-0b0ef06baa36 h1:g9pzLlO6e5/ahobOlHYSesQMa7Ok5hcBH091TIeVr4s=
-github.com/opentelekomcloud/gophertelekomcloud v0.4.2-0.20210617094609-0b0ef06baa36/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
+github.com/opentelekomcloud/gophertelekomcloud v0.4.2-0.20210618152005-46781edf65ae h1:RSozA5I98/YXi8fhkL13EP9zuVvGJYM5yugtXryKJxU=
+github.com/opentelekomcloud/gophertelekomcloud v0.4.2-0.20210618152005-46781edf65ae/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/opentelekomcloud/acceptance/ecs/import_opentelekomcloud_ecs_instance_v1_test.go
+++ b/opentelekomcloud/acceptance/ecs/import_opentelekomcloud_ecs_instance_v1_test.go
@@ -17,7 +17,7 @@ func TestAccEcsV1Instance_importBasic(t *testing.T) {
 		CheckDestroy:      testAccCheckEcsV1InstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEcsV1Instance_basic,
+				Config: testAccEcsV1InstanceBasic,
 			},
 
 			{

--- a/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_ecs_instance_v1_test.go
+++ b/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_ecs_instance_v1_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 )
 
-func TestAccEcsV1Instance_basic(t *testing.T) {
+func TestAccEcsV1InstanceBasic(t *testing.T) {
 	var instance cloudservers.CloudServer
 	resourceName := "opentelekomcloud_ecs_instance_v1.instance_1"
 
@@ -25,7 +25,7 @@ func TestAccEcsV1Instance_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckEcsV1InstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEcsV1Instance_basic,
+				Config: testAccEcsV1InstanceBasic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEcsV1InstanceExists(resourceName, &instance),
 					resource.TestCheckResourceAttr(resourceName, "availability_zone", env.OS_AVAILABILITY_ZONE),
@@ -35,7 +35,7 @@ func TestAccEcsV1Instance_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccEcsV1Instance_update,
+				Config: testAccEcsV1InstanceUpdate,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEcsV1InstanceExists(resourceName, &instance),
 					resource.TestCheckResourceAttr(resourceName, "availability_zone", env.OS_AVAILABILITY_ZONE),
@@ -48,23 +48,23 @@ func TestAccEcsV1Instance_basic(t *testing.T) {
 	})
 }
 
-func TestAccEcsV1Instance_diskTypeValidation(t *testing.T) {
+func TestAccEcsV1InstanceDiskTypeValidation(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccEcsV1Instance_invalidTypeForAZ,
+				Config:      testAccEcsV1InstanceInvalidTypeForAZ,
 				PlanOnly:    true,
 				ExpectError: regexp.MustCompile(`volume type .+ is not supported in`),
 			},
 			{
-				Config:      testAccEcsV1Instance_invalidType,
+				Config:      testAccEcsV1InstanceInvalidType,
 				PlanOnly:    true,
 				ExpectError: regexp.MustCompile(`volume type .+ doesn't exist`),
 			},
 			{
-				Config:      testAccEcsV1Instance_invalidDataDisk,
+				Config:      testAccEcsV1InstanceInvalidDataDisk,
 				PlanOnly:    true,
 				ExpectError: regexp.MustCompile(`volume type .+ doesn't exist`),
 			},
@@ -72,18 +72,37 @@ func TestAccEcsV1Instance_diskTypeValidation(t *testing.T) {
 	})
 }
 
-func TestAccEcsV1Instance_VPCValidation(t *testing.T) {
+func TestAccEcsV1InstanceVPCValidation(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccEcsV1Instance_invalidVPC,
+				Config:      testAccEcsV1InstanceInvalidVPC,
 				PlanOnly:    true,
 				ExpectError: regexp.MustCompile(`can't find VPC`),
 			},
 			{
-				Config: testAccEcsV1Instance_computedVPC,
+				Config: testAccEcsV1InstanceComputedVPC,
+			},
+		},
+	})
+}
+
+func TestAccEcsV1InstanceEncryption(t *testing.T) {
+	var instance cloudservers.CloudServer
+	resourceName := "opentelekomcloud_ecs_instance_v1.instance_1"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckEcsV1InstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEcsV1InstanceDataVolumeEncryption,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEcsV1InstanceExists(resourceName, &instance),
+				),
 			},
 		},
 	})
@@ -143,7 +162,7 @@ func testAccCheckEcsV1InstanceExists(n string, instance *cloudservers.CloudServe
 	}
 }
 
-var testAccEcsV1Instance_basic = fmt.Sprintf(`
+var testAccEcsV1InstanceBasic = fmt.Sprintf(`
 resource "opentelekomcloud_ecs_instance_v1" "instance_1" {
   name     = "server_1"
   image_id = "%s"
@@ -165,7 +184,7 @@ resource "opentelekomcloud_ecs_instance_v1" "instance_1" {
 }
 `, env.OS_IMAGE_ID, env.OS_VPC_ID, env.OS_NETWORK_ID, env.OS_AVAILABILITY_ZONE)
 
-var testAccEcsV1Instance_update = fmt.Sprintf(`
+var testAccEcsV1InstanceUpdate = fmt.Sprintf(`
 resource "opentelekomcloud_compute_secgroup_v2" "secgroup_1" {
   name        = "secgroup_ecs"
   description = "a security group"
@@ -193,7 +212,7 @@ resource "opentelekomcloud_ecs_instance_v1" "instance_1" {
 }
 `, env.OS_IMAGE_ID, env.OS_VPC_ID, env.OS_NETWORK_ID, env.OS_AVAILABILITY_ZONE)
 
-var testAccEcsV1Instance_invalidTypeForAZ = fmt.Sprintf(`
+var testAccEcsV1InstanceInvalidTypeForAZ = fmt.Sprintf(`
 resource "opentelekomcloud_ecs_instance_v1" "instance_1" {
   name     = "server_1"
   image_id = "%s"
@@ -217,7 +236,7 @@ resource "opentelekomcloud_ecs_instance_v1" "instance_1" {
 }
 `, env.OS_IMAGE_ID, env.OS_VPC_ID, env.OS_NETWORK_ID)
 
-var testAccEcsV1Instance_invalidType = fmt.Sprintf(`
+var testAccEcsV1InstanceInvalidType = fmt.Sprintf(`
 resource "opentelekomcloud_ecs_instance_v1" "instance_1" {
   name     = "server_1"
   image_id = "%s"
@@ -241,7 +260,7 @@ resource "opentelekomcloud_ecs_instance_v1" "instance_1" {
 }
 `, env.OS_IMAGE_ID, env.OS_VPC_ID, env.OS_NETWORK_ID)
 
-var testAccEcsV1Instance_invalidDataDisk = fmt.Sprintf(`
+var testAccEcsV1InstanceInvalidDataDisk = fmt.Sprintf(`
 resource "opentelekomcloud_ecs_instance_v1" "instance_1" {
   name     = "server_1"
   image_id = "%s"
@@ -268,7 +287,7 @@ resource "opentelekomcloud_ecs_instance_v1" "instance_1" {
 }
 `, env.OS_IMAGE_ID, env.OS_VPC_ID, env.OS_NETWORK_ID)
 
-var testAccEcsV1Instance_invalidVPC = fmt.Sprintf(`
+var testAccEcsV1InstanceInvalidVPC = fmt.Sprintf(`
 resource "opentelekomcloud_ecs_instance_v1" "instance_1" {
   name     = "server_1"
   image_id = "%s"
@@ -292,7 +311,7 @@ resource "opentelekomcloud_ecs_instance_v1" "instance_1" {
 }
 `, env.OS_IMAGE_ID, env.OS_NETWORK_ID)
 
-var testAccEcsV1Instance_computedVPC = fmt.Sprintf(`
+var testAccEcsV1InstanceComputedVPC = fmt.Sprintf(`
 resource "opentelekomcloud_vpc_v1" "vpc" {
   cidr = "192.168.0.0/16"
   name = "vpc-ecs-test"
@@ -327,3 +346,26 @@ resource "opentelekomcloud_ecs_instance_v1" "instance_1" {
   }
 }
 `, env.OS_IMAGE_ID)
+
+var testAccEcsV1InstanceDataVolumeEncryption = fmt.Sprintf(`
+resource "opentelekomcloud_ecs_instance_v1" "instance_1" {
+  name     = "server_1"
+  image_id = "%s"
+  flavor   = "s2.medium.1"
+  vpc_id   = "%s"
+
+  nics {
+    network_id = "%s"
+  }
+
+  password          = "Password@123"
+  availability_zone = "%s"
+  auto_recovery     = true
+
+  data_disks {
+    size   = 10
+    type   = "SAS"
+    kms_id = "%s"
+  }
+}
+`, env.OS_IMAGE_ID, env.OS_VPC_ID, env.OS_NETWORK_ID, env.OS_AVAILABILITY_ZONE, env.OS_KMS_ID)

--- a/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_ecs_instance_v1_test.go
+++ b/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_ecs_instance_v1_test.go
@@ -174,6 +174,11 @@ resource "opentelekomcloud_ecs_instance_v1" "instance_1" {
     network_id = "%s"
   }
 
+  data_disks {
+    size = 10
+    type = "SAS"
+  }
+
   password          = "Password@123"
   availability_zone = "%s"
   auto_recovery     = true
@@ -199,6 +204,11 @@ resource "opentelekomcloud_ecs_instance_v1" "instance_1" {
 
   nics {
     network_id = "%s"
+  }
+
+  data_disks {
+    size = 10
+    type = "SAS"
   }
 
   password                    = "Password@123"

--- a/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_ecs_instance_v1_test.go
+++ b/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_ecs_instance_v1_test.go
@@ -102,6 +102,7 @@ func TestAccEcsV1InstanceEncryption(t *testing.T) {
 				Config: testAccEcsV1InstanceDataVolumeEncryption,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEcsV1InstanceExists(resourceName, &instance),
+					resource.TestCheckResourceAttr(resourceName, "data_disks.0.kms_id", env.OS_KMS_ID),
 				),
 			},
 		},

--- a/opentelekomcloud/services/ecs/common.go
+++ b/opentelekomcloud/services/ecs/common.go
@@ -1,5 +1,5 @@
 package ecs
 
 const (
-	ecsClientError = "error creating OpenTelekomCloud ComputeV1 client: %w"
+	errCreateClient = "error creating OpenTelekomCloud ComputeV1 client: %w"
 )

--- a/opentelekomcloud/services/ecs/common.go
+++ b/opentelekomcloud/services/ecs/common.go
@@ -1,0 +1,5 @@
+package ecs
+
+const (
+	ecsClientError = "error creating OpenTelekomCloud ComputeV1 client: %w"
+)

--- a/opentelekomcloud/services/ecs/resource_opentelekomcloud_ecs_instance_v1.go
+++ b/opentelekomcloud/services/ecs/resource_opentelekomcloud_ecs_instance_v1.go
@@ -47,7 +47,6 @@ func ResourceEcsInstanceV1() *schema.Resource {
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: false,
 			},
 			"image_id": {
 				Type:     schema.TypeString,
@@ -57,7 +56,6 @@ func ResourceEcsInstanceV1() *schema.Resource {
 			"flavor": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: false,
 			},
 			"user_data": {
 				Type:     schema.TypeString,
@@ -160,7 +158,6 @@ func ResourceEcsInstanceV1() *schema.Resource {
 			"security_groups": {
 				Type:     schema.TypeSet,
 				Optional: true,
-				ForceNew: false,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,

--- a/opentelekomcloud/services/ecs/resource_opentelekomcloud_ecs_instance_v1.go
+++ b/opentelekomcloud/services/ecs/resource_opentelekomcloud_ecs_instance_v1.go
@@ -188,7 +188,7 @@ func resourceEcsInstanceV1Create(ctx context.Context, d *schema.ResourceData, me
 	config := meta.(*cfg.Config)
 	client, err := config.ComputeV1Client(config.GetRegion(d))
 	if err != nil {
-		return fmterr.Errorf(ecsClientError, err)
+		return fmterr.Errorf(errCreateClient, err)
 	}
 
 	createOpts := &cloudservers.CreateOpts{
@@ -250,7 +250,7 @@ func resourceEcsInstanceV1Read(ctx context.Context, d *schema.ResourceData, meta
 	config := meta.(*cfg.Config)
 	client, err := config.ComputeV1Client(config.GetRegion(d))
 	if err != nil {
-		return fmterr.Errorf(ecsClientError, err)
+		return fmterr.Errorf(errCreateClient, err)
 	}
 
 	server, err := cloudservers.Get(client, d.Id()).Extract()
@@ -291,11 +291,12 @@ func resourceEcsInstanceV1Read(ctx context.Context, d *schema.ResourceData, meta
 			)
 			continue
 		}
-		dataVolume := make(map[string]interface{})
-		dataVolume["type"] = disk.VolumeType
-		dataVolume["size"] = disk.Size
-		dataVolume["kms_id"] = disk.Metadata["__system__cmkid"]
-		dataVolume["snapshot_id"] = disk.SnapshotID
+		dataVolume := map[string]interface{}{
+			"type":        disk.VolumeType,
+			"size":        disk.Size,
+			"kms_id":      disk.Metadata["__system__cmkid"],
+			"snapshot_id": disk.SnapshotID,
+		}
 		volumeList = append(volumeList, dataVolume)
 	}
 	mErr = multierror.Append(mErr,
@@ -436,7 +437,7 @@ func resourceEcsInstanceV1Update(ctx context.Context, d *schema.ResourceData, me
 	if d.HasChange("tags") {
 		computeClient, err := config.ComputeV1Client(config.GetRegion(d))
 		if err != nil {
-			return fmterr.Errorf(ecsClientError, err)
+			return fmterr.Errorf(errCreateClient, err)
 		}
 		if err := common.UpdateResourceTags(computeClient, d, "cloudservers", d.Id()); err != nil {
 			return fmterr.Errorf("error updating tags of CloudServer %s: %w", d.Id(), err)
@@ -458,7 +459,7 @@ func resourceEcsInstanceV1Delete(_ context.Context, d *schema.ResourceData, meta
 	config := meta.(*cfg.Config)
 	client, err := config.ComputeV1Client(config.GetRegion(d))
 	if err != nil {
-		return fmterr.Errorf(ecsClientError, err)
+		return fmterr.Errorf(errCreateClient, err)
 	}
 
 	var serverRequests []cloudservers.Server

--- a/opentelekomcloud/services/vpc/resource_opentelekomcloud_vpc_v1.go
+++ b/opentelekomcloud/services/vpc/resource_opentelekomcloud_vpc_v1.go
@@ -154,6 +154,8 @@ func resourceVirtualPrivateCloudV1Create(ctx context.Context, d *schema.Resource
 		return diag.FromErr(err)
 	}
 
+	d.SetId(n.ID)
+
 	return resourceVirtualPrivateCloudV1Read(ctx, d, meta)
 
 }
@@ -175,7 +177,6 @@ func resourceVirtualPrivateCloudV1Read(_ context.Context, d *schema.ResourceData
 		return fmterr.Errorf("error retrieving OpenTelekomCloud Vpc: %s", err)
 	}
 
-	d.Set("id", n.ID)
 	d.Set("name", n.Name)
 	d.Set("cidr", n.CIDR)
 	d.Set("status", n.Status)


### PR DESCRIPTION
## Summary of the Pull Request
Add possibility to encrypt `data_volumes` with the KMS
Read `data_disks` of the `resource/opentelekomcloud_ecs_instance_v1`

Fixes: #1112

## PR Checklist

* [x] Refers to: #1112, #1136 
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
=== RUN   TestAccEcsV1InstanceBasic
--- PASS: TestAccEcsV1InstanceBasic (224.15s)
=== RUN   TestAccEcsV1InstanceDiskTypeValidation
--- PASS: TestAccEcsV1InstanceDiskTypeValidation (23.58s)
=== RUN   TestAccEcsV1InstanceVPCValidation
--- PASS: TestAccEcsV1InstanceVPCValidation (205.73s)
=== RUN   TestAccEcsV1InstanceEncryption
--- PASS: TestAccEcsV1InstanceEncryption (175.88s)
PASS

Process finished with the exit code 0
```
