### PR TITLE
[RDS] Fix issue with wrong order of AZs

### DIFF
--- a/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_instance_v3.go
+++ b/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_instance_v3.go
@@ -883,7 +883,7 @@ func resourceRdsInstanceV3Read(_ context.Context, d *schema.ResourceData, meta i
 			}
 		}
 	default:
-		fmterr.Errorf("RDSv3 instance expects 1 or 2 nodes")
+		fmterr.Errorf("RDSv3 instance expects 1 or 2 nodes, but got %d", n)
 	}
 
 	if err := d.Set("availability_zone", availabilityZones); err != nil {

--- a/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_instance_v3.go
+++ b/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_instance_v3.go
@@ -866,16 +866,13 @@ func resourceRdsInstanceV3Read(_ context.Context, d *schema.ResourceData, meta i
 
 	availabilityZones := make([]string, len(rdsInstance.Nodes))
 	if len(rdsInstance.Nodes) == 1 {
-		az1 := rdsInstance.Nodes[0].AvailabilityZone
-		availabilityZones = append(availabilityZones, az1)
+		availabilityZones[0] = rdsInstance.Nodes[0].AvailabilityZone
 	} else if rdsInstance.Nodes[0].Role == "master" {
-		az1 := rdsInstance.Nodes[0].AvailabilityZone
-		az2 := rdsInstance.Nodes[1].AvailabilityZone
-		availabilityZones = append(availabilityZones, az1, az2)
+		availabilityZones[0] = rdsInstance.Nodes[0].AvailabilityZone
+		availabilityZones[1] = rdsInstance.Nodes[1].AvailabilityZone
 	} else {
-		az1 := rdsInstance.Nodes[0].AvailabilityZone
-		az2 := rdsInstance.Nodes[1].AvailabilityZone
-		availabilityZones = append(availabilityZones, az2, az1)
+		availabilityZones[0] = rdsInstance.Nodes[1].AvailabilityZone
+		availabilityZones[1] = rdsInstance.Nodes[0].AvailabilityZone
 	}
 
 	if err := d.Set("availability_zone", availabilityZones); err != nil {

--- a/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_instance_v3.go
+++ b/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_instance_v3.go
@@ -864,10 +864,8 @@ func resourceRdsInstanceV3Read(_ context.Context, d *schema.ResourceData, meta i
 		return fmterr.Errorf("error setting node list: %s", err)
 	}
 
-	availabilityZones := make([]string, len(rdsInstance.Nodes))
+	var availabilityZones []string
 	switch n := len(rdsInstance.Nodes); n {
-	case 0:
-		return fmterr.Errorf("RDSv3 instance doesn't have nodes")
 	case 1:
 		availabilityZones = []string{
 			rdsInstance.Nodes[0].AvailabilityZone,
@@ -885,7 +883,7 @@ func resourceRdsInstanceV3Read(_ context.Context, d *schema.ResourceData, meta i
 			}
 		}
 	default:
-		fmterr.Errorf("RDSv3 instance has more than 2 nodes")
+		fmterr.Errorf("RDSv3 instance expects 1 or 2 nodes")
 	}
 
 	if err := d.Set("availability_zone", availabilityZones); err != nil {

--- a/releasenotes/notes/rds-as-fix-91f078232add2ee5.yaml
+++ b/releasenotes/notes/rds-as-fix-91f078232add2ee5.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    [RDS] Fix wrong order of AZs in ``resource/opentelekomcloud_rds_instance_v3`` (`#1203 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1203>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Fix issue with wrong order of AZs in `resource/opentelekomcloud_rds_instance_v3`
Fixes: #1199

## PR Checklist

* [x] Refers to: #1199
* [x] Tests added/passed.

## Acceptance Steps Performed

```
=== RUN   TestAccRdsInstanceV3Basic
--- PASS: TestAccRdsInstanceV3Basic (1154.10s)

Process finished with the exit code 0
```
