### PR TITLE
Fix wait after creation in `router_interface_v2`

### DIFF
--- a/opentelekomcloud/services/vpc/resource_opentelekomcloud_networking_router_interface_v2.go
+++ b/opentelekomcloud/services/vpc/resource_opentelekomcloud_networking_router_interface_v2.go
@@ -77,7 +77,7 @@ func resourceNetworkingRouterInterfaceV2Create(ctx context.Context, d *schema.Re
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"BUILD", "PENDING_CREATE", "PENDING_UPDATE"},
-		Target:     []string{"ACTIVE"},
+		Target:     []string{"ACTIVE", "DOWN"},
 		Refresh:    waitForRouterInterfaceActive(networkingClient, n.PortID),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
 		Delay:      5 * time.Second,

--- a/releasenotes/notes/router-interface-8ffd9dd50be6cec9.yaml
+++ b/releasenotes/notes/router-interface-8ffd9dd50be6cec9.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[VPC]** Fix failing wait after creation in ``resource/opentelekomcloud_networking_router_interface_v2`` (`#1302 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1302>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Make `DOWN` a valid target state for router interface after creation
Fix #1301 

## PR Checklist

* [x] Refers to: #1301
* [x] Tests added/passed.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccNetworkingV2RouterInterface_basic_subnet
--- PASS: TestAccNetworkingV2RouterInterface_basic_subnet (64.95s)
=== RUN   TestAccNetworkingV2RouterInterface_basic_port
--- PASS: TestAccNetworkingV2RouterInterface_basic_port (77.99s)
=== RUN   TestAccNetworkingV2RouterInterface_timeout
--- PASS: TestAccNetworkingV2RouterInterface_timeout (63.82s)
PASS

Process finished with the exit code 0

```
