### PR TITLE
[IAM] Clarify usage of `d/auth_scope_v3`

### DIFF
--- a/docs/data-sources/identity_auth_scope_v3.md
+++ b/docs/data-sources/identity_auth_scope_v3.md
@@ -22,7 +22,7 @@ data "opentelekomcloud_identity_auth_scope_v3" "scope" {
   only used as a unique identifier so an actual token isn't used as the ID.
 
 -> This data source requires `token` in order to get authentication information.
-You need to specify `OS_TOKEN` env variable or set it in terraform config.
+You need to set `OS_TOKEN` env variable or fill it in terraform config.
 
 ## Attributes Reference
 

--- a/docs/data-sources/identity_auth_scope_v3.md
+++ b/docs/data-sources/identity_auth_scope_v3.md
@@ -21,6 +21,9 @@ data "opentelekomcloud_identity_auth_scope_v3" "scope" {
 * `name` - (Required) The name of the scope. This is an arbitrary name which is
   only used as a unique identifier so an actual token isn't used as the ID.
 
+-> This data source requires `token` in order to get authentication information.
+You need to specify `OS_TOKEN` env variable or set it in terraform config.
+
 ## Attributes Reference
 
 `id` is set to the name given to the scope. In addition, the following attributes are exported:

--- a/releasenotes/notes/auth-scope-doc-30a2345909450b29.yaml
+++ b/releasenotes/notes/auth-scope-doc-30a2345909450b29.yaml
@@ -1,0 +1,4 @@
+---
+other:
+  - |
+    **[IAM]** Clarify usage of ``data_source/opentelekomcloud_identity_auth_scope_v3`` (`#1219 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1219>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Clarify usage of `data_source/opentelekomcloud_identity_auth_scope_v3`
Resolves: #1064

## PR Checklist

* [x] Refers to: #1064
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccOpenTelekomCloudIdentityAuthScopeV3DataSource_basic
--- PASS: TestAccOpenTelekomCloudIdentityAuthScopeV3DataSource_basic (32.89s)
PASS

Process finished with the exit code 0
```
