### PR TITLE
Add documentation preview script

### DIFF
--- a/scripts/build-docs.sh
+++ b/scripts/build-docs.sh
@@ -1,0 +1,13 @@
+venv="./.rn-venv"
+python -m venv $venv >/dev/null || exit 1
+echo "Python venv created"
+source $venv/bin/activate || exit 1
+pip install reno sphinx otcdocstheme >/dev/null || exit 1
+echo "Dependencies installed"
+
+built_path="releasenotes/build/html"
+rm -rf $built_path
+echo "Old docs removed"
+
+sphinx-build -W --keep-going -b html releasenotes/source $built_path || exit 1
+echo "Release notes are available at $(pwd)/releasenotes/build/html/current.html"


### PR DESCRIPTION
## Summary of the Pull Request
Add script with `sphinx-build`. Requires python to run.

This script to be used to preview release notes:
```shell
./scripts/build-docs.sh
```
