### PR TITLE
[Acceptance] Get rid of `OS_EXTGW_ID` in `VPN`

### DIFF
--- a/opentelekomcloud/acceptance/common/data_sources.go
+++ b/opentelekomcloud/acceptance/common/data_sources.go
@@ -19,7 +19,7 @@ data "opentelekomcloud_subnet_v1" "shared_subnet"  {
 `, env.OsSubnetName)
 
 var DataSourceExtNetwork = fmt.Sprintf(`
-data "opentelekomcloud_network_network_v2" "ext_network" {
+data "opentelekomcloud_networking_network_v2" "ext_network" {
   name = "%s"
 }
 `, env.OsExtNetworkName)

--- a/opentelekomcloud/acceptance/vpn/resource_opentelekomcloud_vpnaas_endpoint_group_v2_test.go
+++ b/opentelekomcloud/acceptance/vpn/resource_opentelekomcloud_vpnaas_endpoint_group_v2_test.go
@@ -94,19 +94,17 @@ func testAccCheckEndpointGroupV2Exists(n string, group *endpointgroups.EndpointG
 }
 
 var testAccEndpointGroupV2_basic = `
-	resource "opentelekomcloud_vpnaas_endpoint_group_v2" "group_1" {
-		name = "Group 1"
-		type = "cidr"
-		endpoints = ["10.3.0.0/24",
-			"10.2.0.0/24",]
-	}
+resource "opentelekomcloud_vpnaas_endpoint_group_v2" "group_1" {
+  name      = "Group 1"
+  type      = "cidr"
+  endpoints = ["10.3.0.0/24", "10.2.0.0/24"]
+}
 `
 
 var testAccEndpointGroupV2_update = `
-	resource "opentelekomcloud_vpnaas_endpoint_group_v2" "group_1" {
-		name = "Updated Group 1"
-		type = "cidr"
-		endpoints = ["10.2.0.0/24",
-			"10.3.0.0/24",]
-	}
+resource "opentelekomcloud_vpnaas_endpoint_group_v2" "group_1" {
+  name      = "Updated Group 1"
+  type      = "cidr"
+  endpoints = ["10.2.0.0/24", "10.3.0.0/24"]
+}
 `

--- a/opentelekomcloud/acceptance/vpn/resource_opentelekomcloud_vpnaas_ike_policy_v2_test.go
+++ b/opentelekomcloud/acceptance/vpn/resource_opentelekomcloud_vpnaas_ike_policy_v2_test.go
@@ -22,7 +22,7 @@ func TestAccVpnIKEPolicyV2_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckIKEPolicyV2Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIKEPolicyV2_basic,
+				Config: testAccIKEPolicyV2Basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIKEPolicyV2Exists("opentelekomcloud_vpnaas_ike_policy_v2.policy_1", &policy),
 					resource.TestCheckResourceAttrPtr("opentelekomcloud_vpnaas_ike_policy_v2.policy_1", "name", &policy.Name),
@@ -31,7 +31,7 @@ func TestAccVpnIKEPolicyV2_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccIKEPolicyV2_Update,
+				Config: testAccIKEPolicyV2Update,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIKEPolicyV2Exists("opentelekomcloud_vpnaas_ike_policy_v2.policy_1", &policy),
 					resource.TestCheckResourceAttrPtr("opentelekomcloud_vpnaas_ike_policy_v2.policy_1", "name", &policy.Name),
@@ -49,7 +49,7 @@ func TestAccVpnIKEPolicyV2_withLifetime(t *testing.T) {
 		CheckDestroy:      testAccCheckIKEPolicyV2Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIKEPolicyV2_withLifetime,
+				Config: testAccIKEPolicyV2WithLifetime,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIKEPolicyV2Exists("opentelekomcloud_vpnaas_ike_policy_v2.policy_1", &policy),
 					resource.TestCheckResourceAttrPtr("opentelekomcloud_vpnaas_ike_policy_v2.policy_1", "auth_algorithm", &policy.AuthAlgorithm),
@@ -57,7 +57,7 @@ func TestAccVpnIKEPolicyV2_withLifetime(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccIKEPolicyV2_withLifetimeUpdate,
+				Config: testAccIKEPolicyV2WithLifetimeUpdate,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIKEPolicyV2Exists("opentelekomcloud_vpnaas_ike_policy_v2.policy_1", &policy),
 				),
@@ -74,7 +74,7 @@ func TestAccVpnIKEPolicyV2_withNewParams(t *testing.T) {
 		CheckDestroy:      testAccCheckIKEPolicyV2Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIKEPolicyV2_withNewParams,
+				Config: testAccIKEPolicyV2WithNewParams,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIKEPolicyV2Exists("opentelekomcloud_vpnaas_ike_policy_v2.policy_1", &policy),
 					resource.TestCheckResourceAttr("opentelekomcloud_vpnaas_ike_policy_v2.policy_1", "ike_version", "v2"),
@@ -134,17 +134,17 @@ func testAccCheckIKEPolicyV2Exists(n string, policy *ikepolicies.Policy) resourc
 	}
 }
 
-const testAccIKEPolicyV2_basic = `
+const testAccIKEPolicyV2Basic = `
 resource "opentelekomcloud_vpnaas_ike_policy_v2" "policy_1" {}
 `
 
-const testAccIKEPolicyV2_Update = `
+const testAccIKEPolicyV2Update = `
 resource "opentelekomcloud_vpnaas_ike_policy_v2" "policy_1" {
   name = "updatedname"
 }
 `
 
-const testAccIKEPolicyV2_withLifetime = `
+const testAccIKEPolicyV2WithLifetime = `
 resource "opentelekomcloud_vpnaas_ike_policy_v2" "policy_1" {
   auth_algorithm = "sha2-256"
   pfs            = "group14"
@@ -155,7 +155,7 @@ resource "opentelekomcloud_vpnaas_ike_policy_v2" "policy_1" {
 }
 `
 
-const testAccIKEPolicyV2_withLifetimeUpdate = `
+const testAccIKEPolicyV2WithLifetimeUpdate = `
 resource "opentelekomcloud_vpnaas_ike_policy_v2" "policy_1" {
   auth_algorithm = "sha2-256"
   pfs            = "group14"
@@ -166,7 +166,7 @@ resource "opentelekomcloud_vpnaas_ike_policy_v2" "policy_1" {
 }
 `
 
-const testAccIKEPolicyV2_withNewParams = `
+const testAccIKEPolicyV2WithNewParams = `
 resource "opentelekomcloud_vpnaas_ike_policy_v2" "policy_1" {
   auth_algorithm = "sha2-256"
   pfs            = "group16"

--- a/opentelekomcloud/acceptance/vpn/resource_opentelekomcloud_vpnaas_ipsec_policy_v2_test.go
+++ b/opentelekomcloud/acceptance/vpn/resource_opentelekomcloud_vpnaas_ipsec_policy_v2_test.go
@@ -24,7 +24,7 @@ func TestAccVpnIPSecPolicyV2_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckIPSecPolicyV2Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIPSecPolicyV2_basic,
+				Config: testAccIPSecPolicyV2Basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIPSecPolicyV2Exists(resourceName, &policy),
 					resource.TestCheckResourceAttrPtr(resourceName, "name", &policy.Name),
@@ -38,7 +38,7 @@ func TestAccVpnIPSecPolicyV2_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccIPSecPolicyV2_update,
+				Config: testAccIPSecPolicyV2Update,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIPSecPolicyV2Exists(resourceName, &policy),
 					resource.TestCheckResourceAttrPtr(resourceName, "name", &policy.Name),
@@ -58,7 +58,7 @@ func TestAccVpnIPSecPolicyV2_withLifetime(t *testing.T) {
 		CheckDestroy:      testAccCheckIPSecPolicyV2Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIPSecPolicyV2_withLifetime,
+				Config: testAccIPSecPolicyV2WithLifetime,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIPSecPolicyV2Exists(resourceName, &policy),
 					resource.TestCheckResourceAttrPtr(resourceName, "auth_algorithm", &policy.AuthAlgorithm),
@@ -66,7 +66,7 @@ func TestAccVpnIPSecPolicyV2_withLifetime(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccIPSecPolicyV2_withLifetimeUpdate,
+				Config: testAccIPSecPolicyV2WithLifetimeUpdate,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIPSecPolicyV2Exists(resourceName, &policy),
 				),
@@ -123,17 +123,17 @@ func testAccCheckIPSecPolicyV2Exists(n string, policy *ipsecpolicies.Policy) res
 	}
 }
 
-const testAccIPSecPolicyV2_basic = `
+const testAccIPSecPolicyV2Basic = `
 resource "opentelekomcloud_vpnaas_ipsec_policy_v2" "policy_1" { }
 `
 
-const testAccIPSecPolicyV2_update = `
+const testAccIPSecPolicyV2Update = `
 resource "opentelekomcloud_vpnaas_ipsec_policy_v2" "policy_1" {
   name = "updatedname"
 }
 `
 
-const testAccIPSecPolicyV2_withLifetime = `
+const testAccIPSecPolicyV2WithLifetime = `
 resource "opentelekomcloud_vpnaas_ipsec_policy_v2" "policy_1" {
   auth_algorithm = "md5"
   pfs            = "group14"
@@ -144,7 +144,7 @@ resource "opentelekomcloud_vpnaas_ipsec_policy_v2" "policy_1" {
 }
 `
 
-const testAccIPSecPolicyV2_withLifetimeUpdate = `
+const testAccIPSecPolicyV2WithLifetimeUpdate = `
 resource "opentelekomcloud_vpnaas_ipsec_policy_v2" "policy_1" {
   auth_algorithm = "md5"
   pfs            = "group14"

--- a/opentelekomcloud/acceptance/vpn/resource_opentelekomcloud_vpnaas_service_v2_test.go
+++ b/opentelekomcloud/acceptance/vpn/resource_opentelekomcloud_vpnaas_service_v2_test.go
@@ -23,7 +23,7 @@ func TestAccVpnServiceV2_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckVpnServiceV2Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVpnServiceV2_basic,
+				Config: testAccVpnServiceV2Basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVpnServiceV2Exists(
 						"opentelekomcloud_vpnaas_service_v2.service_1", &service),
@@ -85,14 +85,17 @@ func testAccCheckVpnServiceV2Exists(n string, serv *services.Service) resource.T
 	}
 }
 
-var testAccVpnServiceV2_basic = fmt.Sprintf(`
-	resource "opentelekomcloud_networking_router_v2" "router_1" {
-	  name = "router_1"
-	  admin_state_up = "true"
-	  external_gateway = "%s"
-	}
-	resource "opentelekomcloud_vpnaas_service_v2" "service_1" {
-		router_id = opentelekomcloud_networking_router_v2.router_1.id
-		admin_state_up = "false"
-	}
-	`, env.OS_EXTGW_ID)
+var testAccVpnServiceV2Basic = fmt.Sprintf(`
+%s
+
+resource "opentelekomcloud_networking_router_v2" "router_1" {
+  name             = "router_1"
+  admin_state_up   = "true"
+  external_gateway = data.opentelekomcloud_networking_network_v2.ext_network.id
+}
+
+resource "opentelekomcloud_vpnaas_service_v2" "service_1" {
+  router_id      = opentelekomcloud_networking_router_v2.router_1.id
+  admin_state_up = "false"
+}
+`, common.DataSourceExtNetwork)

--- a/opentelekomcloud/acceptance/vpn/resource_opentelekomcloud_vpnaas_site_connection_v2_test.go
+++ b/opentelekomcloud/acceptance/vpn/resource_opentelekomcloud_vpnaas_site_connection_v2_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/vpnaas/siteconnections"
-
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
@@ -23,7 +22,7 @@ func TestAccVpnSiteConnectionV2_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckSiteConnectionV2Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSiteConnectionV2_basic,
+				Config: testAccSiteConnectionV2Basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSiteConnectionV2Exists(
 						"opentelekomcloud_vpnaas_site_connection_v2.conn_1", &conn),
@@ -93,64 +92,66 @@ func testAccCheckSiteConnectionV2Exists(n string, conn *siteconnections.Connecti
 	}
 }
 
-var testAccSiteConnectionV2_basic = fmt.Sprintf(`
-	resource "opentelekomcloud_networking_network_v2" "network_1" {
-		name           = "tf_test_network"
-  		admin_state_up = "true"
-	}
+var testAccSiteConnectionV2Basic = fmt.Sprintf(`
+%s
 
-	resource "opentelekomcloud_networking_subnet_v2" "subnet_1" {
-  		network_id = opentelekomcloud_networking_network_v2.network_1.id
-  		cidr       = "192.168.199.0/24"
-  		ip_version = 4
-	}
+resource "opentelekomcloud_networking_network_v2" "network_1" {
+  name           = "tf_test_network"
+  admin_state_up = "true"
+}
 
-	resource "opentelekomcloud_networking_router_v2" "router_1" {
-  		name             = "my_router"
-  		external_gateway = "%s"
-	}
+resource "opentelekomcloud_networking_subnet_v2" "subnet_1" {
+  network_id = opentelekomcloud_networking_network_v2.network_1.id
+  cidr       = "192.168.199.0/24"
+  ip_version = 4
+}
 
-	resource "opentelekomcloud_networking_router_interface_v2" "router_interface_1" {
-  		router_id = opentelekomcloud_networking_router_v2.router_1.id
-  		subnet_id = opentelekomcloud_networking_subnet_v2.subnet_1.id
-	}
+resource "opentelekomcloud_networking_router_v2" "router_1" {
+  name             = "my_router"
+  external_gateway = data.opentelekomcloud_networking_network_v2.ext_network.id
+}
 
-	resource "opentelekomcloud_vpnaas_service_v2" "service_1" {
-		router_id = opentelekomcloud_networking_router_v2.router_1.id
-		admin_state_up = "false"
-	}
+resource "opentelekomcloud_networking_router_interface_v2" "router_interface_1" {
+  router_id = opentelekomcloud_networking_router_v2.router_1.id
+  subnet_id = opentelekomcloud_networking_subnet_v2.subnet_1.id
+}
 
-	resource "opentelekomcloud_vpnaas_ipsec_policy_v2" "policy_1" {
-	}
+resource "opentelekomcloud_vpnaas_service_v2" "service_1" {
+  router_id      = opentelekomcloud_networking_router_v2.router_1.id
+  admin_state_up = "false"
+}
 
-	resource "opentelekomcloud_vpnaas_ike_policy_v2" "policy_2" {
-	}
+resource "opentelekomcloud_vpnaas_ipsec_policy_v2" "policy_1" {
+}
 
-	resource "opentelekomcloud_vpnaas_endpoint_group_v2" "group_1" {
-		type = "cidr"
-		endpoints = ["10.2.0.0/24", "10.3.0.0/24"]
-	}
-	resource "opentelekomcloud_vpnaas_endpoint_group_v2" "group_2" {
-		type = "subnet"
-		endpoints = [ opentelekomcloud_networking_subnet_v2.subnet_1.id ]
-	}
+resource "opentelekomcloud_vpnaas_ike_policy_v2" "policy_2" {
+}
 
-	resource "opentelekomcloud_vpnaas_site_connection_v2" "conn_1" {
-		name = "connection_1"
-		ikepolicy_id = opentelekomcloud_vpnaas_ike_policy_v2.policy_2.id
-		ipsecpolicy_id = opentelekomcloud_vpnaas_ipsec_policy_v2.policy_1.id
-		vpnservice_id = opentelekomcloud_vpnaas_service_v2.service_1.id
-		psk = "secret"
-		peer_address = "192.168.10.1"
-		peer_id = "192.168.10.1"
-		local_ep_group_id = opentelekomcloud_vpnaas_endpoint_group_v2.group_2.id
-		peer_ep_group_id = opentelekomcloud_vpnaas_endpoint_group_v2.group_1.id
+resource "opentelekomcloud_vpnaas_endpoint_group_v2" "group_1" {
+  type      = "cidr"
+  endpoints = ["10.2.0.0/24", "10.3.0.0/24"]
+}
+resource "opentelekomcloud_vpnaas_endpoint_group_v2" "group_2" {
+  type      = "subnet"
+  endpoints = [opentelekomcloud_networking_subnet_v2.subnet_1.id]
+}
 
-		tags = {
-		  foo = "bar"
-		  key = "value"
-		}
+resource "opentelekomcloud_vpnaas_site_connection_v2" "conn_1" {
+  name              = "connection_1"
+  ikepolicy_id      = opentelekomcloud_vpnaas_ike_policy_v2.policy_2.id
+  ipsecpolicy_id    = opentelekomcloud_vpnaas_ipsec_policy_v2.policy_1.id
+  vpnservice_id     = opentelekomcloud_vpnaas_service_v2.service_1.id
+  psk               = "secret"
+  peer_address      = "192.168.10.1"
+  peer_id           = "192.168.10.1"
+  local_ep_group_id = opentelekomcloud_vpnaas_endpoint_group_v2.group_2.id
+  peer_ep_group_id  = opentelekomcloud_vpnaas_endpoint_group_v2.group_1.id
 
-		depends_on = ["opentelekomcloud_networking_router_interface_v2.router_interface_1"]
-	}
-	`, env.OS_EXTGW_ID)
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+
+  depends_on = ["opentelekomcloud_networking_router_interface_v2.router_interface_1"]
+}
+`, common.DataSourceExtNetwork)


### PR DESCRIPTION
## Summary of the Pull Request
Use a data source instead of `env.OS_EXTGW_ID` in VPN acceptance tests

Minor refactoring of VPC acceptance tests

## PR Checklist

* [x] Refers to: #1320
* [x] Tests added/passed.

## Acceptance Steps Performed

```
=== RUN   TestAccVpnServiceV2DataSource_byId
--- PASS: TestAccVpnServiceV2DataSource_byId (33.33s)
=== RUN   TestAccVpnServiceV2DataSource_byName
--- PASS: TestAccVpnServiceV2DataSource_byName (35.08s)
=== RUN   TestAccVpnGroupV2_basic
--- PASS: TestAccVpnGroupV2_basic (18.67s)
=== RUN   TestAccVpnIKEPolicyV2_basic
--- PASS: TestAccVpnIKEPolicyV2_basic (18.88s)
=== RUN   TestAccVpnIKEPolicyV2_withLifetime
--- PASS: TestAccVpnIKEPolicyV2_withLifetime (20.89s)
=== RUN   TestAccVpnIKEPolicyV2_withNewParams
--- PASS: TestAccVpnIKEPolicyV2_withNewParams (11.28s)
=== RUN   TestAccVpnIPSecPolicyV2_basic
--- PASS: TestAccVpnIPSecPolicyV2_basic (17.53s)
=== RUN   TestAccVpnIPSecPolicyV2_withLifetime
--- PASS: TestAccVpnIPSecPolicyV2_withLifetime (17.93s)
=== RUN   TestAccVpnServiceV2_basic
--- PASS: TestAccVpnServiceV2_basic (35.03s)
=== RUN   TestAccVpnSiteConnectionV2_basic
--- PASS: TestAccVpnSiteConnectionV2_basic (75.82s)
PASS
ok  	github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/vpn	285.272s

Process finished with the exit code 0
```
