### PR TITLE
[NAT] Fix `source_type` field type setting in `Read()`

### DIFF
--- a/docs/resources/nat_snat_rule_v2.md
+++ b/docs/resources/nat_snat_rule_v2.md
@@ -9,10 +9,24 @@ Manages a V2 snat rule resource within OpenTelekomCloud Nat.
 ## Example Usage
 
 ```hcl
+variable "network_id" {}
+variable "vpc_id" {}
+
+resource "opentelekomcloud_networking_floatingip_v2" "fip_1" {}
+
+resource "opentelekomcloud_nat_gateway_v2" "nat_1" {
+  name                = "nat_1"
+  description         = "test for terraform"
+  spec                = "1"
+  internal_network_id = var.network_id
+  router_id           = var.vpc_id
+}
+
 resource "opentelekomcloud_nat_snat_rule_v2" "snat_1" {
-  nat_gateway_id = "3c0dffda-7c76-452b-9dcc-5bce7ae56b17"
-  network_id     = "dc8632e2-d9ff-41b1-aa0c-d455557314a0"
-  floating_ip_id = "0a166fc5-a904-42fb-b1ef-cf18afeeddca"
+  nat_gateway_id = opentelekomcloud_nat_gateway_v2.nat_1.id
+  floating_ip_id = opentelekomcloud_networking_floatingip_v2.fip_1.id
+  cidr           = "192.168.0.0/24"
+  source_type    = 0
 }
 ```
 
@@ -24,18 +38,18 @@ The following arguments are supported:
   Changing this creates a new snat rule.
 
 * `network_id` - (Optional) ID of the network this snat rule connects to. This parameter
-  and cidr are alternative. Changing this creates a new snat rule.
+  and `cidr` are alternative. Changing this creates a new snat rule.
 
-* `source_type` - (Optional) 0: Either network_id or cidr can be specified in a VPC. 1:
-  Only cidr can be specified over a dedicated network. Changing this creates a new snat rule.
+* `source_type` - (Optional) `0`: Either `network_id` or cidr can be specified in a VPC. `1`:
+  Only `cidr` can be specified over a dedicated network. Changing this creates a new snat rule.
 
 * `cidr` - (Optional) Specifies CIDR, which can be in the format of a network segment or
-  a host IP address. This parameter and network_id are alternative. If the value of
-  source_type is 0, the CIDR block must be a subset of the VPC subnet CIDR block. If
-  the value of source_type is 1, the CIDR block must be a CIDR block of Direct Connect
+  a host IP address. This parameter and `network_id` are alternative. If the value of
+  `source_type` is `0`, the CIDR block must be a subset of the VPC subnet CIDR block. If
+  the value of `source_type` is `1`, the CIDR block must be a CIDR block of Direct Connect
   and cannot conflict with the VPC CIDR blocks. Changing this creates a new snat rule.
 
-* `floating_ip_id` - (Required) ID of the floating ip this snat rule connets to.
+* `floating_ip_id` - (Required) ID of the floating ip this snat rule connects to.
   Changing this creates a new snat rule.
 
 ## Attributes Reference

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/jinzhu/copier v0.2.3
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.5.1-0.20210802142209-8c183682e7c5
+	github.com/opentelekomcloud/gophertelekomcloud v0.5.1-0.20210813120405-351a3bba053d
 	github.com/unknwon/com v1.0.1
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -287,8 +287,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.5.1-0.20210802142209-8c183682e7c5 h1:lJkhXdd2ZlVqWOKNpRTEe+979PA/UIKagC6t5d29Do8=
-github.com/opentelekomcloud/gophertelekomcloud v0.5.1-0.20210802142209-8c183682e7c5/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
+github.com/opentelekomcloud/gophertelekomcloud v0.5.1-0.20210813120405-351a3bba053d h1:ssZNjwzCpvxZ09wEXnZLsk2La3+ea86MdjArvda8ZXc=
+github.com/opentelekomcloud/gophertelekomcloud v0.5.1-0.20210813120405-351a3bba053d/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/opentelekomcloud/acceptance/nat/resource_opentelekomcloud_nat_snat_rule_v2_test.go
+++ b/opentelekomcloud/acceptance/nat/resource_opentelekomcloud_nat_snat_rule_v2_test.go
@@ -7,23 +7,15 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/layer3/floatingips"
-	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/layer3/routers"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/snatrules"
-	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/networks"
-	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/subnets"
-
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
-	vpc "github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/vpc"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 )
 
 func TestAccNatSnatRule_basic(t *testing.T) {
-	var fip floatingips.FloatingIP
-	var network networks.Network
-	var router routers.Router
-	var subnet subnets.Subnet
+	resourceName := "opentelekomcloud_nat_gateway_v2.nat_1"
+	snatResourceName := "opentelekomcloud_nat_snat_rule_v2.snat_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -31,15 +23,10 @@ func TestAccNatSnatRule_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckNatV2SnatRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNatV2SnatRule_basic,
+				Config: testAccNatV2SnatRuleBasic(),
 				Check: resource.ComposeTestCheckFunc(
-					vpc.TestAccCheckNetworkingV2NetworkExists("opentelekomcloud_networking_network_v2.network_1", &network),
-					vpc.TestAccCheckNetworkingV2SubnetExists("opentelekomcloud_networking_subnet_v2.subnet_1", &subnet),
-					vpc.TestAccCheckNetworkingV2RouterExists("opentelekomcloud_networking_router_v2.router_1", &router),
-					vpc.TestAccCheckNetworkingV2FloatingIPExists("opentelekomcloud_networking_floatingip_v2.fip_1", &fip),
-					vpc.TestAccCheckNetworkingV2RouterInterfaceExists("opentelekomcloud_networking_router_interface_v2.int_1"),
-					testAccCheckNatV2GatewayExists("opentelekomcloud_nat_gateway_v2.nat_1"),
-					testAccCheckNatV2SnatRuleExists("opentelekomcloud_nat_snat_rule_v2.snat_1"),
+					testAccCheckNatV2GatewayExists(resourceName),
+					testAccCheckNatV2SnatRuleExists(snatResourceName),
 				),
 			},
 		},
@@ -48,9 +35,9 @@ func TestAccNatSnatRule_basic(t *testing.T) {
 
 func testAccCheckNatV2SnatRuleDestroy(s *terraform.State) error {
 	config := common.TestAccProvider.Meta().(*cfg.Config)
-	natClient, err := config.NatV2Client(env.OS_REGION_NAME)
+	client, err := config.NatV2Client(env.OS_REGION_NAME)
 	if err != nil {
-		return fmt.Errorf("error creating OpenTelekomCloud nat client: %s", err)
+		return fmt.Errorf("error creating OpenTelekomCloud NATv2 client: %w", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -58,7 +45,7 @@ func testAccCheckNatV2SnatRuleDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := snatrules.Get(natClient, rs.Primary.ID).Extract()
+		_, err := snatrules.Get(client, rs.Primary.ID).Extract()
 		if err == nil {
 			return fmt.Errorf("snat rule still exists")
 		}
@@ -79,12 +66,12 @@ func testAccCheckNatV2SnatRuleExists(n string) resource.TestCheckFunc {
 		}
 
 		config := common.TestAccProvider.Meta().(*cfg.Config)
-		natClient, err := config.NatV2Client(env.OS_REGION_NAME)
+		client, err := config.NatV2Client(env.OS_REGION_NAME)
 		if err != nil {
-			return fmt.Errorf("error creating OpenTelekomCloud nat client: %s", err)
+			return fmt.Errorf("error creating OpenTelekomCloud NATv2 client: %w", err)
 		}
 
-		found, err := snatrules.Get(natClient, rs.Primary.ID).Extract()
+		found, err := snatrules.Get(client, rs.Primary.ID).Extract()
 		if err != nil {
 			return err
 		}
@@ -97,44 +84,23 @@ func testAccCheckNatV2SnatRuleExists(n string) resource.TestCheckFunc {
 	}
 }
 
-const testAccNatV2SnatRule_basic = `
-resource "opentelekomcloud_networking_router_v2" "router_1" {
-  name = "router_1"
-  admin_state_up = "true"
-}
-
-resource "opentelekomcloud_networking_network_v2" "network_1" {
-  name = "network_1"
-  admin_state_up = "true"
-}
-
-resource "opentelekomcloud_networking_subnet_v2" "subnet_1" {
-  cidr = "192.168.0.0/16"
-  ip_version = 4
-  network_id = opentelekomcloud_networking_network_v2.network_1.id
-}
-
-resource "opentelekomcloud_networking_router_interface_v2" "int_1" {
-  subnet_id = opentelekomcloud_networking_subnet_v2.subnet_1.id
-  router_id = opentelekomcloud_networking_router_v2.router_1.id
-}
-
-resource "opentelekomcloud_networking_floatingip_v2" "fip_1" {
-}
+func testAccNatV2SnatRuleBasic() string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_networking_floatingip_v2" "fip_1" {}
 
 resource "opentelekomcloud_nat_gateway_v2" "nat_1" {
-  name   = "nat_1"
-  description = "test for terraform"
-  spec = "1"
-  internal_network_id = opentelekomcloud_networking_network_v2.network_1.id
-  router_id = opentelekomcloud_networking_router_v2.router_1.id
-  depends_on = ["opentelekomcloud_networking_router_interface_v2.int_1"]
+  name                = "nat_1"
+  description         = "test for terraform"
+  spec                = "1"
+  internal_network_id = "%s"
+  router_id           = "%s"
 }
 
 resource "opentelekomcloud_nat_snat_rule_v2" "snat_1" {
   nat_gateway_id = opentelekomcloud_nat_gateway_v2.nat_1.id
   floating_ip_id = opentelekomcloud_networking_floatingip_v2.fip_1.id
-  cidr = "192.168.0.0/24"
-  source_type = 0
+  cidr           = "192.168.0.0/24"
+  source_type    = 0
 }
-`
+`, env.OS_NETWORK_ID, env.OS_VPC_ID)
+}

--- a/opentelekomcloud/services/nat/common.go
+++ b/opentelekomcloud/services/nat/common.go
@@ -1,5 +1,5 @@
 package nat
 
 const (
-	errCreationClient = "error creating OpenTelekomCloud NATv2 client: %2"
+	errCreationClient = "error creating OpenTelekomCloud NATv2 client: %w"
 )

--- a/opentelekomcloud/services/nat/common.go
+++ b/opentelekomcloud/services/nat/common.go
@@ -1,0 +1,5 @@
+package nat
+
+const (
+	errCreationClient = "error creating OpenTelekomCloud NATv2 client: %2"
+)

--- a/opentelekomcloud/services/nat/resource_opentelekomcloud_nat_snat_rule_v2.go
+++ b/opentelekomcloud/services/nat/resource_opentelekomcloud_nat_snat_rule_v2.go
@@ -3,6 +3,7 @@ package nat
 import (
 	"context"
 	"log"
+	"strconv"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -133,9 +134,15 @@ func resourceNatSnatRuleV2Read(_ context.Context, d *schema.ResourceData, meta i
 		d.Set("nat_gateway_id", snatRule.NatGatewayID),
 		d.Set("network_id", snatRule.NetworkID),
 		d.Set("floating_ip_id", snatRule.FloatingIPID),
-		d.Set("source_type", snatRule.SourceType),
 		d.Set("cidr", snatRule.Cidr),
 		d.Set("region", config.GetRegion(d)),
+	)
+	sourceType, err := strconv.Atoi(snatRule.SourceType)
+	if err != nil {
+		return fmterr.Errorf("error converting `source_type`: %w", err)
+	}
+	mErr = multierror.Append(mErr,
+		d.Set("source_type", sourceType),
 	)
 
 	if err := mErr.ErrorOrNil(); err != nil {

--- a/releasenotes/notes/snat-fix-579e54320256e4c2.yaml
+++ b/releasenotes/notes/snat-fix-579e54320256e4c2.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    **[NAT]** Fix wrong ``source_type`` field type in ``resource/opentelekomcloud_nat_snat_rule_v2`` (`#1286 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1286>`_)
+other:
+  - |
+    **[NAT]** Add validations for UUIDs in ``resource/opentelekomcloud_nat_snat_rule_v2`` (`#1286 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1286>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Fix `source_type` field type in `resource/opentelekomcloud_nat_snat_rule_v2`
Fixes: #1283

## PR Checklist

* [x] Refers to: #1283, #1288
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccNatSnatRule_basic
--- PASS: TestAccNatSnatRule_basic (179.19s)
PASS

Process finished with the exit code 0
```
