### PR TITLE
[CCE] Fix wrong name in `node_pool` example

### DIFF
--- a/docs/resources/cce_node_pool_v3.md
+++ b/docs/resources/cce_node_pool_v3.md
@@ -15,7 +15,7 @@ variable "availability_zone" {}
 
 resource "opentelekomcloud_cce_node_pool_v3" "node_pool_1" {
   cluster_id         = var.cluster_id
-  name               = "opentelekomcloud-cce-node-pool_test"
+  name               = "opentelekomcloud-cce-node-pool-test"
   os                 = "EulerOS 2.5"
   flavor             = "s2.xlarge.2"
   initial_node_count = 2


### PR DESCRIPTION
## Summary of the Pull Request
Fix wrong name in `resource/opentelekomcloud_cce_node_pool_v3` example
Fixes: #1198

## PR Checklist

* [x] Refers to: #1198
* [x] Documentation updated.

