### PR TITLE
Initialize releasenotes building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ localrc
 !command/test-fixtures/**/.terraform/
 
 dist
+releasenotes/build

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,6 +1,9 @@
 ---
 - project:
     merge-mode: squash-merge
+    default-branch: devel
+    templates:
+      - release-notes-jobs
     check:
       jobs:
         - golang-make-test

--- a/releasenotes/notes/init-release-notes-685b908da3b0042d.yaml
+++ b/releasenotes/notes/init-release-notes-685b908da3b0042d.yaml
@@ -1,0 +1,4 @@
+---
+other:
+  - |
+    Initialize releasenotes building with reno.

--- a/releasenotes/requirements.txt
+++ b/releasenotes/requirements.txt
@@ -1,0 +1,2 @@
+reno>=3.1.0 # Apache-2.0
+otcdocstheme # Apache-2.0

--- a/releasenotes/source/conf.py
+++ b/releasenotes/source/conf.py
@@ -1,0 +1,100 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import warnings
+
+# -- General configuration ----------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
+extensions = [
+    'reno.sphinxext',
+    'otcdocstheme',
+]
+
+# openstackdocstheme options
+otcdocs_repo = 'opentelekomcloud/terraform-provider-opentelekomcloud'
+html_last_updated_fmt = '%Y-%m-%d %H:%M'
+html_theme = 'otcdocs'
+
+# TODO(shade) Set this to true once the build-openstack-sphinx-docs job is
+# updated to use sphinx-build.
+# When True, this will raise an exception that kills sphinx-build.
+enforcer_warnings_as_errors = False
+
+# autodoc generation is a bit aggressive and a nuisance when doing heavy
+# text edit cycles.
+# execute "export SPHINX_DEBUG=1" in your terminal to disable
+
+# General information about the project.
+project = u'terraform-provider-opentelekomcloud'
+copyright = u'2021, Various members of the OpenTelekomCloud'
+
+# A few variables have to be set for the log-a-bug feature.
+#   gitsha: The SHA checksum of the bug description. Extracted from git log.
+#   bug_tag: Tag for categorizing the bug. Must be set manually.
+#   bug_project: Launchpad project to file bugs against.
+# These variables are passed to the logabug code via html_context.
+git_cmd = "/usr/bin/git log | head -n1 | cut -f2 -d' '"
+try:
+    gitsha = os.popen(git_cmd).read().strip('\n')
+except Exception:
+    warnings.warn("Can not get git sha.")
+    gitsha = "unknown"
+
+otcdocs_bug_tag = "docs"
+pwd = os.getcwd()
+# html_context allows us to pass arbitrary values into the html template
+html_context = {"pwd": pwd,
+                "gitsha": gitsha}
+
+# If true, '()' will be appended to :func: etc. cross-reference text.
+add_function_parentheses = True
+
+# If true, the current module name will be prepended to all description
+# unit titles (such as .. function::).
+add_module_names = True
+
+# The name of the Pygments (syntax highlighting) style to use.
+pygments_style = 'native'
+
+autodoc_member_order = "bysource"
+
+# Locations to exclude when looking for source files.
+exclude_patterns = []
+
+# -- Options for HTML output ----------------------------------------------
+
+# Don't let openstackdocstheme insert TOCs automatically.
+theme_include_auto_toc = False
+
+# Output file base name for HTML help builder.
+htmlhelp_basename = '%sdoc' % project
+
+# Grouping the document tree into LaTeX files. List of tuples
+# (source start file, target name, title, author, documentclass
+# [howto/manual]).
+latex_documents = [
+    ('index',
+     '%s.tex' % project,
+     u'%s Documentation' % project,
+     u'OpenTelekomCloud', 'manual'),
+]
+
+html_theme_options = {
+    'display_toc': False,
+}
+
+# Include both the class and __init__ docstrings when describing the class
+autoclass_content = "both"

--- a/releasenotes/source/current.rst
+++ b/releasenotes/source/current.rst
@@ -1,0 +1,61 @@
+=====================
+Current Release Notes
+=====================
+
+.. release-notes::
+
+1.24.2
+------
+
+New Features
+============
+
+* `resource/opentelekomcloud_waf_certificate_v1`: Add possibility to configure TLS ([#1132](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/1132))
+* `resource/opentelekomcloud_ecs_instance_v1`: Add possibility to encrypt `data_volumes` ([#1135](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/1135))
+
+Bug Fixes
+=========
+
+* `provider`: Store temporary AK/SK in OBS client only ([#1133](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/1133))
+* `resource/opentelekomcloud_rds_instance_v3`: Fix not setting `availability_zone` during import/refresh ([#1137](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/1137))
+* `resource/opentelekomcloud_obs_bucket`: Fix not creating bucket for `eu-nl` region ([#1139](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/1139))
+* `resource/opentelekomcloud_rds_instance_v3`: Fix configuration template applied partially ([#1150](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/1150))
+
+Other Notes
+===========
+
+* `resources/opentelekomcloud_nat_gateway_v2`: Note that `router_id` can be a VPC ID ([#1140](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/1140))
+
+1.24.1
+------
+
+New Features
+============
+
+* **New Resource:** `opentelekomcloud_swr_organization_v2` ([#1120](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1120))
+* **New Resource:** `opentelekomcloud_swr_repository_v2` ([#1123](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1123))
+* **New Resource:** `opentelekomcloud_swr_domain_v2` ([#1127](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1127))
+* **New Resource:** `opentelekomcloud_swr_organization_permissions_v2` ([#1129](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1129))
+* `resource/opentelekomcloud_waf_certificate_v1`: Add name certificate name validation ([#1116](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1116))
+* `resource/opentelekomcloud_cce_node_v3`: Add possibility to encrypt `data_volumes` ([#1117](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1117))
+* `resource/opentelekomcloud_waf_certificate_v1`: Add possibility to import by name ([#1119](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1119))
+* `resource/opentelekomcloud_obs_bucket_v1`: Add possibility to create buckets with encryption ([#1125](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1125))
+
+Bug Fixes
+=========
+
+* `resource/opentelekomcloud_as_configuration_v1`: Fix wrong SHA1 sum in `Read` operation ([#1130](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1130))
+
+1.24.0
+------
+
+Deprecation Notes
+=================
+
+* Move to `terraform-plugin-sdk/v2`, only Terraform versions `0.12+` are supported ([#1104](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/1104))
+
+Other Notes
+===========
+
+This release contains no functional differences from `1.23.13`.
+

--- a/releasenotes/source/index.rst
+++ b/releasenotes/source/index.rst
@@ -1,0 +1,10 @@
+=================================================
+terraform-provider-opentelekomcloud Release Notes
+=================================================
+
+.. toctree::
+   :maxdepth: 1
+
+   current
+   older
+

--- a/releasenotes/source/older.rst
+++ b/releasenotes/source/older.rst
@@ -1,0 +1,1287 @@
+=================
+Old Release Notes
+=================
+
+
+1.23.13
+-------
+
+New Features
+============
+
+* `resource/opentelekomcloud_identity_user_v3`: Add possibility to send welcome email on user creation ([#1103](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/1103))
+* `provider/opentelekomcloud`: Add `passcode` argument for TOTP MFA support ([#1106](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/1106))
+* `resource/opentelekomcloud_cce_cluster_v3`: Improve error for missing CCE authorization ([#1108](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/1108))
+
+Bug Fixes
+=========
+
+* `resource/opentelekomcloud_obs_bucket_policy`: Malformed policy is no more stored in the state ([#1097](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/1097))
+* `resource/pentelekomcloud_waf_certificate_v1`: Fix not creating certificate with valid certificate and key values ([#1098](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/1098))
+
+Deprecation Notes
+=================
+
+* `resource/opentelekomcloud_lb_loadbalancer_v2`:  Remove deprecated `security_group_ids` ([#1101](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/1101))
+
+Other Notes
+===========
+
+* `resource/opentelekomcloud_rds_instance_v3`: Make clear user_name is part of the db ([#1093](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/1093))
+* `resource/pentelekomcloud_waf_certificate_v1`: Use valid certificate and key example ([#1098](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/1098))
+* `resource/pentelekomcloud_rds_read_replica_v3`: Fix `id` field description ([#1100](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/1100))
+* `resource/opentelekomcloud_css_cluster_v1`: Remove `css.large.8` flavor from the valid flavor list ([#1102](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/1102))
+* This is the last release to support Terraform versions lower than `0.12`.
+
+
+1.23.12
+-------
+
+New Features
+============
+
+* `resource/opentelekomcloud_cce_addon_v3`: Add possibility to import ([#1066](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1066))
+* `resource/opentelekomcloud_evs_volume_v3`: Add possibility to increase volume size ([#1074](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1074))
+* `resource/opentelekomcloud_cce_node_pool_v3`: Add possibility to import ([#1082](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1082))
+* `resource/opentelekomcloud_rds_instance_v3`: Unify usage of `tags` ([#1085](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1085))
+* `resource/opentelekomcloud_cce_cluster_v3`: Allow creating cluster without addons ([#1087](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1087))
+
+Bug Fixes
+=========
+* `resource/opentelekomcloud_cce_node_pool_v3`: Add missing field in `Update` operation ([#1068](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1068))
+* `resource/opentelekomcloud_cce_node_pool_v3`: Add missing field in `Create` operation ([#1069](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1069))
+* `resource/opentelekomcloud_cce_node_pool_v3`: Skip setting scale fields when scale disabled  ([#1071](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1071))
+* `resource/opentelekomcloud_cce_node_pool_v3`: Fix infinite retrial creation  ([#1075](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1075))
+* `resource/opentelekomcloud_dds_instance_v3`: Fix empty state file ([#1077](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1077))
+* `resource/opentelekomcloud_cce_addon_v3`: Fix false-positive `Delete` operation ([#1080](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1080))
+* `resource/opentelekomcloud_cce_addon_v3`: Remove `Update` operation which produces issues ([#1080](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1080))
+* `resource/opentelekomcloud_cce_addon_v3`: Improve `SYS` disk size validation ([#1084](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1084))
+
+Other Notes
+===========
+
+* `resource/opentelekomcloud_cce_addon_v3`: Fix wrong version of EuleorOS ([#1070](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1070))
+* `resource/opentelekomcloud_dds_instance_v3`: Add examples of creating a Replica Set ([#1079](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1079))
+
+1.23.11
+-------
+
+New Features
+============
+
+* **New Resource:** `opentelekomcloud_rds_replica_v3` ([#1037](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1037))
+* `resource/opentelekomcloud_lb_pool_v2`: Make `persistence.type` optional ([#1052](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1052))
+* `data_source/opentelekomcloud_vpc_eip_v1`: Add possibility to query by `tags` ([#1058](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1058))
+
+Bug Fixes
+=========
+
+* `resource/opentelekomcloud_compute_instance_v2`: Fix issue with reading `networks` ([#1057](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/1057))
+* `resource/opentelekomcloud_identity_provider_v3`: Fix issue with failing provider operations ([#1059](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/1059))
+* `resource/opentelekomcloud_css_cluster_v1`: Fix potential nil pointer issue ([#1060](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/1060))
+
+DOCUMENTATION
+=============
+
+* `resource/opentelekomcloud_networking_port_v2`: Fix wrong ordering of `port_security_enabled` ([#1051](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1051))
+
+Deprecation Notes
+=================
+
+* `resource/opentelekomcloud_lb_loadbalancer_v2`: Deprecate `security_group_ids` ([#1055](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1055))
+
+1.23.10 (May 6, 2021)
+---------------------
+
+New Features
+============
+
+* **New Data Source:** `opentelekomcloud_vpc_eip_v1` ([#1042](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1042))
+
+ENHANCEMENTS
+============
+
+* `resource/opentelekomcloud_networking_port_v2`: Allow to set a `port_security_enabled` ([#1045](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1045))
+
+Bug Fixes
+=========
+
+* `resource/opentelekomcloud_cce_addon_v3`: Fix issue with CCE cluster recreation with installed addon ([#1047](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/1047))
+
+DOCUMENTATION
+=============
+
+* `resource/opentelekomcloud_networking_port_v2`: Add missing field `no_security_groups` ([#1045](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1045))
+
+Deprecation Notes
+=================
+
+* `resource/opentelekomcloud_elb_backend`: Classic load balancers are no longer provided. Please use elastic load balancers instead ([#1035](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1035))
+* `resource/opentelekomcloud_elb_health`: Classic load balancers are no longer provided. Please use elastic load balancers instead ([#1035](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1035))
+* `resource/opentelekomcloud_elb_listener`: Classic load balancers are no longer provided. Please use elastic load balancers instead ([#1035](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1035))
+* `resource/opentelekomcloud_elb_loadbalacer`: Classic load balancers are no longer provided. Please use elastic load balancers instead ([#1035](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1035))
+
+1.23.9 (April 28, 2021)
+-----------------------
+
+ENHANCEMENTS
+============
+
+* `data_source/opentelekomcloud_images_image_v2`: Add possibility to filter images by regex ([#1012](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/1012))
+* `resource/opentelekomcloud_vpc_subnet_v1`: Add `network_id` attribute ([#1021](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/1021))
+* `data_source/opentelekomcloud_vpc_subnet_v1`: Add `network_id` attribute ([#1021](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/1021))
+* `resource/opentelekomcloud_compute_instance_v2`: Add resource import support ([#1029](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/1029))
+
+Bug Fixes
+=========
+
+* `resource/opentelekomcloud_cce_addon_v3`: Fix passing all `values` as strings ([#1003](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/1003))
+* `resource/opentelekomcloud_cce_addon_v3`:  Fix error during update ([#1009](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/1009))
+
+DOCUMENTATION
+=============
+
+* `resource/opentelekomcloud_vpc_subnet_v1`: Add note about primary DNS ([#1018](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/1018))
+* `resource/opentelekomcloud_cce_cluster_v3`: Add note for authorizing CCE without console ([#1024](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/1024))
+* `resource/opentelekomcloud_dds_instance_v3`: Fix resource name in the examples ([#1031](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/1031))
+* `resource/opentelekomcloud_cce_cluster_v3`: Add auth note for usage with SWR ([#1032](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/1032))
+
+1.23.8 (April 21, 2021)
+-----------------------
+
+ENHANCEMENTS
+============
+
+* `resource/opentelekomcloud_as_group_v1`: Make `security_groups` optional ([#991](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/991))
+
+Bug Fixes
+=========
+
+* `resource/opentelekomcloud_lb_certificate_v2`: Fix constantly updating `private_key`, `certificate` and `domain` fields ([#988](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/988))
+* `resource/opentelekomcloud_lb_certificate_v2`: Fix deleting certificates used in LB listener ([#987](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/987))
+* `resource/opentelekomcloud_vpc_subnet_v1`: Fix subnet creation when `dns_list` is set ([#995](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/995), follow-up of [#977](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/977))
+
+DOCUMENTATION
+=============
+
+* `resource/opentelekomcloud_cce_cluster_v3`: Add note about CCE authorization required ([#998](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/998))
+
+1.23.7 (April 15, 2021)
+-----------------------
+
+ENHANCEMENTS
+============
+* `resource/opentelekomcloud_networking_subnet_v2`: Add default value for `dns_nameservers` ([#977](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/977))
+* `resource/opentelekomcloud_vpc_subnet_v1`: Add default value for `primary_dns`, `secondary_dns` ([#977](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/977))
+
+Bug Fixes
+=========
+
+* `resource/opentelekomcloud_cce_node_v3`: Remove passing empty `private_ip` in create request ([#973](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/973))
+* `resource/opentelekomcloud_s3_bucket`: Make unversioned bucket creation possible ([#976](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/976), [#979](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/979))
+* `resource/opentelekomcloud_obs_bucket`: Make unversioned bucket creation possible ([#978](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/978))
+* `resource/opentelekomcloud_lb_listener_v2`: Fix schema to avoid resource always updating ([#983](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/983), [#984](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/984))
+
+DOCUMENTATION
+=============
+
+* `resource/opentelekomcloud_cce_addon_v3`:  Fix documentation issues ([#969](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/969))
+
+1.23.6 (April 08, 2021)
+-----------------------
+
+New Features
+============
+
+* **New Resource:** `opentelekomcloud_identity_provider_v3` ([#946](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/946))
+* **New Resource:** `opentelekomcloud_identity_mapping_v3` ([#947](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/947))
+* **New Resource:** `opentelekomcloud_sfs_share_access_rules_v2` ([#955](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/955))
+* **New Resource:** `opentelekomcloud_sdrs_protected_instance_v1` ([#963](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/963))
+
+ENHANCEMENTS
+============
+
+* `resource/opentelekomcloud_cce_node_v3`: Allow to set a `private_ip` ([#938](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/938))
+* `resource/opentelekomcloud_as_configuration_v1`: Allow to set a `security_groups` ([#941](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/941))
+* `resource/opentelekomcloud_cce_nodepool_v3`: Increase timeouts ([#945](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/945))
+* `resource/opentelekomcloud_sfs_file_share_v2`: Make `access` params optional ([#953](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/953))
+* `resource/opentelekomcloud_сompute_instance_v2`: Add possibility to set `power_state` param  ([#956](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/956))
+
+DOCUMENTATION
+=============
+
+* `resource/opentelekomcloud_ecs_instance_v1`: Clarify that `nics` is required ([#951](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/951))
+* `resource/opentelekomcloud_dns_recordset_v2`: Clarify that `type` and `records` are required ([#961](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/961))
+
+1.23.5 (March 24, 2021)
+-----------------------
+
+ENHANCEMENTS
+============
+
+* `resource/opentelekomcloud_ecs_instance_v1`: Use common `tags` approach in resource ([#919](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/919))
+* `provider/opentelekomcloud`: Retry `502` error one time ([#921](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/921))
+* `resource/opentelekomcloud_lb_monitor_v2`: Add possibility to set `domain_name` argument ([#925](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/925))
+* `resource/opentelekomcloud_css_cluster_v1`: Add possibility to set `datastore` argument ([#926](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/926))
+* `resource/opentelekomcloud_compute_instance_v2`: Use common `tags` approach in resource ([#927](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/927))
+* `resource/opentelekomcloud_css_cluster_v1`: Add disk size validation during a plan ([#928](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/928))
+
+DOCUMENTATION
+=============
+
+* `resource/opentelekomcloud_compute_instance_v2`: Update `security_groups` description ([#929](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/929))
+* `resource/opentelekomcloud_cce_addon_v3`: Add description of addon template input values ([#931](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/931))
+
+1.23.4 (March 17, 2021)
+-----------------------
+
+New Features
+============
+
+* **New Data Source:** `opentelekomcloud_css_flavor_v1` ([#913](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/913))
+
+ENHANCEMENTS
+============
+
+* `resource/opentelekomcloud_css_cluster_v1`: Add support of `enable_authority` and `admin_pass` arguments ([#902](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/902))
+* `resource/opentelekomcloud_ecs_instance_v1`: Use security group IDs in all operations ([#909](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/909))
+
+Bug Fixes
+=========
+
+* `resource/opentelekomcloud_vpnaas_ipsec_policy_v2`: Missing support of PFS groups ([#906](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/906))
+* `resource/opentelekomcloud_as_group_v1`: Limit `security_groups` maximum number to one ([#907](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/907))
+* `resource/opentelekomcloud_cce_node_pool_v3`: Fix too strict `k8s_tags` validations ([#911](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/911))
+* `resource/opentelekomcloud_cce_node_pool_v3`: Changes in `k8s_tags` and `taints` trigger resource re-creation no more ([#911](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/911))
+
+1.23.3 (March 12, 2021)
+-----------------------
+
+ENHANCEMENTS
+============
+
+* `resource/opentelekomcloud_lb_loadbalancer_v2`: Add possibility to set tags ([#890](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/890))
+* `resource/opentelekomcloud_lb_listener_v2`: Add possibility to set tags ([#895](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/895))
+* `resource/opentelekomcloud_compute_keypair_v2`: Add new keypair creation support ([#896](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/896))
+
+Bug Fixes
+=========
+
+* `resource/opentelekomcloud_cbr_vault_v3`: Fix not unassignable resources ([#897](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/897))
+
+DOCUMENTATION
+=============
+
+* Improve repository `README.md` ([#894](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/894))
+* `resource/opentelekomcloud_dns_zone_v2`: Clarify that private zones are not searched by default ([#905](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/905))
+
+1.23.2 (March 4, 2021)
+----------------------
+
+ENHANCEMENTS
+============
+
+* `resource/opentelekomcloud_as_group_v1`: Add possibility to set tags ([#877](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/877))
+* `resource/opentelekomcloud_kms_key_v1`: Add possibility to set tags ([#884](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/884))
+
+Bug Fixes
+=========
+
+* `resource/opentelekomcloud_cce_node_v3`: Remove reading empty CCE Node `Spec.ExtendParam` ([#876](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/876))
+* `resource/opentelekomcloud_css_cluster_v1`: Fix error with reading cluster without encryption ([#882](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/882))
+* `resource/opentelekomcloud_cbr_policy_v3`: Make `timezone` argument required ([#883](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/883))
+* `resource/opentelekomcloud_compute_keypair_v2`: Fix raising error on changing existing public key ([#887](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/887))
+
+1.23.1 (February 25, 2021)
+--------------------------
+
+ENHANCEMENTS
+============
+
+* `resource/opentelekomcloud_sfs_file_system_v2`: Add possibility to set tags ([#867](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/867))
+
+Bug Fixes
+=========
+
+* `resource/opentelekomcloud_cce_node_pool_v3`: Fix pool not creating with `random` availability zone ([#864](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/864))
+* `resource/opentelekomcloud_compute_instance_v2`: Fix ignored `OS_IMAGE_ID` env variable ([#866](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/866))
+* `resource/opentelekomcloud_compute_bms_server_v2`: Fix ignored `OS_IMAGE_ID` env variable ([#866](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/866))
+* `resource/opentelekomcloud_vbs_backup_policy_v2`: Fix panic on refresh when policy is missing ([#872](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/872))
+
+1.23.0 (February 17, 2021)
+--------------------------
+
+Deprecation Notes
+=================
+
+* Binary build matrix is narrowed ([#858](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/858)).
+  Binaries for the following OS/architecture combinations are built:
+
+  * **Linux**
+    * `AMD64`
+    * `i386`
+    * `ARMv6`
+    * `ARMv8` (`ARM64`)
+
+  * **Darwin**
+    * `AMD64`
+
+  * **Windows**
+    * `AMD64`
+    * `i386`
+
+  * **FreeBSD**
+      * `AMD64`
+      * `i386`
+
+  `Darwin/ARMv8` (new `M1` chip) to be also built in future
+
+New Features
+============
+
+* **New Resource:** `opentelekomcloud_sfs_turbo_share_v1` ([#852](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/852))
+
+ENHANCEMENTS
+============
+
+* `resource/opentelekomcloud_dns_zone_v2`: Make DNS resources diff ignore ending dot in name ([#850](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/850))
+* `resource/opentelekomcloud_dns_recordset_v2`: Make DNS resources diff ignore ending dot in name ([#850](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/850))
+* `resource/opentelekomcloud_dns_ptrrecord_v2`: Make DNS resources diff ignore ending dot in name ([#850](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/850))
+* `resource/opentelekomcloud_compute_instance_v2`: Remove `Deprecated` and `Removed` fields from schema ([#859](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/859))
+
+Bug Fixes
+=========
+
+* `resource/opentelekomcloud_dns_recordset_v2`: Fix shared DNS recordset searching ([#848](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/848))
+* `resource/opentelekomcloud_vbs_backup_v2`: Fix reading backup description ([#855](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/855))
+
+1.22.8 (February 10, 2021)
+--------------------------
+
+New Features
+============
+
+* **New Resource:** `opentelekomcloud_cce_node_pool_v3` ([#825](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/825))
+* **New Resource:** `opentelekomcloud_cbr_vault_v3` ([#833](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/833))
+
+Bug Fixes
+=========
+
+* `provider/opentelekomcloud`: Fix not loading cloud config ([#828](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/828))
+* `resource/opentelekomcloud_vpc_eip_v1`: Fix missing `tags` argument in the documentation ([#830](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/830))
+* `resource/opentelekomcloud_dns_prrecord_v2`: Repair tags workflow in resource ([#832](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/832))
+* `resource/opentelekomcloud_cce_addon_v3`: Fix crash on empty `basic` addon values ([#836](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/836))
+
+1.22.7 (February 03, 2021)
+--------------------------
+
+ENHANCEMENTS
+============
+
+* `resource/opentelekomcloud_ecs_instance_v1`: Implement plan stage network and volume validation ([#820](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/820))
+* `resource/opentelekomcloud_as_configuration`: Add possibility to set `5_mailbgp` to `ip_type` ([#821](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/821))
+* `resource/opentelekomcloud_evs_volume_v3`: Add volume type validation ([#823](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/823))
+
+Deprecation Notes
+=================
+
+* `resource/opentelekomcloud_compute_instance_v2`: Deprecate `personality` field ([#819](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/819))
+
+1.22.6 (January 27, 2021)
+-------------------------
+
+Bug Fixes
+=========
+
+* `resource/opentelekomcloud_obs_bucket`: Fix invalid AK/SK signature for OBS ([#811](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/811))
+* `resource/opentelekomcloud_obs_bucket_object`: Fix invalid AK/SK signature for OBS ([#811](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/811))
+* `resource/opentelekomcloud_obs_bucket_object`: Fix issue with deleting versioned objects ([#812](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/812))
+
+ENHANCEMENTS
+============
+
+* `provider/opentelekomcloud`: Add provider credentials validation ([#813](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/813))
+* `provider/opentelekomcloud`: Mark sensitive fields as `Sensitive` ([#816](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/816))
+
+1.22.5 (January 22, 2021)
+-------------------------
+
+Bug Fixes
+=========
+
+* `resource/opentelekomcloud_cce_cluster_v3`: Fix `vpc_id` and `subnet_id` validation during plan ([#804](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/804))
+
+1.22.4 (January 21, 2021)
+-------------------------
+
+New Features
+============
+* **New Data Source:** `opentelekomcloud_rds_versions_v3` ([#792](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/792))
+
+ENHANCEMENTS
+============
+
+* `resource/opentelekomcloud_cce_cluster_v3`: Implement plan stage network validation ([#787](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/787))
+* `resource/opentelekomcloud_cce_cluster_v3`: Add timeouts section to CCE documentation ([#788](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/788))
+* `resource/opentelekomcloud_cce_node_v3`: Add timeouts section to CCE documentation ([#788](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/788))
+* `resource/opentelekomcloud_compute_keypair_v2`: Allow shared ("global") key pairs ([#794](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/794))
+* `resource/opentelekomcloud_rds_instance_v3`: Implement plan stage db version validation ([#795](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/795))
+* `resource/opentelekomcloud_rds_parametergroup_v3`: Implement plan stage db version validation ([#796](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/796))
+* `resource/opentelekomcloud_dns_recordset_v2`: Allow shared ("global") DNS record sets ([#800](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/800))
+
+Bug Fixes
+=========
+
+* `resource/opentelekomcloud_rds_instance_v3`: Add `param_group_id` support ([#784](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/784))
+* `resource/opentelekomcloud_rds_parametergroup_v3`: Fix `rds_parametergroup_v3` recreation ([#789](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/789))
+
+1.22.3 (December 23, 2020)
+--------------------------
+
+New Features
+============
+
+* **New Resource:** `opentelekomcloud_obs_bucket_policy` ([#773](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/773))
+* **New Data Source:** `opentelekomcloud_obs_bucket_object` ([#780](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/780))
+
+ENHANCEMENTS
+============
+
+* `resource/opentelekomcloud_cce_node_v3`: Add `os` argument ([#778](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/778))
+
+Bug Fixes
+=========
+
+* `resource/opentelekomcloud_obs_bucket_object`: Remove unused `credentials` argument ([#781](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/781))
+
+DOCUMENTATION
+=============
+
+* `data_source/opentelekomcloud_s3_bucket_object`:  Move to `"Object Storage Service (S3)"` subcategory ([#772](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/772))
+* `resource/opentelekomcloud_s3_bucket`: Move to `"Object Storage Service (S3)"` subcategory ([#772](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/772))
+* `resource/opentelekomcloud_s3_bucket_object`: Move to `"Object Storage Service (S3)"` subcategory ([#772](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/772))
+* `resource/opentelekomcloud_s3_bucket_policy`: Move to `"Object Storage Service (S3)"` subcategory ([#772](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/772))
+
+1.22.2 (December 16, 2020)
+--------------------------
+
+New Features
+============
+
+* **New Resource:** `opentelekomcloud_cce_addon_v3` ([#711](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/711))
+
+ENHANCEMENTS
+============
+
+* `resource/opentelekomcloud_lb_loadbalancer_v2`: Clarify usage `lb_loadbalancer_v2` with `vpc_subnet_v1` in docs ([#766](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/766))
+* `resource/opentelekomcloud_cce_cluster_v3`: Add cluster name validation ([#768](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/768))
+
+1.22.1 (December 10, 2020)
+--------------------------
+
+New Features
+============
+
+* **New Resource:** `opentelekomcloud_cbr_policy_v3`([#758](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/758))`
+
+Bug Fixes
+=========
+
+* `resource/opentelekomcloud_identity_credential_v3`: Remove non-existing credential instead returning error ([#753](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/753))
+* `resource/opentelekomcloud_lb_pool_v2`: Fix LB protocol to pool protocol mapping description ([#754](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/754))
+* `resource/opentelekomcloud_rds_instance_v3`: Fix issue with update volume size ([#755](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/755))
+* `data_source/opentelekomcloud_networking_secgroup_v2`: Prevent panic due to unhandled error ([#756](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/756))
+
+
+1.22.0 (December 03, 2020)
+--------------------------
+
+New Features
+============
+
+* **New Data Source:** `opetelekomcloud_dds_instance_v3` ([#725](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/725))
+
+ENHANCEMENTS
+============
+
+* `resource/opentelekomcloud_cce_cluster_v3`: Add new argument `authenticating_proxy_ca` ([#727](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/727))
+* `data_source/opentelekomcloud_cce_cluster_v3`: Add new argument `authentication_mode` ([#727](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/727))
+* `resource/opentelekomcloud_obs_bucket`: Setting up AK/SK is not required anymore ([#745](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/745))
+* `resource/opentelekomcloud_obs_bucket_object`: Setting up AK/SK is not required anymore ([#745](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/745))
+
+Bug Fixes
+=========
+
+* `resource/opentelekomcloud_identity_credential_v3`: Add the missing documentation ([#731](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/731))
+* `resource/opentelekomcloud_vpnaas_ike_policy_v2`: Fix hardcoded values for `PFS` and `phase1_negotiation_mode` ([#733](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/733))
+* `resource/opentelekomcloud_identity_credential_v3`: Make `user_id` Optional ([#737](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/737))
+
+
+1.21.6 (November 25, 2020)
+--------------------------
+
+New Features
+============
+
+* **New Resource:** `opetelekomcloud_dds_instance_v3` ([#717](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/717))
+* **New Data Source:** `opetelekomcloud_dds_flavors_v3` ([#718](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/718))
+* **New Data Source:** `opentelekomcloud_vpc_bandwidth` ([#719](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/719))
+
+Bug Fixes
+=========
+
+* `resource/opentelekomcloud_as_group_v1`: Fix failing autoscaling group deletion ([#722](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/722))
+
+
+1.21.5 (November 19, 2020)
+--------------------------
+
+ENHANCEMENTS
+============
+
+* `provider/opentelekomcloud`: Add `OS_TOKEN` as alternative env var for `token` ([#706](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/706))
+* `resource/opentelekomcloud_lb_monitor_v2`: Add `monitor_port` argument ([#709](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/709))
+* `resource/opentelekomcloud_waf_domain_v1`: Rename WAF domain server attributes ([#710](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/710))
+* `resource/opentelekomcloud_csbs_backup_policy_v1`: Add fields to CSBS policy ([#714](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/714))
+
+
+1.21.4 (November 12, 2020)
+--------------------------
+
+Bug Fixes
+=========
+
+* `provider/opentelekomcloud`: Fix retries for 409 and 503 error codes ([#688](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/688))
+* `provider/opentelekomcloud`: Fix region handling ([#697](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/697))
+* `resource/opentelekomcloud_s3_bucket`: Fix panic creating `s3_bucket` without `tenant_name` in provider config ([#698](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/698))
+* `resource/opentelekomcloud_compute_instance_v2`: Revert changes from [#686](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/686) ([#701](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/701))
+* `resource/opentelekomcloud_rds_instance_v3`: Fix RDSv3 instance import ([#704](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/704))
+
+ENHANCEMENTS
+============
+
+* `resource/opentelekomcloud_lb_listener_v2`: Add new field `type` and make `private_key` as Optional ([#688](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/688))
+* `resource/opentelekomcloud_lb_certificate_v2`: Add new fields `http2_enable`, `client_ca_tls_container_ref` and `tls_ciphers_policy` ([#688](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/688))
+* `resource/opentelekomcloud_cce_cluster_v3`: Add new fields `kubernetes_svc_ip_range` and `kube_proxy_mode` ([#699](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/699))
+
+
+1.21.3 (November 6, 2020)
+-------------------------
+
+Bug Fixes
+=========
+
+* `resource/opentelekomcloud_compute_instance_v2`: Fix diff on every apply when using security group IDs instead of names ([#686](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/686))
+* `resource/opentelekomcloud_s3_bucket_policy`: Fix not working policy example in documentation ([#692](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/692))
+
+ENHANCEMENTS
+============
+
+* `resource/opentelekomcloud_cce_node_v3`: Make `iptype`, `bandwidth_charge_mode`, `sharetype` settable ([#681](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/681))
+* `resource/opentelekomcloud_cce_node_v3`: Fix not existing flavor in documentation ([#684](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/684))
+* `resource/opentelekomcloud_ecs_instance_v1`: Fix not existing flavor in documentation ([#689](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/689))
+
+
+1.21.2 (October 29, 2020)
+-------------------------
+
+Bug Fixes
+=========
+
+* `resource/opentelekomcloud_cce_cluster_v3`: Suppress schema diff in CCE version ([#666](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/666))
+* `resource/opentelekomcloud_cce_cluster_v3`: Increase delete timeout to 30m ([#674](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/674))
+* `resource/opentelekomcloud_compute_secgroup_v2`: Fix delete group if it's used ([#677](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/677))
+* `resource/opentelekomcloud_networking_secgroup_v2`: Fix delete group if it's used ([#676](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/676))
+
+New Features
+============
+
+* **New Data Source:** `opentelekomcloud_identity_auth_scope_v3` ([#669](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/669))
+
+ENHANCEMENTS
+============
+
+* `resource/opentelekomcloud_identity_user_v3`: Add email field to schema ([668](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/668))
+
+
+1.21.1 (October 23, 2020)
+-------------------------
+
+Bug Fixes
+=========
+
+* `resource/opentelekomcloud_rds_instance_v3`: Fix not assigning public IP ([#658](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/658))
+
+ENHANCEMENTS
+============
+
+* `resource/opentelekomcloud_blockstorage_volume_v2`: Allow expanding volume without re-creation ([#661](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/661))
+
+1.21.0 (October 15, 2020)
+-------------------------
+
+ENHANCEMENTS
+============
+
+* Migrate to `opentelekomcloud/gophertelekomcloud` from `huaweicloud/golangsdk`: ([#641](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/641))
+
+
+1.20.3 (October 14, 2020)
+-------------------------
+
+Bug Fixes
+=========
+
+* `resource/opentelekomcloud_dcs_instance_v1`: Fix issues with DCS schema ([#643](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/643))
+* `data_source/opentelekomcloud_role_v3`: Update role list ([#654](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/654))
+
+
+1.20.2 (September 30, 2020)
+---------------------------
+
+Bug Fixes
+=========
+
+* `resource/opentelekomcloud_lb_monitor_v2`: Fix `UDP-CONNECT` in type validation ([#634](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/634))
+* `resource/opentelekomcloud_cce_node_v3`: Handle 404 during reading tags for CCE node ([#635](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/635))
+* `resource/opentelekomcloud_obs_bucket`: Fix not creating OBS bucket with `security_token` ([#636](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/636))
+
+ENHANCEMENTS
+============
+
+* `resource/opentelekomcloud_cce_node_v3`: Add k8sTags to CCE node resource ([#621](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/621))
+* `resource/opentelekomcloud_csbs_backup_policy_v1`: Add `created_at` attribute ([#628](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/628))
+* `provider/opentelekomcloud`: Allow setting security token by env variable ([#627](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/627))
+
+
+1.20.1 (September 24, 2020)
+---------------------------
+
+Bug Fixes
+=========
+
+* `resource/opentelekomcloud_cce_node_v3`: `public_key` attribute not setting ([#616](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/616))
+
+New Features
+============
+
+* **New Data Source:** `opentelekomcloud_dns_zone_v2` ([#620](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/620))
+
+ENHANCEMENTS
+============
+
+* `resource/opentelekomcloud_cce_node_v3`: Only `bandwidth_charge_mode` is now required for EIP creation ([#616](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/616))
+
+1.20.0 (September 16, 2020)
+---------------------------
+
+Bug Fixes
+=========
+
+* `data_source/opentelekomcloud_cce_cluster_v3`: Update outdated docs ([#614](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/614))
+* `resource/opentelekomcloud_cce_cluster_v3`: Update outdated docs ([#614](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/614))
+* `resource/opentelekomcloud_lb_listener_v2`: Update outdated docs ([#615](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/615))
+
+New Features
+============
+
+* **New Data Source:** `opentelekomcloud_identity_credential_v3` ([#613](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/613))
+* **New Resource:** `opentelekomcloud_identity_credential_v3` ([#613](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/613))
+
+1.19.5 (September 4, 2020)
+--------------------------
+
+Bug Fixes
+=========
+
+* `resource/opentelekomcloud_blockstorage_volume_v2`: Ignore metadata.policy changes in blockstorage_volume_v2 ([#604](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/604))
+* `resource/opentelekomcloud_smn_subscription_v2`: Fix r/smn_subscription_v2 and d/cts_tracker_v1 ([608](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/608))
+* `data_source/opentelekomcloud_cts_tracker_v1`: Fix r/smn_subscription_v2 and d/cts_tracker_v1 ([608](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/608))
+
+New Features
+============
+
+* **New Data Source:** `opentelekomcloud_vpnaas_service_v2` ([#605](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/605))
+
+1.19.4 (September 1, 2020)
+--------------------------
+
+Bug Fixes
+=========
+
+* **Multiple Resources:** Documentation fixes after migration ([#599](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/599))
+
+1.19.3 (September 1, 2020)
+--------------------------
+
+Upgrade Notes
+=============
+
+* **Removed Resource:** `opentelekomcloud_maas_task_v1` ([#585](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/585))
+
+ENHANCEMENTS
+============
+
+* `resource/opentelekomcloud_compute_instance_v2`: Fix ECS tags-tag confusion ([#586](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/586))
+* `resource/opentelekomcloud_rds_instance_v3`: Add setting public IP for RDS instance v3 ([#596](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/596))
+
+1.19.2 (August 24, 2020)
+------------------------
+
+ENHANCEMENTS
+============
+
+* `data_source/opentelekomcloud_cce_cluster_v3`: Add certificates to cce_cluster_v3 data source ([#581](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/581))
+* `resource/opentelekomcloud_vpc_eip_v1`: Add `tags` support ([#570](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/570))
+
+1.19.1 (August 21, 2020)
+------------------------
+
+Bug Fixes
+=========
+
+* `resource/opentelekomcloud_rds_instance_v3`: Fix HTTP 415 when retrieving tags after nodes role switch ([#564](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/564))
+* `resource/opentelekomcloud_cce_cluster_v3`: Add setting `cluster_version` on resource read ([#568](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/568))
+
+1.19.0 (August 08, 2020)
+------------------------
+
+ENHANCEMENTS
+============
+
+* `resource/opentelekomcloud_as_group_v1`: Add health_periodic_audit_grace_period to as group ([#545](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/545))
+* `resource/opentelekomcloud_smn_topic_v2`: Add project_name to SMN topic ([#554](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/554))
+* `resource/opentelekomcloud_vpc_eip_v1`: Update documentation ([#550](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/550))
+* `resource/opentelekomcloud_cts_tracker_v1`: Add project_name to CTS tracker ([#555](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/555))
+* `resource/opentelekomcloud_compute_instance_v2`: Improve getting instance NICs ([#559](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/559))
+
+Bug Fixes
+=========
+
+* `resource/opentelekomcloud_rds_instance_v3`: Fix documentation ([#549](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/549))
+
+New Features
+============
+
+* **New Data Source:** `compute_availability_zones_v2`([#558](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/558))`
+
+1.18.1 (July 10, 2020)
+----------------------
+
+ENHANCEMENTS
+============
+
+* `resource/opentelekomcloud_as_group_v1`: Add `current_instance_number` and `status` attributes ([#522](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/522))
+* `provider/opentelekomcloud`: Add `max_retries` argument to the provider's options ([#537](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/537))
+
+Bug Fixes
+=========
+
+* `resource/rds_instance_v3`: Fix argument description ([#525](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/525))
+* `resource/cce_cluster_v3`: Update subnet_id description of CCE cluster ([#535](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/535))
+
+1.18.0 (June 16, 2020)
+----------------------
+
+ENHANCEMENTS
+============
+
+* `opentelekomcloud_vpc_v1`: Add tag support ([#508](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/508))
+* `opentelekomcloud_vpc_subnet_v1`: Add tag support ([#508](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/508))
+* `opentelekomcloud_dns_zone_v2`: Add tag support ([#510](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/510))
+* `opentelekomcloud_dns_recordset_v2`: Add tag support ([#514](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/514))
+* `opentelekomcloud_cce_node_v3`: Add tag support ([#513](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/513))
+
+
+Bug Fixes
+=========
+
+* `opentelekomcloud_waf_domain_v1`: Fix waf_domain_v1 using old waf API ([#496](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/496))
+* `opentelekomcloud_dcs_instance_v1`, `opentelekomcloud_dms_instance_v1`, `opentelekomcloud_rds_instance_v3`: Set sensitive flag for password parameter ([#504](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/504))
+* `opentelekomcloud_cts_tracker_v1`: Fix handling of missing tracker ([#518](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/518))
+
+1.17.1 (May 07, 2020)
+---------------------
+
+Bug Fixes
+=========
+
+* `resource/opentelekomcloud_vpc_subnet_v1`: Fix VPC subnet delete issue ([#492](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/492))
+
+1.17.0 (April 26, 2020)
+-----------------------
+
+New Features
+============
+
+* **New Data Source:** `opentelekomcloud_dms_az_v1` ([#485](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/485))
+* **New Data Source:** `opentelekomcloud_dms_product_v1` ([#485](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/485))
+* **New Data Source:** `opentelekomcloud_dms_maintainwindow_v1` ([#485](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/485))
+* **New Resource:** `opentelekomcloud_obs_bucket` ([#467](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/467))
+* **New Resource:** `opentelekomcloud_obs_bucket_object` ([#467](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/467))
+* **New Resource:** `opentelekomcloud_dns_ptrrecord_v2` ([#480](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/480))
+* **New Resource:** `opentelekomcloud_dms_instance_v1` ([#485](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/485))
+
+ENHANCEMENTS
+============
+
+* `resource/opentelekomcloud_ces_alarmrule`: Add alarm_level argument support ([#481](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/481))
+* `resource/opentelekomcloud_vbs_backup_policy_v2`: Add associating volumes support ([#478](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/478))
+* `resource/opentelekomcloud_rds_instance_v3`: Clean up ID if the intance couldn't be found ([#479](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/479))
+* `resource/opentelekomcloud_vbs_backup_policy_v3`: Add week_frequency and rentention_day support ([#489](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/489))
+
+Bug Fixes
+=========
+
+* `resource/opentelekomcloud_fw_rule_v2`: Fix removing assigned FW rule ([#462](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/462))
+* `resource/opentelekomcloud_dns_recordset_v2`: Fix updating only TTL value issue ([#465](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/465))
+* `resource/opentelekomcloud_vbs_backup_policy_v2`: Fix missing required `frequency` value ([#469](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/469))
+* `resource/opentelekomcloud_mrs_cluster_v1`: Update core nodes number validate func ([#477](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/477))
+
+1.16.0 (March 06, 2020)
+-----------------------
+
+New Features
+============
+
+* **New Resource:** `opentelekomcloud_nat_dnat_rule_v2` ([#447](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/447))
+
+ENHANCEMENTS
+=============
+
+* `resource/opentelekomcloud_cce_node_v3`: Add preinstall/postinstall script support ([#452](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/452))
+* `resource/opentelekomcloud_mrs_cluster_v1`: Add tags parameter support ([#453](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/453))
+* `resource/opentelekomcloud_mrs_cluster_v1`: Add bootstrap scripts parameter support ([#455](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/455))
+
+Bug Fixes
+=========
+
+* `resource/opentelekomcloud_elb_loadbalancer`: Increase bandwidth range to 1000 ([#459](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/459))
+* `data_source/opentelekomcloud_vpc_subnet_v1`: Fix vpc_subnet_v1 retrieval by id ([#460](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/460))
+
+1.15.1 (February 11, 2020)
+--------------------------
+
+Bug Fixes
+=========
+
+* `resource/opentelekomcloud_rds_instance_v3`: Fix RDS instance node id issue ([#450](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/450))
+
+1.15.0 (January 16, 2020)
+-------------------------
+
+New Features
+============
+
+* **New Resource:** `opentelekomcloud_logtank_group_v2` ([#435](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/435))
+* **New Resource:** `opentelekomcloud_logtank_topic_v2` ([#435](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/435))
+* **New Resource:** `opentelekomcloud_lb_certificate_v2` ([#437](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/437))
+* **New Resource:** `opentelekomcloud_vpc_flow_log_v1` ([#439](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/439))
+* **New Resource:** `opentelekomcloud_lb_l7policy_v2` ([#441](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/441))
+* **New Resource:** `opentelekomcloud_lb_l7rule_v2` ([#441](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/441))
+
+ENHANCEMENTS
+============
+
+* `resource/opentelekomcloud_networking_secgroup_v2`: Add description to secgroup_rule_v2 ([#432](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/432))
+* `resource/opentelekomcloud_blockstorage_volume_v2`: Update list of values for volume type ([#433](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/433))
+* Add clouds.yaml support ([#434](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/434))
+
+1.14.0 (December 02, 2019)
+--------------------------
+
+New Features
+============
+
+* **New Data Source:** `opentelekomcloud_cce_node_ids_v3` ([#411](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/411))
+* **New Resource:** `opentelekomcloud_vpnaas_endpoint_group_v2` ([#412](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/412))
+* **New Resource:** `opentelekomcloud_vpnaas_ike_policy_v2` ([#412](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/412))
+* **New Resource:** `opentelekomcloud_vpnaas_ipsec_policy_v2` ([#412](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/412))
+* **New Resource:** `opentelekomcloud_vpnaas_service_v2` ([#412](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/412))
+* **New Resource:** `opentelekomcloud_vpnaas_site_connection_v2` ([#412](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/412))
+
+ENHANCEMENTS
+============
+
+* `resource/opentelekomcloud_evs_volume_v3`: Add kms_id parameter support ([#403](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/403))
+* `resource/opentelekomcloud_cce_cluster_v3`: Add eip update support ([#410](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/410))
+* `resource/opentelekomcloud_compute_instance_v2`: Log fault message when build compute instance failed ([#413](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/413))
+* `resource/opentelekomcloud_evs_volume_v3`: Add device_type parameter support ([#419](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/419))
+* `resource/opentelekomcloud_evs_volume_v3`: Add wwn attribute support ([#420](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/420))
+
+Bug Fixes
+=========
+
+* `resource/opentelekomcloud_cce_node_v3`: Fix cce node update issue ([#405](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/405))
+* `resource/opentelekomcloud_dcs_instance_v1`: Fix ip/port attributes issue ([#408](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/408))
+* `resource/opentelekomcloud_mrs_cluster_v1`: Fix MRS region issue ([#409](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/409))
+* `resource/opentelekomcloud_compute_bms_server_v2`: Fix BMS boot from volume issue ([#422](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/422))
+
+1.13.1 (October 22, 2019)
+-------------------------
+
+ENHANCEMENTS
+============
+
+* `resource/opentelekomcloud_cce_cluster_v3`: Add eip parameter support ([#400](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/400))
+* `resource/opentelekomcloud_compute_bms_server_v2`: Add tags parameter support ([#401](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/401))
+
+1.13.0 (October 18, 2019)
+-------------------------
+
+New Features
+============
+
+* **New Resource:** `opentelekomcloud_evs_volume_v3` ([#380](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/380))
+* **New Resource:** `opentelekomcloud_lb_whitelist_v2` ([#390](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/390))
+* **New Resource:** `opentelekomcloud_ims_image_v2` ([#391](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/391))
+* **New Resource:** `opentelekomcloud_ims_data_image_v2` ([#396](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/396))
+
+ENHANCEMENTS
+============
+
+* `resource/opentelekomcloud_vpc_subnet_v1`: Add NTP server addresses support ([#369](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/369))
+* `resource/opentelekomcloud_rds_instance_v3`: Add tag support ([#373](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/373))
+* `resource/opentelekomcloud_rds_instance_v3`: Add flavor update support ([#377](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/377))
+* `resource/opentelekomcloud_rds_instance_v3`: Add volume resize support ([#378](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/378))
+* `resource/opentelekomcloud_waf_domain_v1`: Add policy_id parameter support ([#381](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/381))
+* `resource/opentelekomcloud_as_group_v1`: Add lbaas_listeners parameter support ([#385](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/385))
+* `resource/opentelekomcloud_as_configuration_v1`: Add kms_id parameter support ([#389](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/389))
+
+Bug Fixes
+=========
+
+* `resource/opentelekomcloud_rds_instance_v3`: Fix RDS backup_strategy parameter issue ([#367](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/367))
+* `data resource/opentelekomcloud_vpc_v1`: Fix id filter issue ([#379](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/379))
+
+1.12.0 (August 30, 2019)
+------------------------
+
+New Features
+============
+
+* **New Resource:** `opentelekomcloud_ecs_instance_v1` ([#347](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/347))
+
+ENHANCEMENTS
+============
+
+* `resource/opentelekomcloud_cce_cluster_v3`: Add CCE cluster certificates ([#349](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/349))
+* `resource/opentelekomcloud_cce_cluster_v3`: Add multi-az support for CCE cluster ([#350](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/350))
+* Add detailed error message for 404 ([#352](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/352))
+
+Bug Fixes
+=========
+
+* `resource/opentelekomcloud_vpc_subnet_v1`: Fix dns_list type issue ([#351](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/351))
+* `resource/opentelekomcloud_cce_node_v3`: Fix data_volumes type issue ([#354](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/354))
+* Fix common user ak/sk authentication issue with domain_name ([#362](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/362))
+* `resource/opentelekomcloud_rds_instance_v3`: Fix backup_strategy parameter issue ([#363](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/363))
+
+
+1.11.0 (August 01, 2019)
+------------------------
+
+New Features
+============
+
+* **New Data Source:** `opentelekomcloud_sdrs_domain_v1` ([#328](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/328))
+* **New Resource:** `opentelekomcloud_sdrs_protectiongroup_v1` ([#326](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/326))
+
+ENHANCEMENTS
+============
+
+* `resource/opentelekomcloud_vpc_v1`: Add enable_shared_snat support ([#333](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/333))
+* `resource/opentelekomcloud_networking_floatingip_v2`: Add default value for floating_ip pool ([#335](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/335))
+* `resource/opentelekomcloud_blockstorage_volume_v2`: Add device_type argument support ([#338](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/338))
+* `resource/opentelekomcloud_blockstorage_volume_v2`: Add wwn attribute support ([#339](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/339))
+
+Bug Fixes
+=========
+
+* `resource/opentelekomcloud_sfs_file_system_v2`: Set availability_zone to Computed ([#330](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/330))
+* `resource/opentelekomcloud_rds_configuration_v3`: Fix RDS parametergroup acc test ([#331](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/331))
+
+1.10.0 (July 01, 2019)
+----------------------
+
+New Features
+============
+
+* **New Resource:** `opentelekomcloud_waf_whiteblackip_rule_v1` ([#313](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/313))
+* **New Resource:** `opentelekomcloud_waf_datamasking_rule_v1` ([#315](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/315))
+* **New Resource:** `opentelekomcloud_waf_falsealarmmasking_rule_v1` ([#317](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/317))
+* **New Resource:** `opentelekomcloud_waf_ccattackprotection_rule_v1` ([#320](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/320))
+* **New Resource:** `opentelekomcloud_waf_preciseprotection_rule_v1` ([#322](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/322))
+* **New Resource:** `opentelekomcloud_waf_webtamperprotection_rule_v1` ([#324](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/324))
+
+ENHANCEMENTS
+============
+
+* `resource/opentelekomcloud_mrs_cluster_v1`: Add master/core data volume support to MRS cluster ([#308](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/308))
+* `resource/opentelekomcloud_mrs_cluster_v1`: Add SAS volume type support to MRS cluster ([#310](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/310))
+
+Bug Fixes
+=========
+
+* `resource/opentelekomcloud_identity_project_v3`: Fix project creation issue ([#305](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/305))
+
+1.9.0 (June 06, 2019)
+---------------------
+
+New Features
+============
+
+* **New Resource:** `opentelekomcloud_waf_certificate_v1` ([#285](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/285))
+* **New Resource:** `opentelekomcloud_waf_domain_v1` ([#286](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/286))
+* **New Resource:** `opentelekomcloud_waf_policy_v1` ([#293](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/293))
+* **New Resource:** `opentelekomcloud_rds_parametergroup_v3` ([#290](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/290))
+
+ENHANCEMENTS
+============
+
+* The provider is now compatible with Terraform v0.12, while retaining compatibility with prior versions.
+* `resource/opentelekomcloud_rds_instance_v3`: Add import support ([#274](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/274))
+* `resource/opentelekomcloud_cce_node_v3`: Add private_ip attribute ([#280](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/280))
+
+Bug Fixes
+=========
+
+* `resource/opentelekomcloud_cce_node_v3`: Fix eip_count issue ([#279](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/279))
+
+1.8.0 (May 06, 2019)
+--------------------
+
+New Features
+============
+
+* **New Data Source:** `opentelekomcloud_networking_port_v2` ([#263](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/263))
+* **New Data Source:** `opentelekomcloud_rds_flavors_v3` ([#267](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/267))
+* **New Resource:** `opentelekomcloud_identity_role_v3` ([#213](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/213))
+* **New Resource:** `opentelekomcloud_css_cluster_v1` ([#255](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/255))
+* **New Resource:** `opentelekomcloud_rds_instance_v3` ([#267](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/267))
+
+ENHANCEMENTS
+============
+
+* `resource/opentelekomcloud_dns_zone_v2`: Add support for attaching multi routers to dns zone ([#261](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/261))
+* `resource/opentelekomcloud_cce_cluster_v3`: Add authentication mode option support for CCE cluster ([#262](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/262))
+* `provider`: Add security_token option for OBS federated authentication ([#264](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/264))
+* `resource/opentelekomcloud_rds_instance_v1`: Add RDS tag support ([#268](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/268))
+
+Bug Fixes
+=========
+
+* `resource/opentelekomcloud_dms_group_v1`: Fix wrong error message ([#260](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/260))
+* `data_source/opentelekomcloud_cce_node_v3`: Fix node data source with node_id ([#265](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/265))
+* `resource/opentelekomcloud_cce_node_v3`: Remove Abnormal from cce node creating target state ([#266](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/266))
+
+1.7.0 (March 20, 2019)
+----------------------
+
+Deprecation Notes
+=================
+
+* provider: The `region`, `tenant_id`, `domain_id`, `user_id` arguments have been deprecated and `tenant_name`, `domain_name` changed to be `required`. Please update your configurations as it might be removed in the future releases.
+
+New Features
+============
+
+* **New Resource:** `opentelekomcloud_identity_agency_v3` ([#232](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/232))
+
+ENHANCEMENTS
+============
+
+* `provider`: Remove region, tenant_id, domain_id, user_id parameters ([#230](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/230))
+* `resource/opentelekomcloud_compute_instance_v2`: Add support of security_groups update ([#234](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/234))
+* `resource/opentelekomcloud_nat_snat_rule_v2`: Add `cidr` and `source_type` parameters support ([#237](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/237))
+
+Bug Fixes
+=========
+
+* `resource/opentelekomcloud_identity_role_assignment_v3`: Fix attributes set issue ([#226](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/226))
+* `resource/opentelekomcloud_csbs_backup_policy_v1`: Fix csbs policies parameters issue ([#244](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/244))
+
+1.6.1 (February 18, 2019)
+-------------------------
+
+Bug Fixes
+=========
+
+* `provider authentication`: Fix authentication with tenant ([#216](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/216))
+* `resource/opentelekomcloud_dcs_instance_v1`: Update `password` and `engine_version` of dcs instance from Option to Required ([#217](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/217))
+* `resource/opentelekomcloud_smn_topic_v2`: Fix some smn topic parameters issue ([#218](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/218))
+
+1.6.0 (February 01, 2019)
+-------------------------
+
+New Features
+============
+
+* **New Data Source:** `opentelekomcloud_identity_role_v3` ([#167](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/167))
+* **New Data Source:** `opentelekomcloud_identity_project_v3` ([#167](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/167))
+* **New Data Source:** `opentelekomcloud_identity_user_v3` ([#167](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/167))
+* **New Data Source:** `opentelekomcloud_identity_group_v3` ([#167](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/167))
+* **New Resource:** `opentelekomcloud_identity_project_v3` ([#167](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/167))
+* **New Resource:** `opentelekomcloud_identity_role_v3` ([#167](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/167))
+* **New Resource:** `opentelekomcloud_identity_role_assignment_v3` ([#167](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/167))
+* **New Resource:** `opentelekomcloud_identity_user_v3` ([#167](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/167))
+* **New Resource:** `opentelekomcloud_identity_group_v3` ([#167](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/167))
+* **New Resource:** `opentelekomcloud_identity_group_membership_v3` ([#167](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/167))
+
+Bug Fixes
+=========
+
+* `resource/opentelekomcloud_rts_stack_v1`: Re-sign for 302 redirect in ak/sk scenario ([#204](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/204))
+* `resource/opentelekomcloud_elb_listener`: Fix elb listener update error for backend_port ([#209](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/209))
+
+1.5.2 (January 11, 2019)
+------------------------
+
+Bug Fixes
+=========
+
+* `resource/opentelekomcloud_compute_instance_v2`: Fix instance tag update error ([#178](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/178))
+* `resource/opentelekomcloud_dns_recordset_v2`: Fix dns records update error ([#179](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/179))
+* `resource/opentelekomcloud_dns_recordset_v2`: Fix dns entries re-sort issue ([#185](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/185))
+
+1.5.1 (January 08, 2019)
+------------------------
+
+Bug Fixes
+=========
+
+* Fix ak/sk authentication issue ([#176](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/176))
+
+1.5.0 (January 07, 2019)
+------------------------
+
+New Features
+============
+
+* **New Data Source:** `opentelekomcloud_dcs_az_v1` ([#154](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/154))
+* **New Data Source:** `opentelekomcloud_dcs_maintainwindow_v1` ([#154](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/154))
+* **New Data Source:** `opentelekomcloud_dcs_product_v1` ([#154](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/154))
+* **New Resource:** `opentelekomcloud_networking_floatingip_associate_v2` ([#153](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/153))
+* **New Resource:** `opentelekomcloud_dcs_instance_v1` ([#154](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/154))
+
+Bug Fixes
+=========
+
+* `resource/opentelekomcloud_vpc_subnet_v1`: Remove UNKNOWN status to avoid error ([#158](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/158))
+* `resource/opentelekomcloud_rds_instance_v1`: Suppress rds name change ([#161](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/161))
+* `resource/opentelekomcloud_kms_key_v1`: Add default value of pending_days ([#163](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/163))
+* `all resources`: Expose real error message of BadRequest error ([#164](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/164))
+* `resource/opentelekomcloud_sfs_file_system_v2`: Suppress sfs system metadata ([#168](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/168))
+
+ENHANCEMENTS
+============
+
+* Add AKSK authentication support ([#157](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/157))
+* `data_source/opentelekomcloud_images_image_v2`: Add properties filter support for images data source ([#165](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/165))
+* `resource/opentelekomcloud_compute_instance_v2`: Add key/value tag support ([#169](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/169))
+* `data_source/opentelekomcloud_vpc_subnet_v1`: Sort vpc subnet ids by network ip availabilities ([#171](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/171))
+
+1.4.0 (December 10, 2018)
+-------------------------
+
+New Features
+============
+
+* **New Data Source:** `opentelekomcloud_cts_tracker_v1` ([#135](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/135))
+* **New Data Source:** `opentelekomcloud_antiddos_v1` ([#138](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/138))
+* **New Data Source:** `opentelekomcloud_cce_node_v3` ([#140](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/140))
+* **New Data Source:** `opentelekomcloud_cce_cluster_v3` ([#140](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/140))
+* **New Resource:** `opentelekomcloud_compute_bms_server_v2` ([#132](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/132))
+* **New Resource:** `opentelekomcloud_cts_tracker_v1` ([#135](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/135))
+* **New Resource:** `opentelekomcloud_antiddos_v1` ([#138](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/138))
+* **New Resource:** `opentelekomcloud_cce_node_v3` ([#140](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/140))
+* **New Resource:** `opentelekomcloud_cce_cluster_v3` ([#140](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/140))
+* **New Resource:** `opentelekomcloud_maas_task_v1` ([#142](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/142))
+
+1.3.0 (November 05, 2018)
+-------------------------
+
+New Features
+============
+
+* **New Data Source:** `opentelekomcloud_vbs_backup_policy_v2` ([#121](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/121))
+* **New Data Source:** `opentelekomcloud_vbs_backup_v2` ([#121](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/121))
+* **New Resource:** `opentelekomcloud_vbs_backup_policy_v2` ([#121](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/121))
+* **New Resource:** `opentelekomcloud_vbs_backup_v2` ([#121](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/121))
+* **New Resource:** `opentelekomcloud_vbs_backup_share_v2` ([#121](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/121))
+* **New Resource:** `opentelekomcloud_mrs_cluster_v1` ([#126](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/126))
+* **New Resource:** `opentelekomcloud_mrs_job_v1` ([#126](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/126))
+
+Bug Fixes
+=========
+
+* `resource/opentelekomcloud_elb_loadbalancer`: Fix ELB client error ([#129](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/129))
+
+1.2.0 (October 01, 2018)
+------------------------
+
+New Features
+============
+
+* **New Data Source:** `opentelekomcloud_deh_host_v1` ([#98](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/98))
+* **New Data Source:** `opentelekomcloud_deh_server_v1` ([#98](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/98))
+* **New Data Source:** `opentelekomcloud_rts_software_config_v1` ([#97](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/97))
+* **New Data Source:** `opentelekomcloud_rts_software_deployment_v1` ([#97](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/97))
+* **New Data Source:** `opentelekomcloud_vpc_v1` ([#87](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/87))
+* **New Data Source:** `opentelekomcloud_vpc_subnet_v1` ([#87](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/87))
+* **New Data Source:** `opentelekomcloud_vpc_subnet_ids_v1` ([#87](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/87))
+* **New Data Source:** `opentelekomcloud_vpc_route_v2` ([#87](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/87))
+* **New Data Source:** `opentelekomcloud_vpc_route_ids_v2` ([#87](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/87))
+* **New Data Source:** `opentelekomcloud_vpc_peering_connection_v2` ([#87](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/87))
+* **New Data Source:** `opentelekomcloud_compute_bms_nic_v2` ([#101](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/101))
+* **New Data Source:** `opentelekomcloud_compute_bms_keypairs_v2` ([#101](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/101))
+* **New Data Source:** `opentelekomcloud_compute_bms_flavors_v2` ([#101](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/101))
+* **New Data Source:** `opentelekomcloud_compute_bms_server_v2` ([#101](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/101))
+* **New Data Source:** `opentelekomcloud_rts_stack_v1` ([#95](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/95))
+* **New Data Source:** `opentelekomcloud_rts_stack_resource_v1` ([#95](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/95))
+* **New Data Source:** `opentelekomcloud_sfs_file_system_v2` ([#92](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/92))
+* **New Data Source:** `opentelekomcloud_csbs_backup_v1` ([#117](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/117))
+* **New Data Source:** `opentelekomcloud_csbs_backup_policy_v1` ([#117](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/117))
+* **New Resource:** `opentelekomcloud_deh_host_v1` ([#98](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/98))
+* **New Resource:** `opentelekomcloud_rts_software_config_v1` ([#97](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/97))
+* **New Resource:** `opentelekomcloud_rts_software_deployment_v1` ([#97](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/97))
+* **New Resource:** `opentelekomcloud_vpc_v1` ([#87](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/87))
+* **New Resource:** `opentelekomcloud_vpc_subnet_v1` ([#87](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/87))
+* **New Resource:** `opentelekomcloud_vpc_route_v2` ([#87](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/87))
+* **New Resource:** `opentelekomcloud_vpc_peering_connection_v2` ([#87](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/87))
+* **New Resource:** `opentelekomcloud_vpc_peering_connection_accepter_v2` ([#87](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/87))
+* **New Resource:** `opentelekomcloud_sfs_file_system_v2` ([#92](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/92))
+* **New Resource:** `opentelekomcloud_rts_stack_v1` ([#95](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/95))
+* **New Resource:** `opentelekomcloud_nat_gateway_v2` ([#107](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/107))
+* **New Resource:** `opentelekomcloud_nat_snat_rule_v2` ([#107](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/107))
+* **New Resource:** `opentelekomcloud_as_configuration_v1` ([#108](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/108))
+* **New Resource:** `opentelekomcloud_as_group_v1` ([#108](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/108))
+* **New Resource:** `opentelekomcloud_as_policy_v1` ([#108](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/108))
+* **New Resource:** `opentelekomcloud_dms_queue_v1` ([#114](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/114))
+* **New Resource:** `opentelekomcloud_dms_group_v1` ([#114](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/114))
+* **New Resource:** `opentelekomcloud_csbs_backup_v1` ([#117](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/117))
+* **New Resource:** `opentelekomcloud_csbs_backup_policy_v1` ([#117](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/117))
+* **New Resource:** `opentelekomcloud_networking_vip_v2` ([#119](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/119))
+* **New Resource:** `opentelekomcloud_networking_vip_associate_v2` ([#119](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/119))
+
+1.1.0 (May 26, 2018)
+--------------------
+
+New Features
+============
+
+* **New Data Source:** `opentelekomcloud_kms_key_v1` ([#14](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/14))
+* **New Data Source:** `opentelekomcloud_kms_data_key_v1` ([#14](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/14))
+* **New Data Source:** `opentelekomcloud_rds_flavors_v1` ([#15](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/15))
+* **New Resource:** `opentelekomcloud_kms_key_v1` ([#14](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/14))
+* **New Resource:** `opentelekomcloud_rds_instance_v1` ([#15](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/15))
+* **New Resource:** `opentelekomcloud_vpc_eip_v1` ([#48](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/48))
+* resource/opentelekomcloud_compute_instance_v2: Add `auto_recovery` argument ([#20](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/20))
+* resource/opentelekomcloud_networking_router_v2: Add `enable_snat` argument ([#53](https://github.com/terraform-providers/terraform-provider-opentelekomcloud/issues/53))
+
+1.0.0 (December 08, 2017)
+-------------------------
+
+Initial release of the OpenTelekom Cloud Provider
+
+


### PR DESCRIPTION
- setup releasenotes structure to be build by sphinx&reno (same as other python otc tools)
- migrate content of the changelog into older releasenotes

=======
- RN publishing is going to be implemented separately in the job-template (bit later)
- PR's that have interface effect "must" contain RN note (can be generated according to https://docs.openstack.org/reno/latest/user/usage.html)
- PR's without external visibility "should" have RN note.
- it is in the reviewers responsibility to check/enforce RN presence. Generally RN can be added later, but should be done before release, cause otherwise will be related to wrong release.
