### PR TITLE
[CCE] Add possibility to set `subnet_id`

### DIFF
--- a/docs/resources/cce_node_v3.md
+++ b/docs/resources/cce_node_v3.md
@@ -57,6 +57,8 @@ The following arguments are supported:
 
 * `name` - (Optional) Node Name.
 
+* `subnet_id` - (Optional) The ID of the subnet to which the NIC belongs. Changing this parameter will create a new resource.
+
 * `labels` - (Optional) Node tag, key/value pair format. Changing this parameter will create a new resource.
 
 * `tags` - (Optional) The field is alternative to `labels`, key/value pair format.

--- a/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_v3.go
+++ b/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_v3.go
@@ -41,6 +41,12 @@ func ResourceCCENodeV3() *schema.Resource {
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
+		CustomizeDiff: common.MultipleCustomizeDiffs(
+			common.ValidateVolumeType("root_volume.*.volumetype"),
+			common.ValidateVolumeType("data_volumes.*.volumetype"),
+			common.ValidateSubnet("subnet_id"),
+		),
+
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:     schema.TypeString,
@@ -186,6 +192,11 @@ func ResourceCCENodeV3() *schema.Resource {
 				Optional:      true,
 				ConflictsWith: []string{"eip_ids"},
 				ValidateFunc:  validation.IntAtLeast(1),
+			},
+			"subnet_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
 			},
 			"billing_mode": {
 				Type:     schema.TypeInt,
@@ -418,6 +429,11 @@ func resourceCCENodeV3Create(ctx context.Context, d *schema.ResourceData, meta i
 					},
 				},
 			},
+			NodeNicSpec: nodes.NodeNicSpec{
+				PrimaryNic: nodes.PrimaryNic{
+					SubnetId: d.Get("subnet_id").(string),
+				},
+			},
 			BillingMode: d.Get("billing_mode").(int),
 			Count:       1,
 			ExtendParam: nodes.ExtendParam{
@@ -565,6 +581,7 @@ func resourceCCENodeV3Read(_ context.Context, d *schema.ResourceData, meta inter
 		d.Set("private_ip", node.Status.PrivateIP),
 		d.Set("public_ip", node.Status.PublicIP),
 		d.Set("status", node.Status.Phase),
+		d.Set("subnet_id", node.Spec.NodeNicSpec.PrimaryNic.SubnetId),
 	)
 	if err := me.ErrorOrNil(); err != nil {
 		return fmterr.Errorf("[DEBUG] Error saving IP conf to state for OpenTelekomCloud Node (%s): %s", d.Id(), err)

--- a/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_v3.go
+++ b/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_v3.go
@@ -581,7 +581,6 @@ func resourceCCENodeV3Read(_ context.Context, d *schema.ResourceData, meta inter
 		d.Set("private_ip", node.Status.PrivateIP),
 		d.Set("public_ip", node.Status.PublicIP),
 		d.Set("status", node.Status.Phase),
-		d.Set("subnet_id", node.Spec.NodeNicSpec.PrimaryNic.SubnetId),
 	)
 	if err := me.ErrorOrNil(); err != nil {
 		return fmterr.Errorf("[DEBUG] Error saving IP conf to state for OpenTelekomCloud Node (%s): %s", d.Id(), err)

--- a/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_v3.go
+++ b/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_v3.go
@@ -196,6 +196,7 @@ func ResourceCCENodeV3() *schema.Resource {
 			"subnet_id": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 			"billing_mode": {
@@ -581,6 +582,7 @@ func resourceCCENodeV3Read(_ context.Context, d *schema.ResourceData, meta inter
 		d.Set("private_ip", node.Status.PrivateIP),
 		d.Set("public_ip", node.Status.PublicIP),
 		d.Set("status", node.Status.Phase),
+		d.Set("subnet_id", node.Spec.NodeNicSpec.PrimaryNic.SubnetId),
 	)
 	if err := me.ErrorOrNil(); err != nil {
 		return fmterr.Errorf("[DEBUG] Error saving IP conf to state for OpenTelekomCloud Node (%s): %s", d.Id(), err)

--- a/releasenotes/notes/cce-node-subnet-9fe3199a7ff7a2de.yaml
+++ b/releasenotes/notes/cce-node-subnet-9fe3199a7ff7a2de.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    **[CCE]** Add possibility to set ``subnet_id`` in ``resource/opentelekomcloud_cce_node_v3`` (`#1214 (https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1214)`_)

--- a/releasenotes/notes/cce-node-subnet-9fe3199a7ff7a2de.yaml
+++ b/releasenotes/notes/cce-node-subnet-9fe3199a7ff7a2de.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   - |
-    **[CCE]** Add possibility to set ``subnet_id`` in ``resource/opentelekomcloud_cce_node_v3`` (`#1214 (https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1214)`_)
+    **[CCE]** Add possibility to set ``subnet_id`` in ``resource/opentelekomcloud_cce_node_v3`` (`#1214 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1214>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Add possibility to set `subnet_id` in `resource/opentelekomcloud_cce_node_v3`

Fixes: #1208

## PR Checklist

* [x] Refers to: #1208
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccCCENodesV3Basic
--- PASS: TestAccCCENodesV3Basic (986.12s)
PASS

Process finished with the exit code 0
```
