### PR TITLE
[CCE] Fix node pool reverting autoscaling

### DIFF
--- a/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_pool_v3.go
+++ b/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_pool_v3.go
@@ -387,7 +387,6 @@ func resourceCCENodePoolV3Read(_ context.Context, d *schema.ResourceData, meta i
 		d.Set("availability_zone", s.Spec.NodeTemplate.Az),
 		d.Set("os", s.Spec.NodeTemplate.Os),
 		d.Set("key_pair", s.Spec.NodeTemplate.Login.SshKey),
-		d.Set("initial_node_count", s.Spec.InitialNodeCount),
 		d.Set("scale_enable", s.Spec.Autoscaling.Enable),
 	)
 

--- a/releasenotes/notes/node-pool-resize-9227480cf482d2cd.yaml
+++ b/releasenotes/notes/node-pool-resize-9227480cf482d2cd.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[CCE]** Fix ``apply`` reverting autoscaling for ``resource/opentelekomcloud_cce_node_pool_v3`` (`#1279 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1279>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Stop reading `initial_node_count` from the service

Fix #1255

## PR Checklist

* [x] Refers to: #1255
* [x] Tests added/passed.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccCCENodePoolsV3_basic
--- PASS: TestAccCCENodePoolsV3_basic (882.68s)
=== RUN   TestAccCCENodePoolsV3_randomAZ
--- PASS: TestAccCCENodePoolsV3_randomAZ (745.64s)
=== RUN   TestAccCCENodePoolsV3EncryptedVolume
--- PASS: TestAccCCENodePoolsV3EncryptedVolume (698.58s)
PASS

Process finished with the exit code 0

```
