### PR TITLE
[EVS] Unify usage of `tags` in `evs_volume_v3`

### DIFF
--- a/opentelekomcloud/acceptance/evs/resource_opentelekomcloud_evs_volume_v3_test.go
+++ b/opentelekomcloud/acceptance/evs/resource_opentelekomcloud_evs_volume_v3_test.go
@@ -44,8 +44,6 @@ func TestAccEvsStorageV3Volume_basic(t *testing.T) {
 }
 
 func TestAccEvsStorageV3Volume_tags(t *testing.T) {
-	resNameTags := "opentelekomcloud_evs_volume_v3.volume_tags"
-
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
@@ -54,15 +52,13 @@ func TestAccEvsStorageV3Volume_tags(t *testing.T) {
 			{
 				Config: testAccEvsStorageV3VolumeTags,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEvsStorageV3VolumeTags(resNameTags, "foo", "bar"),
-					testAccCheckEvsStorageV3VolumeTags(resNameTags, "key", "value"),
+					resource.TestCheckResourceAttr(resourceName, "tags.muh", "value-create"),
 				),
 			},
 			{
 				Config: testAccEvsStorageV3VolumeTagsUpdate,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEvsStorageV3VolumeTags(resNameTags, "foo2", "bar2"),
-					testAccCheckEvsStorageV3VolumeTags(resNameTags, "key2", "value2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.muh", "value-update"),
 				),
 			},
 		},
@@ -236,50 +232,6 @@ func testAccCheckEvsStorageV3VolumePersists(n string, volume, oldVolume *volumes
 	}
 }
 
-func testAccCheckEvsStorageV3VolumeTags(n string, k string, v string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("not found: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no ID is set")
-		}
-
-		config := common.TestAccProvider.Meta().(*cfg.Config)
-		blockStorageClient, err := config.BlockStorageV3Client(env.OS_REGION_NAME)
-		if err != nil {
-			return fmt.Errorf("error creating OpenTelekomCloud block storage client: %s", err)
-		}
-
-		found, err := volumes.Get(blockStorageClient, rs.Primary.ID).Extract()
-		if err != nil {
-			return err
-		}
-
-		if found.ID != rs.Primary.ID {
-			return fmt.Errorf("volume not found")
-		}
-
-		if found.Tags == nil {
-			return fmt.Errorf("no Tags")
-		}
-
-		for key, value := range found.Tags {
-			if k != key {
-				continue
-			}
-
-			if v == value {
-				return nil
-			}
-			return fmt.Errorf("bad value for %s: %s", k, value)
-		}
-		return fmt.Errorf("tag not found: %s", k)
-	}
-}
-
 var (
 	testAccEvsStorageV3VolumeBasic = fmt.Sprintf(`
 resource "opentelekomcloud_evs_volume_v3" "volume_1" {
@@ -300,27 +252,26 @@ resource "opentelekomcloud_evs_volume_v3" "volume_1" {
 }
 `, env.OS_AVAILABILITY_ZONE)
 	testAccEvsStorageV3VolumeTags = fmt.Sprintf(`
-resource "opentelekomcloud_evs_volume_v3" "volume_tags" {
+resource "opentelekomcloud_evs_volume_v3" "volume_1" {
   name              = "volume_tags"
   description       = "test volume with tags"
   availability_zone = "%s"
   volume_type       = "SATA"
   tags = {
-    foo = "bar"
-    key = "value"
+    muh = "value-create"
+    kuh = "value-create"
   }
   size = 12
 }
 `, env.OS_AVAILABILITY_ZONE)
 	testAccEvsStorageV3VolumeTagsUpdate = fmt.Sprintf(`
-resource "opentelekomcloud_evs_volume_v3" "volume_tags" {
+resource "opentelekomcloud_evs_volume_v3" "volume_1" {
   name              = "volume_tags-updated"
   description       = "test volume with tags"
   availability_zone = "%s"
   volume_type       = "SATA"
   tags = {
-    foo2 = "bar2"
-    key2 = "value2"
+    muh = "value-update"
   }
   size = 12
 }

--- a/opentelekomcloud/services/evs/common.go
+++ b/opentelekomcloud/services/evs/common.go
@@ -1,0 +1,5 @@
+package evs
+
+const (
+	errCreationClient = "error creating OpenTelekomCloud BlockStorageV3 client: %w"
+)

--- a/opentelekomcloud/services/evs/resource_opentelekomcloud_evs_volume_v3.go
+++ b/opentelekomcloud/services/evs/resource_opentelekomcloud_evs_volume_v3.go
@@ -13,8 +13,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud"
 	cinderV3 "github.com/opentelekomcloud/gophertelekomcloud/openstack/blockstorage/v3/volumes"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/tags"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/evs/v3/volumes"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/helper/hashcode"
 
@@ -91,11 +92,7 @@ func ResourceEvsStorageVolumeV3() *schema.Resource {
 				Default:      "VBD",
 				ValidateFunc: validation.StringInSlice([]string{"VBD", "SCSI"}, true),
 			},
-			"tags": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				ForceNew: false,
-			},
+			"tags": common.TagsSchema(),
 			"attachment": {
 				Type:     schema.TypeSet,
 				Computed: true,
@@ -146,13 +143,13 @@ func resourceEvsVolumeV3Create(ctx context.Context, d *schema.ResourceData, meta
 	config := meta.(*cfg.Config)
 	client, err := config.BlockStorageV3Client(config.GetRegion(d))
 	if err != nil {
-		return fmterr.Errorf("error creating OpenTelekomCloud EVS storage client: %s", err)
+		return fmterr.Errorf(errCreationClient, err)
 	}
 
 	if !common.HasFilledOpt(d, "backup_id") && !common.HasFilledOpt(d, "size") {
 		return fmterr.Errorf("missing required argument: 'size' is required, but no definition was found")
 	}
-	tags := resourceContainerTags(d)
+
 	createOpts := &volumes.CreateOpts{
 		BackupID:         d.Get("backup_id").(string),
 		AvailabilityZone: d.Get("availability_zone").(string),
@@ -163,7 +160,6 @@ func resourceEvsVolumeV3Create(ctx context.Context, d *schema.ResourceData, meta
 		ImageRef:         d.Get("image_id").(string),
 		VolumeType:       d.Get("volume_type").(string),
 		Multiattach:      d.Get("multiattach").(bool),
-		Tags:             tags,
 	}
 	m := make(map[string]string)
 	if v, ok := d.GetOk("kms_id"); ok {
@@ -200,6 +196,15 @@ func resourceEvsVolumeV3Create(ctx context.Context, d *schema.ResourceData, meta
 		log.Printf("[INFO] Volume ID: %s", id)
 		// Store the ID now
 		d.SetId(id)
+
+		// set tags
+		tagRaw := d.Get("tags").(map[string]interface{})
+		if len(tagRaw) > 0 {
+			tagList := common.ExpandResourceTags(tagRaw)
+			if err := tags.Create(client, "os-vendor-volumes", id, tagList).ExtractErr(); err != nil {
+				return fmterr.Errorf("error setting tags for EVSv3 Volume: %w", err)
+			}
+		}
 		return resourceEvsVolumeV3Read(ctx, d, meta)
 	}
 	return fmterr.Errorf("unexpected conversion error in resourceEvsVolumeV3Create")
@@ -207,12 +212,12 @@ func resourceEvsVolumeV3Create(ctx context.Context, d *schema.ResourceData, meta
 
 func resourceEvsVolumeV3Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	blockStorageClient, err := config.BlockStorageV3Client(config.GetRegion(d))
+	client, err := config.BlockStorageV3Client(config.GetRegion(d))
 	if err != nil {
-		return fmterr.Errorf("error creating OpenTelekomCloud EVS storage client: %s", err)
+		return fmterr.Errorf(errCreationClient, err)
 	}
 
-	v, err := volumes.Get(blockStorageClient, d.Id()).Extract()
+	v, err := volumes.Get(client, d.Id()).Extract()
 	if err != nil {
 		return diag.FromErr(common.CheckDeleted(d, err, "volume"))
 	}
@@ -232,13 +237,14 @@ func resourceEvsVolumeV3Read(_ context.Context, d *schema.ResourceData, meta int
 		return diag.FromErr(err)
 	}
 
-	// set tags
-	tags := make(map[string]string)
-	for key, val := range v.Tags {
-		tags[key] = val
+	// save tags
+	resourceTags, err := tags.Get(client, "os-vendor-volumes", d.Id()).Extract()
+	if err != nil {
+		return fmterr.Errorf("error fetching OpenTelekomCloud SFS File System tags: %s", err)
 	}
-	if err := d.Set("tags", tags); err != nil {
-		return fmterr.Errorf("[DEBUG] Error saving tags to state for OpenTelekomCloud evs storage (%s): %s", d.Id(), err)
+	tagMap := common.TagsToMap(resourceTags)
+	if err := d.Set("tags", tagMap); err != nil {
+		return fmterr.Errorf("error saving tags for OpenTelekomCloud EVSv3 Volume: %s", err)
 	}
 
 	// set attachments
@@ -262,7 +268,7 @@ func resourceEvsVolumeV3Update(ctx context.Context, d *schema.ResourceData, meta
 	config := meta.(*cfg.Config)
 	client, err := config.BlockStorageV3Client(config.GetRegion(d))
 	if err != nil {
-		return fmterr.Errorf("error creating OpenTelekomCloud block storage client: %s", err)
+		return fmterr.Errorf(errCreationClient, err)
 	}
 
 	updateOpts := cinderV3.UpdateOpts{
@@ -275,8 +281,11 @@ func resourceEvsVolumeV3Update(ctx context.Context, d *schema.ResourceData, meta
 		return fmterr.Errorf("error updating OpenTelekomCloud volume: %s", err)
 	}
 
+	// update tags
 	if d.HasChange("tags") {
-		_, err = resourceEVSTagV2Create(ctx, d, meta, "volumes", d.Id(), resourceContainerTags(d))
+		if err := common.UpdateResourceTags(client, d, "os-vendor-volumes", d.Id()); err != nil {
+			return fmterr.Errorf("error updating tags for EVSv3 Volume %s: %w", d.Id(), err)
+		}
 	}
 
 	if d.HasChange("size") {

--- a/releasenotes/notes/evs3-tags-4ef7d26c6b400e7a.yaml
+++ b/releasenotes/notes/evs3-tags-4ef7d26c6b400e7a.yaml
@@ -1,0 +1,4 @@
+---
+other:
+  - |
+    **[EVS]** Change ``v2`` to ``v3`` ``tags`` API in ``resource/opentelekomcloud_evs_volume_v3`` (`#1218 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1218>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Use EVSv3 tags API against v2 in `resource/opentelekomcloud_evs_volume_v3`
Fixes: #1073

## PR Checklist

* [x] Refers to: #1073
* [x] Tests added/passed.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccEvsStorageV3Volume_basic
--- PASS: TestAccEvsStorageV3Volume_basic (97.54s)
=== RUN   TestAccEvsStorageV3Volume_tags
--- PASS: TestAccEvsStorageV3Volume_tags (95.90s)
=== RUN   TestAccEvsStorageV3Volume_image
--- PASS: TestAccEvsStorageV3Volume_image (64.62s)
=== RUN   TestAccEvsStorageV3Volume_timeout
--- PASS: TestAccEvsStorageV3Volume_timeout (58.34s)
=== RUN   TestAccEvsStorageV3Volume_volumeType
--- PASS: TestAccEvsStorageV3Volume_volumeType (10.29s)
=== RUN   TestAccEvsStorageV3Volume_resize
--- PASS: TestAccEvsStorageV3Volume_resize (109.41s)
PASS

Process finished with the exit code 0
```
