### PR TITLE
[CCE] Read assigned `k8s_tags` in `cce_node_v3`

### DIFF
--- a/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_node_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_node_v3_test.go
@@ -249,7 +249,7 @@ func TestAccCCENodesV3EncryptedVolume(t *testing.T) {
 	})
 }
 
-func TestAccCCENodesV3Taints(t *testing.T) {
+func TestAccCCENodesV3TaintsK8sTags(t *testing.T) {
 	var node nodes.Nodes
 
 	resource.Test(t, resource.TestCase{
@@ -258,12 +258,13 @@ func TestAccCCENodesV3Taints(t *testing.T) {
 		CheckDestroy:      testAccCheckCCENodeV3Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCCENodeV3Taints,
+				Config: testAccCCENodeV3TaintsK8sTags,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCCENodeV3Exists(resourceNameNode, "opentelekomcloud_cce_cluster_v3.cluster_1", &node),
 					resource.TestCheckResourceAttr(resourceNameNode, "taints.0.key", "dedicated"),
 					resource.TestCheckResourceAttr(resourceNameNode, "taints.0.value", "database"),
 					resource.TestCheckResourceAttr(resourceNameNode, "taints.0.effect", "NoSchedule"),
+					resource.TestCheckResourceAttr(resourceNameNode, "k8s_tags.app", "sometag"),
 				),
 			},
 		},
@@ -751,7 +752,7 @@ resource "opentelekomcloud_cce_node_v3" "node_1" {
 }
 `, env.OS_VPC_ID, env.OS_NETWORK_ID, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME, env.OS_KMS_ID)
 
-	testAccCCENodeV3Taints = fmt.Sprintf(`
+	testAccCCENodeV3TaintsK8sTags = fmt.Sprintf(`
 resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   name         = "opentelekomcloud-cce"
   cluster_type = "VirtualMachine"
@@ -779,6 +780,10 @@ resource "opentelekomcloud_cce_node_v3" "node_1" {
     key    = "dedicated"
     value  = "database"
     effect = "NoSchedule"
+  }
+
+  k8s_tags = {
+    "app" = "sometag"
   }
   private_ip = "%s"
 }

--- a/releasenotes/notes/cce-node-k8s-tags-3953b8ac3223be8e.yaml
+++ b/releasenotes/notes/cce-node-k8s-tags-3953b8ac3223be8e.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[CCE]** Read ``taints`` in ``resource/opentelekomcloud_cce_node_v3`` (`#1223 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1223>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Read assigned `k8s_tags` in `resource/opentelekomcloud_cce_node_v3`
Fixes: #1107

## PR Checklist

* [x] Refers to: #1107
* [x] Tests added/passed.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccCCENodesV3TaintsK8sTags
--- PASS: TestAccCCENodesV3TaintsK8sTags (750.16s)
PASS

Process finished with the exit code 0
```
