### PR TITLE
[VPC] Fix wrong `network_id` setting in `d/vpc_subnet_v1`

### DIFF
--- a/opentelekomcloud/services/vpc/common.go
+++ b/opentelekomcloud/services/vpc/common.go
@@ -2,4 +2,5 @@ package vpc
 
 const (
 	errCreationV2Client = "error creating OpenTelekomCloud NetworkingV2 client: %w"
+	errCreationV1Client = "error creating OpenTelekomCloud NetworkingV1 client: %w"
 )

--- a/opentelekomcloud/services/vpc/data_source_opentelekomcloud_vpc_subnet_v1.go
+++ b/opentelekomcloud/services/vpc/data_source_opentelekomcloud_vpc_subnet_v1.go
@@ -88,7 +88,7 @@ func dataSourceVpcSubnetV1Read(_ context.Context, d *schema.ResourceData, meta i
 	config := meta.(*cfg.Config)
 	client, err := config.NetworkingV1Client(config.GetRegion(d))
 	if err != nil {
-		return fmterr.Errorf("error creating OpenTelekomCloud NetworkingV1 client: %w", err)
+		return fmterr.Errorf(errCreationV1Client, err)
 	}
 
 	listOpts := subnets.ListOpts{
@@ -133,7 +133,7 @@ func dataSourceVpcSubnetV1Read(_ context.Context, d *schema.ResourceData, meta i
 		d.Set("availability_zone", subnet.AvailabilityZone),
 		d.Set("vpc_id", subnet.VpcID),
 		d.Set("subnet_id", subnet.SubnetID),
-		d.Set("network_id", subnet.SubnetID),
+		d.Set("network_id", subnet.NetworkID),
 		d.Set("region", config.GetRegion(d)),
 	)
 	if mErr.ErrorOrNil() != nil {

--- a/releasenotes/notes/d-vpc-subnet-fix-c0bf993a4eb4a533.yaml
+++ b/releasenotes/notes/d-vpc-subnet-fix-c0bf993a4eb4a533.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[VPC]** Fix wrong ``network_id`` setting in ``resource/opentelekomcloud_vpc_subnet_v1`` (`#1341 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1341>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Fix wrong `network_id` setting in `data_source/opentelekomcloud_vpc_subnet_v1`
Fixes: 1334

## PR Checklist

* [x] Refers to: #1334
* [x] Tests added/passed.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccVpcSubnetV1DataSource_basic
--- PASS: TestAccVpcSubnetV1DataSource_basic (90.80s)
PASS

Process finished with the exit code 0
```
