### PR TITLE
Fix invalid ID setting of VPC route data source

### DIFF
--- a/opentelekomcloud/services/vpc/data_source_opentelekomcloud_vpc_route_v2.go
+++ b/opentelekomcloud/services/vpc/data_source_opentelekomcloud_vpc_route_v2.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/routes"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -89,13 +90,17 @@ func dataSourceVpcRouteV2Read(_ context.Context, d *schema.ResourceData, meta in
 	log.Printf("[INFO] Retrieved Vpc Route using given filter %s: %+v", Route.RouteID, Route)
 	d.SetId(Route.RouteID)
 
-	d.Set("type", Route.Type)
-	d.Set("nexthop", Route.NextHop)
-	d.Set("destination", Route.Destination)
-	d.Set("tenant_id", Route.Tenant_Id)
-	d.Set("vpc_id", Route.VPC_ID)
-	d.Set("id", Route.RouteID)
-	d.Set("region", config.GetRegion(d))
+	mErr := multierror.Append(
+		d.Set("type", Route.Type),
+		d.Set("nexthop", Route.NextHop),
+		d.Set("destination", Route.Destination),
+		d.Set("tenant_id", Route.Tenant_Id),
+		d.Set("vpc_id", Route.VPC_ID),
+		d.Set("region", config.GetRegion(d)),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return fmterr.Errorf("error setting VPC route attributes: %w", err)
+	}
 
 	return nil
 }

--- a/releasenotes/notes/vpc-route-data-a2466437587da4f4.yaml
+++ b/releasenotes/notes/vpc-route-data-a2466437587da4f4.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[VPC]** Fix panic when using ``data_source/opentelekomcloud_vpc_route_v2`` (`#1240 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1240>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Get rid of `d.Set("id", ...)`

Handle `d.Set` errors

Part of #1136

## PR Checklist

* [x] Refers to: #1136
* [x] Tests passed
* [x] Release notes added

## Acceptance Steps Performed

```
=== RUN   TestAccOTCVpcRouteV2DataSource_basic
--- PASS: TestAccOTCVpcRouteV2DataSource_basic (56.00s)
PASS

Process finished with the exit code 0
```
