### PR TITLE
[OBS] Add event bucket notification configuration

### DIFF
--- a/opentelekomcloud/acceptance/obs/resource_opentelekomcloud_obs_bucket_test.go
+++ b/opentelekomcloud/acceptance/obs/resource_opentelekomcloud_obs_bucket_test.go
@@ -193,6 +193,27 @@ func TestAccObsBucket_cors(t *testing.T) {
 	})
 }
 
+func TestAccObsBucket_notifications(t *testing.T) {
+	rInt := acctest.RandInt()
+	resourceName := "opentelekomcloud_obs_bucket.bucket"
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckObsBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccObsBucketConfigWithNotifications(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "event_notifications.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "event_notifications.0.events.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "event_notifications.0.filter_rule.#", "2"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckObsBucketDestroy(s *terraform.State) error {
 	config := common.TestAccProvider.Meta().(*cfg.Config)
 	client, err := config.NewObjectStorageClient(env.OS_REGION_NAME)
@@ -460,6 +481,68 @@ resource "opentelekomcloud_obs_bucket" "bucket" {
     expose_headers  = ["x-amz-server-side-encryption", "ETag"]
     max_age_seconds = 3000
   }
+}
+`, randInt)
+}
+
+func testAccObsBucketConfigWithNotifications(randInt int) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_smn_topic_v2" "topic" {
+  name         = "obs-notifications"
+  display_name = "The display name of topic_1"
+}
+
+resource "opentelekomcloud_smn_topic_attribute_v2" "policy" {
+  topic_urn       = opentelekomcloud_smn_topic_v2.topic.id
+  attribute_name  = "access_policy"
+  topic_attribute = <<EOF
+{
+  "Version": "2016-09-07",
+  "Id": "__default_policy_ID",
+  "Statement": [
+    {
+      "Sid": "__service_pub_0",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "obs",
+          "s3"
+        ]
+      },
+      "Action": [
+        "SMN:Publish",
+        "SMN:QueryTopicDetail"
+      ],
+      "Resource": "${opentelekomcloud_smn_topic_v2.topic.id}"
+    }
+  ]
+}
+EOF
+
+  depends_on = [opentelekomcloud_smn_topic_v2.topic]
+}
+
+resource "opentelekomcloud_obs_bucket" "bucket" {
+  bucket = "tf-test-bucket-%[1]d"
+  acl    = "private"
+
+  event_notifications {
+    topic  = opentelekomcloud_smn_topic_v2.topic.id
+    events = [
+      "ObjectCreated:*",
+      "ObjectRemoved:*",
+    ]
+    filter_rule {
+      name  = "prefix"
+      value = "smn"
+    }
+    filter_rule {
+      name  = "suffix"
+      value = ".jpg"
+    }
+  }
+
+  depends_on = [ opentelekomcloud_smn_topic_attribute_v2.policy ]
 }
 `, randInt)
 }

--- a/releasenotes/notes/obs-notifications-738bc6b5cb60a43d.yaml
+++ b/releasenotes/notes/obs-notifications-738bc6b5cb60a43d.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[OBS]** Add ``event_notifications`` to ``resource/opentelekomcloud_obs_bucket`` (`#1235 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1235>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Add `event_notifications` argument to `opentelekomcloud_obs_bucket` resource

Fix #1167

## PR Checklist

* [x] Refers to: #1167
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccObsBucket_notifications
--- PASS: TestAccObsBucket_notifications (23.33s)
PASS

Process finished with the exit code 0
```
