### PR TITLE
[Acceptance] Get rid of IDs in SFS and SFS-Turbo

### DIFF
--- a/opentelekomcloud/acceptance/sfs/data_source_opentelekomcloud_sfs_file_system_v2_test.go
+++ b/opentelekomcloud/acceptance/sfs/data_source_opentelekomcloud_sfs_file_system_v2_test.go
@@ -16,7 +16,7 @@ func TestAccOTCSFSFileSystemV2DataSource_basic(t *testing.T) {
 		ProviderFactories: common.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSFSFileSystemV2DataSource_basic,
+				Config: testAccSFSFileSystemV2DataSourceBasic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSFSFileSystemV2DataSourceID("data.opentelekomcloud_sfs_file_system_v2.shares"),
 					resource.TestCheckResourceAttr("data.opentelekomcloud_sfs_file_system_v2.shares", "name", "sfs-c2c-1"),
@@ -43,18 +43,21 @@ func testAccCheckSFSFileSystemV2DataSourceID(n string) resource.TestCheckFunc {
 	}
 }
 
-var testAccSFSFileSystemV2DataSource_basic = `
+var testAccSFSFileSystemV2DataSourceBasic = fmt.Sprintf(`
+%s
+
 resource "opentelekomcloud_sfs_file_system_v2" "sfs_1" {
-	share_proto = "NFS"
-	size=1
-	name="sfs-c2c-1"
-  	availability_zone="eu-de-01"
-	access_to="%s"
-  	access_type="cert"
-  	access_level="rw"
-	description="sfs_c2c_test-file"
+  share_proto       = "NFS"
+  size              = 1
+  name              = "sfs-c2c-1"
+  availability_zone = "eu-de-01"
+  access_to         = data.opentelekomcloud_vpc_v1.shared_vpc.id
+  access_type       = "cert"
+  access_level      = "rw"
+  description       = "sfs_c2c_test-file"
 }
+
 data "opentelekomcloud_sfs_file_system_v2" "shares" {
   id = opentelekomcloud_sfs_file_system_v2.sfs_1.id
 }
-`
+`, common.DataSourceVPC)

--- a/opentelekomcloud/acceptance/sfs/data_source_opentelekomcloud_sfs_turbo_share_v1_test.go
+++ b/opentelekomcloud/acceptance/sfs/data_source_opentelekomcloud_sfs_turbo_share_v1_test.go
@@ -17,7 +17,7 @@ func TestAccSFSTurboShareV1DataSource_basic(t *testing.T) {
 		ProviderFactories: common.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSFSTurboShareV1_basic(name),
+				Config: testAccSFSTurboShareV1Basic(name),
 			},
 			{
 				Config: testAccSFSTurboShareV1DataSourceBasic(name),
@@ -39,5 +39,5 @@ func testAccSFSTurboShareV1DataSourceBasic(name string) string {
 data "opentelekomcloud_sfs_turbo_share_v1" "share" {
   name = "%s"
 }
-`, testAccSFSTurboShareV1_basic(name), name)
+`, testAccSFSTurboShareV1Basic(name), name)
 }

--- a/opentelekomcloud/acceptance/sfs/import_opentelekomcloud_sfs_file_system_v2_test.go
+++ b/opentelekomcloud/acceptance/sfs/import_opentelekomcloud_sfs_file_system_v2_test.go
@@ -21,9 +21,10 @@ func TestAccOTCSFSFileSystemV2_importBasic(t *testing.T) {
 			},
 
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"access_level", "access_to", "access_type"},
 			},
 		},
 	})

--- a/opentelekomcloud/acceptance/sfs/import_opentelekomcloud_sfs_turbo_share_v1_test.go
+++ b/opentelekomcloud/acceptance/sfs/import_opentelekomcloud_sfs_turbo_share_v1_test.go
@@ -19,7 +19,7 @@ func TestAccSFSTurboShareV1_importBasic(t *testing.T) {
 		CheckDestroy:      testAccCheckSFSTurboShareV1Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSFSTurboShareV1_basic(shareName),
+				Config: testAccSFSTurboShareV1Basic(shareName),
 			},
 			{
 				ResourceName:      resourceName,

--- a/opentelekomcloud/acceptance/sfs/resource_opentelekomcloud_sfs_file_system_v2_test.go
+++ b/opentelekomcloud/acceptance/sfs/resource_opentelekomcloud_sfs_file_system_v2_test.go
@@ -31,7 +31,6 @@ func TestAccSFSFileSystemV2_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "status", "available"),
 					resource.TestCheckResourceAttr(resourceName, "size", "1"),
 					resource.TestCheckResourceAttr(resourceName, "access_level", "rw"),
-					resource.TestCheckResourceAttr(resourceName, "access_to", env.OS_VPC_ID),
 					resource.TestCheckResourceAttr(resourceName, "access_type", "cert"),
 					resource.TestCheckResourceAttr(resourceName, "tags.muh", "value-create"),
 				),
@@ -45,7 +44,6 @@ func TestAccSFSFileSystemV2_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "status", "available"),
 					resource.TestCheckResourceAttr(resourceName, "size", "2"),
 					resource.TestCheckResourceAttr(resourceName, "access_level", "rw"),
-					resource.TestCheckResourceAttr(resourceName, "access_to", env.OS_VPC_ID),
 					resource.TestCheckResourceAttr(resourceName, "access_type", "cert"),
 					resource.TestCheckResourceAttr(resourceName, "tags.muh", "value-update"),
 				),
@@ -93,7 +91,6 @@ func TestAccSFSFileSystemV2_clean(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSFSFileSystemV2Exists("opentelekomcloud_sfs_file_system_v2.sfs_1", &share),
 					resource.TestCheckResourceAttr(resourceName, "access_level", "rw"),
-					resource.TestCheckResourceAttr(resourceName, "access_to", env.OS_VPC_ID),
 					resource.TestCheckResourceAttr(resourceName, "access_type", "cert"),
 				),
 			},
@@ -161,12 +158,14 @@ func testAccCheckSFSFileSystemV2Exists(n string, share *shares.Share) resource.T
 }
 
 var testAccSFSFileSystemV2Basic = fmt.Sprintf(`
+%s
+
 resource "opentelekomcloud_sfs_file_system_v2" "sfs_1" {
   share_proto       = "NFS"
   size              = 1
   name              = "sfs-test1"
   availability_zone = "eu-de-01"
-  access_to         = "%s"
+  access_to         = data.opentelekomcloud_vpc_v1.shared_vpc.id
   access_type       = "cert"
   access_level      = "rw"
   description       = "sfs_c2c_test-file"
@@ -176,15 +175,17 @@ resource "opentelekomcloud_sfs_file_system_v2" "sfs_1" {
     kuh = "value-create"
   }
 }
-`, env.OS_VPC_ID)
+`, common.DataSourceVPC)
 
 var testAccSFSFileSystemV2Update = fmt.Sprintf(`
+%s
+
 resource "opentelekomcloud_sfs_file_system_v2" "sfs_1" {
   share_proto       = "NFS"
   size              = 2
   name              = "sfs-test2"
   availability_zone = "eu-de-01"
-  access_to         = "%s"
+  access_to         = data.opentelekomcloud_vpc_v1.shared_vpc.id
   access_type       = "cert"
   access_level      = "rw"
   description       = "sfs_c2c_test-file"
@@ -193,14 +194,16 @@ resource "opentelekomcloud_sfs_file_system_v2" "sfs_1" {
     muh = "value-update"
   }
 }
-`, env.OS_VPC_ID)
+`, common.DataSourceVPC)
 
 var testAccSFSFileSystemV2Timeout = fmt.Sprintf(`
+%s
+
 resource "opentelekomcloud_sfs_file_system_v2" "sfs_1" {
   share_proto  = "NFS"
   size         = 1
   name         = "sfs-test1"
-  access_to    = "%s"
+  access_to    = data.opentelekomcloud_vpc_v1.shared_vpc.id
   access_type  = "cert"
   access_level = "rw"
   description  = "sfs_c2c_test-file"
@@ -209,7 +212,7 @@ resource "opentelekomcloud_sfs_file_system_v2" "sfs_1" {
     create = "5m"
     delete = "5m"
   }
-}`, env.OS_VPC_ID)
+}`, common.DataSourceVPC)
 
 const testAccSFSFileSystemV2Clean = `
 resource "opentelekomcloud_sfs_file_system_v2" "sfs_1" {


### PR DESCRIPTION
## Summary of the Pull Request
Replace `OS_VPC_ID` and `OS_NETWORK_ID` with data sources in SFS tests

Add usage notice to shared data sources documentation

## PR Checklist

* [x] Refers to: #1320 
* [x] Tests added/passed.

## Acceptance Steps Performed

```
=== RUN   TestAccOTCSFSFileSystemV2DataSource_basic
--- PASS: TestAccOTCSFSFileSystemV2DataSource_basic (53.95s)
=== RUN   TestAccSFSTurboShareV1DataSource_basic
--- PASS: TestAccSFSTurboShareV1DataSource_basic (318.98s)
=== RUN   TestAccOTCSFSFileSystemV2_importBasic
--- PASS: TestAccOTCSFSFileSystemV2_importBasic (51.41s)
=== RUN   TestAccSFSShareAccessRulesV2_importBasic
--- PASS: TestAccSFSShareAccessRulesV2_importBasic (46.58s)
=== RUN   TestAccSFSTurboShareV1_importBasic
--- PASS: TestAccSFSTurboShareV1_importBasic (342.81s)
=== RUN   TestAccSFSFileSystemV2_basic
--- PASS: TestAccSFSFileSystemV2_basic (79.43s)
=== RUN   TestAccSFSFileSystemV2_timeout
--- PASS: TestAccSFSFileSystemV2_timeout (37.04s)
=== RUN   TestAccSFSFileSystemV2_clean
--- PASS: TestAccSFSFileSystemV2_clean (86.20s)
=== RUN   TestAccSFSShareAccessRulesV2_basic
--- PASS: TestAccSFSShareAccessRulesV2_basic (100.05s)
=== RUN   TestAccSFSTurboShareV1_basic
--- PASS: TestAccSFSTurboShareV1_basic (444.30s)
=== RUN   TestAccSFSTurboShareV1_withKMS
--- PASS: TestAccSFSTurboShareV1_withKMS (344.34s)

PASS
PASS	github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/sfs	1538.066s

```
