### PR TITLE
Fix errors in `fw_firewall_group` and `fw_policy`

### DIFF
--- a/opentelekomcloud/acceptance/fw/resource_opentelekomcloud_fw_firewall_group_v2_test.go
+++ b/opentelekomcloud/acceptance/fw/resource_opentelekomcloud_fw_firewall_group_v2_test.go
@@ -283,12 +283,10 @@ resource "opentelekomcloud_fw_firewall_group_v2" "fw_1" {
   ingress_policy_id = opentelekomcloud_fw_policy_v2.policy_2.id
   egress_policy_id = opentelekomcloud_fw_policy_v2.policy_2.id
   admin_state_up = true
+}
 
-  timeouts {
-    create = "5m"
-    update = "5m"
-    delete = "5m"
-  }
+resource "opentelekomcloud_fw_policy_v2" "policy_1" {
+  name = "policy_1"
 }
 
 resource "opentelekomcloud_fw_policy_v2" "policy_2" {

--- a/opentelekomcloud/acceptance/fw/resource_opentelekomcloud_fw_policy_v2_test.go
+++ b/opentelekomcloud/acceptance/fw/resource_opentelekomcloud_fw_policy_v2_test.go
@@ -2,7 +2,6 @@ package acceptance
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 	"time"
 
@@ -85,7 +84,6 @@ func TestAccFWPolicyV2_timeout(t *testing.T) {
 }
 
 func TestAccFWPolicyV2_removeSingleRule(t *testing.T) {
-	notEmptyPlan := regexp.MustCompile(".+?plan was not empty:")
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
@@ -102,9 +100,6 @@ func TestAccFWPolicyV2_removeSingleRule(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckFWPolicyV2Exists("opentelekomcloud_fw_policy_v2.policy_1", "policy_1", "", 0),
 				),
-				// There is non-empty plan before refresh and empty one after
-				// So `ExpectNonEmptyPlan: true` won't work
-				ExpectError: notEmptyPlan,
 			},
 		},
 	})

--- a/opentelekomcloud/services/fw/resource_opentelekomcloud_fw_firewall_group_v2.go
+++ b/opentelekomcloud/services/fw/resource_opentelekomcloud_fw_firewall_group_v2.go
@@ -133,7 +133,7 @@ func resourceFWFirewallGroupV2Create(ctx context.Context, d *schema.ResourceData
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"PENDING_CREATE"},
-		Target:     []string{"ACTIVE"},
+		Target:     []string{"ACTIVE", "INACTIVE"},
 		Refresh:    waitForFirewallGroupActive(networkingClient, firewall_group.ID),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
 		Delay:      0,
@@ -240,7 +240,7 @@ func resourceFWFirewallGroupV2Update(ctx context.Context, d *schema.ResourceData
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"PENDING_CREATE", "PENDING_UPDATE"},
-		Target:     []string{"ACTIVE"},
+		Target:     []string{"ACTIVE", "INACTIVE"},
 		Refresh:    waitForFirewallGroupActive(networkingClient, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutUpdate),
 		Delay:      0,
@@ -267,7 +267,7 @@ func resourceFWFirewallGroupV2Delete(ctx context.Context, d *schema.ResourceData
 	// Ensure the firewall group was fully created/updated before being deleted.
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"PENDING_CREATE", "PENDING_UPDATE"},
-		Target:     []string{"ACTIVE"},
+		Target:     []string{"ACTIVE", "INACTIVE"},
 		Refresh:    waitForFirewallGroupActive(networkingClient, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutUpdate),
 		Delay:      0,

--- a/releasenotes/notes/fix-fw-0eafc632703c8486.yaml
+++ b/releasenotes/notes/fix-fw-0eafc632703c8486.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    **[FW]** Fix errors when creating/updating/deleting ``resource/opentelekomcloud_fw_firewall_group_v2`` (`#1329 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1329>`_)
+  - |
+    **[FW]** Fix incorrect wait for ``resource/opentelekomcloud_fw_policy_v2`` deletion (`#1329 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1329>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Fix incorrect waits for the active state in `fw_firewall_group_v2`

Fix incorrect deletion of `fw_policy_v2`

Fix #1328

## PR Checklist

* [x] Refers to: #1328
* [x] Tests added/passed.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccFWFirewallV2_importBasic
--- PASS: TestAccFWFirewallV2_importBasic (19.37s)
=== RUN   TestAccFWPolicyV2_importBasic
--- PASS: TestAccFWPolicyV2_importBasic (20.67s)
=== RUN   TestAccFWRuleV2_importBasic
--- PASS: TestAccFWRuleV2_importBasic (11.67s)
=== RUN   TestAccFWFirewallGroupV2_basic
--- PASS: TestAccFWFirewallGroupV2_basic (28.14s)
=== RUN   TestAccFWFirewallGroupV2_port0
--- PASS: TestAccFWFirewallGroupV2_port0 (81.38s)
=== RUN   TestAccFWFirewallGroupV2_no_ports
--- PASS: TestAccFWFirewallGroupV2_no_ports (18.60s)
=== RUN   TestAccFWFirewallGroupV2_port_update
--- PASS: TestAccFWFirewallGroupV2_port_update (122.51s)
=== RUN   TestAccFWFirewallGroupV2_port_remove
--- PASS: TestAccFWFirewallGroupV2_port_remove (96.32s)
=== RUN   TestAccFWPolicyV2_basic
--- PASS: TestAccFWPolicyV2_basic (15.21s)
=== RUN   TestAccFWPolicyV2_addRules
--- PASS: TestAccFWPolicyV2_addRules (18.23s)
=== RUN   TestAccFWPolicyV2_deleteRules
--- PASS: TestAccFWPolicyV2_deleteRules (18.75s)
=== RUN   TestAccFWPolicyV2_timeout
--- PASS: TestAccFWPolicyV2_timeout (15.61s)
=== RUN   TestAccFWPolicyV2_removeSingleRule
--- PASS: TestAccFWPolicyV2_removeSingleRule (29.12s)
=== RUN   TestAccFWRuleV2_basic
--- PASS: TestAccFWRuleV2_basic (27.82s)
=== RUN   TestAccFWRuleV2_anyProtocol
--- PASS: TestAccFWRuleV2_anyProtocol (10.46s)
PASS
ok  	github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/fw	534.918s

Process finished with the exit code 0

```
