### PR TITLE
[AS] Fix wrong SHA1 calculation

### DIFF
--- a/opentelekomcloud/common/diff_suppress_funcs.go
+++ b/opentelekomcloud/common/diff_suppress_funcs.go
@@ -94,3 +94,13 @@ func SuppressStrippedNewLines(_, old, new string, _ *schema.ResourceData) bool {
 	newline := "\n"
 	return strings.Trim(old, newline) == strings.Trim(new, newline)
 }
+
+func SuppressEmptyLineSHA(k, old, new string, d *schema.ResourceData) bool {
+	// Sometimes the API responds with the equivalent, empty SHA1 sum
+	// echo -n "" | shasum
+	if (old == "da39a3ee5e6b4b0d3255bfef95601890afd80709" && new == "") ||
+		(old == "" && new == "da39a3ee5e6b4b0d3255bfef95601890afd80709") {
+		return true
+	}
+	return false
+}

--- a/opentelekomcloud/common/diff_suppress_funcs.go
+++ b/opentelekomcloud/common/diff_suppress_funcs.go
@@ -95,7 +95,7 @@ func SuppressStrippedNewLines(_, old, new string, _ *schema.ResourceData) bool {
 	return strings.Trim(old, newline) == strings.Trim(new, newline)
 }
 
-func SuppressEmptyLineSHA(k, old, new string, d *schema.ResourceData) bool {
+func SuppressEmptyStringSHA(k, old, new string, d *schema.ResourceData) bool {
 	// Sometimes the API responds with the equivalent, empty SHA1 sum
 	// echo -n "" | shasum
 	if (old == "da39a3ee5e6b4b0d3255bfef95601890afd80709" && new == "") ||

--- a/opentelekomcloud/services/as/resource_opentelekomcloud_as_configuration_v1.go
+++ b/opentelekomcloud/services/as/resource_opentelekomcloud_as_configuration_v1.go
@@ -68,7 +68,7 @@ func ResourceASConfiguration() *schema.Resource {
 							Type:             schema.TypeString,
 							Optional:         true,
 							ForceNew:         true,
-							DiffSuppressFunc: common.SuppressEmptyLineSHA,
+							DiffSuppressFunc: common.SuppressEmptyStringSHA,
 							// just stash the hash for state & diff comparisons
 							StateFunc: func(v interface{}) string {
 								switch v.(type) {

--- a/opentelekomcloud/services/as/resource_opentelekomcloud_as_configuration_v1.go
+++ b/opentelekomcloud/services/as/resource_opentelekomcloud_as_configuration_v1.go
@@ -65,9 +65,10 @@ func ResourceASConfiguration() *schema.Resource {
 							Required: true,
 						},
 						"user_data": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
+							Type:             schema.TypeString,
+							Optional:         true,
+							ForceNew:         true,
+							DiffSuppressFunc: common.SuppressEmptyLineSHA,
 							// just stash the hash for state & diff comparisons
 							StateFunc: func(v interface{}) string {
 								switch v.(type) {


### PR DESCRIPTION
## Summary of the Pull Request
Fix wrong SHA1 sum calculation of empty `user_data` in `resource/opentelekomcloud_as_configuration_v1`
Fixes: #1158

## PR Checklist

* [x] Refers to: #1158
* [x] Tests added/passed.
* [x] Schema updated.

## Acceptance Steps Performed

```
=== RUN   TestAccASV1Configuration_basic
--- PASS: TestAccASV1Configuration_basic (32.52s)
=== RUN   TestAccASV1Configuration_publicIP
--- PASS: TestAccASV1Configuration_publicIP (32.31s)
=== RUN   TestAccASV1Configuration_invalidDiskSize
--- PASS: TestAccASV1Configuration_invalidDiskSize (7.46s)
=== RUN   TestAccASV1Configuration_multipleSecurityGroups
--- PASS: TestAccASV1Configuration_multipleSecurityGroups (49.96s)
PASS

Process finished with the exit code 0
```
