### PR TITLE
[VPC] Fix issue with wrong ID setting

### DIFF
--- a/docs/data-sources/vpc_v1.md
+++ b/docs/data-sources/vpc_v1.md
@@ -6,12 +6,13 @@ subcategory: "Virtual Private Cloud (VPC)"
 
 Use this data source to get details about a specific VPC.
 
-This data source can prove useful when a module accepts a VPC id as an input variable and needs to, for example, determine the CIDR block of that VPC.
+This data source can prove useful when a module accepts a VPC id as an input variable and needs to, for example,
+determine the CIDR block of that VPC.
 
 ## Example Usage
 
 ```hcl
-variable "vpc_name" { }
+variable "vpc_name" {}
 
 data "opentelekomcloud_vpc_v1" "vpc" {
   name   = var.vpc_name
@@ -35,8 +36,6 @@ The given filters must match exactly one VPC whose data will be exported as attr
 * `cidr` - (Optional) The cidr block of the desired VPC.
 
 * `shared` - (Optional) Enable SNAT (In order to let instances without an EIP access the internet).
-
-
 
 ## Attributes Reference
 

--- a/opentelekomcloud/services/vpc/data_source_opentelekomcloud_vpc_v1.go
+++ b/opentelekomcloud/services/vpc/data_source_opentelekomcloud_vpc_v1.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v1/vpcs"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -22,7 +23,6 @@ func DataSourceVirtualPrivateCloudVpcV1() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				ForceNew: true,
 			},
 			"id": {
 				Type:     schema.TypeString,
@@ -66,7 +66,7 @@ func DataSourceVirtualPrivateCloudVpcV1() *schema.Resource {
 
 func dataSourceVirtualPrivateCloudV1Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	vpcClient, err := config.NetworkingV1Client(config.GetRegion(d))
+	client, err := config.NetworkingV1Client(config.GetRegion(d))
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -78,42 +78,45 @@ func dataSourceVirtualPrivateCloudV1Read(_ context.Context, d *schema.ResourceDa
 		CIDR:   d.Get("cidr").(string),
 	}
 
-	refinedVpcs, err := vpcs.List(vpcClient, listOpts)
+	refinedVPCs, err := vpcs.List(client, listOpts)
 	if err != nil {
-		return fmterr.Errorf("Unable to retrieve vpcs: %s", err)
+		return fmterr.Errorf("Unable to retrieve VPCs: %w", err)
 	}
 
-	if len(refinedVpcs) < 1 {
+	if len(refinedVPCs) < 1 {
 		return fmterr.Errorf("Your query returned no results. " +
 			"Please change your search criteria and try again.")
 	}
 
-	if len(refinedVpcs) > 1 {
-		return fmterr.Errorf("Your query returned more than one result." +
-			" Please try a more specific search criteria")
+	if len(refinedVPCs) > 1 {
+		return fmterr.Errorf("Your query returned more than one result. " +
+			"Please try a more specific search criteria.")
 	}
 
-	Vpc := refinedVpcs[0]
+	singleVpc := refinedVPCs[0]
 
-	var s []map[string]interface{}
-	for _, route := range Vpc.Routes {
+	var routes []map[string]interface{}
+	for _, route := range singleVpc.Routes {
 		mapping := map[string]interface{}{
 			"destination": route.DestinationCIDR,
 			"nexthop":     route.NextHop,
 		}
-		s = append(s, mapping)
+		routes = append(routes, mapping)
 	}
 
-	log.Printf("[INFO] Retrieved Vpc using given filter %s: %+v", Vpc.ID, Vpc)
-	d.SetId(Vpc.ID)
+	log.Printf("[INFO] Retrieved Vpc using given filter %s: %+v", singleVpc.ID, singleVpc)
+	d.SetId(singleVpc.ID)
 
-	d.Set("name", Vpc.Name)
-	d.Set("cidr", Vpc.CIDR)
-	d.Set("status", Vpc.Status)
-	d.Set("id", Vpc.ID)
-	d.Set("shared", Vpc.EnableSharedSnat)
-	d.Set("region", config.GetRegion(d))
-	if err := d.Set("routes", s); err != nil {
+	mErr := multierror.Append(
+		d.Set("name", singleVpc.Name),
+		d.Set("cidr", singleVpc.CIDR),
+		d.Set("status", singleVpc.Status),
+		d.Set("shared", singleVpc.EnableSharedSnat),
+		d.Set("region", config.GetRegion(d)),
+		d.Set("routes", routes),
+	)
+
+	if err := mErr.ErrorOrNil(); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/releasenotes/notes/d-vpc-v1-d07b98c8030a6a03.yaml
+++ b/releasenotes/notes/d-vpc-v1-d07b98c8030a6a03.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[VPC]** Fix issue with setting ``id`` in ``data_source/opentelekomcloud_vpc_v1`` (`#1237 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1237>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Fix issue with wrong `id` setting in `data_source/opentelekomcloud_vpc_v1`

## PR Checklist

* [x] Refers to: #1136
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccVpcV1DataSource_basic
--- PASS: TestAccVpcV1DataSource_basic (69.27s)
PASS

Process finished with the exit code 0
```
