### PR TITLE
[KMS] Add new resource `opentelekomcloud_kms_grant_v1`

### DIFF
--- a/docs/resources/kms_grant_v1.md
+++ b/docs/resources/kms_grant_v1.md
@@ -1,0 +1,58 @@
+---
+subcategory: "Key Management Service (KMS)"
+---
+
+# opentelekomcloud_kms_grant_v1
+
+Manages a V1 KMS grant resource within OpenTelekomCloud.
+
+## Example Usage
+
+```hcl
+resource "opentelekomcloud_kms_grant_v1" "grant_1" {
+  key_id            = var.kms_id
+  name              = "my_grant"
+  grantee_principal = var.user_id
+  operations        = ["describe-key", "create-datakey", "encrypt-datakey"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `key_id` - (Required) Indicates the ID of the KMS. Changing this creates new grant.
+
+* `grantee_principal` - (Required) Indicates the ID of the authorized user.
+  Changing this creates new grant.
+
+* `operations` - (Required) Permissions that can be granted.
+  The valid values are: `create-datakey`, `create-datakey-without-plaintext`,
+  `encrypt-datakey`, `decrypt-datakey`, `describe-key`, `create-grant`, `retire-grant`.
+  Changing this creates new grant.
+
+* `name` - (Optional) Name of a grant which can be 1 to 255 characters in length
+  and matches the regular expression `^[a-zA-Z0-9:/_-]{1,255}$`.
+  Changing this creates new grant.
+
+* `retiring_principal` - (Optional) Indicates the ID of the retiring user.
+  Changing this creates new grant.
+
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `issuing_principal` - Indicates the ID of the user who created the grant.
+
+* `creation_date` - Creation time. The value is a timestamp expressed in the number of
+  seconds since 00:00:00 UTC on January 1, 1970.
+
+
+## Import
+
+KMS Grants can be imported using the `key_id/grant_id`, e.g.
+
+```shell
+terraform import opentelekomcloud_kms_grant_v1.grant_1 4779ab1c-7c1a-44b1-a02e-93dfc361b32d/7056d636-ac60-4663-8a6c-82d3c32c1c64
+```

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/jinzhu/copier v0.2.3
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.4.2-0.20210622175442-0d79e23f9cd6
+	github.com/opentelekomcloud/gophertelekomcloud v0.4.2-0.20210701090532-c94a53dc0e6f
 	github.com/unknwon/com v1.0.1
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -287,8 +287,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.4.2-0.20210622175442-0d79e23f9cd6 h1:l1r9vrwt5jeNfOSbXNEk1GigsxQKlkk26dox3CLCnfU=
-github.com/opentelekomcloud/gophertelekomcloud v0.4.2-0.20210622175442-0d79e23f9cd6/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
+github.com/opentelekomcloud/gophertelekomcloud v0.4.2-0.20210701090532-c94a53dc0e6f h1:g3lMh1sWJ21Rotu8MrfTD3IkNOd0UOL5H0R94CQL8Gk=
+github.com/opentelekomcloud/gophertelekomcloud v0.4.2-0.20210701090532-c94a53dc0e6f/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/opentelekomcloud/acceptance/kms/import_opentelekomcloud_kms_grant_v1_test.go
+++ b/opentelekomcloud/acceptance/kms/import_opentelekomcloud_kms_grant_v1_test.go
@@ -1,0 +1,34 @@
+package acceptance
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+)
+
+func TestAccKmsV1GrantImportBasic(t *testing.T) {
+	resourceName := "opentelekomcloud_kms_grant_v1.grant_1"
+
+	granteePrincipal := os.Getenv("OS_USER_ID")
+	if granteePrincipal == "" {
+		t.Skip("OS_USER_ID must be set for acceptance test")
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckKmsV1GrantDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKmsGrantV1Basic(granteePrincipal),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/opentelekomcloud/acceptance/kms/resource_opentelekomcloud_kms_grant_v1_test.go
+++ b/opentelekomcloud/acceptance/kms/resource_opentelekomcloud_kms_grant_v1_test.go
@@ -1,0 +1,135 @@
+package acceptance
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/kms/v1/grants"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/services/kms"
+)
+
+func TestAccKmsGrantV1Basic(t *testing.T) {
+	var grant grants.Grant
+	resourceName := "opentelekomcloud_kms_grant_v1.grant_1"
+
+	granteePrincipal := os.Getenv("OS_USER_ID")
+	if granteePrincipal == "" {
+		t.Skip("OS_USER_ID must be set for acceptance test")
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckKmsV1GrantDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKmsGrantV1Basic(granteePrincipal),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKmsV1GrantExists(resourceName, &grant),
+					resource.TestCheckResourceAttr(resourceName, "key_id", env.OS_KMS_ID),
+					resource.TestCheckResourceAttr(resourceName, "name", "my_grant"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckKmsV1GrantDestroy(s *terraform.State) error {
+	config := common.TestAccProvider.Meta().(*cfg.Config)
+	client, err := config.KmsKeyV1Client(env.OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("error creating OpenTelekomCloud KMSv1 client: %w", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "opentelekomcloud_kms_grant_v1" {
+			continue
+		}
+		kmsID, grantID, err := kms.ResourceKMSGrantV1ParseID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+		listOpts := grants.ListOpts{
+			KeyID: kmsID,
+		}
+
+		grantsList, err := grants.List(client, listOpts).Extract()
+		if err != nil {
+			return err
+		}
+		var found *grants.Grant
+		for _, grant := range grantsList.Grants {
+			if grant.GrantID == grantID {
+				found = &grant
+				break
+			}
+		}
+
+		if found != nil {
+			return fmt.Errorf("grant still exists")
+		}
+	}
+	return nil
+}
+
+func testAccCheckKmsV1GrantExists(n string, grant *grants.Grant) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		config := common.TestAccProvider.Meta().(*cfg.Config)
+		client, err := config.KmsKeyV1Client(env.OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("error creating OpenTelekomCloud KMSv1 client: %w", err)
+		}
+
+		kmsID, grantID, err := kms.ResourceKMSGrantV1ParseID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+		listOpts := grants.ListOpts{
+			KeyID: kmsID,
+		}
+
+		grantsList, err := grants.List(client, listOpts).Extract()
+		if err != nil {
+			return err
+		}
+		var found *grants.Grant
+		for _, grant := range grantsList.Grants {
+			if grant.GrantID == grantID {
+				found = &grant
+				break
+			}
+		}
+
+		if found == nil {
+			return fmt.Errorf("grant not found")
+		}
+
+		*grant = *found
+		return nil
+	}
+}
+
+func testAccKmsGrantV1Basic(granteePrincipal string) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_kms_grant_v1" "grant_1" {
+  key_id            = "%s"
+  name              = "my_grant"
+  grantee_principal = "%s"
+  operations        = ["describe-key", "create-datakey", "encrypt-datakey"]
+}`, env.OS_KMS_ID, granteePrincipal)
+}

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -346,6 +346,7 @@ func Provider() *schema.Provider {
 			"opentelekomcloud_images_image_v2":                    ims.ResourceImagesImageV2(),
 			"opentelekomcloud_ims_data_image_v2":                  ims.ResourceImsDataImageV2(),
 			"opentelekomcloud_ims_image_v2":                       ims.ResourceImsImageV2(),
+			"opentelekomcloud_kms_grant_v1":                       kms.ResourceKmsGrantV1(),
 			"opentelekomcloud_kms_key_v1":                         kms.ResourceKmsKeyV1(),
 			"opentelekomcloud_lb_certificate_v2":                  elb.ResourceCertificateV2(),
 			"opentelekomcloud_lb_l7policy_v2":                     elb.ResourceL7PolicyV2(),

--- a/opentelekomcloud/services/kms/common.go
+++ b/opentelekomcloud/services/kms/common.go
@@ -1,0 +1,5 @@
+package kms
+
+const (
+	errCreationClient = "error creating OpenTelekomCloud KMSv1 client: %w"
+)

--- a/opentelekomcloud/services/kms/common.go
+++ b/opentelekomcloud/services/kms/common.go
@@ -1,5 +1,22 @@
 package kms
 
+import (
+	"fmt"
+	"strings"
+)
+
 const (
 	errCreationClient = "error creating OpenTelekomCloud KMSv1 client: %w"
 )
+
+func ResourceKMSGrantV1ParseID(componentID string) (string, string, error) {
+	parts := strings.Split(componentID, "/")
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("unable to determine KMS Grant ID")
+	}
+
+	kmsID := parts[0]
+	grantID := parts[1]
+
+	return kmsID, grantID, nil
+}

--- a/opentelekomcloud/services/kms/resource_opentelekomcloud_kms_grant_v1.go
+++ b/opentelekomcloud/services/kms/resource_opentelekomcloud_kms_grant_v1.go
@@ -3,7 +3,6 @@ package kms
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -102,7 +101,7 @@ func resourceKmsGrantV1Read(_ context.Context, d *schema.ResourceData, meta inte
 		return fmterr.Errorf(errCreationClient, err)
 	}
 
-	kmsID, grantID, err := resourceKMSGrantV1ParseID(d.Id())
+	kmsID, grantID, err := ResourceKMSGrantV1ParseID(d.Id())
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -151,7 +150,7 @@ func resourceKmsGrantV1Delete(_ context.Context, d *schema.ResourceData, meta in
 		return fmterr.Errorf(errCreationClient, err)
 	}
 
-	kmsID, grantID, err := resourceKMSGrantV1ParseID(d.Id())
+	kmsID, grantID, err := ResourceKMSGrantV1ParseID(d.Id())
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -167,16 +166,4 @@ func resourceKmsGrantV1Delete(_ context.Context, d *schema.ResourceData, meta in
 
 	d.SetId("")
 	return nil
-}
-
-func resourceKMSGrantV1ParseID(componentID string) (string, string, error) {
-	parts := strings.Split(componentID, "/")
-	if len(parts) != 2 {
-		return "", "", fmt.Errorf("unable to determine KMS Grant ID")
-	}
-
-	kmsID := parts[0]
-	grantID := parts[1]
-
-	return kmsID, grantID, nil
 }

--- a/opentelekomcloud/services/kms/resource_opentelekomcloud_kms_grant_v1.go
+++ b/opentelekomcloud/services/kms/resource_opentelekomcloud_kms_grant_v1.go
@@ -1,0 +1,182 @@
+package kms
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/kms/v1/grants"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
+)
+
+func ResourceKmsGrantV1() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceKmsGrantV1Create,
+		ReadContext:   resourceKmsGrantV1Read,
+		DeleteContext: resourceKmsGrantV1Delete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"key_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"grantee_principal": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"operations": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"retiring_principal": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"issuing_principal": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"creation_date": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceKmsGrantV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := config.KmsKeyV1Client(config.GetRegion(d))
+	if err != nil {
+		return fmterr.Errorf(errCreationClient, err)
+	}
+
+	rawOperations := d.Get("operations").(*schema.Set).List()
+	operations := make([]string, len(rawOperations))
+	for i, operation := range rawOperations {
+		operations[i] = operation.(string)
+	}
+
+	keyID := d.Get("key_id").(string)
+	createOpts := grants.CreateOpts{
+		KeyID:             keyID,
+		GranteePrincipal:  d.Get("grantee_principal").(string),
+		Operations:        operations,
+		Name:              d.Get("name").(string),
+		RetiringPrincipal: d.Get("retiring_principal").(string),
+	}
+
+	createGrant, err := grants.Create(client, createOpts).Extract()
+	if err != nil {
+		return fmterr.Errorf("error creating OpenTelekomCloud KMSv1 Grant: %w", err)
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s", keyID, createGrant.GrantID))
+
+	return resourceKmsGrantV1Read(ctx, d, meta)
+}
+
+func resourceKmsGrantV1Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := config.KmsKeyV1Client(config.GetRegion(d))
+	if err != nil {
+		return fmterr.Errorf(errCreationClient, err)
+	}
+
+	kmsID, grantID, err := resourceKMSGrantV1ParseID(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	listOpts := grants.ListOpts{
+		KeyID: kmsID,
+	}
+	grantList, err := grants.List(client, listOpts).Extract()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	var createdGrant *grants.Grant
+	for _, grant := range grantList.Grants {
+		if grant.GrantID == grantID {
+			createdGrant = &grant
+			break
+		}
+	}
+	if createdGrant == nil {
+		d.SetId("")
+		return nil
+	}
+
+	mErr := multierror.Append(
+		d.Set("key_id", createdGrant.KeyID),
+		d.Set("grantee_principal", createdGrant.GranteePrincipal),
+		d.Set("operations", createdGrant.Operations),
+		d.Set("name", createdGrant.Name),
+		d.Set("retiring_principal", createdGrant.RetiringPrincipal),
+		d.Set("creation_date", createdGrant.CreationDate),
+		d.Set("creation_date", createdGrant.IssuingPrincipal),
+	)
+
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func resourceKmsGrantV1Delete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := config.KmsKeyV1Client(config.GetRegion(d))
+	if err != nil {
+		return fmterr.Errorf(errCreationClient, err)
+	}
+
+	kmsID, grantID, err := resourceKMSGrantV1ParseID(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	deleteOpts := &grants.DeleteOpts{
+		KeyID:   kmsID,
+		GrantID: grantID,
+	}
+
+	if err := grants.Delete(client, deleteOpts).ExtractErr(); err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func resourceKMSGrantV1ParseID(componentID string) (string, string, error) {
+	parts := strings.Split(componentID, "/")
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("unable to determine KMS Grant ID")
+	}
+
+	kmsID := parts[0]
+	grantID := parts[1]
+
+	return kmsID, grantID, nil
+}

--- a/releasenotes/notes/r-kms-grant-63d17d3ddbdace63.yaml
+++ b/releasenotes/notes/r-kms-grant-63d17d3ddbdace63.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   - |
-    [KMS] Add new `resource/opentelekomcloud_kms_grant_v1` (`#1185 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1185>`_)
+    **New Resource:** ``opentelekomcloud_kms_grant_v1`` (`#1185 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1185>`_)

--- a/releasenotes/notes/r-kms-grant-63d17d3ddbdace63.yaml
+++ b/releasenotes/notes/r-kms-grant-63d17d3ddbdace63.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    [KMS] Add new `resource/opentelekomcloud_kms_grant_v1` (`#1185 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1185>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Add new `resource/opentelekomcloud_kms_grant_v1`
Resolves: #1146

## PR Checklist

* [x] Refers to: #1146
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

resource_opentelekomcloud_kms_grant_v1
```
=== RUN   TestAccKmsGrantV1Basic
--- PASS: TestAccKmsGrantV1Basic (135.54s)
PASS

Process finished with the exit code 0
```

import resource_opentelekomcloud_kms_grant_v1
```
=== RUN   TestAccKmsV1GrantImportBasic
--- PASS: TestAccKmsV1GrantImportBasic (158.98s)
PASS

Process finished with the exit code 0
```
