### PR TITLE
[Acceptance] Use shared `data_sources` in `CCE`

### DIFF
--- a/opentelekomcloud/acceptance/cce/data_source_opentelekomcloud_cce_cluster_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/data_source_opentelekomcloud_cce_cluster_v3_test.go
@@ -58,7 +58,7 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   cluster_type           = "VirtualMachine"
   flavor_id              = "cce.s1.small"
   vpc_id                 = data.opentelekomcloud_vpc_v1.shared_vpc.id
-  subnet_id              = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  subnet_id              = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
   container_network_type = "overlay_l2"
 }
 

--- a/opentelekomcloud/acceptance/cce/data_source_opentelekomcloud_cce_cluster_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/data_source_opentelekomcloud_cce_cluster_v3_test.go
@@ -4,25 +4,28 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
-	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
 )
 
 func TestAccCCEClusterV3DataSource_basic(t *testing.T) {
+	var cceName = fmt.Sprintf("cce-test-%s", acctest.RandString(5))
+	dataSourceName := "data.opentelekomcloud_cce_cluster_v3.clusters"
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCCEClusterV3DataSource_basic,
+				Config: testAccCCEClusterV3DataSourceBasic(cceName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCCEClusterV3DataSourceID("data.opentelekomcloud_cce_cluster_v3.clusters"),
-					resource.TestCheckResourceAttr("data.opentelekomcloud_cce_cluster_v3.clusters", "name", "opentelekomcloud-cce"),
-					resource.TestCheckResourceAttr("data.opentelekomcloud_cce_cluster_v3.clusters", "status", "Available"),
-					resource.TestCheckResourceAttr("data.opentelekomcloud_cce_cluster_v3.clusters", "cluster_type", "VirtualMachine"),
+					testAccCheckCCEClusterV3DataSourceID(dataSourceName),
+					resource.TestCheckResourceAttr(dataSourceName, "name", cceName),
+					resource.TestCheckResourceAttr(dataSourceName, "status", "Available"),
+					resource.TestCheckResourceAttr(dataSourceName, "cluster_type", "VirtualMachine"),
 				),
 			},
 		},
@@ -44,17 +47,23 @@ func testAccCheckCCEClusterV3DataSourceID(n string) resource.TestCheckFunc {
 	}
 }
 
-var testAccCCEClusterV3DataSource_basic = fmt.Sprintf(`
+func testAccCCEClusterV3DataSourceBasic(cceName string) string {
+	return fmt.Sprintf(`
+%s
+
+%s
+
 resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
-  name                   = "opentelekomcloud-cce"
+  name                   = "%s"
   cluster_type           = "VirtualMachine"
   flavor_id              = "cce.s1.small"
-  vpc_id                 = "%s"
-  subnet_id              = "%s"
+  vpc_id                 = data.opentelekomcloud_vpc_v1.shared_vpc.id
+  subnet_id              = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   container_network_type = "overlay_l2"
 }
 
 data "opentelekomcloud_cce_cluster_v3" "clusters" {
   name = opentelekomcloud_cce_cluster_v3.cluster_1.name
 }
-`, env.OS_VPC_ID, env.OS_NETWORK_ID)
+`, common.DataSourceVPC, common.DataSourceSubnet, cceName)
+}

--- a/opentelekomcloud/acceptance/cce/data_source_opentelekomcloud_cce_node_ids_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/data_source_opentelekomcloud_cce_node_ids_v3_test.go
@@ -58,7 +58,7 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   cluster_type           = "VirtualMachine"
   flavor_id              = "cce.s1.small"
   vpc_id                 = data.opentelekomcloud_vpc_v1.shared_vpc.id
-  subnet_id              = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  subnet_id              = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
   container_network_type = "overlay_l2"
 }
 

--- a/opentelekomcloud/acceptance/cce/data_source_opentelekomcloud_cce_node_ids_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/data_source_opentelekomcloud_cce_node_ids_v3_test.go
@@ -15,15 +15,17 @@ import (
 func TestAccCceNodeIdsV3DataSource_basic(t *testing.T) {
 	var cceName = fmt.Sprintf("cce-test-%s", acctest.RandString(5))
 	var cceNodeName = fmt.Sprintf("node-test-%s", acctest.RandString(5))
+	dataSourceName := "data.opentelekomcloud_cce_node_ids_v3.node_ids"
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCceNodeIdsV3DataSource_basic(cceName, cceNodeName),
+				Config: testAccCceNodeIdsV3DataSourceBasic(cceName, cceNodeName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCceNodeIdsV3DataSourceID("data.opentelekomcloud_cce_node_ids_v3.node_ids"),
-					resource.TestCheckResourceAttr("data.opentelekomcloud_cce_node_ids_v3.node_ids", "ids.#", "1"),
+					testAccCceNodeIdsV3DataSourceID(dataSourceName),
+					resource.TestCheckResourceAttr(dataSourceName, "ids.#", "1"),
 				),
 			},
 		},
@@ -45,14 +47,18 @@ func testAccCceNodeIdsV3DataSourceID(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccCceNodeIdsV3DataSource_basic(cceName string, cceNodeName string) string {
+func testAccCceNodeIdsV3DataSourceBasic(cceName string, cceNodeName string) string {
 	return fmt.Sprintf(`
+%s
+
+%s
+
 resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   name                   = "%s"
   cluster_type           = "VirtualMachine"
   flavor_id              = "cce.s1.small"
-  vpc_id                 = "%s"
-  subnet_id              = "%s"
+  vpc_id                 = data.opentelekomcloud_vpc_v1.shared_vpc.id
+  subnet_id              = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   container_network_type = "overlay_l2"
 }
 
@@ -75,5 +81,5 @@ resource "opentelekomcloud_cce_node_v3" "node_1" {
 data "opentelekomcloud_cce_node_ids_v3" "node_ids" {
   cluster_id = opentelekomcloud_cce_cluster_v3.cluster_1.id
 }
-`, cceName, env.OS_VPC_ID, env.OS_NETWORK_ID, cceNodeName, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME)
+`, common.DataSourceVPC, common.DataSourceSubnet, cceName, cceNodeName, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME)
 }

--- a/opentelekomcloud/acceptance/cce/data_source_opentelekomcloud_cce_node_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/data_source_opentelekomcloud_cce_node_v3_test.go
@@ -66,7 +66,7 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
 resource "opentelekomcloud_cce_node_v3" "node_1" {
   cluster_id        = opentelekomcloud_cce_cluster_v3.cluster_1.id
   name              = "%s"
-  flavor_id         = "s1.medium"
+  flavor_id         = "s2.large.2"
   availability_zone = "%s"
   key_pair          = "%s"
   root_volume {

--- a/opentelekomcloud/acceptance/cce/data_source_opentelekomcloud_cce_node_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/data_source_opentelekomcloud_cce_node_v3_test.go
@@ -59,7 +59,7 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   cluster_type           = "VirtualMachine"
   flavor_id              = "cce.s1.small"
   vpc_id                 = data.opentelekomcloud_vpc_v1.shared_vpc.id
-  subnet_id              = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  subnet_id              = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
   container_network_type = "overlay_l2"
 }
 

--- a/opentelekomcloud/acceptance/cce/import_opentelekomcloud_cce_addon_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/import_opentelekomcloud_cce_addon_v3_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestAccCCEAddonV3ImportBasic(t *testing.T) {
-	resourceName := "opentelekomcloud_cce_addon_v3.autoscaler"
+	addonResourceName := "opentelekomcloud_cce_addon_v3.autoscaler"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -21,7 +21,7 @@ func TestAccCCEAddonV3ImportBasic(t *testing.T) {
 				Config: testAccCCEAddonV3Basic,
 			},
 			{
-				ResourceName:      resourceName,
+				ResourceName:      addonResourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateIdFunc: testAccCCEAddonV3ImportStateIdFunc(),

--- a/opentelekomcloud/acceptance/cce/import_opentelekomcloud_cce_cluster_test.go
+++ b/opentelekomcloud/acceptance/cce/import_opentelekomcloud_cce_cluster_test.go
@@ -9,8 +9,6 @@ import (
 )
 
 func TestAccCCEClusterV3_importBasic(t *testing.T) {
-	resourceName := "opentelekomcloud_cce_cluster_v3.cluster_1"
-
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,

--- a/opentelekomcloud/acceptance/cce/import_opentelekomcloud_cce_node_pool_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/import_opentelekomcloud_cce_node_pool_v3_test.go
@@ -20,7 +20,6 @@ func TestAccCCENodePoolV3ImportBasic(t *testing.T) {
 			{
 				Config: testAccCCENodePoolV3Basic,
 			},
-
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,

--- a/opentelekomcloud/acceptance/cce/import_opentelekomcloud_cce_node_pool_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/import_opentelekomcloud_cce_node_pool_v3_test.go
@@ -26,7 +26,7 @@ func TestAccCCENodePoolV3ImportBasic(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateIdFunc: testAccCCENodePoolV3ImportStateIdFunc(),
 				ImportStateVerifyIgnore: []string{
-					"max_node_count", "min_node_count", "priority", "scale_down_cooldown_time",
+					"max_node_count", "min_node_count", "priority", "scale_down_cooldown_time", "initial_node_count",
 				},
 			},
 		},

--- a/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_addon_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_addon_v3_test.go
@@ -129,7 +129,7 @@ resource opentelekomcloud_cce_cluster_v3 cluster_1 {
   cluster_type            = "VirtualMachine"
   flavor_id               = "cce.s1.small"
   vpc_id                  = data.opentelekomcloud_vpc_v1.shared_vpc.id
-  subnet_id               = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  subnet_id               = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
   container_network_type  = "overlay_l2"
   kubernetes_svc_ip_range = "10.247.0.0/16"
 }
@@ -185,7 +185,7 @@ resource opentelekomcloud_cce_cluster_v3 cluster_1 {
   cluster_type            = "VirtualMachine"
   flavor_id               = "cce.s1.small"
   vpc_id                  = data.opentelekomcloud_vpc_v1.shared_vpc.id
-  subnet_id               = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  subnet_id               = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
   container_network_type  = "overlay_l2"
   kubernetes_svc_ip_range = "10.247.0.0/16"
 }
@@ -241,7 +241,7 @@ resource opentelekomcloud_cce_cluster_v3 cluster_1 {
   cluster_type            = "VirtualMachine"
   flavor_id               = "cce.s1.medium"
   vpc_id                  = data.opentelekomcloud_vpc_v1.shared_vpc.id
-  subnet_id               = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  subnet_id               = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
   container_network_type  = "overlay_l2"
   kubernetes_svc_ip_range = "10.247.0.0/16"
 }

--- a/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_cluster_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_cluster_v3_test.go
@@ -215,7 +215,7 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   cluster_type            = "VirtualMachine"
   flavor_id               = "cce.s1.small"
   vpc_id                  = data.opentelekomcloud_vpc_v1.shared_vpc.id
-  subnet_id               = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  subnet_id               = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
   container_network_type  = "overlay_l2"
   kubernetes_svc_ip_range = "10.247.0.0/16"
 }`, common.DataSourceVPC, common.DataSourceSubnet, clusterName)
@@ -230,7 +230,7 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   cluster_type            = "VirtualMachine"
   flavor_id               = "cce.s1.small"
   vpc_id                  = data.opentelekomcloud_vpc_v1.shared_vpc.id
-  subnet_id               = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  subnet_id               = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
   container_network_type  = "overlay_l2"
   description             = "new description"
   kubernetes_svc_ip_range = "10.247.0.0/16"
@@ -248,7 +248,7 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   cluster_type           = "VirtualMachine"
   flavor_id              = "cce.s2.small"
   vpc_id                 = data.opentelekomcloud_vpc_v1.shared_vpc.id
-  subnet_id              = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  subnet_id              = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
   eip                    = opentelekomcloud_networking_floatingip_v2.fip_1.address
   container_network_type = "overlay_l2"
   authentication_mode    = "rbac"
@@ -272,13 +272,13 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   flavor_id              = "cce.s1.small"
   cluster_version        = "v1.9.2"
   vpc_id                 = data.opentelekomcloud_vpc_v1.shared_vpc.id
-  subnet_id              = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  subnet_id              = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
   container_network_type = "overlay_l2"
   description            = "new description"
 }`, common.DataSourceVPC, common.DataSourceSubnet, clusterName)
 
 	testAccCCEClusterV3AuthProxy = fmt.Sprintf(`
-%
+%s
 
 %s
 
@@ -287,7 +287,7 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   cluster_type            = "VirtualMachine"
   flavor_id               = "cce.s1.small"
   vpc_id                  = data.opentelekomcloud_vpc_v1.shared_vpc.id
-  subnet_id               = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  subnet_id               = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
   container_network_type  = "overlay_l2"
   kubernetes_svc_ip_range = "10.247.0.0/16"
   authentication_mode     = "authenticating_proxy"

--- a/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_cluster_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_cluster_v3_test.go
@@ -133,7 +133,7 @@ func TestAccCCEClusterV3NoAddons(t *testing.T) {
 
 func testAccCheckCCEClusterV3Destroy(s *terraform.State) error {
 	config := common.TestAccProvider.Meta().(*cfg.Config)
-	cceClient, err := config.CceV3Client(env.OS_REGION_NAME)
+	client, err := config.CceV3Client(env.OS_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("error creating opentelekomcloud CCE client: %s", err)
 	}
@@ -143,7 +143,7 @@ func testAccCheckCCEClusterV3Destroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := clusters.Get(cceClient, rs.Primary.ID).Extract()
+		_, err := clusters.Get(client, rs.Primary.ID).Extract()
 		if err == nil {
 			return fmt.Errorf("cluster still exists")
 		}
@@ -164,12 +164,12 @@ func testAccCheckCCEClusterV3Exists(n string, cluster *clusters.Clusters) resour
 		}
 
 		config := common.TestAccProvider.Meta().(*cfg.Config)
-		cceClient, err := config.CceV3Client(env.OS_REGION_NAME)
+		client, err := config.CceV3Client(env.OS_REGION_NAME)
 		if err != nil {
-			return fmt.Errorf("error creating opentelekomcloud CCE client: %s", err)
+			return fmt.Errorf("error creating OpenTelekomCloud CCE client: %s", err)
 		}
 
-		found, err := clusters.Get(cceClient, rs.Primary.ID).Extract()
+		found, err := clusters.Get(client, rs.Primary.ID).Extract()
 		if err != nil {
 			return err
 		}
@@ -206,38 +206,49 @@ func TestAccCCEClusterV3_withVersionDiff(t *testing.T) {
 
 var (
 	testAccCCEClusterV3Basic = fmt.Sprintf(`
+%s
+
+%s
+
 resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   name                    = "%s"
   cluster_type            = "VirtualMachine"
   flavor_id               = "cce.s1.small"
-  vpc_id                  = "%s"
-  subnet_id               = "%s"
+  vpc_id                  = data.opentelekomcloud_vpc_v1.shared_vpc.id
+  subnet_id               = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   container_network_type  = "overlay_l2"
   kubernetes_svc_ip_range = "10.247.0.0/16"
-}`, clusterName, env.OS_VPC_ID, env.OS_NETWORK_ID)
+}`, common.DataSourceVPC, common.DataSourceSubnet, clusterName)
 
 	testAccCCEClusterV3Update = fmt.Sprintf(`
+%s
+
+%s
+
 resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   name                    = "%s"
   cluster_type            = "VirtualMachine"
   flavor_id               = "cce.s1.small"
-  vpc_id                  = "%s"
-  subnet_id               = "%s"
+  vpc_id                  = data.opentelekomcloud_vpc_v1.shared_vpc.id
+  subnet_id               = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   container_network_type  = "overlay_l2"
   description             = "new description"
   kubernetes_svc_ip_range = "10.247.0.0/16"
-}`, clusterName, env.OS_VPC_ID, env.OS_NETWORK_ID)
+}`, common.DataSourceVPC, common.DataSourceSubnet, clusterName)
 
 	testAccCCEClusterV3Timeout = fmt.Sprintf(`
-resource "opentelekomcloud_networking_floatingip_v2" "fip_1" {
-}
+%s
+
+%s
+
+resource "opentelekomcloud_networking_floatingip_v2" "fip_1" {}
 
 resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   name                   = "%s"
   cluster_type           = "VirtualMachine"
   flavor_id              = "cce.s2.small"
-  vpc_id                 = "%s"
-  subnet_id              = "%s"
+  vpc_id                 = data.opentelekomcloud_vpc_v1.shared_vpc.id
+  subnet_id              = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   eip                    = opentelekomcloud_networking_floatingip_v2.fip_1.address
   container_network_type = "overlay_l2"
   authentication_mode    = "rbac"
@@ -248,27 +259,35 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
 
   multi_az = true
 }
-`, clusterName, env.OS_VPC_ID, env.OS_NETWORK_ID)
+`, common.DataSourceVPC, common.DataSourceSubnet, clusterName)
 
 	testAccCCEClusterV3WithInvalidVersion = fmt.Sprintf(`
+%s
+
+%s
+
 resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   name                   = "%s"
   cluster_type           = "VirtualMachine"
   flavor_id              = "cce.s1.small"
   cluster_version        = "v1.9.2"
-  vpc_id                 = "%s"
-  subnet_id              = "%s"
+  vpc_id                 = data.opentelekomcloud_vpc_v1.shared_vpc.id
+  subnet_id              = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   container_network_type = "overlay_l2"
   description            = "new description"
-}`, clusterName, env.OS_VPC_ID, env.OS_NETWORK_ID)
+}`, common.DataSourceVPC, common.DataSourceSubnet, clusterName)
 
 	testAccCCEClusterV3AuthProxy = fmt.Sprintf(`
+%
+
+%s
+
 resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   name                    = "%s"
   cluster_type            = "VirtualMachine"
   flavor_id               = "cce.s1.small"
-  vpc_id                  = "%s"
-  subnet_id               = "%s"
+  vpc_id                  = data.opentelekomcloud_vpc_v1.shared_vpc.id
+  subnet_id               = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   container_network_type  = "overlay_l2"
   kubernetes_svc_ip_range = "10.247.0.0/16"
   authentication_mode     = "authenticating_proxy"
@@ -296,24 +315,21 @@ i34R7EQDtFeiSvBdeKRsPp8c0KT8H1B4lXNkkCQs2WX5p4lm99+ZtLD4glw8x6Ic
 i1YhgnQbn5E0hz55OLu5jvOkKQjPCW+9Aa==
 -----END CERTIFICATE-----
 EOT
-}`, clusterName, env.OS_VPC_ID, env.OS_NETWORK_ID)
+}`, common.DataSourceVPC, common.DataSourceSubnet, clusterName)
 
 	testAccCCEClusterV3InvalidSubnet = fmt.Sprintf(`
-resource "opentelekomcloud_vpc_v1" "vpc" {
-  cidr = "192.168.0.0/16"
-  name = "cce-test"
-}
+%s
 
 resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   name                    = "%s"
   cluster_type            = "VirtualMachine"
   flavor_id               = "cce.s1.small"
-  vpc_id                  = opentelekomcloud_vpc_v1.vpc.id
+  vpc_id                  = data.opentelekomcloud_vpc_v1.shared_vpc.id
   subnet_id               = "abc"
   container_network_type  = "overlay_l2"
   kubernetes_svc_ip_range = "10.247.0.0/16"
 }
-`, clusterName)
+`, common.DataSourceVPC, clusterName)
 
 	testAccCCEClusterV3InvalidVPC = fmt.Sprintf(`
 resource "opentelekomcloud_vpc_v1" "vpc" {
@@ -374,14 +390,18 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
 `, clusterName)
 
 	testAccCCEClusterV3NoAddons = fmt.Sprintf(`
+%s
+
+%s
+
 resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   name                    = "%s"
   cluster_type            = "VirtualMachine"
   flavor_id               = "cce.s1.small"
-  vpc_id                  = "%s"
-  subnet_id               = "%s"
+  vpc_id                  = data.opentelekomcloud_vpc_v1.shared_vpc.id
+  subnet_id               = data.opentelekomcloud_vpc_v1.shared_vpc.network_id
   container_network_type  = "overlay_l2"
   kubernetes_svc_ip_range = "10.247.0.0/16"
   no_addons               = true
-}`, clusterName, env.OS_VPC_ID, env.OS_NETWORK_ID)
+}`, common.DataSourceVPC, common.DataSourceSubnet, clusterName)
 )

--- a/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_cluster_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_cluster_v3_test.go
@@ -399,7 +399,7 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   cluster_type            = "VirtualMachine"
   flavor_id               = "cce.s1.small"
   vpc_id                  = data.opentelekomcloud_vpc_v1.shared_vpc.id
-  subnet_id               = data.opentelekomcloud_vpc_v1.shared_vpc.network_id
+  subnet_id               = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
   container_network_type  = "overlay_l2"
   kubernetes_svc_ip_range = "10.247.0.0/16"
   no_addons               = true

--- a/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_node_pool_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_node_pool_v3_test.go
@@ -163,7 +163,7 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster" {
   cluster_type = "VirtualMachine"
   flavor_id    = "cce.s1.small"
   vpc_id       = data.opentelekomcloud_vpc_v1.shared_vpc.id
-  subnet_id    = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  subnet_id    = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
 
   container_network_type = "overlay_l2"
   authentication_mode    = "rbac"
@@ -208,7 +208,7 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster" {
   cluster_type = "VirtualMachine"
   flavor_id    = "cce.s1.small"
   vpc_id       = data.opentelekomcloud_vpc_v1.shared_vpc.id
-  subnet_id    = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  subnet_id    = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
 
   container_network_type = "overlay_l2"
   authentication_mode    = "rbac"
@@ -253,7 +253,7 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster" {
   cluster_type = "VirtualMachine"
   flavor_id    = "cce.s1.small"
   vpc_id       = data.opentelekomcloud_vpc_v1.shared_vpc.id
-  subnet_id    = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  subnet_id    = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
 
   container_network_type = "overlay_l2"
   authentication_mode    = "rbac"
@@ -294,7 +294,7 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster" {
   cluster_type = "VirtualMachine"
   flavor_id    = "cce.s1.small"
   vpc_id       = data.opentelekomcloud_vpc_v1.shared_vpc.id
-  subnet_id    = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  subnet_id    = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
 
   container_network_type = "overlay_l2"
   authentication_mode    = "rbac"

--- a/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_node_pool_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_node_pool_v3_test.go
@@ -88,23 +88,23 @@ func TestAccCCENodePoolsV3EncryptedVolume(t *testing.T) {
 
 func testAccCheckCCENodePoolV3Destroy(s *terraform.State) error {
 	config := common.TestAccProvider.Meta().(*cfg.Config)
-	cceClient, err := config.CceV3Client(env.OS_REGION_NAME)
+	client, err := config.CceV3Client(env.OS_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("error creating OpenTelekomCloud CCE client: %s", err)
 	}
 
-	var clusterId string
+	var clusterID string
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type == "opentelekomcloud_cce_cluster_v3" {
-			clusterId = rs.Primary.ID
+			clusterID = rs.Primary.ID
 		}
 
 		if rs.Type != "opentelekomcloud_cce_node_pool_v3" {
 			continue
 		}
 
-		_, err := nodepools.Get(cceClient, clusterId, rs.Primary.ID).Extract()
+		_, err := nodepools.Get(client, clusterID, rs.Primary.ID).Extract()
 		if err == nil {
 			return fmt.Errorf("node pool still exists")
 		}
@@ -132,12 +132,12 @@ func testAccCheckCCENodePoolV3Exists(n string, cluster string, nodePool *nodepoo
 		}
 
 		config := common.TestAccProvider.Meta().(*cfg.Config)
-		cceClient, err := config.CceV3Client(env.OS_REGION_NAME)
+		client, err := config.CceV3Client(env.OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("error creating OpenTelekomCloud CCE client: %s", err)
 		}
 
-		found, err := nodepools.Get(cceClient, c.Primary.ID, rs.Primary.ID).Extract()
+		found, err := nodepools.Get(client, c.Primary.ID, rs.Primary.ID).Extract()
 		if err != nil {
 			return err
 		}
@@ -154,12 +154,16 @@ func testAccCheckCCENodePoolV3Exists(n string, cluster string, nodePool *nodepoo
 
 var (
 	testAccCCENodePoolV3Basic = fmt.Sprintf(`
+%s
+
+%s
+
 resource "opentelekomcloud_cce_cluster_v3" "cluster" {
   name         = "opentelekomcloud-cce-np"
   cluster_type = "VirtualMachine"
   flavor_id    = "cce.s1.small"
-  vpc_id       = "%s"
-  subnet_id    = "%s"
+  vpc_id       = data.opentelekomcloud_vpc_v1.shared_vpc.id
+  subnet_id    = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
 
   container_network_type = "overlay_l2"
   authentication_mode    = "rbac"
@@ -192,15 +196,19 @@ resource "opentelekomcloud_cce_node_pool_v3" "node_pool" {
   k8s_tags = {
     "kubelet.kubernetes.io/namespace" = "muh"
   }
-}`, env.OS_VPC_ID, env.OS_NETWORK_ID, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME)
+}`, common.DataSourceVPC, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME)
 
 	testAccCCENodePoolV3Update = fmt.Sprintf(`
+%s
+
+%s
+
 resource "opentelekomcloud_cce_cluster_v3" "cluster" {
   name         = "opentelekomcloud-cce-np"
   cluster_type = "VirtualMachine"
   flavor_id    = "cce.s1.small"
-  vpc_id       = "%s"
-  subnet_id    = "%s"
+  vpc_id       = data.opentelekomcloud_vpc_v1.shared_vpc.id
+  subnet_id    = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
 
   container_network_type = "overlay_l2"
   authentication_mode    = "rbac"
@@ -233,15 +241,19 @@ resource "opentelekomcloud_cce_node_pool_v3" "node_pool" {
   k8s_tags = {
     "kubelet.kubernetes.io/namespace" = "kuh"
   }
-}`, env.OS_VPC_ID, env.OS_NETWORK_ID, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME)
+}`, common.DataSourceVPC, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME)
 
 	testAccCCENodePoolV3RandomAZ = fmt.Sprintf(`
+%s
+
+%s
+
 resource "opentelekomcloud_cce_cluster_v3" "cluster" {
   name         = "opentelekomcloud-cce-np"
   cluster_type = "VirtualMachine"
   flavor_id    = "cce.s1.small"
-  vpc_id       = "%s"
-  subnet_id    = "%s"
+  vpc_id       = data.opentelekomcloud_vpc_v1.shared_vpc.id
+  subnet_id    = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
 
   container_network_type = "overlay_l2"
   authentication_mode    = "rbac"
@@ -270,15 +282,19 @@ resource "opentelekomcloud_cce_node_pool_v3" "node_pool" {
     size       = 100
     volumetype = "SSD"
   }
-}`, env.OS_VPC_ID, env.OS_NETWORK_ID, env.OS_KEYPAIR_NAME)
+}`, common.DataSourceVPC, common.DataSourceSubnet, env.OS_KEYPAIR_NAME)
 
 	testAccCCENodePoolV3Encrypted = fmt.Sprintf(`
+%s
+
+%s
+
 resource "opentelekomcloud_cce_cluster_v3" "cluster" {
   name         = "opentelekomcloud-cce-np"
   cluster_type = "VirtualMachine"
   flavor_id    = "cce.s1.small"
-  vpc_id       = "%s"
-  subnet_id    = "%s"
+  vpc_id       = data.opentelekomcloud_vpc_v1.shared_vpc.id
+  subnet_id    = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
 
   container_network_type = "overlay_l2"
   authentication_mode    = "rbac"
@@ -308,5 +324,5 @@ resource "opentelekomcloud_cce_node_pool_v3" "node_pool" {
     volumetype = "SSD"
     kms_id     = "%s"
   }
-}`, env.OS_VPC_ID, env.OS_NETWORK_ID, env.OS_KEYPAIR_NAME, env.OS_KMS_ID)
+}`, common.DataSourceVPC, common.DataSourceSubnet, env.OS_KEYPAIR_NAME, env.OS_KMS_ID)
 )

--- a/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_node_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_node_v3_test.go
@@ -338,12 +338,16 @@ func testAccCheckCCENodeV3Exists(n string, cluster string, node *nodes.Nodes) re
 
 var (
 	testAccCCENodeV3OS = fmt.Sprintf(`
+%s
+
+%s
+
 resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   name         = "opentelekomcloud-cce"
   cluster_type = "VirtualMachine"
   flavor_id    = "cce.s1.small"
-  vpc_id       = "%s"
-  subnet_id    = "%s"
+  vpc_id       = data.opentelekomcloud_vpc_v1.shared_vpc.id
+  subnet_id    = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
 
   container_network_type = "overlay_l2"
   authentication_mode    = "rbac"
@@ -389,15 +393,19 @@ resource "opentelekomcloud_cce_node_v3" "node_2" {
   }
 }
 
-`, env.OS_VPC_ID, env.OS_NETWORK_ID, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME)
+`, common.DataSourceVPC, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME)
 
 	testAccCCENodeV3Basic = fmt.Sprintf(`
+%s
+
+%s
+
 resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   name         = "opentelekomcloud-cce"
   cluster_type = "VirtualMachine"
   flavor_id    = "cce.s1.small"
-  vpc_id       = "%s"
-  subnet_id    = "%s"
+  vpc_id       = data.opentelekomcloud_vpc_v1.shared_vpc.id
+  subnet_id    = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
 
   container_network_type = "overlay_l2"
   authentication_mode    = "rbac"
@@ -422,15 +430,19 @@ resource "opentelekomcloud_cce_node_v3" "node_1" {
   }
 
   private_ip = "%s"
-}`, env.OS_VPC_ID, env.OS_NETWORK_ID, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME, privateIP)
+}`, common.DataSourceVPC, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME, privateIP)
 
 	testAccCCENodeV3Update = fmt.Sprintf(`
+%s
+
+%s
+
 resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   name         = "opentelekomcloud-cce"
   cluster_type = "VirtualMachine"
   flavor_id    = "cce.s1.small"
-  vpc_id       = "%s"
-  subnet_id    = "%s"
+  vpc_id       = data.opentelekomcloud_vpc_v1.shared_vpc.id
+  subnet_id    = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
 
   container_network_type = "overlay_l2"
   authentication_mode    = "rbac"
@@ -454,15 +466,19 @@ resource "opentelekomcloud_cce_node_v3" "node_1" {
   }
 
   private_ip = "%s"
-}`, env.OS_VPC_ID, env.OS_NETWORK_ID, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME, privateIP)
+}`, common.DataSourceVPC, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME, privateIP)
 
 	testAccCCENodeV3Timeout = fmt.Sprintf(`
+%s
+
+%s
+
 resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   name         = "opentelekomcloud-cce"
   cluster_type = "VirtualMachine"
   flavor_id    = "cce.s1.small"
-  vpc_id       = "%s"
-  subnet_id    = "%s"
+  vpc_id       = data.opentelekomcloud_vpc_v1.shared_vpc.id
+  subnet_id    = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
 
   container_network_type = "overlay_l2"
   authentication_mode    = "rbac"
@@ -488,15 +504,19 @@ resource "opentelekomcloud_cce_node_v3" "node_1" {
     delete = "10m"
   }
 }
-`, env.OS_VPC_ID, env.OS_NETWORK_ID, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME)
+`, common.DataSourceVPC, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME)
 
 	testAccCCENodeV3Ip = fmt.Sprintf(`
+%s
+
+%s
+
 resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   name         = "opentelekomcloud-cce"
   cluster_type = "VirtualMachine"
   flavor_id    = "cce.s1.small"
-  vpc_id       = "%s"
-  subnet_id    = "%s"
+  vpc_id       = data.opentelekomcloud_vpc_v1.shared_vpc.id
+  subnet_id    = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
 
   container_network_type = "overlay_l2"
   authentication_mode    = "rbac"
@@ -520,15 +540,19 @@ resource "opentelekomcloud_cce_node_v3" "node_1" {
     volumetype = "SATA"
   }
 }
-`, env.OS_VPC_ID, env.OS_NETWORK_ID, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME)
+`, common.DataSourceVPC, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME)
 
 	testAccCCENodeV3BandWidthResize = fmt.Sprintf(`
+%s
+
+%s
+
 resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   name         = "opentelekomcloud-cce"
   cluster_type = "VirtualMachine"
   flavor_id    = "cce.s1.small"
-  vpc_id       = "%s"
-  subnet_id    = "%s"
+  vpc_id       = data.opentelekomcloud_vpc_v1.shared_vpc.id
+  subnet_id    = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
 
   container_network_type = "overlay_l2"
   authentication_mode    = "rbac"
@@ -552,15 +576,19 @@ resource "opentelekomcloud_cce_node_v3" "node_1" {
     volumetype = "SATA"
   }
 }
-`, env.OS_VPC_ID, env.OS_NETWORK_ID, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME)
+`, common.DataSourceVPC, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME)
 
 	testAccCCENodeV3IpUnset = fmt.Sprintf(`
+%s
+
+%s
+
 resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   name         = "opentelekomcloud-cce"
   cluster_type = "VirtualMachine"
   flavor_id    = "cce.s1.small"
-  vpc_id       = "%s"
-  subnet_id    = "%s"
+  vpc_id       = data.opentelekomcloud_vpc_v1.shared_vpc.id
+  subnet_id    = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
 
   container_network_type = "overlay_l2"
   authentication_mode    = "rbac"
@@ -582,15 +610,19 @@ resource "opentelekomcloud_cce_node_v3" "node_1" {
     volumetype = "SATA"
   }
 }
-`, env.OS_VPC_ID, env.OS_NETWORK_ID, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME)
+`, common.DataSourceVPC, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME)
 
 	testAccCCENodeV3IpParams = fmt.Sprintf(`
+%s
+
+%s
+
 resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   name         = "opentelekomcloud-cce"
   cluster_type = "VirtualMachine"
   flavor_id    = "cce.s1.small"
-  vpc_id       = "%s"
-  subnet_id    = "%s"
+  vpc_id       = data.opentelekomcloud_vpc_v1.shared_vpc.id
+  subnet_id    = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
 
   container_network_type = "overlay_l2"
   authentication_mode    = "rbac"
@@ -616,15 +648,19 @@ resource "opentelekomcloud_cce_node_v3" "node_1" {
     volumetype = "SATA"
   }
 }
-`, env.OS_VPC_ID, env.OS_NETWORK_ID, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME)
+`, common.DataSourceVPC, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME)
 
 	testAccCCENodeV3IpNull = fmt.Sprintf(`
+%s
+
+%s
+
 resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   name         = "opentelekomcloud-cce"
   cluster_type = "VirtualMachine"
   flavor_id    = "cce.s1.small"
-  vpc_id       = "%s"
-  subnet_id    = "%s"
+  vpc_id       = data.opentelekomcloud_vpc_v1.shared_vpc.id
+  subnet_id    = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
 
   container_network_type = "overlay_l2"
   authentication_mode    = "rbac"
@@ -650,9 +686,13 @@ resource "opentelekomcloud_cce_node_v3" "node_1" {
     volumetype = "SATA"
   }
 }
-`, env.OS_VPC_ID, env.OS_NETWORK_ID, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME)
+`, common.DataSourceVPC, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME)
 
 	testAccCCENodeV3IpIDs = fmt.Sprintf(`
+%s
+
+%s
+
 resource "opentelekomcloud_networking_floatingip_v2" "fip_1" {}
 resource "opentelekomcloud_networking_floatingip_v2" "fip_2" {}
 
@@ -660,8 +700,8 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   name         = "opentelekomcloud-cce-ids"
   cluster_type = "VirtualMachine"
   flavor_id    = "cce.s1.small"
-  vpc_id       = "%s"
-  subnet_id    = "%s"
+  vpc_id       = data.opentelekomcloud_vpc_v1.shared_vpc.id
+  subnet_id    = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
 
   container_network_type = "overlay_l2"
   authentication_mode    = "rbac"
@@ -685,9 +725,13 @@ resource "opentelekomcloud_cce_node_v3" "node_1" {
     volumetype = "SATA"
   }
 }
-`, env.OS_VPC_ID, env.OS_NETWORK_ID, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME)
+`, common.DataSourceVPC, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME)
 
 	testAccCCENodeV3IpIDsUnset = fmt.Sprintf(`
+%s
+
+%s
+
 resource "opentelekomcloud_networking_floatingip_v2" "fip_1" {}
 resource "opentelekomcloud_networking_floatingip_v2" "fip_2" {}
 
@@ -695,8 +739,8 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   name         = "opentelekomcloud-cce-ids"
   cluster_type = "VirtualMachine"
   flavor_id    = "cce.s1.small"
-  vpc_id       = "%s"
-  subnet_id    = "%s"
+  vpc_id       = data.opentelekomcloud_vpc_v1.shared_vpc.id
+  subnet_id    = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
 
   container_network_type = "overlay_l2"
   authentication_mode    = "rbac"
@@ -719,15 +763,19 @@ resource "opentelekomcloud_cce_node_v3" "node_1" {
     volumetype = "SATA"
   }
 }
-`, env.OS_VPC_ID, env.OS_NETWORK_ID, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME)
+`, common.DataSourceVPC, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME)
 
 	testAccCCENodeV3EncryptedVolume = fmt.Sprintf(`
+%s
+
+%s
+
 resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   name         = "opentelekomcloud-cce-encryption"
   cluster_type = "VirtualMachine"
   flavor_id    = "cce.s1.small"
-  vpc_id       = "%s"
-  subnet_id    = "%s"
+  vpc_id       = data.opentelekomcloud_vpc_v1.shared_vpc.id
+  subnet_id    = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
 
   container_network_type = "overlay_l2"
   authentication_mode    = "rbac"
@@ -750,15 +798,19 @@ resource "opentelekomcloud_cce_node_v3" "node_1" {
     kms_id     = "%s"
   }
 }
-`, env.OS_VPC_ID, env.OS_NETWORK_ID, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME, env.OS_KMS_ID)
+`, common.DataSourceVPC, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME, env.OS_KMS_ID)
 
 	testAccCCENodeV3TaintsK8sTags = fmt.Sprintf(`
+%s
+
+%s
+
 resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   name         = "opentelekomcloud-cce"
   cluster_type = "VirtualMachine"
   flavor_id    = "cce.s1.small"
-  vpc_id       = "%s"
-  subnet_id    = "%s"
+  vpc_id       = data.opentelekomcloud_vpc_v1.shared_vpc.id
+  subnet_id    = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   container_network_type = "overlay_l2"
   authentication_mode    = "rbac"
 }
@@ -787,5 +839,5 @@ resource "opentelekomcloud_cce_node_v3" "node_1" {
   }
   private_ip = "%s"
 }
-`, env.OS_VPC_ID, env.OS_NETWORK_ID, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME, privateIP)
+`, common.DataSourceVPC, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME, privateIP)
 )

--- a/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_node_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_node_v3_test.go
@@ -347,7 +347,7 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   cluster_type = "VirtualMachine"
   flavor_id    = "cce.s1.small"
   vpc_id       = data.opentelekomcloud_vpc_v1.shared_vpc.id
-  subnet_id    = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  subnet_id    = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
 
   container_network_type = "overlay_l2"
   authentication_mode    = "rbac"
@@ -405,7 +405,7 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   cluster_type = "VirtualMachine"
   flavor_id    = "cce.s1.small"
   vpc_id       = data.opentelekomcloud_vpc_v1.shared_vpc.id
-  subnet_id    = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  subnet_id    = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
 
   container_network_type = "overlay_l2"
   authentication_mode    = "rbac"
@@ -442,7 +442,7 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   cluster_type = "VirtualMachine"
   flavor_id    = "cce.s1.small"
   vpc_id       = data.opentelekomcloud_vpc_v1.shared_vpc.id
-  subnet_id    = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  subnet_id    = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
 
   container_network_type = "overlay_l2"
   authentication_mode    = "rbac"
@@ -478,7 +478,7 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   cluster_type = "VirtualMachine"
   flavor_id    = "cce.s1.small"
   vpc_id       = data.opentelekomcloud_vpc_v1.shared_vpc.id
-  subnet_id    = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  subnet_id    = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
 
   container_network_type = "overlay_l2"
   authentication_mode    = "rbac"
@@ -516,7 +516,7 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   cluster_type = "VirtualMachine"
   flavor_id    = "cce.s1.small"
   vpc_id       = data.opentelekomcloud_vpc_v1.shared_vpc.id
-  subnet_id    = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  subnet_id    = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
 
   container_network_type = "overlay_l2"
   authentication_mode    = "rbac"
@@ -552,7 +552,7 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   cluster_type = "VirtualMachine"
   flavor_id    = "cce.s1.small"
   vpc_id       = data.opentelekomcloud_vpc_v1.shared_vpc.id
-  subnet_id    = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  subnet_id    = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
 
   container_network_type = "overlay_l2"
   authentication_mode    = "rbac"
@@ -588,7 +588,7 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   cluster_type = "VirtualMachine"
   flavor_id    = "cce.s1.small"
   vpc_id       = data.opentelekomcloud_vpc_v1.shared_vpc.id
-  subnet_id    = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  subnet_id    = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
 
   container_network_type = "overlay_l2"
   authentication_mode    = "rbac"
@@ -622,7 +622,7 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   cluster_type = "VirtualMachine"
   flavor_id    = "cce.s1.small"
   vpc_id       = data.opentelekomcloud_vpc_v1.shared_vpc.id
-  subnet_id    = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  subnet_id    = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
 
   container_network_type = "overlay_l2"
   authentication_mode    = "rbac"
@@ -660,7 +660,7 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   cluster_type = "VirtualMachine"
   flavor_id    = "cce.s1.small"
   vpc_id       = data.opentelekomcloud_vpc_v1.shared_vpc.id
-  subnet_id    = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  subnet_id    = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
 
   container_network_type = "overlay_l2"
   authentication_mode    = "rbac"
@@ -701,7 +701,7 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   cluster_type = "VirtualMachine"
   flavor_id    = "cce.s1.small"
   vpc_id       = data.opentelekomcloud_vpc_v1.shared_vpc.id
-  subnet_id    = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  subnet_id    = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
 
   container_network_type = "overlay_l2"
   authentication_mode    = "rbac"
@@ -740,7 +740,7 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   cluster_type = "VirtualMachine"
   flavor_id    = "cce.s1.small"
   vpc_id       = data.opentelekomcloud_vpc_v1.shared_vpc.id
-  subnet_id    = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  subnet_id    = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
 
   container_network_type = "overlay_l2"
   authentication_mode    = "rbac"
@@ -775,7 +775,7 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   cluster_type = "VirtualMachine"
   flavor_id    = "cce.s1.small"
   vpc_id       = data.opentelekomcloud_vpc_v1.shared_vpc.id
-  subnet_id    = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  subnet_id    = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
 
   container_network_type = "overlay_l2"
   authentication_mode    = "rbac"
@@ -810,7 +810,7 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   cluster_type = "VirtualMachine"
   flavor_id    = "cce.s1.small"
   vpc_id       = data.opentelekomcloud_vpc_v1.shared_vpc.id
-  subnet_id    = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  subnet_id    = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
   container_network_type = "overlay_l2"
   authentication_mode    = "rbac"
 }

--- a/opentelekomcloud/services/cce/data_source_opentelekomcloud_cce_node_ids_v3.go
+++ b/opentelekomcloud/services/cce/data_source_opentelekomcloud_cce_node_ids_v3.go
@@ -44,8 +44,7 @@ func dataSourceCceNodeIdsV3Read(_ context.Context, d *schema.ResourceData, meta 
 		return fmterr.Errorf("unable to create opentelekomcloud CCE client : %s", err)
 	}
 
-	var listOpts nodes.ListOpts
-	refinedNodes, err := nodes.List(cceClient, d.Get("cluster_id").(string), listOpts)
+	refinedNodes, err := nodes.List(cceClient, d.Get("cluster_id").(string), nodes.ListOpts{})
 	if err != nil {
 		return fmterr.Errorf("unable to retrieve Nodes: %s", err)
 	}


### PR DESCRIPTION
## Summary of the Pull Request
Use shared `data_sources` in `CCE`

## PR Checklist

* [x] Refers to: #1320
* [x] Tests added/passed.

## Acceptance Steps Performed

```
=== RUN   TestAccCCEClusterV3_basic
--- PASS: TestAccCCEClusterV3_basic (679.23s)
=== RUN   TestAccCCEClusterV3_invalidNetwork
--- PASS: TestAccCCEClusterV3_invalidNetwork (87.33s)
=== RUN   TestAccCCEClusterV3_proxyAuth
--- FAIL: TestAccCCEClusterV3_proxyAuth (53.75s)
=== RUN   TestAccCCEClusterV3_timeout
--- PASS: TestAccCCEClusterV3_timeout (515.25s)
=== RUN   TestAccCCEClusterV3NoAddons
--- PASS: TestAccCCEClusterV3NoAddons (605.35s)

FAIL

Process finished with the exit code 1
```
