### PR TITLE
[KMS] Add missing field `expiration_time`

### DIFF
--- a/docs/data-sources/kms_key_v1.md
+++ b/docs/data-sources/kms_key_v1.md
@@ -37,7 +37,7 @@ data "opentelekomcloud_kms_key_v1" "key_1" {
 
 * `key_state` - (Optional) The state of a key. `1` indicates that the key is waiting to be activated.
   `2` indicates that the key is enabled. `3` indicates that the key is disabled. `4` indicates that
-  the key is scheduled for deletion. Changing this gets a new key.
+  the key is scheduled for deletion. `5` indicates that the key waiting to be imported. Changing this gets a new key.
 
 * `domain_id` - (Optional) ID of a user domain for the key. Changing this gets a new key.
 

--- a/docs/data-sources/kms_key_v1.md
+++ b/docs/data-sources/kms_key_v1.md
@@ -26,23 +26,22 @@ data "opentelekomcloud_kms_key_v1" "key_1" {
 * `key_alias` - (Optional) The alias in which to create the key. It is required when
   we create a new key. Changing this gets the new key.
 
-* `key_description` - (Optional) The description of the key as viewed in OpenTelekomCloud console.
-  Changing this gets a new key.
+* `key_description` - (Optional) The description of the key. Changing this gets a new key.
 
 * `realm` - (Optional) Region where a key resides. Changing this gets a new key.
 
 * `key_id` - (Optional) The globally unique identifier for the key. Changing this gets the new key.
 
-* `default_key_flag` - (Optional) Identification of a Master Key. The value "1" indicates a Default
-  Master Key, and the value "0" indicates a key. Changing this gets a new key.
+* `default_key_flag` - (Optional) Identification of a Master Key. The value `1` indicates a Default
+  Master Key, and the value `0` indicates a key. Changing this gets a new key.
 
-* `key_state` - (Optional) The state of a key. "1" indicates that the key is waiting to be activated.
-  "2" indicates that the key is enabled. "3" indicates that the key is disabled. "4" indicates that
+* `key_state` - (Optional) The state of a key. `1` indicates that the key is waiting to be activated.
+  `2` indicates that the key is enabled. `3` indicates that the key is disabled. `4` indicates that
   the key is scheduled for deletion. Changing this gets a new key.
 
 * `domain_id` - (Optional) ID of a user domain for the key. Changing this gets a new key.
 
-* `origin` - Origin of a key. Such as: kms. Changing this gets a new key.
+* `origin` - Origin of a key. Such as: `kms`. Changing this gets a new key.
 
 ## Attributes Reference
 

--- a/opentelekomcloud/acceptance/kms/data_source_opentelekomcloud_kms_key_v1_test.go
+++ b/opentelekomcloud/acceptance/kms/data_source_opentelekomcloud_kms_key_v1_test.go
@@ -4,29 +4,30 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
 )
 
-var keyAlias = fmt.Sprintf("key_alias_%s", acctest.RandString(5))
+var keyAlias = tools.RandomString("key_alias_", 3)
 
 func TestAccKmsKeyV1DataSource_basic(t *testing.T) {
+	dataSourceName := "data.opentelekomcloud_kms_key_v1.key1"
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKmsKeyV1DataSource_key,
+				Config: testAccKmsKeyV1DataSourceKey,
 			},
 			{
-				Config: testAccKmsKeyV1DataSource_basic,
+				Config: testAccKmsKeyV1DataSourceBasic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckKmsKeyV1DataSourceID("data.opentelekomcloud_kms_key_v1.key1"),
-					resource.TestCheckResourceAttr(
-						"data.opentelekomcloud_kms_key_v1.key1", "key_alias", keyAlias),
+					testAccCheckKmsKeyV1DataSourceID(dataSourceName),
+					resource.TestCheckResourceAttr(dataSourceName, "key_alias", keyAlias),
 				),
 			},
 		},
@@ -37,7 +38,7 @@ func testAccCheckKmsKeyV1DataSourceID(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("can't find Kms key data source: %s", n)
+			return fmt.Errorf("can't find KMS key data source: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
@@ -48,7 +49,7 @@ func testAccCheckKmsKeyV1DataSourceID(n string) resource.TestCheckFunc {
 	}
 }
 
-var testAccKmsKeyV1DataSource_key = fmt.Sprintf(`
+var testAccKmsKeyV1DataSourceKey = fmt.Sprintf(`
 resource "opentelekomcloud_kms_key_v1" "key1" {
   key_alias       = "%s"
   key_description = "test description"
@@ -56,7 +57,7 @@ resource "opentelekomcloud_kms_key_v1" "key1" {
   is_enabled      = true
 }`, keyAlias)
 
-var testAccKmsKeyV1DataSource_basic = fmt.Sprintf(`
+var testAccKmsKeyV1DataSourceBasic = fmt.Sprintf(`
 %s
 data "opentelekomcloud_kms_key_v1" "key1" {
   key_alias       = opentelekomcloud_kms_key_v1.key1.key_alias
@@ -64,4 +65,4 @@ data "opentelekomcloud_kms_key_v1" "key1" {
   key_description = "test description"
   key_state       = "2"
 }
-`, testAccKmsKeyV1DataSource_key)
+`, testAccKmsKeyV1DataSourceKey)

--- a/opentelekomcloud/services/kms/data_source_opentelekomcloud_kms_key_v1.go
+++ b/opentelekomcloud/services/kms/data_source_opentelekomcloud_kms_key_v1.go
@@ -50,7 +50,11 @@ func DataSourceKmsKeyV1() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				ValidateFunc: validation.StringInSlice([]string{
-					WaitingForEnableState, EnabledState, DisabledState, PendingDeletionState, WaitingImportState,
+					WaitingForEnableState,
+					EnabledState,
+					DisabledState,
+					PendingDeletionState,
+					WaitingImportState,
 				}, true),
 			},
 			"default_key_flag": {

--- a/opentelekomcloud/services/kms/resource_opentelekomcloud_kms_key_v1.go
+++ b/opentelekomcloud/services/kms/resource_opentelekomcloud_kms_key_v1.go
@@ -23,6 +23,7 @@ const (
 	EnabledState          = "2"
 	DisabledState         = "3"
 	PendingDeletionState  = "4"
+	WaitingImportState    = "5"
 )
 
 func ResourceKmsKeyV1() *schema.Resource {

--- a/releasenotes/notes/d-kms-fix-9c118e8b71548a5e.yaml
+++ b/releasenotes/notes/d-kms-fix-9c118e8b71548a5e.yaml
@@ -1,7 +1,7 @@
 ---
 fixes:
   - |
-    **[KMS]** Add missing field ``expiration_time`` in ``data_source/opentelekomcloud_kms_key_v1`` (#1284 `https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1284`_)
+    **[KMS]** Add missing field ``expiration_time`` in ``data_source/opentelekomcloud_kms_key_v1`` (`#1284 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1284>`_)
 other:
   - |
-    **[KMS]** Update ``key_state`` validation in ``data_source/opentelekomcloud_kms_key_v1`` (#1284 `https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1284`_)
+    **[KMS]** Update ``key_state`` validation in ``data_source/opentelekomcloud_kms_key_v1`` (`#1284 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1284>`_)

--- a/releasenotes/notes/d-kms-fix-9c118e8b71548a5e.yaml
+++ b/releasenotes/notes/d-kms-fix-9c118e8b71548a5e.yaml
@@ -2,3 +2,6 @@
 fixes:
   - |
     **[KMS]** Add missing field ``expiration_time`` in ``data_source/opentelekomcloud_kms_key_v1`` (#1284 `https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1284`_)
+other:
+  - |
+    **[KMS]** Remove ``ForceNew`` in ``data_source/opentelekomcloud_kms_key_v1`` (#1284 `https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1284`_)

--- a/releasenotes/notes/d-kms-fix-9c118e8b71548a5e.yaml
+++ b/releasenotes/notes/d-kms-fix-9c118e8b71548a5e.yaml
@@ -4,4 +4,4 @@ fixes:
     **[KMS]** Add missing field ``expiration_time`` in ``data_source/opentelekomcloud_kms_key_v1`` (#1284 `https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1284`_)
 other:
   - |
-    **[KMS]** Remove ``ForceNew`` in ``data_source/opentelekomcloud_kms_key_v1`` (#1284 `https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1284`_)
+    **[KMS]** Update ``key_state`` validation in ``data_source/opentelekomcloud_kms_key_v1`` (#1284 `https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1284`_)

--- a/releasenotes/notes/d-kms-fix-9c118e8b71548a5e.yaml
+++ b/releasenotes/notes/d-kms-fix-9c118e8b71548a5e.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[KMS]** Add missing field ``expiration_time`` in schema (#1284 `https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1284`_)

--- a/releasenotes/notes/d-kms-fix-9c118e8b71548a5e.yaml
+++ b/releasenotes/notes/d-kms-fix-9c118e8b71548a5e.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    **[KMS]** Add missing field ``expiration_time`` in schema (#1284 `https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1284`_)
+    **[KMS]** Add missing field ``expiration_time`` in ``data_source/opentelekomcloud_kms_key_v1`` (#1284 `https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1284`_)


### PR DESCRIPTION
## Summary of the Pull Request
Fix issue with missing field `expiration_time` in `data_source/opentelekomcloud_kms_key_v1`
Field `key_state` now maybe in two new states: `WaitingForEnableState` and `WaitingImportState`.

## PR Checklist

* [x] Refers to: #1283
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccKmsKeyV1DataSource_basic
--- PASS: TestAccKmsKeyV1DataSource_basic (77.63s)
PASS

Process finished with the exit code 0
```
