### PR TITLE
[RDS] Fix template application

### DIFF
--- a/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
+++ b/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
@@ -444,24 +444,24 @@ func testAccRdsInstanceV3ConfigTemplateBasic(postfix string) string {
 resource "opentelekomcloud_rds_parametergroup_v3" "pg" {
 	name = "pg-rds-test"
 	values = {
-		max_connections = "10"
+		max_connections = "100"
 		autocommit = "OFF"
 	}
 	datastore {
 		type = "postgresql"
-		version = "10"
+		version = "12"
 	}
 }
 
 resource "opentelekomcloud_rds_parametergroup_v3" "pg2" {
 	name = "pg-rds-test-2"
 	values = {
-		max_connections = "10"
+		max_connections = "100"
 		autocommit = "OFF"
 	}
 	datastore {
 		type = "postgresql"
-		version = "10"
+		version = "12"
 	}
 }
 
@@ -475,7 +475,7 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
   db {
     password = "Postgres!120521"
     type     = "PostgreSQL"
-    version  = "10"
+    version  = "12"
   }
   security_group_id  = opentelekomcloud_networking_secgroup_v2.sg.id
   subnet_id          = "%s"
@@ -495,7 +495,7 @@ func testAccRdsInstanceV3ConfigTemplateUpdate(postfix string) string {
 resource "opentelekomcloud_rds_parametergroup_v3" "pg" {
 	name = "pg-rds-test"
 	values = {
-		max_connections = "10"
+		max_connections = "100"
 		autocommit = "OFF"
 	}
 	datastore {
@@ -507,7 +507,7 @@ resource "opentelekomcloud_rds_parametergroup_v3" "pg" {
 resource "opentelekomcloud_rds_parametergroup_v3" "pg2" {
 	name = "pg-rds-test-2"
 	values = {
-		max_connections = "10"
+		max_connections = "100"
 		autocommit = "OFF"
 	}
 	datastore {
@@ -526,7 +526,7 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
   db {
     password = "Postgres!120521"
     type     = "PostgreSQL"
-    version  = "10"
+    version  = "12"
   }
   security_group_id  = opentelekomcloud_networking_secgroup_v2.sg.id
   subnet_id          = "%s"


### PR DESCRIPTION
## Summary of the Pull Request
Re-apply templates with auto-reset parameters (e.g `max_connections`)

Restart RDS instance after re-apply if required

Minor style fixes

Fix template values in the test

Fix #934

## PR Checklist

* [x] Refers to: #934
* [x] Tests added/passed.

## Acceptance Steps Performed

```
=== RUN   TestAccRdsInstanceV3Basic
--- PASS: TestAccRdsInstanceV3Basic (1111.24s)
=== RUN   TestAccRdsInstanceV3ElasticIP
--- PASS: TestAccRdsInstanceV3ElasticIP (683.56s)
=== RUN   TestAccRdsInstanceV3HA
    resource_opentelekomcloud_rds_instance_v3_test.go:93: OS_AVAILABILITY_ZONE_2 is empty
--- SKIP: TestAccRdsInstanceV3HA (0.00s)

Test ignored.
=== RUN   TestAccRdsInstanceV3OptionalParams
--- PASS: TestAccRdsInstanceV3OptionalParams (658.45s)
=== RUN   TestAccRdsInstanceV3Backup
--- PASS: TestAccRdsInstanceV3Backup (689.72s)
=== RUN   TestAccRdsInstanceV3TemplateConfig
restart Rds instance body =  map[restart:{}]
--- PASS: TestAccRdsInstanceV3TemplateConfig (716.29s)
=== RUN   TestAccRdsInstanceV3InvalidDBVersion
--- PASS: TestAccRdsInstanceV3InvalidDBVersion (1.86s)
PASS

Process finished with the exit code 0

```
