### PR TITLE
[ACC] Add alternative provider configuration

### DIFF
--- a/opentelekomcloud/acceptance/common/common.go
+++ b/opentelekomcloud/acceptance/common/common.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"testing"
 
@@ -13,9 +14,24 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 )
 
+const AlternativeProviderAlias = "opentelekomcloud.alternative"
+
 var (
 	TestAccProviderFactories map[string]func() (*schema.Provider, error)
 	TestAccProvider          *schema.Provider
+
+	altCloud                  = os.Getenv("OS_CLOUD_2")
+	altProjectID              = os.Getenv("OS_PROJECT_ID_2")
+	altProjectName            = os.Getenv("OS_PROJECT_NAME_2")
+	AlternativeProviderConfig = fmt.Sprintf(`
+provider opentelekomcloud {
+  alias = "alternative"
+
+  cloud       = "%s"
+  tenant_id   = "%s"
+  tenant_name = "%s"
+}
+`, altCloud, altProjectID, altProjectName)
 )
 
 func init() {
@@ -23,6 +39,17 @@ func init() {
 	TestAccProviderFactories = map[string]func() (*schema.Provider, error){
 		"opentelekomcloud": func() (*schema.Provider, error) {
 			return TestAccProvider, nil
+		},
+		"opentelekomcloudalternative": func() (*schema.Provider, error) {
+			provider := opentelekomcloud.Provider()
+			provider.Configure(context.Background(), &terraform.ResourceConfig{
+				Config: map[string]interface{}{
+					"cloud":       altCloud,
+					"tenant_id":   altProjectID,
+					"tenant_name": altProjectName,
+				},
+			})
+			return provider, nil
 		},
 	}
 

--- a/opentelekomcloud/acceptance/provider_test.go
+++ b/opentelekomcloud/acceptance/provider_test.go
@@ -10,9 +10,11 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
 	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/helper/pathorcontents"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud"
@@ -262,4 +264,32 @@ func TestLoadAndValidate_errors(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAltProvider(t *testing.T) {
+	if os.Getenv("OS_CLOUD_2") == "" &&
+		os.Getenv("OS_PROJECT_ID_2") == "" &&
+		os.Getenv("OS_PROJECT_NAME_2") == "" {
+		t.Skip("missing alternative provider configuration")
+	}
+
+	config := fmt.Sprintf(`
+%s
+
+data "opentelekomcloud_networking_network_v2" "ext" {
+  provider = "%s"
+
+  name = "admin_external_net"
+}
+`, common.AlternativeProviderConfig, common.AlternativeProviderAlias)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+		},
+	})
 }


### PR DESCRIPTION
## Summary of the Pull Request
Allow configuring alternative provider with `OS_CLOUD_2`, `OS_PROJECT_ID_2`, `OS_PROJECT_NAME_2`

## PR Checklist

* [x] Refers to: #1162 
* [x] Tests added/passed.

## Acceptance Steps Performed

```
=== RUN   TestAltProvider
--- PASS: TestAltProvider (23.71s)
PASS

Process finished with the exit code 0

```
