### PR TITLE
[OBS] Always set region on bucket creation

### DIFF
--- a/opentelekomcloud/acceptance/obs/resource_opentelekomcloud_obs_bucket_object_test.go
+++ b/opentelekomcloud/acceptance/obs/resource_opentelekomcloud_obs_bucket_object_test.go
@@ -115,7 +115,7 @@ func TestAccObsBucketObject_nothing(t *testing.T) {
 				PreConfig:   func() {},
 				Config:      testAccObsBucketObject_configNothing(rInt),
 				PlanOnly:    true,
-				ExpectError: regexp.MustCompile("-.+one\\sof\\s`content,source`\\smust\\sbe\\sspecified\\n"),
+				ExpectError: regexp.MustCompile("one of `content,source` must be specified"),
 			},
 		},
 	})

--- a/opentelekomcloud/services/obs/resource_opentelekomcloud_obs_bucket.go
+++ b/opentelekomcloud/services/obs/resource_opentelekomcloud_obs_bucket.go
@@ -285,7 +285,7 @@ func resourceObsBucketCreate(ctx context.Context, d *schema.ResourceData, meta i
 		ACL:          obs.AclType(acl),
 		StorageClass: obs.StorageClassType(class),
 	}
-	opts.Location = d.Get("region").(string)
+	opts.Location = config.GetRegion(d)
 	log.Printf("[DEBUG] OBS bucket create opts: %#v", opts)
 
 	_, err = client.CreateBucket(opts)


### PR DESCRIPTION
## Summary of the Pull Request
Make OBS bucket `Location` always set during creation

Fix obs bucket object validation test

Fix #1121

## PR Checklist

* [x] Refers to: #1121
* [x] Tests added/passed.


## Acceptance Steps Performed

#### For both regions

```
=== RUN   TestAccObsBucket_basic
--- PASS: TestAccObsBucket_basic (46.73s)
=== RUN   TestAccObsBucket_tags
--- PASS: TestAccObsBucket_tags (15.24s)
=== RUN   TestAccObsBucket_versioning
--- PASS: TestAccObsBucket_versioning (29.96s)
=== RUN   TestAccObsBucket_logging
--- PASS: TestAccObsBucket_logging (24.37s)
=== RUN   TestAccObsBucket_lifecycle
--- PASS: TestAccObsBucket_lifecycle (17.50s)
=== RUN   TestAccObsBucket_website
--- PASS: TestAccObsBucket_website (17.09s)
=== RUN   TestAccObsBucket_cors
--- PASS: TestAccObsBucket_cors (19.22s)
PASS

Process finished with the exit code 0
```

#### Other OBS resources also working with `eu-nl` region.

```
=== RUN   TestAccObsBucketPolicyBasic
--- PASS: TestAccObsBucketPolicyBasic (19.23s)
=== RUN   TestAccObsBucketPolicyUpdate
--- PASS: TestAccObsBucketPolicyUpdate (33.30s)
=== RUN   TestAccObsBucketPolicyMalformed
--- PASS: TestAccObsBucketPolicyMalformed (70.89s)
=== RUN   TestAccObsBucketPolicyBasic
--- PASS: TestAccObsBucketPolicyBasic (19.23s)
=== RUN   TestAccObsBucketPolicyUpdate
--- PASS: TestAccObsBucketPolicyUpdate (33.30s)
=== RUN   TestAccObsBucketPolicyMalformed
--- PASS: TestAccObsBucketPolicyMalformed (70.89s)
=== RUN   TestAccObsBucketObject_nothing
--- PASS: TestAccObsBucketObject_nothing (0.67s)
PASS

Process finished with the exit code 0

``
