### PR TITLE
Fix not working tags for `dns_zone_v2` data source

### DIFF
--- a/opentelekomcloud/services/dns/data_source_opentelekomcloud_dns_zone_v2.go
+++ b/opentelekomcloud/services/dns/data_source_opentelekomcloud_dns_zone_v2.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/dns/v2/zones"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
@@ -123,6 +124,14 @@ type TaggedListOpts struct {
 	zones.ListOpts
 
 	Tags string `q:"tags"`
+}
+
+func (opts TaggedListOpts) ToZoneListQuery() (string, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return q.String(), err
 }
 
 func tagsAsString(tags map[string]interface{}) string {

--- a/releasenotes/notes/dns-by-tags-75915acffcb79d7f.yaml
+++ b/releasenotes/notes/dns-by-tags-75915acffcb79d7f.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[DNS]** Fix not working ``tags`` in ``data_source/opentelekomcloud_dns_zone_v2`` (`#1277 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1277>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Fix not passing `tags` to the query string

Fix acceptance test to check querying DNS zone by tag

Resolve #1254

## PR Checklist

* [x] Refers to: #1254
* [x] Tests added/passed.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccOpenStackDNSZoneV2DataSource_basic
--- PASS: TestAccOpenStackDNSZoneV2DataSource_basic (34.30s)
=== RUN   TestAccOpenStackDNSZoneV2DataSource_byTag
--- PASS: TestAccOpenStackDNSZoneV2DataSource_byTag (33.56s)
PASS

Process finished with the exit code 0

```
