### PR TITLE
Fix panic in `networking_secgroup_v2` data source

### DIFF
--- a/releasenotes/notes/fix-secgroup-23e41d4ac82f0f34.yaml
+++ b/releasenotes/notes/fix-secgroup-23e41d4ac82f0f34.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix panic when using `opentelekomcloud_networking_secgroup_v2` data source ([#1176](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1176))


### PR DESCRIPTION
## Summary of the Pull Request
Fix #1175 

## PR Checklist

* [x] Refers to: #1175
* [x] Tests added/passed.
* [x] Schema updated.

## Acceptance Steps Performed

```
=== RUN   TestAccOpenTelekomCloudNetworkingSecGroupV2DataSource_basic
--- PASS: TestAccOpenTelekomCloudNetworkingSecGroupV2DataSource_basic (28.28s)
=== RUN   TestAccOpenTelekomCloudNetworkingSecGroupV2DataSource_secGroupID
--- PASS: TestAccOpenTelekomCloudNetworkingSecGroupV2DataSource_secGroupID (27.95s)
PASS

Process finished with the exit code 0

```
