### PR TITLE
[AS] Update schema in `as_group_v1`

### DIFF
--- a/docs/resources/as_group_v1.md
+++ b/docs/resources/as_group_v1.md
@@ -77,26 +77,28 @@ resource "opentelekomcloud_as_group_v1" "as_group_with_elb" {
   }
 
   vpc_id           = "1d8f7e7c-fe04-4cf5-85ac-08b478c290e9"
-  lb_listener_id   = opentelekomcloud_elb_listener.as_listener.id
   delete_publicip  = true
   delete_instances = "yes"
+
+  lbaas_listeners {
+    pool_id       = opentelekomcloud_lb_pool_v2.pool_1.id
+    protocol_port = opentelekomcloud_lb_listener_v2.as_listener.protocol_port
+  }
 }
 
-resource "opentelekomcloud_elb_listener" "as_listener" {
+resource "opentelekomcloud_lb_listener_v2" "as_listener" {
   name             = "as_listener"
   description      = "as test listener"
   protocol         = "TCP"
-  backend_protocol = "TCP"
-  port             = 12345
-  backend_port     = 21345
-  lb_algorithm     = "roundrobin"
+  protocol_port    = 80
   loadbalancer_id  = "cba48790-baf5-4446-adb3-02069a916e97"
+}
 
-  timeouts {
-    create = "5m"
-    update = "5m"
-    delete = "5m"
-  }
+resource "opentelekomcloud_lb_pool_v2" "pool_1" {
+  name        = "pool_1"
+  protocol    = "HTTP"
+  lb_method   = "ROUND_ROBIN"
+  listener_id = opentelekomcloud_lb_listener_v2.as_listener.id
 }
 ```
 
@@ -123,12 +125,12 @@ The following arguments are supported:
 * `cool_down_time` - (Optional) The cooling duration (in seconds). The value ranges
   from 0 to 86400, and is 900 by default.
 
-* `lb_listener_id` - (Optional) The ELB listener IDs. The system supports up to
-  three ELB listeners, the IDs of which are separated using a comma (,).
+* `lb_listener_id` **DEPRECATED** - (Optional) The Classic LB listener IDs. The system
+  supports up to six Classic LB listeners, the IDs of which are separated using a comma (,).
   This parameter is alternative to `lbaas_listeners`.
 
-* `lbaas_listeners` - (Optional) An array of one or more enhanced load balancer.
-  The system supports the binding of up to three load balancers. The field is
+* `lbaas_listeners` - (Optional) An array of one or more Enhanced Load Balancer.
+  The system supports the binding of up to six Enhanced Load Balancers. The field is
   alternative to `lb_listener_id`. The `lbaas_listeners` object structure is
   documented below.
 

--- a/opentelekomcloud/services/as/resource_opentelekomcloud_as_group_v1.go
+++ b/opentelekomcloud/services/as/resource_opentelekomcloud_as_group_v1.go
@@ -73,14 +73,18 @@ func ResourceASGroup() *schema.Resource {
 				Description:  "The cooling duration, in seconds.",
 			},
 			"lb_listener_id": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: common.ValidateASGroupListenerID,
-				Description:  "The system supports the binding of up to three ELB listeners, the IDs of which are separated using a comma.",
+				Type:          schema.TypeString,
+				Optional:      true,
+				ValidateFunc:  common.ValidateASGroupListenerID,
+				Description:   "The system supports the binding of up to six classic LB listeners, the IDs of which are separated using a comma.",
+				Deprecated:    "Please use `lbaas_listeners` instead",
+				ConflictsWith: []string{"lbaas_listeners"},
 			},
 			"lbaas_listeners": {
-				Type:     schema.TypeList,
-				Optional: true,
+				Type:          schema.TypeList,
+				Optional:      true,
+				MaxItems:      6,
+				ConflictsWith: []string{"lb_listener_id"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"pool_id": {

--- a/releasenotes/notes/as-group-doc-befd791abd9299e3.yaml
+++ b/releasenotes/notes/as-group-doc-befd791abd9299e3.yaml
@@ -1,0 +1,7 @@
+---
+deprecations:
+  - |
+    [AS] Deprecate ``lb_listener_id`` in ``resource/opentelekomcloud_as_group_v1`` (`#1212 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1212>`_)
+other:
+  - |
+    [AS] Update doc examples in ``resource/opentelekomcloud_as_group_v1`` (`#1212 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1212>`_)

--- a/releasenotes/notes/as-group-doc-befd791abd9299e3.yaml
+++ b/releasenotes/notes/as-group-doc-befd791abd9299e3.yaml
@@ -1,7 +1,7 @@
 ---
 deprecations:
   - |
-    [AS] Deprecate ``lb_listener_id`` in ``resource/opentelekomcloud_as_group_v1`` (`#1212 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1212>`_)
+    **[AS]** Deprecate ``lb_listener_id`` in ``resource/opentelekomcloud_as_group_v1`` (`#1212 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1212>`_)
 other:
   - |
-    [AS] Update doc examples in ``resource/opentelekomcloud_as_group_v1`` (`#1212 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1212>`_)
+    **[AS]** Update doc examples in ``resource/opentelekomcloud_as_group_v1`` (`#1212 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1212>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Deprecate `lb_listener_id` in `resource/opentelekomcloud_as_group_v1`
Update `as_group_v1` doc
Resolves: #1115 

## PR Checklist

* [x] Refers to: #1115
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccASV1Group_basic
--- PASS: TestAccASV1Group_basic (163.34s)
=== RUN   TestAccASV1Group_RemoveWithSetMinNumber
--- PASS: TestAccASV1Group_RemoveWithSetMinNumber (186.58s)
=== RUN   TestAccASV1Group_WithoutSecurityGroups
--- PASS: TestAccASV1Group_WithoutSecurityGroups (150.03s)
PASS

Process finished with the exit code 0
```
