### PR TITLE
Fix read in `networking_floatingip_associate_v2`

### DIFF
--- a/opentelekomcloud/services/vpc/resource_opentelekomcloud_networking_floatingip_associate_v2.go
+++ b/opentelekomcloud/services/vpc/resource_opentelekomcloud_networking_floatingip_associate_v2.go
@@ -78,7 +78,7 @@ func resourceNetworkingFloatingIPAssociateV2Create(ctx context.Context, d *schem
 
 	d.SetId(floatingIPID)
 
-	return resourceNetworkFloatingIPV2Read(ctx, d, meta)
+	return resourceNetworkingFloatingIPAssociateV2Read(ctx, d, meta)
 }
 
 func resourceNetworkingFloatingIPAssociateV2Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/releasenotes/notes/fip-associate-49b889a32aa2ca6f.yaml
+++ b/releasenotes/notes/fip-associate-49b889a32aa2ca6f.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[VPC]** Fix invalid read in ``resource/opentelekomcloud_networking_floatingip_associate_v2`` (`#1300 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1300>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Fix used read function in `opentelekomcloud_networking_floatingip_associate_v2` resource

## PR Checklist

* [x] Refers to: #1288
* [x] Tests added/passed.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccNetworkingV2FloatingIPAssociate_basic
--- PASS: TestAccNetworkingV2FloatingIPAssociate_basic (67.30s)
PASS

Process finished with the exit code 0

```
