### PR TITLE
Fix reading `blockstorage_volume_v2` tags

### DIFF
--- a/opentelekomcloud/acceptance/evs/resource_opentelekomcloud_blockstorage_volume_v2_test.go
+++ b/opentelekomcloud/acceptance/evs/resource_opentelekomcloud_blockstorage_volume_v2_test.go
@@ -112,7 +112,7 @@ func TestAccBlockStorageV2Volume_policy(t *testing.T) {
 
 func testPolicyPreCheck(t *testing.T) {
 	if os.Getenv("OS_KMS_KEY") == "" {
-		t.Errorf("OS_KMS_KEY should be set for this test to existing KMS key alias")
+		t.Skipf("OS_KMS_KEY should be set for this test to existing KMS key alias")
 	}
 }
 

--- a/opentelekomcloud/services/evs/resource_opentelekomcloud_blockstorage_volume_v2.go
+++ b/opentelekomcloud/services/evs/resource_opentelekomcloud_blockstorage_volume_v2.go
@@ -291,7 +291,7 @@ OUTER:
 	if err != nil {
 		return fmterr.Errorf("error fetching tags for volume (%s): %s", v.ID, err)
 	}
-	d.Set("tags", taglist)
+	d.Set("tags", taglist.Tags)
 
 	// This is useful for import
 	if d.Get("device_type").(string) == "" {

--- a/releasenotes/notes/blockstorage-tags-8ae3c5562d66e2c5.yaml
+++ b/releasenotes/notes/blockstorage-tags-8ae3c5562d66e2c5.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[EVS]** Fix panic when using ``resource/opentelekomcloud_blockstorage_volume_v2`` (`#1249 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1249>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Fix #1248 

## PR Checklist

* [x] Refers to: #1248
* [x] Tests added/passed.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccBlockStorageV2Volume_basic
--- PASS: TestAccBlockStorageV2Volume_basic (44.51s)
=== RUN   TestAccBlockStorageV2Volume_upscaleDownScale
--- PASS: TestAccBlockStorageV2Volume_upscaleDownScale (90.42s)
=== RUN   TestAccBlockStorageV2Volume_upscaleDownScaleAssigned
--- PASS: TestAccBlockStorageV2Volume_upscaleDownScaleAssigned (159.17s)
=== RUN   TestAccBlockStorageV2Volume_policy
    resource_opentelekomcloud_blockstorage_volume_v2_test.go:115: OS_KMS_KEY should be set for this test to existing KMS key alias
--- SKIP: TestAccBlockStorageV2Volume_policy (0.00s)

Test ignored.
=== RUN   TestAccBlockStorageV2Volume_tags
--- PASS: TestAccBlockStorageV2Volume_tags (47.58s)
=== RUN   TestAccBlockStorageV2Volume_image
--- PASS: TestAccBlockStorageV2Volume_image (34.61s)
=== RUN   TestAccBlockStorageV2Volume_timeout
--- PASS: TestAccBlockStorageV2Volume_timeout (34.40s)
PASS

Process finished with the exit code 0

```
