### PR TITLE
[CCE] Fix wrong schema in `d/cce_node_v3`

### DIFF
--- a/docs/data-sources/cce_node_v3.md
+++ b/docs/data-sources/cce_node_v3.md
@@ -40,13 +40,17 @@ All above argument parameters can be exported as attribute parameters along with
 
 * `key_pair` - Key pair name when logging in to select the key pair mode.
 
-* `billing_mode` - Node's billing mode: The value is 0 (on demand).
+* `billing_mode` - Node's billing mode: The value is `0` (on demand).
 
 * `charge_mode` - Bandwidth billing type.
 
-* `bandwidth_size` - Bandwidth (Mbit/s), in the range of [1, 2000].
+* `bandwidth_size` - Bandwidth (Mbit/s), in the range of `[1, 2000]`.
 
-* `extendparam` - Extended parameters.
+* `disk_size` - Root volume disk size in GB.
+
+* `extend_param` - Root volume extended parameters.
+
+* `volume_type` - Root volume disk type.
 
 * `eip_ids` - List of existing elastic IP IDs.
 
@@ -60,18 +64,10 @@ All above argument parameters can be exported as attribute parameters along with
 
 * `share_type` - The bandwidth sharing type.
 
--> **Note:** This parameter is mandatory when share_type is set to PER and is optional when share_type is set to WHOLE with an ID specified.
+* `spec_extend_param` - Extended parameters of the Node.
 
-Enumerated values: PER (indicates exclusive bandwidth) and WHOLE (indicates sharing)
-
-The `root_volumes` block supports the following arguments:
-
-* `disk_size` - Disk size in GB.
-
-* `volumetype` - Disk type.
-
-The `data_volumes` block supports the following arguments:
-
-* `disk_size` - Disk size in GB.
-
-* `volumetype` - Disk type.
+* `data_volumes` - Represents the data disks configuration.
+  * `size` - Disk size in GB.
+  * `volumetype` - Disk type.
+  * `extend_param` - Disk expansion parameters.
+  * `kms_id` - The Encryption KMS ID of the data volume.

--- a/docs/data-sources/cce_node_v3.md
+++ b/docs/data-sources/cce_node_v3.md
@@ -62,8 +62,6 @@ All above argument parameters can be exported as attribute parameters along with
 
 * `share_type` - The bandwidth sharing type.
 
-* `spec_extend_param` - Extended parameters of the Node.
-
 * `data_volumes` - Represents the data disks configuration.
   * `size` - Disk size in GB.
   * `volumetype` - Disk type.

--- a/docs/data-sources/cce_node_v3.md
+++ b/docs/data-sources/cce_node_v3.md
@@ -48,8 +48,6 @@ All above argument parameters can be exported as attribute parameters along with
 
 * `disk_size` - Root volume disk size in GB.
 
-* `extend_param` - Root volume extended parameters.
-
 * `volume_type` - Root volume disk type.
 
 * `eip_ids` - List of existing elastic IP IDs.

--- a/opentelekomcloud/acceptance/cce/data_source_opentelekomcloud_cce_node_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/data_source_opentelekomcloud_cce_node_v3_test.go
@@ -22,6 +22,9 @@ func TestAccCCENodesV3DataSource_basic(t *testing.T) {
 		ProviderFactories: common.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
+				Config: testAccCCENodeV3DataSourceInit(cceName, cceNodeName),
+			},
+			{
 				Config: testAccCCENodeV3DataSourceBasic(cceName, cceNodeName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCCENodeV3DataSourceID(dataSourceName),
@@ -46,6 +49,39 @@ func testAccCheckCCENodeV3DataSourceID(n string) resource.TestCheckFunc {
 
 		return nil
 	}
+}
+
+func testAccCCENodeV3DataSourceInit(cceName string, cceNodeName string) string {
+	return fmt.Sprintf(`
+%s
+
+%s
+
+resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
+  name                   = "%s"
+  cluster_type           = "VirtualMachine"
+  flavor_id              = "cce.s1.small"
+  vpc_id                 = data.opentelekomcloud_vpc_v1.shared_vpc.id
+  subnet_id              = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
+  container_network_type = "overlay_l2"
+}
+
+resource "opentelekomcloud_cce_node_v3" "node_1" {
+  cluster_id        = opentelekomcloud_cce_cluster_v3.cluster_1.id
+  name              = "%s"
+  flavor_id         = "s2.large.2"
+  availability_zone = "%s"
+  key_pair          = "%s"
+  root_volume {
+    size       = 40
+    volumetype = "SATA"
+  }
+  data_volumes {
+    size       = 100
+    volumetype = "SATA"
+  }
+}
+`, common.DataSourceVPC, common.DataSourceSubnet, cceName, cceNodeName, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME)
 }
 
 func testAccCCENodeV3DataSourceBasic(cceName string, cceNodeName string) string {

--- a/opentelekomcloud/acceptance/cce/data_source_opentelekomcloud_cce_node_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/data_source_opentelekomcloud_cce_node_v3_test.go
@@ -28,8 +28,8 @@ func TestAccCCENodesV3DataSource_basic(t *testing.T) {
 				Config: testAccCCENodeV3DataSourceBasic(cceName, cceNodeName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCCENodeV3DataSourceID(dataSourceName),
-					resource.TestCheckResourceAttr(dataSourceName, "name", "test-node"),
-					resource.TestCheckResourceAttr(dataSourceName, "flavor_id", "s1.medium"),
+					resource.TestCheckResourceAttr(dataSourceName, "name", cceNodeName),
+					resource.TestCheckResourceAttr(dataSourceName, "flavor_id", "s2.large.2"),
 				),
 			},
 		},

--- a/opentelekomcloud/services/cce/data_source_opentelekomcloud_cce_node_v3.go
+++ b/opentelekomcloud/services/cce/data_source_opentelekomcloud_cce_node_v3.go
@@ -175,9 +175,9 @@ func DataSourceCceNodesV3() *schema.Resource {
 
 func dataSourceCceNodesV3Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	cceClient, err := config.CceV3Client(config.GetRegion(d))
+	client, err := config.CceV3Client(config.GetRegion(d))
 	if err != nil {
-		return fmterr.Errorf("unable to create opentelekomcloud CCE client : %s", err)
+		return fmterr.Errorf(cceClientError, err)
 	}
 
 	listOpts := nodes.ListOpts{
@@ -198,7 +198,7 @@ func dataSourceCceNodesV3Read(_ context.Context, d *schema.ResourceData, meta in
 		listOpts.Phase = v.(string)
 	}
 
-	refinedNodes, err := nodes.List(cceClient, d.Get("cluster_id").(string), listOpts)
+	refinedNodes, err := nodes.List(client, d.Get("cluster_id").(string), listOpts)
 
 	if err != nil {
 		return fmterr.Errorf("unable to retrieve Nodes: %s", err)

--- a/opentelekomcloud/services/cce/data_source_opentelekomcloud_cce_node_v3.go
+++ b/opentelekomcloud/services/cce/data_source_opentelekomcloud_cce_node_v3.go
@@ -118,7 +118,7 @@ func DataSourceCceNodesV3() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"spec_extend_param": {
-				Type:     schema.TypeString,
+				Type:     schema.TypeMap,
 				Computed: true,
 			},
 			"eip_count": {
@@ -183,6 +183,18 @@ func dataSourceCceNodesV3Read(_ context.Context, d *schema.ResourceData, meta in
 
 	log.Printf("[DEBUG] Retrieved Nodes using given filter %s: %+v", Node.Metadata.Id, Node)
 	d.SetId(Node.Metadata.Id)
+
+	specExtendParam := map[string]interface{}{
+		"charging_mode":        Node.Spec.ExtendParam.ChargingMode,
+		"ecs_performance_type": Node.Spec.ExtendParam.EcsPerformanceType,
+		"order_id":             Node.Spec.ExtendParam.OrderID,
+		"product_id":           Node.Spec.ExtendParam.ProductID,
+		"public_key":           Node.Spec.ExtendParam.PublicKey,
+		"max_pods":             Node.Spec.ExtendParam.MaxPods,
+		"pre_install":          Node.Spec.ExtendParam.PreInstall,
+		"post_install":         Node.Spec.ExtendParam.PostInstall,
+	}
+
 	mErr := multierror.Append(
 		d.Set("node_id", Node.Metadata.Id),
 		d.Set("name", Node.Metadata.Name),
@@ -202,7 +214,7 @@ func dataSourceCceNodesV3Read(_ context.Context, d *schema.ResourceData, meta in
 		d.Set("server_id", Node.Status.ServerID),
 		d.Set("public_ip", Node.Status.PublicIP),
 		d.Set("private_ip", Node.Status.PrivateIP),
-		d.Set("spec_extend_param", Node.Spec.ExtendParam),
+		d.Set("spec_extend_param", specExtendParam),
 		d.Set("eip_count", Node.Spec.PublicIP.Count),
 		d.Set("eip_ids", Node.Spec.PublicIP.Ids),
 	)

--- a/opentelekomcloud/services/cce/data_source_opentelekomcloud_cce_node_v3.go
+++ b/opentelekomcloud/services/cce/data_source_opentelekomcloud_cce_node_v3.go
@@ -118,8 +118,44 @@ func DataSourceCceNodesV3() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"spec_extend_param": {
-				Type:     schema.TypeMap,
+				Type:     schema.TypeList,
 				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"charging_mode": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"ecs_performance_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"order_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"product_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"public_key": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"max_pods": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"pre_install": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"post_install": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
 			},
 			"eip_count": {
 				Type:     schema.TypeInt,
@@ -184,15 +220,17 @@ func dataSourceCceNodesV3Read(_ context.Context, d *schema.ResourceData, meta in
 	log.Printf("[DEBUG] Retrieved Nodes using given filter %s: %+v", Node.Metadata.Id, Node)
 	d.SetId(Node.Metadata.Id)
 
-	specExtendParam := map[string]interface{}{
-		"charging_mode":        Node.Spec.ExtendParam.ChargingMode,
-		"ecs_performance_type": Node.Spec.ExtendParam.EcsPerformanceType,
-		"order_id":             Node.Spec.ExtendParam.OrderID,
-		"product_id":           Node.Spec.ExtendParam.ProductID,
-		"public_key":           Node.Spec.ExtendParam.PublicKey,
-		"max_pods":             Node.Spec.ExtendParam.MaxPods,
-		"pre_install":          Node.Spec.ExtendParam.PreInstall,
-		"post_install":         Node.Spec.ExtendParam.PostInstall,
+	specExtendParam := []map[string]interface{}{
+		{
+			"charging_mode":        Node.Spec.ExtendParam.ChargingMode,
+			"ecs_performance_type": Node.Spec.ExtendParam.EcsPerformanceType,
+			"order_id":             Node.Spec.ExtendParam.OrderID,
+			"product_id":           Node.Spec.ExtendParam.ProductID,
+			"public_key":           Node.Spec.ExtendParam.PublicKey,
+			"max_pods":             Node.Spec.ExtendParam.MaxPods,
+			"pre_install":          Node.Spec.ExtendParam.PreInstall,
+			"post_install":         Node.Spec.ExtendParam.PostInstall,
+		},
 	}
 
 	mErr := multierror.Append(

--- a/opentelekomcloud/services/cce/data_source_opentelekomcloud_cce_node_v3.go
+++ b/opentelekomcloud/services/cce/data_source_opentelekomcloud_cce_node_v3.go
@@ -121,46 +121,6 @@ func DataSourceCceNodesV3() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-			"spec_extend_param": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"charging_mode": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"ecs_performance_type": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"order_id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"product_id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"public_key": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"max_pods": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
-						"pre_install": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"post_install": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-					},
-				},
-			},
 			"eip_count": {
 				Type:     schema.TypeInt,
 				Computed: true,
@@ -226,19 +186,6 @@ func dataSourceCceNodesV3Read(_ context.Context, d *schema.ResourceData, meta in
 	log.Printf("[DEBUG] Retrieved Nodes using given filter %s: %+v", Node.Metadata.Id, Node)
 	d.SetId(Node.Metadata.Id)
 
-	specExtendParam := []map[string]interface{}{
-		{
-			"charging_mode":        Node.Spec.ExtendParam.ChargingMode,
-			"ecs_performance_type": Node.Spec.ExtendParam.EcsPerformanceType,
-			"order_id":             Node.Spec.ExtendParam.OrderID,
-			"product_id":           Node.Spec.ExtendParam.ProductID,
-			"public_key":           Node.Spec.ExtendParam.PublicKey,
-			"max_pods":             Node.Spec.ExtendParam.MaxPods,
-			"pre_install":          Node.Spec.ExtendParam.PreInstall,
-			"post_install":         Node.Spec.ExtendParam.PostInstall,
-		},
-	}
-
 	mErr := multierror.Append(
 		d.Set("node_id", Node.Metadata.Id),
 		d.Set("name", Node.Metadata.Name),
@@ -257,7 +204,6 @@ func dataSourceCceNodesV3Read(_ context.Context, d *schema.ResourceData, meta in
 		d.Set("server_id", Node.Status.ServerID),
 		d.Set("public_ip", Node.Status.PublicIP),
 		d.Set("private_ip", Node.Status.PrivateIP),
-		d.Set("spec_extend_param", specExtendParam),
 		d.Set("eip_count", Node.Spec.PublicIP.Count),
 		d.Set("eip_ids", Node.Spec.PublicIP.Ids),
 	)

--- a/opentelekomcloud/services/cce/data_source_opentelekomcloud_cce_node_v3.go
+++ b/opentelekomcloud/services/cce/data_source_opentelekomcloud_cce_node_v3.go
@@ -72,10 +72,6 @@ func DataSourceCceNodesV3() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"extend_param": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"data_volumes": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -253,7 +249,6 @@ func dataSourceCceNodesV3Read(_ context.Context, d *schema.ResourceData, meta in
 		d.Set("data_volumes", dataVolumes),
 		d.Set("disk_size", Node.Spec.RootVolume.Size),
 		d.Set("volume_type", Node.Spec.RootVolume.VolumeType),
-		d.Set("extend_param", Node.Spec.RootVolume.ExtendParam),
 		d.Set("key_pair", Node.Spec.Login.SshKey),
 		d.Set("charge_mode", Node.Spec.PublicIP.Eip.Bandwidth.ChargeMode),
 		d.Set("bandwidth_size", Node.Spec.PublicIP.Eip.Bandwidth.Size),

--- a/releasenotes/notes/d-cce-node-fix-dd6d5e0996735f22.yaml
+++ b/releasenotes/notes/d-cce-node-fix-dd6d5e0996735f22.yaml
@@ -1,0 +1,7 @@
+---
+enhancements:
+  - |
+    **[CCE]** Add missing fields in ``data_volumes`` schema in ``data_source/opentelekomcloud_cce_node_v3`` (`#1342 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1342>`_)
+fixes:
+  - |
+    **[CCE]** Fix issue with wrong schema of ``spec_extend_param`` in ``data_source/opentelekomcloud_cce_node_v3`` (`#1342 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1342>`_)

--- a/releasenotes/notes/d-cce-node-fix-dd6d5e0996735f22.yaml
+++ b/releasenotes/notes/d-cce-node-fix-dd6d5e0996735f22.yaml
@@ -4,4 +4,6 @@ enhancements:
     **[CCE]** Add missing fields in ``data_volumes`` schema in ``data_source/opentelekomcloud_cce_node_v3`` (`#1342 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1342>`_)
 fixes:
   - |
-    **[CCE]** Fix issue with wrong schema of ``spec_extend_param`` in ``data_source/opentelekomcloud_cce_node_v3`` (`#1342 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1342>`_)
+    **[CCE]** Remove redundant ``spec_extend_param`` in ``data_source/opentelekomcloud_cce_node_v3`` (`#1342 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1342>`_)
+  - |
+    **[CCE]** Remove redundant ``extend_param`` in ``data_source/opentelekomcloud_cce_node_v3`` (`#1342 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1342>`_)


### PR DESCRIPTION
## Summary of the Pull Request
* Add missing fields in schema of `data_source/opentelekomcloud_cce_node_v3`

* Remove `extend_param`, because it's redundant

Fixes: #1335

## PR Checklist

* [x] Refers to: #1335
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccCCENodesV3DataSource_basic
--- PASS: TestAccCCENodesV3DataSource_basic (986.67s)
PASS

Process finished with the exit code 0
```
