### PR TITLE
Add option to add taints to resource_opentelekomcloud_cce_node_v3

### DIFF
--- a/docs/resources/cce_node_v3.md
+++ b/docs/resources/cce_node_v3.md
@@ -65,6 +65,11 @@ The following arguments are supported:
 
 * `annotations` - (Optional) Node annotation, key/value pair format. Changing this parameter will create a new resource.
 
+* `taints` - (Optional) Taints to created nodes to configure anti-affinity.
+  * `key` - (Required) A key must contain 1 to 63 characters starting with a letter or digit. Only letters, digits, hyphens (-), underscores (_), and periods (.) are allowed. A DNS subdomain name can be used as the prefix of a key.
+  * `value` - (Required) A value must start with a letter or digit and can contain a maximum of 63 characters, including letters, digits, hyphens (-), underscores (_), and periods (.).
+  * `effect` - (Optional) Available options are `NoSchedule`, `PreferNoSchedule`, and `NoExecute`.
+
 * `eip_ids` - (Optional) List of existing elastic IP IDs.
 
 -> If the `eip_ids` parameter is configured, you do not need to configure the `eip_count` and `bandwidth` parameters:

--- a/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_v3.go
+++ b/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_v3.go
@@ -281,6 +281,36 @@ func ResourceCCENodeV3() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			"taints": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringMatch(clusterPoolTaintRegex, "Invalid key. "+
+								"Cluster pool taint key is 1 to 63 characters starting with a letter or digit. "+
+								"Only lowercase letters, digits, and hyphens (-) are allowed."),
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringMatch(clusterPoolTaintRegex, "Invalid value. "+
+								"Cluster pool taint value is 1 to 63 characters starting with a letter or digit. "+
+								"Only letters, digits, hyphens (-), underscores (_), and periods (.) are allowed."),
+						},
+						"effect": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"NoSchedule", "PreferNoSchedule", "NoExecute",
+							}, false),
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -432,6 +462,7 @@ func resourceCCENodeV3Create(ctx context.Context, d *schema.ResourceData, meta i
 			},
 			UserTags: resourceCCENodeTags(d),
 			K8sTags:  resourceCCENodeK8sTags(d),
+			Taints:   resourceCCENodeTaints(d),
 		},
 	}
 


### PR DESCRIPTION
## Summary of the Pull Request

This PR adds the option to add Kubernetes taints to the resource opentelekomcloud_cce_node_v3.

## PR Checklist

* [x] Refers to: #1151 
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

I didn't run the acceptance tests, because I do not have an OTC account that I could use for this, but I did add a test that could be executed.