### PR TITLE
Update nat_gateway_v2.md

### DIFF
--- a/docs/resources/nat_gateway_v2.md
+++ b/docs/resources/nat_gateway_v2.md
@@ -31,7 +31,7 @@ The following arguments are supported:
 * `tenant_id` - (Optional) The target tenant ID in which to allocate the nat
   gateway. Changing this creates a new nat gateway.
 
-* `router_id` - (Required) ID of the router this nat gateway belongs to. Changing
+* `router_id` - (Required) ID of the router (or VPC) this nat gateway belongs to. Changing
   this creates a new nat gateway.
 
 * `internal_network_id` - (Required) ID of the network this nat gateway connects to.


### PR DESCRIPTION
VPC IDs can also be used as "router_id" to create a NAT gateway for a VPC. The documentation does not reflect this

## Summary of the Pull Request


## PR Checklist

* [ ] Refers to: #xxx
* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (101.71s)
=== RUN   TestAccSomethingV0_timeout
--- PASS: TestAccSomethingV0_timeout (128.67s)
PASS

Process finished with exit code 0
```
