### PR TITLE
Make `as_group_v1` parameters OpenStackish

### DIFF
--- a/docs/resources/as_group_v1.md
+++ b/docs/resources/as_group_v1.md
@@ -26,7 +26,7 @@ resource "opentelekomcloud_as_group_v1" "as_group" {
     id = "45e4c6de-6bf0-4843-8953-2babde3d4810"
   }
 
-  vpc_id           = "1d8f7e7c-fe04-4cf5-85ac-08b478c290e9"
+  router_id        = "1d8f7e7c-fe04-4cf5-85ac-08b478c290e9"
   delete_publicip  = true
   delete_instances = "yes"
 
@@ -53,7 +53,7 @@ resource "opentelekomcloud_as_group_v1" "as_group_only_remove_members" {
     id = "45e4c6de-6bf0-4843-8953-2babde3d4810"
   }
 
-  vpc_id           = "1d8f7e7c-fe04-4cf5-85ac-08b478c290e9"
+  router_id        = "1d8f7e7c-fe04-4cf5-85ac-08b478c290e9"
   delete_publicip  = true
   delete_instances = "no"
 }
@@ -76,7 +76,7 @@ resource "opentelekomcloud_as_group_v1" "as_group_with_elb" {
     id = "45e4c6de-6bf0-4843-8953-2babde3d4810"
   }
 
-  vpc_id           = "1d8f7e7c-fe04-4cf5-85ac-08b478c290e9"
+  router_id        = "1d8f7e7c-fe04-4cf5-85ac-08b478c290e9"
   delete_publicip  = true
   delete_instances = "yes"
 
@@ -146,7 +146,7 @@ The following arguments are supported:
   A maximum of one security group can be selected. The `security_groups` object structure is
   documented below.
 
-* `vpc_id` - (Required) The VPC ID. Changing this creates a new group.
+* `router_id` - (Required) The router ID (VPC ID). Changing this creates a new group.
 
 * `health_periodic_audit_method` - (Optional) The health check method for instances
   in the AS group. The health check methods include `ELB_AUDIT` and `NOVA_AUDIT`.

--- a/examples/basic-examples/modules/as/main.tf
+++ b/examples/basic-examples/modules/as/main.tf
@@ -77,7 +77,7 @@ resource "opentelekomcloud_vpc_subnet_v1" "subnet_as" {
   name          = var.subnet_name1_as
   cidr          = var.subnet_cidr1_as
   gateway_ip    = var.subnet_gateway_ip1_as
-  vpc_id        = opentelekomcloud_vpc_v1.vpc_as.id
+  router_id     = opentelekomcloud_vpc_v1.vpc_as.id
   primary_dns   = var.primary_dns_as
   secondary_dns = var.secondary_dns_as
 }
@@ -100,7 +100,7 @@ resource "opentelekomcloud_networking_secgroup_rule_v2" "secgroup_rule_as" {
 resource "opentelekomcloud_elb_loadbalancer" "elb_as" {
   name           = "elb_as"
   type           = "External"
-  vpc_id         = opentelekomcloud_vpc_v1.vpc_as.id
+  router_id      = opentelekomcloud_vpc_v1.vpc_as.id
   admin_state_up = "true"
   #vip_subnet_id  = opentelekomcloud_vpc_subnet_v1.subnet_as.subnet_id
 
@@ -132,7 +132,7 @@ resource "opentelekomcloud_as_group_v1" "my_as_group" {
   lb_listener_id   = opentelekomcloud_elb_listener.listener_as.id
   networks         = [{ id = opentelekomcloud_vpc_subnet_v1.subnet_as.id }]
   security_groups  = [{ id = opentelekomcloud_networking_secgroup_v2.secgroup_as.id }]
-  vpc_id           = opentelekomcloud_vpc_v1.vpc_as.id
+  router_id        = opentelekomcloud_vpc_v1.vpc_as.id
   delete_publicip  = true
   delete_instances = "yes"
   available_zones  = [var.availability_zone_as]
@@ -145,7 +145,7 @@ resource "opentelekomcloud_as_group_v1" "my_as_group2" {
   scaling_group_name       = "as_group_required"
   networks                 = [{ id = opentelekomcloud_vpc_subnet_v1.subnet_as.id }]
   security_groups          = [{ id = opentelekomcloud_networking_secgroup_v2.secgroup_as.id }]
-  vpc_id                   = opentelekomcloud_vpc_v1.vpc_as.id
+  router_id                = opentelekomcloud_vpc_v1.vpc_as.id
   scaling_configuration_id = opentelekomcloud_as_configuration_v1.as_config.id
 }
 

--- a/opentelekomcloud/acceptance/as/resource_opentelekomcloud_as_group_v1_test.go
+++ b/opentelekomcloud/acceptance/as/resource_opentelekomcloud_as_group_v1_test.go
@@ -29,7 +29,7 @@ func TestAccASV1Group_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckASV1GroupExists(resourceName, &asGroup),
 					resource.TestCheckResourceAttr(resourceName, "lbaas_listeners.0.protocol_port", "8080"),
-					resource.TestCheckResourceAttr(resourceName, "vpc_id", env.OsRouterID),
+					resource.TestCheckResourceAttr(resourceName, "router_id", env.OsRouterID),
 					resource.TestCheckResourceAttr(resourceName, "lbaas_listeners.0.protocol_port", "8080"),
 					resource.TestCheckResourceAttr(resourceName, "health_periodic_audit_grace_period", "700"),
 					resource.TestCheckResourceAttr(resourceName, "tags.muh", "value-create"),
@@ -195,7 +195,7 @@ resource "opentelekomcloud_as_group_v1" "hth_as_group"{
     pool_id =       opentelekomcloud_lb_pool_v2.pool_1.id
     protocol_port = opentelekomcloud_lb_listener_v2.listener_1.protocol_port
   }
-  vpc_id = "%s"
+  router_id = "%s"
 
   health_periodic_audit_grace_period = 700
 
@@ -256,7 +256,7 @@ resource "opentelekomcloud_as_group_v1" "hth_as_group"{
     pool_id =       opentelekomcloud_lb_pool_v2.pool_1.id
     protocol_port = opentelekomcloud_lb_listener_v2.listener_1.protocol_port
   }
-  vpc_id = "%s"
+  router_id = "%s"
 
   health_periodic_audit_grace_period = 500
 
@@ -301,7 +301,7 @@ resource "opentelekomcloud_as_group_v1" "proxy_group" {
   desire_instance_number   = 3
   min_instance_number      = 1
   max_instance_number      = 10
-  vpc_id                   = "%s"
+  router_id                   = "%s"
   delete_publicip          = true
   delete_instances         = "yes"
 
@@ -350,7 +350,7 @@ resource "opentelekomcloud_as_group_v1" "proxy_group" {
   desire_instance_number   = 3
   min_instance_number      = 1
   max_instance_number      = 10
-  vpc_id                   = "%s"
+  router_id                   = "%s"
   delete_publicip          = true
   delete_instances         = "yes"
 

--- a/opentelekomcloud/acceptance/as/resource_opentelekomcloud_as_policy_v1_test.go
+++ b/opentelekomcloud/acceptance/as/resource_opentelekomcloud_as_policy_v1_test.go
@@ -118,7 +118,7 @@ resource "opentelekomcloud_as_group_v1" "hth_as_group"{
   security_groups {
     id = opentelekomcloud_networking_secgroup_v2.secgroup.id
   }
-  vpc_id = "%s"
+  router_id = "%s"
 }
 
 resource "opentelekomcloud_as_policy_v1" "hth_as_policy"{

--- a/opentelekomcloud/acceptance/as/resource_opentelekomcloud_as_policy_v2_test.go
+++ b/opentelekomcloud/acceptance/as/resource_opentelekomcloud_as_policy_v2_test.go
@@ -127,7 +127,7 @@ resource "opentelekomcloud_as_group_v1" "group_1"{
   security_groups {
     id = data.opentelekomcloud_networking_secgroup_v2.sg_1.id
   }
-  vpc_id = "%s"
+  router_id = "%s"
 }
 
 resource "opentelekomcloud_as_policy_v2" "policy_1"{
@@ -183,7 +183,7 @@ resource "opentelekomcloud_as_group_v1" "group_1"{
   security_groups {
     id = data.opentelekomcloud_networking_secgroup_v2.sg_1.id
   }
-  vpc_id = "%s"
+  router_id = "%s"
 }
 
 resource "opentelekomcloud_as_policy_v2" "policy_1"{

--- a/opentelekomcloud/services/as/resource_opentelekomcloud_as_group_v1.go
+++ b/opentelekomcloud/services/as/resource_opentelekomcloud_as_group_v1.go
@@ -134,7 +134,7 @@ func ResourceASGroup() *schema.Resource {
 					},
 				},
 			},
-			"vpc_id": {
+			"router_id": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
@@ -377,7 +377,7 @@ func resourceASGroupCreate(ctx context.Context, d *schema.ResourceData, meta int
 		AvailableZones:            common.GetAllAvailableZones(d),
 		Networks:                  networks,
 		SecurityGroup:             secGroups,
-		VpcID:                     d.Get("vpc_id").(string),
+		VpcID:                     d.Get("router_id").(string),
 		HealthPeriodicAuditMethod: d.Get("health_periodic_audit_method").(string),
 		HealthPeriodicAuditTime:   d.Get("health_periodic_audit_time").(int),
 		HealthPeriodicAuditGrace:  d.Get("health_periodic_audit_grace_period").(int),

--- a/releasenotes/notes/os-as-e2544cbf0b378e46.yaml
+++ b/releasenotes/notes/os-as-e2544cbf0b378e46.yaml
@@ -1,0 +1,4 @@
+---
+upgrade:
+  - |
+    **[AS]** ``vpc_id`` was replaced with ``router_id`` in ``resource/opentelekomcloud_as_group_v1`` (`#1314 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1314>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Rename `as_group_v1` `vpc_id` argument to `router_id`

Fix #1315

## PR Checklist

* [x] Refers to: #1017
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccASV1Configuration_basic
--- PASS: TestAccASV1Configuration_basic (12.46s)
=== RUN   TestAccASV1Configuration_publicIP
--- PASS: TestAccASV1Configuration_publicIP (11.44s)
=== RUN   TestAccASV1Configuration_invalidDiskSize
--- PASS: TestAccASV1Configuration_invalidDiskSize (1.17s)
=== RUN   TestAccASV1Configuration_multipleSecurityGroups
--- PASS: TestAccASV1Configuration_multipleSecurityGroups (27.23s)
=== RUN   TestAccASV1Group_basic
--- PASS: TestAccASV1Group_basic (110.92s)
=== RUN   TestAccASV1Group_RemoveWithSetMinNumber
--- PASS: TestAccASV1Group_RemoveWithSetMinNumber (152.33s)
=== RUN   TestAccASV1Group_WithoutSecurityGroups
--- PASS: TestAccASV1Group_WithoutSecurityGroups (130.83s)
=== RUN   TestAccASV1Policy_basic
--- PASS: TestAccASV1Policy_basic (38.44s)
=== RUN   TestAccASPolicyV2_basic
--- PASS: TestAccASPolicyV2_basic (45.48s)
PASS
ok  	github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/as	531.730s

Process finished with the exit code 0
```
