### PR TITLE
[Acceptance] Get rid of `OS_EXTGW_ID` variable

### DIFF
--- a/opentelekomcloud/acceptance/common/common.go
+++ b/opentelekomcloud/acceptance/common/common.go
@@ -84,10 +84,6 @@ func TestAccPreCheckRequiredEnvVars(t *testing.T) {
 	if env.OS_SUBNET_ID == "" {
 		t.Fatal("OS_SUBNET_ID must be set for acceptance tests")
 	}
-
-	if env.OS_EXTGW_ID == "" {
-		t.Fatal("OS_EXTGW_ID must be set for acceptance tests")
-	}
 }
 
 func TestAccPreCheck(t *testing.T) {

--- a/opentelekomcloud/acceptance/env/vars.go
+++ b/opentelekomcloud/acceptance/env/vars.go
@@ -7,7 +7,6 @@ import (
 )
 
 var (
-	OS_EXTGW_ID          = os.Getenv("OS_EXTGW_ID")
 	OS_FLAVOR_ID         = os.Getenv("OS_FLAVOR_ID")
 	OS_FLAVOR_NAME       = os.Getenv("OS_FLAVOR_NAME")
 	OS_IMAGE_ID          = os.Getenv("OS_IMAGE_ID")

--- a/opentelekomcloud/acceptance/fw/import_opentelekomcloud_fw_firewall_group_v2_test.go
+++ b/opentelekomcloud/acceptance/fw/import_opentelekomcloud_fw_firewall_group_v2_test.go
@@ -17,7 +17,7 @@ func TestAccFWFirewallV2_importBasic(t *testing.T) {
 		CheckDestroy:      testAccCheckFWFirewallGroupV2Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFWFirewallGroupV2_basic_1,
+				Config: testAccFWFirewallGroupV2Basic1,
 			},
 
 			{

--- a/opentelekomcloud/acceptance/fw/resource_opentelekomcloud_fw_firewall_group_v2_test.go
+++ b/opentelekomcloud/acceptance/fw/resource_opentelekomcloud_fw_firewall_group_v2_test.go
@@ -26,13 +26,13 @@ func TestAccFWFirewallGroupV2_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckFWFirewallGroupV2Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFWFirewallGroupV2_basic_1,
+				Config: testAccFWFirewallGroupV2Basic1,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFWFirewallGroupV2("opentelekomcloud_fw_firewall_group_v2.fw_1", "", "", ipolicyID, epolicyID),
 				),
 			},
 			{
-				Config: testAccFWFirewallGroupV2_basic_2,
+				Config: testAccFWFirewallGroupV2Basic2,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFWFirewallGroupV2(
 						"opentelekomcloud_fw_firewall_group_v2.fw_1", "fw_1", "terraform acceptance test", ipolicyID, epolicyID),
@@ -43,7 +43,7 @@ func TestAccFWFirewallGroupV2_basic(t *testing.T) {
 }
 
 func TestAccFWFirewallGroupV2_port0(t *testing.T) {
-	var firewall_group fw.FirewallGroup
+	var firewallGroup fw.FirewallGroup
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -51,10 +51,10 @@ func TestAccFWFirewallGroupV2_port0(t *testing.T) {
 		CheckDestroy:      testAccCheckFWFirewallGroupV2Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFWFirewallV2_port,
+				Config: testAccFWFirewallV2Port,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckFWFirewallGroupV2Exists("opentelekomcloud_fw_firewall_group_v2.fw_1", &firewall_group),
-					testAccCheckFWFirewallPortCount(&firewall_group, 1),
+					testAccCheckFWFirewallGroupV2Exists("opentelekomcloud_fw_firewall_group_v2.fw_1", &firewallGroup),
+					testAccCheckFWFirewallPortCount(&firewallGroup, 1),
 				),
 			},
 		},
@@ -62,7 +62,7 @@ func TestAccFWFirewallGroupV2_port0(t *testing.T) {
 }
 
 func TestAccFWFirewallGroupV2_no_ports(t *testing.T) {
-	var firewall_group fw.FirewallGroup
+	var firewallGroup fw.FirewallGroup
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -70,11 +70,11 @@ func TestAccFWFirewallGroupV2_no_ports(t *testing.T) {
 		CheckDestroy:      testAccCheckFWFirewallGroupV2Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFWFirewallV2_no_ports,
+				Config: testAccFWFirewallV2NoPorts,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckFWFirewallGroupV2Exists("opentelekomcloud_fw_firewall_group_v2.fw_1", &firewall_group),
+					testAccCheckFWFirewallGroupV2Exists("opentelekomcloud_fw_firewall_group_v2.fw_1", &firewallGroup),
 					resource.TestCheckResourceAttr("opentelekomcloud_fw_firewall_group_v2.fw_1", "description", "firewall router test"),
-					testAccCheckFWFirewallPortCount(&firewall_group, 0),
+					testAccCheckFWFirewallPortCount(&firewallGroup, 0),
 				),
 			},
 		},
@@ -82,7 +82,7 @@ func TestAccFWFirewallGroupV2_no_ports(t *testing.T) {
 }
 
 func TestAccFWFirewallGroupV2_port_update(t *testing.T) {
-	var firewall_group fw.FirewallGroup
+	var firewallGroup fw.FirewallGroup
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -90,17 +90,17 @@ func TestAccFWFirewallGroupV2_port_update(t *testing.T) {
 		CheckDestroy:      testAccCheckFWFirewallGroupV2Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFWFirewallV2_port,
+				Config: testAccFWFirewallV2Port,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckFWFirewallGroupV2Exists("opentelekomcloud_fw_firewall_group_v2.fw_1", &firewall_group),
-					testAccCheckFWFirewallPortCount(&firewall_group, 1),
+					testAccCheckFWFirewallGroupV2Exists("opentelekomcloud_fw_firewall_group_v2.fw_1", &firewallGroup),
+					testAccCheckFWFirewallPortCount(&firewallGroup, 1),
 				),
 			},
 			{
-				Config: testAccFWFirewallV2_port_add,
+				Config: testAccFWFirewallV2PortAdd,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckFWFirewallGroupV2Exists("opentelekomcloud_fw_firewall_group_v2.fw_1", &firewall_group),
-					testAccCheckFWFirewallPortCount(&firewall_group, 2),
+					testAccCheckFWFirewallGroupV2Exists("opentelekomcloud_fw_firewall_group_v2.fw_1", &firewallGroup),
+					testAccCheckFWFirewallPortCount(&firewallGroup, 2),
 				),
 			},
 		},
@@ -108,7 +108,7 @@ func TestAccFWFirewallGroupV2_port_update(t *testing.T) {
 }
 
 func TestAccFWFirewallGroupV2_port_remove(t *testing.T) {
-	var firewall_group fw.FirewallGroup
+	var firewallGroup fw.FirewallGroup
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -116,17 +116,17 @@ func TestAccFWFirewallGroupV2_port_remove(t *testing.T) {
 		CheckDestroy:      testAccCheckFWFirewallGroupV2Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFWFirewallV2_port,
+				Config: testAccFWFirewallV2Port,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckFWFirewallGroupV2Exists("opentelekomcloud_fw_firewall_group_v2.fw_1", &firewall_group),
-					testAccCheckFWFirewallPortCount(&firewall_group, 1),
+					testAccCheckFWFirewallGroupV2Exists("opentelekomcloud_fw_firewall_group_v2.fw_1", &firewallGroup),
+					testAccCheckFWFirewallPortCount(&firewallGroup, 1),
 				),
 			},
 			{
-				Config: testAccFWFirewallV2_port_remove,
+				Config: testAccFWFirewallV2PortRemove,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckFWFirewallGroupV2Exists("opentelekomcloud_fw_firewall_group_v2.fw_1", &firewall_group),
-					testAccCheckFWFirewallPortCount(&firewall_group, 0),
+					testAccCheckFWFirewallGroupV2Exists("opentelekomcloud_fw_firewall_group_v2.fw_1", &firewallGroup),
+					testAccCheckFWFirewallPortCount(&firewallGroup, 0),
 				),
 			},
 		},
@@ -146,7 +146,7 @@ func testAccCheckFWFirewallGroupV2Destroy(s *terraform.State) error {
 
 		_, err = firewall_groups.Get(networkingClient, rs.Primary.ID).Extract()
 		if err == nil {
-			return fmt.Errorf("firewall group (%s) still exists.", rs.Primary.ID)
+			return fmt.Errorf("firewall group (%s) still exists", rs.Primary.ID)
 		}
 		if _, ok := err.(golangsdk.ErrDefault404); !ok {
 			return err
@@ -155,7 +155,7 @@ func testAccCheckFWFirewallGroupV2Destroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckFWFirewallGroupV2Exists(n string, firewall_group *fw.FirewallGroup) resource.TestCheckFunc {
+func testAccCheckFWFirewallGroupV2Exists(n string, firewallGroup *fw.FirewallGroup) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -182,16 +182,16 @@ func testAccCheckFWFirewallGroupV2Exists(n string, firewall_group *fw.FirewallGr
 			return fmt.Errorf("firewall group not found")
 		}
 
-		*firewall_group = found
+		*firewallGroup = found
 
 		return nil
 	}
 }
 
-func testAccCheckFWFirewallPortCount(firewall_group *fw.FirewallGroup, expected int) resource.TestCheckFunc {
+func testAccCheckFWFirewallPortCount(firewallGroup *fw.FirewallGroup, expected int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if len(firewall_group.PortIDs) != expected {
-			return fmt.Errorf("expected %d Ports, got %d", expected, len(firewall_group.PortIDs))
+		if len(firewallGroup.PortIDs) != expected {
+			return fmt.Errorf("expected %d Ports, got %d", expected, len(firewallGroup.PortIDs))
 		}
 
 		return nil
@@ -259,7 +259,7 @@ func testAccCheckFWFirewallGroupV2(n, expectedName, expectedDescription string, 
 	}
 }
 
-const testAccFWFirewallGroupV2_basic_1 = `
+const testAccFWFirewallGroupV2Basic1 = `
 resource "opentelekomcloud_fw_firewall_group_v2" "fw_1" {
   ingress_policy_id = opentelekomcloud_fw_policy_v2.policy_1.id
   egress_policy_id = opentelekomcloud_fw_policy_v2.policy_1.id
@@ -276,7 +276,7 @@ resource "opentelekomcloud_fw_policy_v2" "policy_1" {
 }
 `
 
-const testAccFWFirewallGroupV2_basic_2 = `
+const testAccFWFirewallGroupV2Basic2 = `
 resource "opentelekomcloud_fw_firewall_group_v2" "fw_1" {
   name = "fw_1"
   description = "terraform acceptance test"
@@ -294,7 +294,9 @@ resource "opentelekomcloud_fw_policy_v2" "policy_2" {
 }
 `
 
-var testAccFWFirewallV2_port = fmt.Sprintf(`
+var testAccFWFirewallV2Port = fmt.Sprintf(`
+%s
+
 resource "opentelekomcloud_networking_network_v2" "network_1" {
   name = "network_1"
   admin_state_up = "true"
@@ -311,7 +313,7 @@ resource "opentelekomcloud_networking_subnet_v2" "subnet_1" {
 resource "opentelekomcloud_networking_router_v2" "router_1" {
   name = "router_1"
   admin_state_up = "true"
-  external_gateway = "%s"
+  external_gateway = data.opentelekomcloud_networking_network_v2.ext_network.id
 }
 
 resource "opentelekomcloud_networking_port_v2" "port_1" {
@@ -340,13 +342,15 @@ resource "opentelekomcloud_fw_firewall_group_v2" "fw_1" {
   ingress_policy_id = opentelekomcloud_fw_policy_v2.policy_1.id
   #egress_policy_id = opentelekomcloud_fw_policy_v2.policy_1.id
   ports = [
-	opentelekomcloud_networking_port_v2.port_1.id
+    opentelekomcloud_networking_port_v2.port_1.id
   ]
   depends_on = ["opentelekomcloud_networking_router_interface_v2.router_interface_1"]
 }
-`, env.OS_EXTGW_ID)
+`, common.DataSourceExtNetwork)
 
-var testAccFWFirewallV2_port_add = fmt.Sprintf(`
+var testAccFWFirewallV2PortAdd = fmt.Sprintf(`
+%s
+
 resource "opentelekomcloud_networking_network_v2" "network_1" {
   name = "network_1"
   admin_state_up = "true"
@@ -374,13 +378,13 @@ resource "opentelekomcloud_networking_subnet_v2" "subnet_2" {
 resource "opentelekomcloud_networking_router_v2" "router_1" {
   name = "router_1"
   admin_state_up = "true"
-  external_gateway = "%s"
+  external_gateway = data.opentelekomcloud_networking_network_v2.ext_network.id
 }
 
 resource "opentelekomcloud_networking_router_v2" "router_2" {
   name = "router_2"
   admin_state_up = "true"
-  external_gateway = "%s"
+  external_gateway = data.opentelekomcloud_networking_network_v2.ext_network.id
 }
 
 resource "opentelekomcloud_networking_port_v2" "port_1" {
@@ -425,14 +429,14 @@ resource "opentelekomcloud_fw_firewall_group_v2" "fw_1" {
   ingress_policy_id = opentelekomcloud_fw_policy_v2.policy_1.id
   egress_policy_id = opentelekomcloud_fw_policy_v2.policy_1.id
   ports = [
-	opentelekomcloud_networking_port_v2.port_1.id,
-	opentelekomcloud_networking_port_v2.port_2.id
+    opentelekomcloud_networking_port_v2.port_1.id,
+    opentelekomcloud_networking_port_v2.port_2.id
   ]
   depends_on = ["opentelekomcloud_networking_router_interface_v2.router_interface_1", "opentelekomcloud_networking_router_interface_v2.router_interface_2"]
 }
-`, env.OS_EXTGW_ID, env.OS_EXTGW_ID)
+`, common.DataSourceExtNetwork)
 
-const testAccFWFirewallV2_port_remove = `
+const testAccFWFirewallV2PortRemove = `
 resource "opentelekomcloud_fw_policy_v2" "policy_1" {
   name = "policy_1"
 }
@@ -445,7 +449,7 @@ resource "opentelekomcloud_fw_firewall_group_v2" "fw_1" {
 }
 `
 
-const testAccFWFirewallV2_no_ports = `
+const testAccFWFirewallV2NoPorts = `
 resource "opentelekomcloud_fw_policy_v2" "policy_1" {
   name = "policy_1"
 }

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_router_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_router_v2_test.go
@@ -57,7 +57,7 @@ func TestAccNetworkingV2Router_update_external_gw(t *testing.T) {
 			{
 				Config: testAccNetworkingV2RouterUpdateExternalGw,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "external_gateway", env.OS_EXTGW_ID),
+					resource.TestCheckResourceAttrSet(resourceName, "external_gateway"),
 				),
 			},
 		},
@@ -121,13 +121,15 @@ resource "opentelekomcloud_networking_router_v2" "router_1" {
 `
 
 var testAccNetworkingV2RouterUpdateExternalGw = fmt.Sprintf(`
+%s
+
 resource "opentelekomcloud_networking_router_v2" "router_1" {
   name             = "router_1"
   admin_state_up   = true
   distributed      = false
-  external_gateway = "%s"
+  external_gateway = data.opentelekomcloud_networking_network_v2.ext_network.id
 }
-`, env.OS_EXTGW_ID)
+`, common.DataSourceExtNetwork)
 
 const testAccNetworkingV2RouterTimeout = `
 resource "opentelekomcloud_networking_router_v2" "router_1" {

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_vip_associate_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_vip_associate_v2_test.go
@@ -28,7 +28,7 @@ func TestAccNetworkingV2VIPAssociate_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkingV2VIPAssociateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: TestAccNetworkingV2VIPAssociateConfig_basic,
+				Config: TestAccNetworkingV2VIPAssociateConfigBasic,
 				Check: resource.ComposeTestCheckFunc(
 					// testAccCheckNetworkingV2PortExists("opentelekomcloud_networking_port_v2.port_1", &port1),
 					// testAccCheckNetworkingV2PortExists("opentelekomcloud_networking_port_v2.port_2", &port2),
@@ -137,8 +137,10 @@ func testAccCheckNetworkingV2VIPAssociateAssociated(p *ports.Port, vip *ports.Po
 	}
 }
 
-// TestAccNetworkingV2VIPAssociateConfig_basic is used to create.
-var TestAccNetworkingV2VIPAssociateConfig_basic = fmt.Sprintf(`
+// TestAccNetworkingV2VIPAssociateConfigBasic is used to create.
+var TestAccNetworkingV2VIPAssociateConfigBasic = fmt.Sprintf(`
+%s
+
 resource "opentelekomcloud_networking_network_v2" "network_1" {
   name = "network_1"
   admin_state_up = "true"
@@ -158,7 +160,7 @@ resource "opentelekomcloud_networking_router_interface_v2" "router_interface_1" 
 
 resource "opentelekomcloud_networking_router_v2" "router_1" {
   name = "router_1"
-  external_gateway = "%s"
+  external_gateway = data.opentelekomcloud_networking_network_v2.ext_network.id
 }
 
 resource "opentelekomcloud_networking_port_v2" "port_1" {
@@ -206,4 +208,4 @@ resource "opentelekomcloud_networking_vip_associate_v2" "vip_associate_1" {
   vip_id = opentelekomcloud_networking_vip_v2.vip_1.id
   port_ids = [opentelekomcloud_networking_port_v2.port_1.id, opentelekomcloud_networking_port_v2.port_2.id]
 }
-`, env.OS_EXTGW_ID)
+`, common.DataSourceExtNetwork)

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_vip_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_vip_v2_test.go
@@ -24,7 +24,7 @@ func TestAccNetworkingV2VIP_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkingV2VIPDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: TestAccNetworkingV2VIPConfig_basic,
+				Config: testAccNetworkingV2VIPConfigBasic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkingV2VIPExists("opentelekomcloud_networking_vip_v2.vip_1", &vip),
 				),
@@ -90,8 +90,10 @@ func testAccCheckNetworkingV2VIPExists(n string, vip *ports.Port) resource.TestC
 	}
 }
 
-// TestAccNetworkingV2VIPConfig_basic is used to create.
-var TestAccNetworkingV2VIPConfig_basic = fmt.Sprintf(`
+// testAccNetworkingV2VIPConfigBasic is used to create.
+var testAccNetworkingV2VIPConfigBasic = fmt.Sprintf(`
+%s
+
 resource "opentelekomcloud_networking_network_v2" "network_1" {
   name = "network_1"
   admin_state_up = "true"
@@ -111,11 +113,11 @@ resource "opentelekomcloud_networking_router_interface_v2" "router_interface_1" 
 
 resource "opentelekomcloud_networking_router_v2" "router_1" {
   name = "router_1"
-  external_gateway = "%s"
+  external_gateway = data.opentelekomcloud_networking_network_v2.ext_network.id
 }
 
 resource "opentelekomcloud_networking_vip_v2" "vip_1" {
   network_id = opentelekomcloud_networking_network_v2.network_1.id
   subnet_id = opentelekomcloud_networking_subnet_v2.subnet_1.id
 }
-`, env.OS_EXTGW_ID)
+`, common.DataSourceExtNetwork)


### PR DESCRIPTION
## Summary of the Pull Request
Replace `env.OS_EXTGW_ID` usages in VPC with a data source

Replace `env.OS_EXTGW_ID` usages in FW with a data source

Remove `env.OS_EXTGW_ID` variable

Minor refactor of the affected tests

## PR Checklist

* [x] Refers to: #1320 
* [x] Tests added/passed.


## Acceptance Steps Performed

### FW
```
=== RUN   TestAccFWFirewallV2_importBasic
--- PASS: TestAccFWFirewallV2_importBasic (13.81s)
=== RUN   TestAccFWPolicyV2_importBasic
--- PASS: TestAccFWPolicyV2_importBasic (14.23s)
=== RUN   TestAccFWRuleV2_importBasic
--- PASS: TestAccFWRuleV2_importBasic (10.30s)
=== RUN   TestAccFWFirewallGroupV2_basic
--- PASS: TestAccFWFirewallGroupV2_basic (23.40s)
=== RUN   TestAccFWFirewallGroupV2_port0
--- PASS: TestAccFWFirewallGroupV2_port0 (80.36s)
=== RUN   TestAccFWFirewallGroupV2_no_ports
--- PASS: TestAccFWFirewallGroupV2_no_ports (11.26s)
=== RUN   TestAccFWFirewallGroupV2_port_update
--- PASS: TestAccFWFirewallGroupV2_port_update (126.73s)
=== RUN   TestAccFWFirewallGroupV2_port_remove
--- PASS: TestAccFWFirewallGroupV2_port_remove (91.51s)
=== RUN   TestAccFWPolicyV2_basic
--- PASS: TestAccFWPolicyV2_basic (9.35s)
=== RUN   TestAccFWPolicyV2_addRules
--- PASS: TestAccFWPolicyV2_addRules (12.08s)
=== RUN   TestAccFWPolicyV2_deleteRules
--- PASS: TestAccFWPolicyV2_deleteRules (12.40s)
=== RUN   TestAccFWPolicyV2_timeout
--- PASS: TestAccFWPolicyV2_timeout (10.53s)
=== RUN   TestAccFWPolicyV2_removeSingleRule
--- PASS: TestAccFWPolicyV2_removeSingleRule (21.19s)
=== RUN   TestAccFWRuleV2_basic
--- PASS: TestAccFWRuleV2_basic (25.11s)
=== RUN   TestAccFWRuleV2_anyProtocol
--- PASS: TestAccFWRuleV2_anyProtocol (10.90s)
PASS
ok  	github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/fw	474.046s

Process finished with the exit code 0

```

### VPC
```
=== RUN   TestAccNetworkingV2Router_basic
--- PASS: TestAccNetworkingV2Router_basic (32.60s)
=== RUN   TestAccNetworkingV2Router_update_external_gw
--- PASS: TestAccNetworkingV2Router_update_external_gw (34.17s)
=== RUN   TestAccNetworkingV2Router_timeout
--- PASS: TestAccNetworkingV2Router_timeout (24.27s)
PASS

Process finished with the exit code 0
```
```
=== RUN   TestAccNetworkingV2VIP_basic
--- PASS: TestAccNetworkingV2VIP_basic (67.32s)
PASS

Process finished with the exit code 0
```
