### PR TITLE
[ELB] Fix wrong `id` setting in `lb_member_v2`

### DIFF
--- a/docs/resources/lb_member_v2.md
+++ b/docs/resources/lb_member_v2.md
@@ -4,16 +4,19 @@ subcategory: "Elastic Load Balance (ELB)"
 
 # opentelekomcloud_lb_member_v2
 
-Manages an Enhanced LB member resource within OpenTelekomCloud.
+Manages an Enhanced Load Balancer member resource within OpenTelekomCloud.
 
 ## Example Usage
 
 ```hcl
-resource "opentelekomcloud_lb_member_v2" "member_1" {
+variable "pool_id" {}
+variable "subnet_id" {}
+
+resource "opentelekomcloud_lb_member_v2" "member1" {
   address       = "192.168.199.23"
   protocol_port = 8080
-  pool_id       = POOL_ID
-  subnet_id     = SUBNET_ID
+  pool_id       = var.pool_id
+  subnet_id     = var.subnet_id
 }
 ```
 
@@ -40,11 +43,11 @@ The following arguments are supported:
 
 * `weight` - (Optional)  A positive integer value that indicates the relative
   portion of traffic that this member should receive from the pool. For
-  example, a member with a weight of 10 receives five times as much traffic
-  as a member with a weight of 2.
+  example, a member with a `weight` of `10` receives five times as much traffic
+  as a member with a `weight` of `2`.
 
 * `admin_state_up` - (Optional) The administrative state of the member.
-  A valid value is true (UP) or false (DOWN).
+  A valid value is `true` (UP) or `false` (DOWN).
 
 ## Attributes Reference
 

--- a/opentelekomcloud/acceptance/elb/resource_opentelekomcloud_lb_member_v2_test.go
+++ b/opentelekomcloud/acceptance/elb/resource_opentelekomcloud_lb_member_v2_test.go
@@ -68,8 +68,7 @@ func testAccCheckLBV2MemberDestroy(s *terraform.State) error {
 
 func testAccCheckLBV2MemberExists(n string, member *pools.Member) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rootModule := s.RootModule()
-		rs, ok := rootModule.Resources[n]
+		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("not found: %s", n)
 		}

--- a/opentelekomcloud/acceptance/elb/resource_opentelekomcloud_lb_member_v2_test.go
+++ b/opentelekomcloud/acceptance/elb/resource_opentelekomcloud_lb_member_v2_test.go
@@ -36,7 +36,7 @@ func TestAccLBV2Member_basic(t *testing.T) {
 				Config:             TestAccLBV2MemberConfigUpdate,
 				ExpectNonEmptyPlan: true, // Because admin_state_up remains false, unfinished elb?
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceMemberName2, "weight", "10"),
+					resource.TestCheckResourceAttr(resourceMemberName1, "weight", "10"),
 					resource.TestCheckResourceAttr(resourceMemberName2, "weight", "15"),
 				),
 			},

--- a/opentelekomcloud/services/elb/common.go
+++ b/opentelekomcloud/services/elb/common.go
@@ -1,5 +1,5 @@
 package elb
 
 const (
-	errCreationClient = "error creating OpenTelekomCloud NetworkingV2 client: %2"
+	errCreationClient = "error creating OpenTelekomCloud NetworkingV2 client: %w"
 )

--- a/opentelekomcloud/services/elb/common.go
+++ b/opentelekomcloud/services/elb/common.go
@@ -1,0 +1,5 @@
+package elb
+
+const (
+	errCreationClient = "error creating OpenTelekomCloud NetworkingV2 client: %2"
+)

--- a/opentelekomcloud/services/elb/resource_opentelekomcloud_lb_member_v2.go
+++ b/opentelekomcloud/services/elb/resource_opentelekomcloud_lb_member_v2.go
@@ -2,13 +2,14 @@ package elb
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/lbaas_v2/pools"
 
@@ -37,57 +38,42 @@ func ResourceMemberV2() *schema.Resource {
 				Computed: true,
 				ForceNew: true,
 			},
-
 			"name": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-
 			"tenant_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
 			},
-
 			"address": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-
 			"protocol_port": {
 				Type:     schema.TypeInt,
 				Required: true,
 				ForceNew: true,
 			},
-
 			"weight": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Computed: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					value := v.(int)
-					if value < 1 {
-						errors = append(errors, fmt.Errorf(
-							"Only numbers greater than 0 are supported values for 'weight'"))
-					}
-					return
-				},
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.IntBetween(0, 100),
 			},
-
 			"subnet_id": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-
 			"admin_state_up": {
 				Type:     schema.TypeBool,
-				Default:  true,
 				Optional: true,
+				Default:  true,
 			},
-
 			"pool_id": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -99,24 +85,20 @@ func ResourceMemberV2() *schema.Resource {
 
 func resourceMemberV2Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	client, err := config.NetworkingV2Client(config.GetRegion(d))
 	if err != nil {
-		return fmterr.Errorf("error creating OpenTelekomCloud networking client: %s", err)
+		return fmterr.Errorf(errCreationClient, err)
 	}
 
 	adminStateUp := d.Get("admin_state_up").(bool)
 	createOpts := pools.CreateMemberOpts{
-		Name:         d.Get("name").(string),
-		TenantID:     d.Get("tenant_id").(string),
 		Address:      d.Get("address").(string),
 		ProtocolPort: d.Get("protocol_port").(int),
+		Name:         d.Get("name").(string),
+		TenantID:     d.Get("tenant_id").(string),
 		Weight:       d.Get("weight").(int),
+		SubnetID:     d.Get("subnet_id").(string),
 		AdminStateUp: &adminStateUp,
-	}
-
-	// Must omit if not set
-	if v, ok := d.GetOk("subnet_id"); ok {
-		createOpts.SubnetID = v.(string)
 	}
 
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)
@@ -124,36 +106,27 @@ func resourceMemberV2Create(ctx context.Context, d *schema.ResourceData, meta in
 	// Wait for LB to become active before continuing
 	poolID := d.Get("pool_id").(string)
 	timeout := d.Timeout(schema.TimeoutCreate)
-	err = waitForLBV2viaPool(ctx, networkingClient, poolID, "ACTIVE", timeout)
-	if err != nil {
+	if err := waitForLBV2viaPool(ctx, client, poolID, "ACTIVE", timeout); err != nil {
 		return diag.FromErr(err)
 	}
 
 	log.Printf("[DEBUG] Attempting to create member")
 	var member *pools.Member
 	err = resource.RetryContext(ctx, timeout, func() *resource.RetryError {
-		member, err = pools.CreateMember(networkingClient, poolID, createOpts).Extract()
+		member, err = pools.CreateMember(client, poolID, createOpts).Extract()
 		if err != nil {
 			return common.CheckForRetryableError(err)
 		}
 		return nil
 	})
-
 	if err != nil {
-		return fmterr.Errorf("error creating member: %s", err)
+		return fmterr.Errorf("error creating member: %w", err)
 	}
 
 	// Wait for LB to become ACTIVE again
-	err = waitForLBV2viaPool(ctx, networkingClient, poolID, "ACTIVE", timeout)
-	if err != nil {
+	if err := waitForLBV2viaPool(ctx, client, poolID, "ACTIVE", timeout); err != nil {
 		return diag.FromErr(err)
 	}
-	// Wait for LB member to become ACTIVE too
-	/*
-		err = waitForLBV2Member(networkingClient, poolID, "admin_state_up", "true", nil, timeout)
-		if err != nil {
-			return err
-		} */
 
 	d.SetId(member.ID)
 
@@ -162,36 +135,43 @@ func resourceMemberV2Create(ctx context.Context, d *schema.ResourceData, meta in
 
 func resourceMemberV2Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	client, err := config.NetworkingV2Client(config.GetRegion(d))
 	if err != nil {
-		return fmterr.Errorf("error creating OpenTelekomCloud networking client: %s", err)
+		return fmterr.Errorf(errCreationClient, err)
 	}
 
-	member, err := pools.GetMember(networkingClient, d.Get("pool_id").(string), d.Id()).Extract()
+	poolID := d.Get("pool_id").(string)
+	member, err := pools.GetMember(client, poolID, d.Id()).Extract()
 	if err != nil {
 		return diag.FromErr(common.CheckDeleted(d, err, "member"))
 	}
 
 	log.Printf("[DEBUG] Retrieved member %s: %#v", d.Id(), member)
 
-	d.Set("name", member.Name)
-	d.Set("weight", member.Weight)
-	d.Set("admin_state_up", member.AdminStateUp)
-	d.Set("tenant_id", member.TenantID)
-	d.Set("subnet_id", member.SubnetID)
-	d.Set("address", member.Address)
-	d.Set("protocol_port", member.ProtocolPort)
-	d.Set("id", member.ID)
-	d.Set("region", config.GetRegion(d))
+	mErr := multierror.Append(
+		d.Set("name", member.Name),
+		d.Set("weight", member.Weight),
+		d.Set("admin_state_up", member.AdminStateUp),
+		d.Set("tenant_id", member.TenantID),
+		d.Set("subnet_id", member.SubnetID),
+		d.Set("address", member.Address),
+		d.Set("protocol_port", member.ProtocolPort),
+		d.Set("pool_id", member.PoolID),
+		d.Set("region", config.GetRegion(d)),
+	)
+
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.FromErr(err)
+	}
 
 	return nil
 }
 
 func resourceMemberV2Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	client, err := config.NetworkingV2Client(config.GetRegion(d))
 	if err != nil {
-		return fmterr.Errorf("error creating OpenTelekomCloud networking client: %s", err)
+		return fmterr.Errorf(errCreationClient, err)
 	}
 
 	var updateOpts pools.UpdateMemberOpts
@@ -209,14 +189,13 @@ func resourceMemberV2Update(ctx context.Context, d *schema.ResourceData, meta in
 	// Wait for LB to become active before continuing
 	poolID := d.Get("pool_id").(string)
 	timeout := d.Timeout(schema.TimeoutUpdate)
-	err = waitForLBV2viaPool(ctx, networkingClient, poolID, "ACTIVE", timeout)
-	if err != nil {
+	if err := waitForLBV2viaPool(ctx, client, poolID, "ACTIVE", timeout); err != nil {
 		return diag.FromErr(err)
 	}
 
 	log.Printf("[DEBUG] Updating member %s with options: %#v", d.Id(), updateOpts)
 	err = resource.RetryContext(ctx, timeout, func() *resource.RetryError {
-		_, err = pools.UpdateMember(networkingClient, poolID, d.Id(), updateOpts).Extract()
+		_, err = pools.UpdateMember(client, poolID, d.Id(), updateOpts).Extract()
 		if err != nil {
 			return common.CheckForRetryableError(err)
 		}
@@ -224,11 +203,10 @@ func resourceMemberV2Update(ctx context.Context, d *schema.ResourceData, meta in
 	})
 
 	if err != nil {
-		return fmterr.Errorf("Unable to update member %s: %s", d.Id(), err)
+		return fmterr.Errorf("Unable to update member %s: %w", d.Id(), err)
 	}
 
-	err = waitForLBV2viaPool(ctx, networkingClient, poolID, "ACTIVE", timeout)
-	if err != nil {
+	if err := waitForLBV2viaPool(ctx, client, poolID, "ACTIVE", timeout); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -237,34 +215,32 @@ func resourceMemberV2Update(ctx context.Context, d *schema.ResourceData, meta in
 
 func resourceMemberV2Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
+	client, err := config.NetworkingV2Client(config.GetRegion(d))
 	if err != nil {
-		return fmterr.Errorf("error creating OpenTelekomCloud networking client: %s", err)
+		return fmterr.Errorf(errCreationClient, err)
 	}
 
 	// Wait for Pool to become active before continuing
 	poolID := d.Get("pool_id").(string)
 	timeout := d.Timeout(schema.TimeoutDelete)
-	err = waitForLBV2viaPool(ctx, networkingClient, poolID, "ACTIVE", timeout)
-	if err != nil {
+	if err := waitForLBV2viaPool(ctx, client, poolID, "ACTIVE", timeout); err != nil {
 		return diag.FromErr(err)
 	}
 
 	log.Printf("[DEBUG] Attempting to delete member %s", d.Id())
 	err = resource.RetryContext(ctx, timeout, func() *resource.RetryError {
-		err = pools.DeleteMember(networkingClient, poolID, d.Id()).ExtractErr()
+		err = pools.DeleteMember(client, poolID, d.Id()).ExtractErr()
 		if err != nil {
 			return common.CheckForRetryableError(err)
 		}
 		return nil
 	})
 	if err != nil {
-		return fmterr.Errorf("Unable to delete member %s: %s", d.Id(), err)
+		return fmterr.Errorf("Unable to delete member %s: %w", d.Id(), err)
 	}
 
 	// Wait for LB to become ACTIVE
-	err = waitForLBV2viaPool(ctx, networkingClient, poolID, "ACTIVE", timeout)
-	if err != nil {
+	if err := waitForLBV2viaPool(ctx, client, poolID, "ACTIVE", timeout); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/opentelekomcloud/services/elb/resource_opentelekomcloud_lb_member_v2.go
+++ b/opentelekomcloud/services/elb/resource_opentelekomcloud_lb_member_v2.go
@@ -62,7 +62,7 @@ func ResourceMemberV2() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Computed:     true,
-				ValidateFunc: validation.IntBetween(0, 100),
+				ValidateFunc: validation.IntBetween(1, 100),
 			},
 			"subnet_id": {
 				Type:     schema.TypeString,

--- a/opentelekomcloud/services/elb/resource_opentelekomcloud_lb_member_v2.go
+++ b/opentelekomcloud/services/elb/resource_opentelekomcloud_lb_member_v2.go
@@ -156,7 +156,6 @@ func resourceMemberV2Read(_ context.Context, d *schema.ResourceData, meta interf
 		d.Set("subnet_id", member.SubnetID),
 		d.Set("address", member.Address),
 		d.Set("protocol_port", member.ProtocolPort),
-		d.Set("pool_id", member.PoolID),
 		d.Set("region", config.GetRegion(d)),
 	)
 

--- a/releasenotes/notes/lb-member-fix-40509a2a4c852643.yaml
+++ b/releasenotes/notes/lb-member-fix-40509a2a4c852643.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[ELB]** Fix issue with setting ``id`` in ``resource/opentelekomcloud_lb_member_v2`` (`#1229 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1229>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Fix wrong `id` setting in `resource/opentelekomcloud_lb_member_v2`

## PR Checklist

* [x] Refers to: #1136
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccLBV2Member_basic
--- PASS: TestAccLBV2Member_basic (178.94s)
PASS

Process finished with the exit code 0
```
