### PR TITLE
[AS] Mark all fields `ForceNew`

### DIFF
--- a/opentelekomcloud/services/as/resource_opentelekomcloud_as_configuration_v1.go
+++ b/opentelekomcloud/services/as/resource_opentelekomcloud_as_configuration_v1.go
@@ -49,20 +49,24 @@ func ResourceASConfiguration() *schema.Resource {
 						"instance_id": {
 							Type:     schema.TypeString,
 							Optional: true,
+							ForceNew: true,
 						},
 						"flavor": {
 							Type:        schema.TypeString,
 							Optional:    true,
+							ForceNew:    true,
 							DefaultFunc: schema.EnvDefaultFunc("OS_FLAVOR_ID", nil),
 						},
 						"image": {
 							Type:        schema.TypeString,
 							Optional:    true,
+							ForceNew:    true,
 							DefaultFunc: schema.EnvDefaultFunc("OS_IMAGE_ID", nil),
 						},
 						"key_name": {
 							Type:     schema.TypeString,
 							Required: true,
+							ForceNew: true,
 						},
 						"user_data": {
 							Type:             schema.TypeString,
@@ -82,15 +86,18 @@ func ResourceASConfiguration() *schema.Resource {
 						"disk": {
 							Type:     schema.TypeList,
 							Optional: true,
+							ForceNew: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"size": {
 										Type:     schema.TypeInt,
 										Required: true,
+										ForceNew: true,
 									},
 									"volume_type": {
 										Type:     schema.TypeString,
 										Required: true,
+										ForceNew: true,
 										ValidateFunc: validation.StringInSlice([]string{
 											"SATA", "SAS", "SSD", "co-p1", "uh-l1",
 										}, false),
@@ -98,6 +105,7 @@ func ResourceASConfiguration() *schema.Resource {
 									"disk_type": {
 										Type:     schema.TypeString,
 										Required: true,
+										ForceNew: true,
 										ValidateFunc: validation.StringInSlice([]string{
 											"DATA", "SYS",
 										}, false),
@@ -114,15 +122,18 @@ func ResourceASConfiguration() *schema.Resource {
 							Type:     schema.TypeList,
 							Optional: true,
 							MaxItems: 5,
+							ForceNew: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"path": {
 										Type:     schema.TypeString,
 										Required: true,
+										ForceNew: true,
 									},
 									"content": {
 										Type:     schema.TypeString,
 										Required: true,
+										ForceNew: true,
 									},
 								},
 							},
@@ -131,17 +142,20 @@ func ResourceASConfiguration() *schema.Resource {
 							Type:     schema.TypeList,
 							Optional: true,
 							MaxItems: 1,
+							ForceNew: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"eip": {
 										Type:     schema.TypeList,
 										MaxItems: 1,
 										Required: true,
+										ForceNew: true,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"ip_type": {
 													Type:     schema.TypeString,
 													Required: true,
+													ForceNew: true,
 													ValidateFunc: validation.StringInSlice([]string{
 														"5_bgp", "5_mailbgp",
 													}, false),
@@ -150,16 +164,19 @@ func ResourceASConfiguration() *schema.Resource {
 													Type:     schema.TypeList,
 													MaxItems: 1,
 													Required: true,
+													ForceNew: true,
 													Elem: &schema.Resource{
 														Schema: map[string]*schema.Schema{
 															"size": {
 																Type:         schema.TypeInt,
 																Required:     true,
+																ForceNew:     true,
 																ValidateFunc: validation.IntBetween(1, 500),
 															},
 															"share_type": {
 																Type:     schema.TypeString,
 																Required: true,
+																ForceNew: true,
 																ValidateFunc: validation.StringInSlice([]string{
 																	"PER",
 																}, false),
@@ -167,6 +184,7 @@ func ResourceASConfiguration() *schema.Resource {
 															"charging_mode": {
 																Type:     schema.TypeString,
 																Required: true,
+																ForceNew: true,
 																ValidateFunc: validation.StringInSlice([]string{
 																	"traffic",
 																}, false),
@@ -183,10 +201,12 @@ func ResourceASConfiguration() *schema.Resource {
 						"metadata": {
 							Type:     schema.TypeMap,
 							Optional: true,
+							ForceNew: true,
 						},
 						"security_groups": {
 							Type:     schema.TypeSet,
 							Optional: true,
+							ForceNew: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 							Set:      schema.HashString,
 						},


### PR DESCRIPTION
## Summary of the Pull Request
Mark all fields `ForceNew` in `resource/opentelekomcloud_as_configuration_v1` 
Fixes: #1149 

## PR Checklist

* [x] Refers to: #1149
* [x] Tests added/passed.
* [x] Schema updated.

## Acceptance Steps Performed

```
=== RUN   TestAccASV1Configuration_basic
--- PASS: TestAccASV1Configuration_basic (33.10s)
=== RUN   TestAccASV1Configuration_publicIP
--- PASS: TestAccASV1Configuration_publicIP (31.78s)
=== RUN   TestAccASV1Configuration_invalidDiskSize
--- PASS: TestAccASV1Configuration_invalidDiskSize (7.40s)
=== RUN   TestAccASV1Configuration_multipleSecurityGroups
--- PASS: TestAccASV1Configuration_multipleSecurityGroups (50.44s)
PASS

Process finished with the exit code 0
```
