### PR TITLE
[CSS] Fix incorrect addressing of `encryption_key`

### DIFF
--- a/opentelekomcloud/services/css/resource_opentelekomcloud_css_cluster_v1.go
+++ b/opentelekomcloud/services/css/resource_opentelekomcloud_css_cluster_v1.go
@@ -234,7 +234,7 @@ func resourceCssClusterV1Create(ctx context.Context, d *schema.ResourceData, met
 	if enable, ok := d.GetOk("enable_https"); ok {
 		opts.HttpsEnabled = fmt.Sprint(enable.(bool))
 	}
-	if cmkID, ok := d.GetOk("node_config.0.volume.encryption_key"); ok {
+	if cmkID, ok := d.GetOk("node_config.0.volume.0.encryption_key"); ok {
 		opts.DiskEncryption = &clusters.DiskEncryption{
 			Encrypted: "1",
 			CmkID:     cmkID.(string),

--- a/releasenotes/notes/css-encryption-6f8b7ff4bf9a860e.yaml
+++ b/releasenotes/notes/css-encryption-6f8b7ff4bf9a860e.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[CSS]** Fix incorrect usage of ``encryption_key`` in ``resource/opentelekomcloud_css_cluster_v1`` (`#1343 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1343>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Fix reading non-existent argument during CSS cluster creation

## PR Checklist

* [x] Refers to: #1337
* [x] Tests added/passed.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccCssClusterV1_encrypted
--- PASS: TestAccCssClusterV1_encrypted (956.49s)
PASS

Process finished with the exit code 0
```
