### PR TITLE
Fix panic using `vpc_peering_connection_v2`

### DIFF
--- a/releasenotes/notes/vpc-peering-d5f0618eeb9fa55e.yaml
+++ b/releasenotes/notes/vpc-peering-d5f0618eeb9fa55e.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[VPC]** Fix panic when using ``resource/opentelekomcloud_vpc_peering_connection_v2`` and ``data_source/opentelekomcloud_vpc_peering_connection_v2`` (`#1242 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1242>`_)


### PR DESCRIPTION
Get rid of `d.Set("id", ...)` crashing the provider

## Summary of the Pull Request
Fix #1241

## PR Checklist

* [x] Refers to: #1136, #1241
* [x] Tests added/passed.
* [x] Release notes added.

## Acceptance Steps Performed

### Resource
```
=== RUN   TestAccOTCVpcPeeringConnectionV2_basic
--- PASS: TestAccOTCVpcPeeringConnectionV2_basic (54.31s)
=== RUN   TestAccOTCVpcPeeringConnectionV2_timeout
--- PASS: TestAccOTCVpcPeeringConnectionV2_timeout (44.42s)
PASS

Process finished with the exit code 0
```

### Data Source
```
=== RUN   TestAccOTCVpcPeeringConnectionV2DataSource_basic
--- PASS: TestAccOTCVpcPeeringConnectionV2DataSource_basic (47.27s)
PASS

Process finished with the exit code 0
```