### PR TITLE
[RDS] Read `availability_zone` from each node

### DIFF
--- a/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_instance_v3.go
+++ b/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_instance_v3.go
@@ -766,6 +766,7 @@ func resourceRdsInstanceV3Read(_ context.Context, d *schema.ResourceData, meta i
 	}
 
 	var nodesList []map[string]interface{}
+	var availabilityZones []string
 	for _, nodeObj := range rdsInstance.Nodes {
 		node := make(map[string]interface{})
 		node["id"] = nodeObj.Id
@@ -774,9 +775,13 @@ func resourceRdsInstanceV3Read(_ context.Context, d *schema.ResourceData, meta i
 		node["availability_zone"] = nodeObj.AvailabilityZone
 		node["status"] = nodeObj.Status
 		nodesList = append(nodesList, node)
+		availabilityZones = append(availabilityZones, nodeObj.AvailabilityZone)
 	}
 	if err := d.Set("nodes", nodesList); err != nil {
 		return fmterr.Errorf("error setting node list: %s", err)
+	}
+	if err := d.Set("availability_zone", availabilityZones); err != nil {
+		return diag.FromErr(err)
 	}
 
 	var backupStrategyList []map[string]interface{}


### PR DESCRIPTION
## Summary of the Pull Request
Read `availability_zone` which are coming from node object.
Fixes: #1026

## PR Checklist

* [x] Refers to: #1026
* [x] Tests added/passed.

## Acceptance Steps Performed

```
=== RUN   TestAccRdsInstanceV3Basic
--- PASS: TestAccRdsInstanceV3Basic (1232.82s)
=== RUN   TestAccRdsInstanceV3ElasticIP
--- PASS: TestAccRdsInstanceV3ElasticIP (763.69s)
=== RUN   TestAccRdsInstanceV3HA
--- PASS: TestAccRdsInstanceV3HA (585.49s)
=== RUN   TestAccRdsInstanceV3OptionalParams
--- PASS: TestAccRdsInstanceV3OptionalParams (772.31s)
=== RUN   TestAccRdsInstanceV3Backup
--- PASS: TestAccRdsInstanceV3Backup (739.27s)
=== RUN   TestAccRdsInstanceV3TemplateConfig
--- PASS: TestAccRdsInstanceV3TemplateConfig (774.67s)
=== RUN   TestAccRdsInstanceV3InvalidDBVersion
--- PASS: TestAccRdsInstanceV3InvalidDBVersion (10.95s)
PASS

Process finished with the exit code 0
```
