### PR TITLE
[Acceptance] Get rid of IDs in AS

### DIFF
--- a/opentelekomcloud/acceptance/as/resource_opentelekomcloud_as_configuration_v1_test.go
+++ b/opentelekomcloud/acceptance/as/resource_opentelekomcloud_as_configuration_v1_test.go
@@ -47,6 +47,7 @@ func TestAccASV1Configuration_publicIP(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckASV1ConfigurationExists(resourceName, &asConfig),
 					resource.TestCheckResourceAttr(resourceName, "scaling_configuration_name", "as_config"),
+					resource.TestCheckResourceAttrSet(resourceName, "instance_config.0.image"),
 					resource.TestCheckResourceAttr(resourceName, "instance_config.0.key_name", env.OS_KEYPAIR_NAME),
 				),
 			},

--- a/opentelekomcloud/acceptance/as/resource_opentelekomcloud_as_group_v1_test.go
+++ b/opentelekomcloud/acceptance/as/resource_opentelekomcloud_as_group_v1_test.go
@@ -153,7 +153,7 @@ var testAccASV1GroupBasic = fmt.Sprintf(`
 
 resource "opentelekomcloud_lb_loadbalancer_v2" "loadbalancer_1" {
   name          = "loadbalancer_1"
-  vip_subnet_id = data.opentelekomcloud_subnet_v1.shared_subnet.id
+  vip_subnet_id = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.subnet_id
 }
 
 resource "opentelekomcloud_lb_listener_v2" "listener_1" {
@@ -211,9 +211,6 @@ var testAccASV1GroupUpdate = fmt.Sprintf(`
 // default SecGroup data-source
 %s
 
-// default Subnet data-source
-%s
-
 // default Image data-source
 %s
 
@@ -225,7 +222,7 @@ var testAccASV1GroupUpdate = fmt.Sprintf(`
 
 resource "opentelekomcloud_lb_loadbalancer_v2" "loadbalancer_1" {
   name          = "loadbalancer_1"
-  vip_subnet_id = data.opentelekomcloud_subnet_v1.shared_subnet.id
+  vip_subnet_id = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.subnet_id
 }
 
 resource "opentelekomcloud_lb_listener_v2" "listener_1" {
@@ -276,7 +273,7 @@ resource "opentelekomcloud_as_group_v1" "as_group"{
     muh = "value-update"
   }
 }
-`, common.DataSourceSecGroupDefault, common.DataSourceSubnet, common.DataSourceImage, common.DataSourceSubnet, common.DataSourceVPC, env.OS_KEYPAIR_NAME)
+`, common.DataSourceSecGroupDefault, common.DataSourceImage, common.DataSourceSubnet, common.DataSourceVPC, env.OS_KEYPAIR_NAME)
 
 var testAccASV1GroupRemoveWithSetMinNumber = fmt.Sprintf(`
 // default SecGroup data-source

--- a/opentelekomcloud/acceptance/as/resource_opentelekomcloud_as_group_v1_test.go
+++ b/opentelekomcloud/acceptance/as/resource_opentelekomcloud_as_group_v1_test.go
@@ -26,8 +26,7 @@ func TestAccASV1Group_basic(t *testing.T) {
 				Config: testAccASV1GroupBasic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckASV1GroupExists(resourceName, &asGroup),
-					resource.TestCheckResourceAttr(resourceName, "lbaas_listeners.0.protocol_port", "8080"),
-					resource.TestCheckResourceAttr(resourceName, "vpc_id", env.OS_VPC_ID),
+					resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
 					resource.TestCheckResourceAttr(resourceName, "lbaas_listeners.0.protocol_port", "8080"),
 					resource.TestCheckResourceAttr(resourceName, "health_periodic_audit_grace_period", "700"),
 					resource.TestCheckResourceAttr(resourceName, "tags.muh", "value-create"),
@@ -59,7 +58,7 @@ func TestAccASV1Group_RemoveWithSetMinNumber(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckASV1GroupExists(resourceName, &asGroup),
 					resource.TestCheckResourceAttr(resourceName, "delete_publicip", "true"),
-					resource.TestCheckResourceAttr(resourceName, "scaling_group_name", "proxy-test-asg"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_group_name", "as_group"),
 				),
 			},
 		},
@@ -194,10 +193,10 @@ resource "opentelekomcloud_as_group_v1" "as_group"{
     id = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
   }
   security_groups {
-    id = opentelekomcloud_networking_secgroup_v2.secgroup.id
+    id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
   }
   lbaas_listeners {
-    pool_id =       opentelekomcloud_lb_pool_v2.pool_1.id
+    pool_id       = opentelekomcloud_lb_pool_v2.pool_1.id
     protocol_port = opentelekomcloud_lb_listener_v2.listener_1.protocol_port
   }
   vpc_id = data.opentelekomcloud_vpc_v1.shared_vpc.id
@@ -266,10 +265,10 @@ resource "opentelekomcloud_as_group_v1" "as_group"{
     id = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
   }
   security_groups {
-    id = opentelekomcloud_networking_secgroup_v2.secgroup.id
+    id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
   }
   lbaas_listeners {
-    pool_id =       opentelekomcloud_lb_pool_v2.pool_1.id
+    pool_id       = opentelekomcloud_lb_pool_v2.pool_1.id
     protocol_port = opentelekomcloud_lb_listener_v2.listener_1.protocol_port
   }
   vpc_id = data.opentelekomcloud_vpc_v1.shared_vpc.id
@@ -331,7 +330,7 @@ resource "opentelekomcloud_as_group_v1" "as_group" {
     id = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
   }
   security_groups {
-    id = opentelekomcloud_compute_secgroup_v2.secgroup.id
+    id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
   }
 
   lifecycle {

--- a/opentelekomcloud/acceptance/as/resource_opentelekomcloud_as_group_v1_test.go
+++ b/opentelekomcloud/acceptance/as/resource_opentelekomcloud_as_group_v1_test.go
@@ -142,9 +142,6 @@ var testAccASV1GroupBasic = fmt.Sprintf(`
 // default SecGroup data-source
 %s
 
-// default Subnet data-source
-%s
-
 // default Image data-source
 %s
 
@@ -208,7 +205,7 @@ resource "opentelekomcloud_as_group_v1" "as_group"{
     kuh = "value-create"
   }
 }
-`, common.DataSourceSecGroupDefault, common.DataSourceSubnet, common.DataSourceImage, common.DataSourceSubnet, common.DataSourceVPC, env.OS_KEYPAIR_NAME)
+`, common.DataSourceSecGroupDefault, common.DataSourceImage, common.DataSourceSubnet, common.DataSourceVPC, env.OS_KEYPAIR_NAME)
 
 var testAccASV1GroupUpdate = fmt.Sprintf(`
 // default SecGroup data-source

--- a/opentelekomcloud/acceptance/as/resource_opentelekomcloud_as_policy_v2_test.go
+++ b/opentelekomcloud/acceptance/as/resource_opentelekomcloud_as_policy_v2_test.go
@@ -122,7 +122,7 @@ resource "opentelekomcloud_as_configuration_v1" "as_config"{
 
 resource "opentelekomcloud_as_group_v1" "as_group"{
   scaling_group_name       = "as_group"
-  scaling_configuration_id = opentelekomcloud_as_configuration_v1.config_1.id
+  scaling_configuration_id = opentelekomcloud_as_configuration_v1.as_config.id
 
   networks {
     id = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
@@ -181,7 +181,7 @@ resource "opentelekomcloud_as_configuration_v1" "as_config"{
 
 resource "opentelekomcloud_as_group_v1" "as_group"{
   scaling_group_name       = "as_group"
-  scaling_configuration_id = opentelekomcloud_as_configuration_v1.config_1.id
+  scaling_configuration_id = opentelekomcloud_as_configuration_v1.as_config.id
 
   networks {
     id = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
@@ -195,7 +195,7 @@ resource "opentelekomcloud_as_group_v1" "as_group"{
 resource "opentelekomcloud_as_policy_v2" "as_policy"{
   scaling_policy_name   = "as_policy_update"
   scaling_policy_type   = "RECURRENCE"
-  scaling_resource_id   = opentelekomcloud_as_group_v1.group_1.id
+  scaling_resource_id   = opentelekomcloud_as_group_v1.as_group.id
   scaling_resource_type = "SCALING_GROUP"
 
   scaling_policy_action {


### PR DESCRIPTION
## Summary of the Pull Request
Replace `env.OS_NETWORK_ID` usages in AS with a data source

Replace `env.OS_SUBNET_ID` usages in AS with a data source

Use `default` sec group instead of creating everytime

Minor refactor of the affected tests

## PR Checklist

* [x] Refers to: #1320
* [x] Tests added/passed.

## Acceptance Steps Performed

```
=== RUN   TestAccASV1Configuration_basic
--- PASS: TestAccASV1Configuration_basic (159.50s)
=== RUN   TestAccASV1Configuration_publicIP
--- PASS: TestAccASV1Configuration_publicIP (169.48s)
=== RUN   TestAccASV1Configuration_invalidDiskSize
--- PASS: TestAccASV1Configuration_invalidDiskSize (38.96s)
=== RUN   TestAccASV1Configuration_multipleSecurityGroups
--- PASS: TestAccASV1Configuration_multipleSecurityGroups (178.11s)
=== RUN   TestAccASV1Group_basic
--- PASS: TestAccASV1Group_basic (406.06s)
=== RUN   TestAccASV1Group_RemoveWithSetMinNumber
--- PASS: TestAccASV1Group_RemoveWithSetMinNumber (296.87s)
=== RUN   TestAccASV1Group_WithoutSecurityGroups
--- PASS: TestAccASV1Group_WithoutSecurityGroups (299.43s)
=== RUN   TestAccASV1Policy_basic
--- PASS: TestAccASV1Policy_basic (189.02s)
=== RUN   TestAccASPolicyV2_basic
=== RUN   TestAccASPolicyV2_basic
--- PASS: TestAccASPolicyV2_basic (318.44s)
PASS

Process finished with the exit code 0
```
