### PR TITLE
Add `sfs_turbo_share_v1` data source

### DIFF
--- a/docs/data-sources/sfs_turbo_share_v1.md
+++ b/docs/data-sources/sfs_turbo_share_v1.md
@@ -1,0 +1,52 @@
+---
+subcategory: "Scalable File Service (SFS)"
+---
+
+# opentelekomcloud_sfs_turbo_share_v1
+
+Use this data source to get details about a Shared File System (SFS) Turbo resource.
+
+## Example Usage
+
+```hcl
+data "opentelekomcloud_sfs_turbo_share_v1" "turbo" {
+  name = "turbo-share-1"
+}
+```
+
+## Argument Reference
+The following arguments are supported:
+
+* `name` - (Required) The name of an SFS Turbo share.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The UUID of the SFS Turbo file system.
+
+* `region` - The region of the SFS Turbo file system.
+
+* `version` - The version ID of the SFS Turbo file system.
+
+* `export_location` - The mount point of the SFS Turbo file system.
+
+* `available_capacity` - The available capacity of the SFS Turbo file system in the unit of GB.
+
+* `region` - The region of SFS Turbo share.
+
+* `size` - Capacity of the share common file system, in GB.
+
+* `share_proto` - The protocol for sharing file systems.
+
+* `share_type` - The file system type.
+
+* `availability_zone` - Tthe availability zone where the file system is located.
+
+* `vpc_id` - The share VPC ID.
+
+* `subnet_id` - Specifies the share network ID of the subnet.
+
+* `security_group_id` - The share security group ID.
+
+* `crypt_key_id` - The ID of a KMS key to encrypt the file system.

--- a/opentelekomcloud/acceptance/sfs/data_source_opentelekomcloud_sfs_turbo_share_v1_test.go
+++ b/opentelekomcloud/acceptance/sfs/data_source_opentelekomcloud_sfs_turbo_share_v1_test.go
@@ -1,0 +1,43 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+)
+
+func TestAccSFSTurboShareV1DataSource_basic(t *testing.T) {
+	name := tools.RandomString("turbo-", 5)
+	dsName := "data.opentelekomcloud_sfs_turbo_share_v1.share"
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSFSTurboShareV1_basic(name),
+			},
+			{
+				Config: testAccSFSTurboShareV1DataSourceBasic(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dsName, "name", name),
+					resource.TestCheckResourceAttr(dsName, "share_proto", "NFS"),
+					resource.TestCheckResourceAttr(dsName, "share_type", "STANDARD"),
+					resource.TestCheckResourceAttr(dsName, "size", "500"),
+				),
+			},
+		},
+	})
+}
+
+func testAccSFSTurboShareV1DataSourceBasic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "opentelekomcloud_sfs_turbo_share_v1" "share" {
+  name = "%s"
+}
+`, testAccSFSTurboShareV1_basic(name), name)
+}

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -275,6 +275,7 @@ func Provider() *schema.Provider {
 			"opentelekomcloud_rts_stack_v1":                    rts.DataSourceRTSStackV1(),
 			"opentelekomcloud_s3_bucket_object":                s3.DataSourceS3BucketObject(),
 			"opentelekomcloud_sfs_file_system_v2":              sfs.DataSourceSFSFileSystemV2(),
+			"opentelekomcloud_sfs_turbo_share_v1":              sfs.DataSourceSFSTurboShareV1(),
 			"opentelekomcloud_sdrs_domain_v1":                  sdrs.DataSourceSdrsDomainV1(),
 			"opentelekomcloud_vpc_eip_v1":                      vpc.DataSourceVPCEipV1(),
 			"opentelekomcloud_vpc_v1":                          vpc.DataSourceVirtualPrivateCloudVpcV1(),

--- a/opentelekomcloud/services/sfs/data_source_opentelekomcloud_sfs_turbo_share_v1.go
+++ b/opentelekomcloud/services/sfs/data_source_opentelekomcloud_sfs_turbo_share_v1.go
@@ -1,0 +1,138 @@
+package sfs
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/sfs_turbo/v1/shares"
+	"github.com/opentelekomcloud/gophertelekomcloud/pagination"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
+)
+
+func DataSourceSFSTurboShareV1() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceSFSTurboShareV1Read,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: common.ValidateName,
+			},
+			"region": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"size": {
+				Type:     schema.TypeFloat,
+				Computed: true,
+			},
+			"share_proto": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"share_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"availability_zone": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"subnet_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"security_group_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"crypt_key_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"export_location": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"available_capacity": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceSFSTurboShareV1Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := config.SfsTurboV1Client(config.GetRegion(d))
+	if err != nil {
+		return fmterr.Errorf("error creating OpenTelekomCloud SFSTurboV1 client: %s", err)
+	}
+
+	var share *shares.Turbo
+	name := d.Get("name")
+	err = shares.List(client, shares.ListOpts{}).EachPage(func(p pagination.Page) (bool, error) {
+		results, err := shares.ExtractTurbos(p)
+		if err != nil {
+			return false, err
+		}
+		for _, turbo := range results {
+			if turbo.Name == name {
+				share = &turbo
+				return false, nil
+			}
+		}
+		return true, nil
+	})
+	if err != nil {
+		return fmterr.Errorf("error listing SFS turbo shares: %w", err)
+	}
+
+	if share == nil {
+		return fmterr.Errorf("your query returned no results. " +
+			"Please change your search criteria and try again")
+	}
+
+	// n.Size is a string of float64, should convert it to int
+	fSize, err := strconv.ParseFloat(share.Size, 64)
+	if err != nil {
+		return fmterr.Errorf("error parsing SFS Turbo sharing size: %w", err)
+	}
+
+	d.SetId(share.ID)
+	mErr := multierror.Append(nil,
+		d.Set("name", share.Name),
+		d.Set("share_proto", share.ShareProto),
+		d.Set("share_type", share.ShareType),
+		d.Set("vpc_id", share.VpcID),
+		d.Set("subnet_id", share.SubnetID),
+		d.Set("security_group_id", share.SecurityGroupID),
+		d.Set("version", share.Version),
+		d.Set("region", config.GetRegion(d)),
+		d.Set("availability_zone", share.AvailabilityZone),
+		d.Set("available_capacity", share.AvailCapacity),
+		d.Set("export_location", share.ExportLocation),
+		d.Set("crypt_key_id", share.CryptKeyID),
+		d.Set("size", fSize),
+	)
+
+	if mErr.ErrorOrNil() != nil {
+		return diag.FromErr(mErr)
+	}
+
+	return nil
+}

--- a/releasenotes/notes/sfs-turbo-share-27da15eeceb7f106.yaml
+++ b/releasenotes/notes/sfs-turbo-share-27da15eeceb7f106.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    **New Data Source:** ``opentelekomcloud_sfs_turbo_share_v1`` (`#1299 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1299>`_)


### PR DESCRIPTION
## Summary of the Pull Request
New data source: `opentelekomcloud_sfs_turbo_share_v1`

Resolve #1295 

## PR Checklist

* [x] Refers to: #1295
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccSFSTurboShareV1DataSource_basic
--- PASS: TestAccSFSTurboShareV1DataSource_basic (293.12s)
PASS

Process finished with the exit code 0
```
