### PR TITLE
[Networking] Remove using of `mutexkv` in router

### DIFF
--- a/docs/resources/networking_router_v2.md
+++ b/docs/resources/networking_router_v2.md
@@ -23,7 +23,7 @@ The following arguments are supported:
   updates the `name` of an existing router.
 
 * `admin_state_up` - (Optional) Administrative up/down status for the router
-  (must be "true" or "false" if provided). Changing this updates the
+  (must be `true` or `false` if provided). Changing this updates the
   `admin_state_up` of an existing router.
 
 * `distributed` - (Optional) Indicates whether or not to create a
@@ -36,7 +36,7 @@ The following arguments are supported:
   updates the `external_gateway` of an existing router.
 
 * `enable_snat` - (Optional) Enable Source NAT for the router. Valid values are
-  "true" or "false". An `external_gateway` has to be set in order to set this
+  `true` or `false`. An `external_gateway` has to be set in order to set this
   property. Changing this updates the `enable_snat` of the router.
 
 * `tenant_id` - (Optional) The owner of the floating IP. Required if admin wants

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_router_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_router_v2_test.go
@@ -14,8 +14,9 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 )
 
-func TestAccNetworkingV2Router_basic(t *testing.T) {
+func TestAccNetworkingV2RouterBasic(t *testing.T) {
 	var router routers.Router
+	resourceName := "opentelekomcloud_networking_router_v2.router_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -23,24 +24,24 @@ func TestAccNetworkingV2Router_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkingV2RouterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkingV2Router_basic,
+				Config: testAccNetworkingV2RouterBasic,
 				Check: resource.ComposeTestCheckFunc(
-					TestAccCheckNetworkingV2RouterExists("opentelekomcloud_networking_router_v2.router_1", &router),
+					TestAccCheckNetworkingV2RouterExists(resourceName, &router),
 				),
 			},
 			{
-				Config: testAccNetworkingV2Router_update,
+				Config: testAccNetworkingV2RouterUpdate,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_networking_router_v2.router_1", "name", "router_2"),
+					resource.TestCheckResourceAttr(resourceName, "name", "router_2"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccNetworkingV2Router_update_external_gw(t *testing.T) {
+func TestAccNetworkingV2RouterUpdateExternalGw(t *testing.T) {
 	var router routers.Router
+	resourceName := "opentelekomcloud_networking_router_v2.router_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -48,16 +49,15 @@ func TestAccNetworkingV2Router_update_external_gw(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkingV2RouterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkingV2Router_update_external_gw_1,
+				Config: testAccNetworkingV2RouterBasic,
 				Check: resource.ComposeTestCheckFunc(
-					TestAccCheckNetworkingV2RouterExists("opentelekomcloud_networking_router_v2.router_1", &router),
+					TestAccCheckNetworkingV2RouterExists(resourceName, &router),
 				),
 			},
 			{
-				Config: testAccNetworkingV2Router_update_external_gw_2,
+				Config: testAccNetworkingV2RouterUpdateExternalGw,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_networking_router_v2.router_1", "external_gateway", env.OS_EXTGW_ID),
+					resource.TestCheckResourceAttr(resourceName, "external_gateway", env.OS_EXTGW_ID),
 				),
 			},
 		},
@@ -66,6 +66,7 @@ func TestAccNetworkingV2Router_update_external_gw(t *testing.T) {
 
 func TestAccNetworkingV2Router_timeout(t *testing.T) {
 	var router routers.Router
+	resourceName := "opentelekomcloud_networking_router_v2.router_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -73,9 +74,9 @@ func TestAccNetworkingV2Router_timeout(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkingV2RouterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkingV2Router_timeout,
+				Config: testAccNetworkingV2RouterTimeout,
 				Check: resource.ComposeTestCheckFunc(
-					TestAccCheckNetworkingV2RouterExists("opentelekomcloud_networking_router_v2.router_1", &router),
+					TestAccCheckNetworkingV2RouterExists(resourceName, &router),
 				),
 			},
 		},
@@ -84,9 +85,9 @@ func TestAccNetworkingV2Router_timeout(t *testing.T) {
 
 func testAccCheckNetworkingV2RouterDestroy(s *terraform.State) error {
 	config := common.TestAccProvider.Meta().(*cfg.Config)
-	networkingClient, err := config.NetworkingV2Client(env.OS_REGION_NAME)
+	client, err := config.NetworkingV2Client(env.OS_REGION_NAME)
 	if err != nil {
-		return fmt.Errorf("error creating OpenTelekomCloud networking client: %s", err)
+		return fmt.Errorf("error creating OpenTelekomCloud NetworkingV2 client: %w", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -94,53 +95,45 @@ func testAccCheckNetworkingV2RouterDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := routers.Get(networkingClient, rs.Primary.ID).Extract()
+		_, err := routers.Get(client, rs.Primary.ID).Extract()
 		if err == nil {
-			return fmt.Errorf("Router still exists")
+			return fmt.Errorf("router still exists")
 		}
 	}
 
 	return nil
 }
 
-const testAccNetworkingV2Router_basic = `
+const testAccNetworkingV2RouterBasic = `
 resource "opentelekomcloud_networking_router_v2" "router_1" {
-	name = "router_1"
-	admin_state_up = "true"
-	distributed = "false"
+  name           = "router_1"
+  admin_state_up = true
+  distributed    = false
 }
 `
 
-const testAccNetworkingV2Router_update = `
+const testAccNetworkingV2RouterUpdate = `
 resource "opentelekomcloud_networking_router_v2" "router_1" {
-	name = "router_2"
-	admin_state_up = "true"
-	distributed = "false"
+  name           = "router_2"
+  admin_state_up = true
+  distributed    = false
 }
 `
 
-const testAccNetworkingV2Router_update_external_gw_1 = `
+var testAccNetworkingV2RouterUpdateExternalGw = fmt.Sprintf(`
 resource "opentelekomcloud_networking_router_v2" "router_1" {
-	name = "router"
-	admin_state_up = "true"
-	distributed = "false"
-}
-`
-
-var testAccNetworkingV2Router_update_external_gw_2 = fmt.Sprintf(`
-resource "opentelekomcloud_networking_router_v2" "router_1" {
-	name = "router"
-	admin_state_up = "true"
-	distributed = "false"
-	external_gateway = "%s"
+  name             = "router_1"
+  admin_state_up   = true
+  distributed      = false
+  external_gateway = "%s"
 }
 `, env.OS_EXTGW_ID)
 
-const testAccNetworkingV2Router_timeout = `
+const testAccNetworkingV2RouterTimeout = `
 resource "opentelekomcloud_networking_router_v2" "router_1" {
-	name = "router_1"
-	admin_state_up = "true"
-	distributed = "false"
+  name           = "router_1"
+  admin_state_up = true
+  distributed    = false
 
   timeouts {
     create = "5m"

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_router_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_router_v2_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 )
 
-func TestAccNetworkingV2RouterBasic(t *testing.T) {
+func TestAccNetworkingV2Router_basic(t *testing.T) {
 	var router routers.Router
 	resourceName := "opentelekomcloud_networking_router_v2.router_1"
 
@@ -39,7 +39,7 @@ func TestAccNetworkingV2RouterBasic(t *testing.T) {
 	})
 }
 
-func TestAccNetworkingV2RouterUpdateExternalGw(t *testing.T) {
+func TestAccNetworkingV2Router_update_external_gw(t *testing.T) {
 	var router routers.Router
 	resourceName := "opentelekomcloud_networking_router_v2.router_1"
 

--- a/opentelekomcloud/services/vpc/common.go
+++ b/opentelekomcloud/services/vpc/common.go
@@ -1,0 +1,5 @@
+package vpc
+
+const (
+	errCreationV2Client = "error creating OpenTelekomCloud NetworkingV2 client: %w"
+)

--- a/releasenotes/notes/ref-nw-router-aa9282594f0a774d.yaml
+++ b/releasenotes/notes/ref-nw-router-aa9282594f0a774d.yaml
@@ -1,4 +1,4 @@
 ---
 other:
   - |
-    [Networking] Refcatoring of ``resource/opentelekomcloud_netwroking_router_v2``
+    [Networking] Refaсtoring of ``resource/opentelekomcloud_networking_router_v2`` (`#1190 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1190>`_)

--- a/releasenotes/notes/ref-nw-router-aa9282594f0a774d.yaml
+++ b/releasenotes/notes/ref-nw-router-aa9282594f0a774d.yaml
@@ -1,0 +1,4 @@
+---
+other:
+  - |
+    [Networking] Refcatoring of ``resource/opentelekomcloud_netwroking_router_v2``


### PR DESCRIPTION
## Summary of the Pull Request
Refactoring of `resource/opentelekomcloud_networking_router_v2`
Remove redundant `mutexkv` pkg

## PR Checklist

* [x] Refers to: #1110
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
=== RUN   TestAccNetworkingV2Router_basic
--- PASS: TestAccNetworkingV2Router_basic (84.83s)
=== RUN   TestAccNetworkingV2Router_update_external_gw
--- PASS: TestAccNetworkingV2Router_update_external_gw (79.87s)
=== RUN   TestAccNetworkingV2Router_timeout
--- PASS: TestAccNetworkingV2Router_timeout (52.50s)
PASS

Process finished with the exit code 0
```
