### PR TITLE
[Makefile] Fix `terrafmt` installation

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -51,7 +51,7 @@ test-compile:
 
 tools:
 	@echo "==> installing required tooling..."
-	go install github.com/katbyte/terrafmt
+	go install github.com/katbyte/terrafmt@latest
 
 tflint: tools
 	./scripts/run-tflint.sh


### PR DESCRIPTION
## Summary of the Pull Request
Fix make trying to install `terrafmt` without a version

## PR Checklist

* [x] Refers to: #1245 
* [x] Tests added/passed.

## Acceptance Steps Performed

```
$ make tools 
==> installing required tooling...
go install github.com/katbyte/terrafmt@latest

```
