### PR TITLE
Fix panic during CCE node creation

### DIFF
--- a/releasenotes/notes/cce-node-736f0379edfbe7af.yaml
+++ b/releasenotes/notes/cce-node-736f0379edfbe7af.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[CCE]** Fix panic at ``resource/opentelekomcloud_cce_node_v3`` creation (`#1319 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1319>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Fix panic at `resource/cce_node_v3` creation

Fix #1318

## PR Checklist

* [x] Refers to: #1318 
* [x] Tests added/passed.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccCCENodesV3Basic
--- PASS: TestAccCCENodesV3Basic (726.92s)
PASS

Process finished with the exit code 0
```
