### PR TITLE
[WAF] Fix `certificate_id` change for domain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/jinzhu/copier v0.2.3
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.5.1
+	github.com/opentelekomcloud/gophertelekomcloud v0.5.2-0.20210817150104-15541c56e48e
 	github.com/unknwon/com v1.0.1
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -287,8 +287,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.5.1 h1:cSOPxofUpILSCna4qR+5ors+OOjfIabsn2j0vb0Jb/U=
-github.com/opentelekomcloud/gophertelekomcloud v0.5.1/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
+github.com/opentelekomcloud/gophertelekomcloud v0.5.2-0.20210817150104-15541c56e48e h1:lSdgAFSAvFHaCzeDwntebi51gAON9ehDXT+//8MZLw0=
+github.com/opentelekomcloud/gophertelekomcloud v0.5.2-0.20210817150104-15541c56e48e/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/opentelekomcloud/acceptance/waf/resource_opentelekomcloud_waf_domain_v1_test.go
+++ b/opentelekomcloud/acceptance/waf/resource_opentelekomcloud_waf_domain_v1_test.go
@@ -44,6 +44,12 @@ func TestAccWafDomainV1Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceDomainName, "cipher", "cipher_default"),
 				),
 			},
+			{
+				Config: testAccWafDomainV1UpdateCertificate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafDomainV1CertificateChanged(resourceDomainName, &domain),
+				),
+			},
 		},
 	})
 }
@@ -93,6 +99,42 @@ func testAccCheckWafDomainV1Exists(n string, domain *domains.Domain) resource.Te
 
 		if found.Id != rs.Primary.ID {
 			return fmt.Errorf("WAF domain not found")
+		}
+
+		*domain = *found
+
+		return nil
+	}
+}
+
+func testAccCheckWafDomainV1CertificateChanged(n string, domain *domains.Domain) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		config := common.TestAccProvider.Meta().(*cfg.Config)
+		client, err := config.WafV1Client(env.OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("error creating OpenTelekomCloud WAF client: %w", err)
+		}
+
+		found, err := domains.Get(client, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.Id != rs.Primary.ID {
+			return fmt.Errorf("WAF domain not found")
+		}
+
+		if found.CertificateId == domain.CertificateId {
+			return fmt.Errorf("certificate has not changed")
 		}
 
 		*domain = *found
@@ -165,6 +207,45 @@ resource "opentelekomcloud_waf_domain_v1" "domain_1" {
     port            = 80
   }
   certificate_id = opentelekomcloud_waf_certificate_v1.certificate_1.id
+  policy_id      = opentelekomcloud_waf_policy_v1.policy_1.id
+  proxy          = false
+}
+`
+
+const testAccWafDomainV1UpdateCertificate = `
+resource "opentelekomcloud_networking_floatingip_v2" "fip_1" { }
+
+resource "opentelekomcloud_waf_certificate_v1" "certificate_1" {
+  name    = "cert_1"
+  content = "-----BEGIN CERTIFICATE-----MIIDIjCCAougAwIBAgIJALV96mEtVF4EMA0GCSqGSIb3DQEBBQUAMGoxCzAJBgNVBAYTAnh4MQswCQYDVQQIEwJ4eDELMAkGA1UEBxMCeHgxCzAJBgNVBAoTAnh4MQswCQYDVQQLEwJ-----END CERTIFICATE-----"
+  key     = "-----BEGIN RSA PRIVATE KEY-----MIICXQIBAAKBgQDFPN9ojPndxSC4E1pqWQVKGHCFlXAAGBOxbGfSzXqzsoyacotueqMqXQbxrPSQFATeVmhZPNVEMdvcAMjYsV/mymtAwVqVA6q/OFdX/b3UHO+b/VqLo3J5SrM-----END RSA PRIVATE KEY-----"
+}
+
+resource "opentelekomcloud_waf_certificate_v1" "certificate_2" {
+  name    = "cert_2"
+  content = "-----BEGIN CERTIFICATE-----MIIDIjCCAougAwIBAgIJALV96mEtVF4EMA0GCSqGSIb3DQEBBQUAMGoxCzAJBgNVBAYTAnh4MQswCQYDVQQIEwJ4eDELMAkGA1UEBxMCeHgxCzAJBgNVBAoTAnh4MQswCQYDVQQLEwJ-----END CERTIFICATE-----"
+  key     = "-----BEGIN RSA PRIVATE KEY-----MIICXQIBAAKBgQDFPN9ojPndxSC4E1pqWQVKGHCFlXAAGBOxbGfSzXqzsoyacotueqMqXQbxrPSQFATeVmhZPNVEMdvcAMjYsV/mymtAwVqVA6q/OFdX/b3UHO+b/VqLo3J5SrM-----END RSA PRIVATE KEY-----"
+}
+
+resource "opentelekomcloud_waf_policy_v1" "policy_1" {
+  name = "policy_1"
+  options {
+    webattack = true
+    crawler   = true
+  }
+  full_detection = false
+}
+
+resource "opentelekomcloud_waf_domain_v1" "domain_1" {
+  hostname = "www.b.com"
+  cipher   = "cipher_default"
+  server {
+    client_protocol = "HTTPS"
+    server_protocol = "HTTP"
+    address         = opentelekomcloud_networking_floatingip_v2.fip_1.address
+    port            = 80
+  }
+  certificate_id = opentelekomcloud_waf_certificate_v1.certificate_2.id
   policy_id      = opentelekomcloud_waf_policy_v1.policy_1.id
   proxy          = false
 }

--- a/releasenotes/notes/waf-domain-cert-c14833015960902e.yaml
+++ b/releasenotes/notes/waf-domain-cert-c14833015960902e.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[WAF]** Fix ``certificate_id`` change not applied in ``resource/opentelekomcloud_waf_domain_v1`` (`#1294 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1294>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Update SDK to fixed version

Add acceptance test for `opentelekomcloud_waf_domain_v1` `certificate_id` change

## PR Checklist

* [x] Refers to: #1278
* [x] Tests added/passed.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccWafDomainV1Basic
--- PASS: TestAccWafDomainV1Basic (48.82s)
PASS

Process finished with the exit code 0
```
