### PR TITLE
[ECS] Fix issue with reading `image_name`

### DIFF
--- a/opentelekomcloud/services/ecs/resource_opentelekomcloud_compute_instance_v2.go
+++ b/opentelekomcloud/services/ecs/resource_opentelekomcloud_compute_instance_v2.go
@@ -1085,8 +1085,8 @@ func setImageInformation(client *golangsdk.ServiceClient, server *servers.Server
 		if err := d.Set("image_id", imageId); err != nil {
 			return err
 		}
-		imageName := d.Get("image_name").(string)
-		if imageName == "" {
+
+		if imageName := d.Get("image_name").(string); imageName == "" {
 			if image, err := images.Get(client, imageId).Extract(); err != nil {
 				if _, ok := err.(golangsdk.ErrDefault404); ok {
 					// If the image name can't be found, don't set name.

--- a/opentelekomcloud/services/ecs/resource_opentelekomcloud_compute_instance_v2.go
+++ b/opentelekomcloud/services/ecs/resource_opentelekomcloud_compute_instance_v2.go
@@ -1085,16 +1085,19 @@ func setImageInformation(client *golangsdk.ServiceClient, server *servers.Server
 		if err := d.Set("image_id", imageId); err != nil {
 			return err
 		}
-		if image, err := images.Get(client, imageId).Extract(); err != nil {
-			if _, ok := err.(golangsdk.ErrDefault404); ok {
-				// If the image name can't be found, don't set name.
-				// The most likely scenario is that the image no longer exists in the Image Service
-				// but the instance still has a record from when it existed.
-				return d.Set("image_name", "Not Found")
+		imageName := d.Get("image_name").(string)
+		if imageName == "" {
+			if image, err := images.Get(client, imageId).Extract(); err != nil {
+				if _, ok := err.(golangsdk.ErrDefault404); ok {
+					// If the image name can't be found, don't set name.
+					// The most likely scenario is that the image no longer exists in the Image Service
+					// but the instance still has a record from when it existed.
+					return d.Set("image_name", "Not Found")
+				}
+				return err
+			} else {
+				return d.Set("image_name", image.Name)
 			}
-			return err
-		} else {
-			return d.Set("image_name", image.Name)
 		}
 	}
 

--- a/releasenotes/notes/fix-image-name-reading-c76e900fed0647e2.yaml
+++ b/releasenotes/notes/fix-image-name-reading-c76e900fed0647e2.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    [ECS] Don't read `image_name` if it's set in `resource/opentelekomcloud_compute_instance_v2` `#1181 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1181>`_


### PR DESCRIPTION
## Summary of the Pull Request
Fix issue with reading `image_name` in `resource/opentelekomcloud_compute_instance_v2`
Fixes: #1141

## PR Checklist

* [x] Refers to: #1141
* [x] Tests added/passed.

## Acceptance Steps Performed

```
=== RUN   TestAccComputeV2Instance_basic
--- PASS: TestAccComputeV2Instance_basic (135.87s)
PASS

Process finished with the exit code 0
```
