### PR TITLE
[Acceptance] Get rid of IDs in `RTS`

### DIFF
--- a/opentelekomcloud/acceptance/rts/data_source_opentelekomcloud_rts_software_config_v1_test.go
+++ b/opentelekomcloud/acceptance/rts/data_source_opentelekomcloud_rts_software_config_v1_test.go
@@ -10,17 +10,19 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
 )
 
-func TestAccOTCRtsSoftwareConfigV1DataSource_basic(t *testing.T) {
+const configDataName = "data.opentelekomcloud_rts_software_config_v1.configs"
+
+func TestAccRTSSoftwareConfigV1DataSource_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRtsSoftwareConfigV1DataSource_basic,
+				Config: testAccRtsSoftwareConfigV1DataSourceBasic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRtsSoftwareConfigV1DataSourceID("data.opentelekomcloud_rts_software_config_v1.configs"),
-					resource.TestCheckResourceAttr("data.opentelekomcloud_rts_software_config_v1.configs", "name", "opentelekomcloud-config"),
-					resource.TestCheckResourceAttr("data.opentelekomcloud_rts_software_config_v1.configs", "group", "script"),
+					testAccCheckRtsSoftwareConfigV1DataSourceID(configDataName),
+					resource.TestCheckResourceAttr(configDataName, "name", "opentelekomcloud-config"),
+					resource.TestCheckResourceAttr(configDataName, "group", "script"),
 				),
 			},
 		},
@@ -42,7 +44,7 @@ func testAccCheckRtsSoftwareConfigV1DataSourceID(n string) resource.TestCheckFun
 	}
 }
 
-var testAccRtsSoftwareConfigV1DataSource_basic = `
+const testAccRtsSoftwareConfigV1DataSourceBasic = `
 resource "opentelekomcloud_rts_software_config_v1" "config_1" {
   name = "opentelekomcloud-config"
   output_values = [{

--- a/opentelekomcloud/acceptance/rts/data_source_opentelekomcloud_rts_software_deployment_v1_test.go
+++ b/opentelekomcloud/acceptance/rts/data_source_opentelekomcloud_rts_software_deployment_v1_test.go
@@ -6,20 +6,20 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
-	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
 )
 
-func TestAccOTCRtsSoftwareDeploymentV1DataSource_basic(t *testing.T) {
+func TestAccRTSSoftwareDeploymentV1DataSource_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccOTCRtsSoftwareDeploymentV1DataSource_basic,
+				Config: testAccRTSSoftwareDeploymentV1DataSourceBasic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckOTCRtsSoftwareDeploymentV1DataSourceID("data.opentelekomcloud_rts_software_deployment_v1.deployment_1"),
+					testAccCheckRTSSoftwareDeploymentV1DataSourceID("data.opentelekomcloud_rts_software_deployment_v1.deployment_1"),
 					resource.TestCheckResourceAttr("data.opentelekomcloud_rts_software_deployment_v1.deployment_1", "status_reason", "Deploy data"),
 					resource.TestCheckResourceAttr("data.opentelekomcloud_rts_software_deployment_v1.deployment_1", "action", "CREATE"),
 					resource.TestCheckResourceAttr("data.opentelekomcloud_rts_software_deployment_v1.deployment_1", "status", "COMPLETE"),
@@ -29,7 +29,7 @@ func TestAccOTCRtsSoftwareDeploymentV1DataSource_basic(t *testing.T) {
 	})
 }
 
-func testAccCheckOTCRtsSoftwareDeploymentV1DataSourceID(n string) resource.TestCheckFunc {
+func testAccCheckRTSSoftwareDeploymentV1DataSourceID(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -44,13 +44,16 @@ func testAccCheckOTCRtsSoftwareDeploymentV1DataSourceID(n string) resource.TestC
 	}
 }
 
-var testAccOTCRtsSoftwareDeploymentV1DataSource_basic = fmt.Sprintf(`
+var testAccRTSSoftwareDeploymentV1DataSourceBasic = fmt.Sprintf(`
+%s
+%s
+
 resource "opentelekomcloud_compute_instance_v2" "vm_1" {
   name = "instance_1"
-  image_id = "%s"
+  image_id = data.opentelekomcloud_images_image_v2.latest_image.id
   flavor_id = "%s"
   network {
-    uuid = "%s"
+    uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
 }
 resource "opentelekomcloud_rts_software_config_v1" "config_1" {
@@ -68,4 +71,4 @@ resource "opentelekomcloud_rts_software_deployment_v1" "deployment_1" {
 data "opentelekomcloud_rts_software_deployment_v1" "deployment_1" {
   id = opentelekomcloud_rts_software_deployment_v1.deployment_1.id
  }
-`, env.OS_IMAGE_ID, env.OS_FLAVOR_ID, env.OS_NETWORK_ID)
+`, common.DataSourceSubnet, common.DataSourceImage, env.OsFlavorID)

--- a/opentelekomcloud/acceptance/rts/data_source_opentelekomcloud_rts_stack_resource_v1_test.go
+++ b/opentelekomcloud/acceptance/rts/data_source_opentelekomcloud_rts_stack_resource_v1_test.go
@@ -10,28 +10,27 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
 )
 
-func TestAccOTCRTSStackResourcesV1DataSource_basic(t *testing.T) {
+const resourceDataName = "data.opentelekomcloud_rts_stack_resource_v1.resource_1"
+
+func TestAccRTSStackResourcesV1DataSource_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceOTCRTSStackResourcesV1Config,
+				Config: testAccDataSourceRTSStackResourcesV1Config,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckOTCRTSStackResourcesV1DataSourceID("data.opentelekomcloud_rts_stack_resource_v1.resource_1"),
-					resource.TestCheckResourceAttr(
-						"data.opentelekomcloud_rts_stack_resource_v1.resource_1", "resource_name", "random"),
-					resource.TestCheckResourceAttr(
-						"data.opentelekomcloud_rts_stack_resource_v1.resource_1", "resource_type", "OS::Heat::RandomString"),
-					resource.TestCheckResourceAttr(
-						"data.opentelekomcloud_rts_stack_resource_v1.resource_1", "resource_status", "CREATE_COMPLETE"),
+					testAccCheckRTSStackResourcesV1DataSourceID(resourceDataName),
+					resource.TestCheckResourceAttr(resourceDataName, "resource_name", "random"),
+					resource.TestCheckResourceAttr(resourceDataName, "resource_type", "OS::Heat::RandomString"),
+					resource.TestCheckResourceAttr(resourceDataName, "resource_status", "CREATE_COMPLETE"),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckOTCRTSStackResourcesV1DataSourceID(n string) resource.TestCheckFunc {
+func testAccCheckRTSStackResourcesV1DataSourceID(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -46,7 +45,7 @@ func testAccCheckOTCRTSStackResourcesV1DataSourceID(n string) resource.TestCheck
 	}
 }
 
-const testAccDataSourceOTCRTSStackResourcesV1Config = `
+const testAccDataSourceRTSStackResourcesV1Config = `
 
 resource "opentelekomcloud_rts_stack_v1" "stack_1" {
   name = "opentelekomcloud_rts_stack"

--- a/opentelekomcloud/acceptance/rts/data_source_opentelekomcloud_rts_stack_v1_test.go
+++ b/opentelekomcloud/acceptance/rts/data_source_opentelekomcloud_rts_stack_v1_test.go
@@ -10,26 +10,28 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
 )
 
-func TestAccOTCRTSStackV1DataSource_basic(t *testing.T) {
+const stackDataName = "data.opentelekomcloud_rts_stack_v1.stacks"
+
+func TestAccRTSStackV1DataSource_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccOTCRTSStackV1DataSource_basic,
+				Config: testAccRTSStackV1DataSourceBasic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckOTCRTSStackV1DataSourceID("data.opentelekomcloud_rts_stack_v1.stacks"),
-					resource.TestCheckResourceAttr("data.opentelekomcloud_rts_stack_v1.stacks", "name", "terraform_provider_stack"),
-					resource.TestCheckResourceAttr("data.opentelekomcloud_rts_stack_v1.stacks", "disable_rollback", "true"),
-					resource.TestCheckResourceAttr("data.opentelekomcloud_rts_stack_v1.stacks", "parameters.%", "4"),
-					resource.TestCheckResourceAttr("data.opentelekomcloud_rts_stack_v1.stacks", "status", "CREATE_COMPLETE"),
+					testAccCheckRTSStackV1DataSourceID(stackDataName),
+					resource.TestCheckResourceAttr(stackDataName, "name", "terraform_provider_stack"),
+					resource.TestCheckResourceAttr(stackDataName, "disable_rollback", "true"),
+					resource.TestCheckResourceAttr(stackDataName, "parameters.%", "4"),
+					resource.TestCheckResourceAttr(stackDataName, "status", "CREATE_COMPLETE"),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckOTCRTSStackV1DataSourceID(n string) resource.TestCheckFunc {
+func testAccCheckRTSStackV1DataSourceID(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -44,45 +46,43 @@ func testAccCheckOTCRTSStackV1DataSourceID(n string) resource.TestCheckFunc {
 	}
 }
 
-var testAccOTCRTSStackV1DataSource_basic = `
+var testAccRTSStackV1DataSourceBasic = `
 resource "opentelekomcloud_rts_stack_v1" "stack_1" {
-  name = "terraform_provider_stack"
-  disable_rollback= true
-  timeout_mins=60
-  template_body = <<JSON
-          {
-			"outputs": {
-              "str1": {
-                 "description": "The description of the nat server.",
-                 "value": {
-                   "get_resource": "random"
-                 }
-	          }
-            },
-            "heat_template_version": "2013-05-23",
-            "description": "A HOT template that create a single server and boot from volume.",
-            "parameters": {
-              "key_name": {
-                "type": "string",
-                "description": "Name of existing key pair for the instance to be created.",
-                "default": "KeyPair-click2cloud"
-	          }
-	        },
-            "resources": {
-               "random": {
-                  "type": "OS::Heat::RandomString",
-                  "properties": {
-                  "length": "6"
-                  }
-	          }
-	       }
+  name             = "terraform_provider_stack"
+  disable_rollback = true
+  timeout_mins     = 60
+  template_body    = <<JSON
+{
+  "outputs": {
+    "str1": {
+      "description": "The description of the nat server.",
+      "value": {
+        "get_resource": "random"
+      }
+    }
+  },
+  "heat_template_version": "2013-05-23",
+  "description": "A HOT template that create a single server and boot from volume.",
+  "parameters": {
+    "key_name": {
+      "type": "string",
+      "description": "Name of existing key pair for the instance to be created.",
+      "default": "KeyPair-click2cloud"
+    }
+  },
+  "resources": {
+    "random": {
+      "type": "OS::Heat::RandomString",
+      "properties": {
+        "length": "6"
+      }
+    }
+  }
 }
 JSON
 }
 
 data "opentelekomcloud_rts_stack_v1" "stacks" {
-
-        name = opentelekomcloud_rts_stack_v1.stack_1.name
-
+  name = opentelekomcloud_rts_stack_v1.stack_1.name
 }
 `

--- a/opentelekomcloud/acceptance/rts/import_opentelekomcloud_rts_software_config_v1_test.go
+++ b/opentelekomcloud/acceptance/rts/import_opentelekomcloud_rts_software_config_v1_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
 )
 
-func TestAccOTCRtsSoftwareConfigV1_importBasic(t *testing.T) {
+func TestAccRTSSoftwareConfigV1_importBasic(t *testing.T) {
 	resourceName := "opentelekomcloud_rts_software_config_v1.config_1"
 
 	resource.Test(t, resource.TestCase{
@@ -17,7 +17,7 @@ func TestAccOTCRtsSoftwareConfigV1_importBasic(t *testing.T) {
 		CheckDestroy:      testAccCheckRtsSoftwareConfigV1Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRtsSoftwareConfigV1_basic,
+				Config: testAccRtsSoftwareConfigV1Basic,
 			},
 
 			{

--- a/opentelekomcloud/acceptance/rts/import_opentelekomcloud_rts_software_deployment_v1_test.go
+++ b/opentelekomcloud/acceptance/rts/import_opentelekomcloud_rts_software_deployment_v1_test.go
@@ -8,16 +8,16 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
 )
 
-func TestAccOTCRtsSoftwareDeploymentV1_importBasic(t *testing.T) {
+func TestAccRTSSoftwareDeploymentV1_importBasic(t *testing.T) {
 	resourceName := "opentelekomcloud_rts_software_deployment_v1.deployment_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
-		CheckDestroy:      testAccCheckOTCRtsSoftwareDeploymentV1Destroy,
+		CheckDestroy:      testAccCheckRTSSoftwareDeploymentV1Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRtsSoftwareDeploymentV1_basic,
+				Config: testAccRtsSoftwareDeploymentV1Basic,
 			},
 
 			{

--- a/opentelekomcloud/acceptance/rts/import_opentelekomcloud_rts_stack_v1_test.go
+++ b/opentelekomcloud/acceptance/rts/import_opentelekomcloud_rts_stack_v1_test.go
@@ -8,16 +8,16 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
 )
 
-func TestAccOTCRTSStackV1_importBasic(t *testing.T) {
+func TestAccRTSStackV1_importBasic(t *testing.T) {
 	resourceName := "opentelekomcloud_rts_stack_v1.stack_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
-		CheckDestroy:      testAccCheckOTCRTSStackV1Destroy,
+		CheckDestroy:      testAccCheckRTSStackV1Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRTSStackV1_basic,
+				Config: testAccRTSStackV1Basic,
 			},
 
 			{

--- a/opentelekomcloud/acceptance/rts/resource_opentelekomcloud_rts_software_config_v1_test.go
+++ b/opentelekomcloud/acceptance/rts/resource_opentelekomcloud_rts_software_config_v1_test.go
@@ -14,7 +14,9 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 )
 
-func TestAccOTCRtsSoftwareConfigV1_basic(t *testing.T) {
+const configResourceName = "opentelekomcloud_rts_software_config_v1.config_1"
+
+func TestAccRTSSoftwareConfigV1_basic(t *testing.T) {
 	var config softwareconfig.SoftwareConfig
 
 	resource.Test(t, resource.TestCase{
@@ -23,20 +25,18 @@ func TestAccOTCRtsSoftwareConfigV1_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckRtsSoftwareConfigV1Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRtsSoftwareConfigV1_basic,
+				Config: testAccRtsSoftwareConfigV1Basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRtsSoftwareConfigV1Exists("opentelekomcloud_rts_software_config_v1.config_1", &config),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_rts_software_config_v1.config_1", "name", "opentelekomcloud-config"),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_rts_software_config_v1.config_1", "group", "script"),
+					testAccCheckRtsSoftwareConfigV1Exists(configResourceName, &config),
+					resource.TestCheckResourceAttr(configResourceName, "name", "opentelekomcloud-config"),
+					resource.TestCheckResourceAttr(configResourceName, "group", "script"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccOTCRtsSoftwareConfigV1_timeout(t *testing.T) {
+func TestAccRTSSoftwareConfigV1_timeout(t *testing.T) {
 	var config softwareconfig.SoftwareConfig
 
 	resource.Test(t, resource.TestCase{
@@ -45,9 +45,9 @@ func TestAccOTCRtsSoftwareConfigV1_timeout(t *testing.T) {
 		CheckDestroy:      testAccCheckRtsSoftwareConfigV1Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRtsSoftwareConfigV1_timeout,
+				Config: testAccRtsSoftwareConfigV1Timeout,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRtsSoftwareConfigV1Exists("opentelekomcloud_rts_software_config_v1.config_1", &config),
+					testAccCheckRtsSoftwareConfigV1Exists(configResourceName, &config),
 				),
 			},
 		},
@@ -107,7 +107,8 @@ func testAccCheckRtsSoftwareConfigV1Exists(n string, configs *softwareconfig.Sof
 	}
 }
 
-const testAccRtsSoftwareConfigV1_basic = `
+const (
+	testAccRtsSoftwareConfigV1Basic = `
 resource "opentelekomcloud_rts_software_config_v1" "config_1" {
   name = "opentelekomcloud-config"
   output_values = [{
@@ -125,8 +126,7 @@ resource "opentelekomcloud_rts_software_config_v1" "config_1" {
   group = "script"
 }
 `
-
-const testAccRtsSoftwareConfigV1_timeout = `
+	testAccRtsSoftwareConfigV1Timeout = `
 resource "opentelekomcloud_rts_software_config_v1" "config_1" {
   name = "opentelekomcloud-config"
   output_values = [{
@@ -148,3 +148,4 @@ resource "opentelekomcloud_rts_software_config_v1" "config_1" {
   }
 }
 `
+)

--- a/opentelekomcloud/acceptance/rts/resource_opentelekomcloud_rts_stack_v1_test.go
+++ b/opentelekomcloud/acceptance/rts/resource_opentelekomcloud_rts_stack_v1_test.go
@@ -14,63 +14,58 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 )
 
-func TestAccOTCRTSStackV1_basic(t *testing.T) {
-	var stacks stacks.RetrievedStack
+const stackResourceName = "opentelekomcloud_rts_stack_v1.stack_1"
+
+func TestAccRTSStackV1_basic(t *testing.T) {
+	var stack stacks.RetrievedStack
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
-		CheckDestroy:      testAccCheckOTCRTSStackV1Destroy,
+		CheckDestroy:      testAccCheckRTSStackV1Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRTSStackV1_basic,
+				Config: testAccRTSStackV1Basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckOTCRTSStackV1Exists("opentelekomcloud_rts_stack_v1.stack_1", &stacks),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_rts_stack_v1.stack_1", "name", "terraform_provider_stack"),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_rts_stack_v1.stack_1", "status", "CREATE_COMPLETE"),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_rts_stack_v1.stack_1", "disable_rollback", "true"),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_rts_stack_v1.stack_1", "timeout_mins", "60"),
+					testAccCheckRTSStackV1Exists(stackResourceName, &stack),
+					resource.TestCheckResourceAttr(stackResourceName, "name", "terraform_provider_stack"),
+					resource.TestCheckResourceAttr(stackResourceName, "status", "CREATE_COMPLETE"),
+					resource.TestCheckResourceAttr(stackResourceName, "disable_rollback", "true"),
+					resource.TestCheckResourceAttr(stackResourceName, "timeout_mins", "60"),
 				),
 			},
 			{
-				Config: testAccRTSStackV1_update,
+				Config: testAccRTSStackV1Update,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckOTCRTSStackV1Exists("opentelekomcloud_rts_stack_v1.stack_1", &stacks),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_rts_stack_v1.stack_1", "disable_rollback", "false"),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_rts_stack_v1.stack_1", "timeout_mins", "50"),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_rts_stack_v1.stack_1", "status", "UPDATE_COMPLETE"),
+					testAccCheckRTSStackV1Exists(stackResourceName, &stack),
+					resource.TestCheckResourceAttr(stackResourceName, "disable_rollback", "false"),
+					resource.TestCheckResourceAttr(stackResourceName, "timeout_mins", "50"),
+					resource.TestCheckResourceAttr(stackResourceName, "status", "UPDATE_COMPLETE"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccOTCRTSStackV1_timeout(t *testing.T) {
-	var stacks stacks.RetrievedStack
+func TestAccRTSStackV1_timeout(t *testing.T) {
+	var stack stacks.RetrievedStack
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
-		CheckDestroy:      testAccCheckOTCRTSStackV1Destroy,
+		CheckDestroy:      testAccCheckRTSStackV1Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRTSStackV1_timeout,
+				Config: testAccRTSStackV1Timeout,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckOTCRTSStackV1Exists("opentelekomcloud_rts_stack_v1.stack_1", &stacks),
+					testAccCheckRTSStackV1Exists(stackResourceName, &stack),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckOTCRTSStackV1Destroy(s *terraform.State) error {
+func testAccCheckRTSStackV1Destroy(s *terraform.State) error {
 	config := common.TestAccProvider.Meta().(*cfg.Config)
 	orchestrationClient, err := config.OrchestrationV1Client(env.OS_REGION_NAME)
 	if err != nil {
@@ -94,7 +89,7 @@ func testAccCheckOTCRTSStackV1Destroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckOTCRTSStackV1Exists(n string, stack *stacks.RetrievedStack) resource.TestCheckFunc {
+func testAccCheckRTSStackV1Exists(n string, stack *stacks.RetrievedStack) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -126,7 +121,8 @@ func testAccCheckOTCRTSStackV1Exists(n string, stack *stacks.RetrievedStack) res
 	}
 }
 
-const testAccRTSStackV1_basic = `
+const (
+	testAccRTSStackV1Basic = `
 resource "opentelekomcloud_rts_stack_v1" "stack_1" {
   name = "terraform_provider_stack"
   disable_rollback= true
@@ -146,7 +142,7 @@ resource "opentelekomcloud_rts_stack_v1" "stack_1" {
     "parameters": {
       "key_name": {
         "type": "string",
-  		"default": "keysclick",
+        "default": "keysclick",
         "description": "Name of existing key pair for the instance to be created."
       }
     },
@@ -163,8 +159,7 @@ JSON
 
 }
 `
-
-const testAccRTSStackV1_update = `
+	testAccRTSStackV1Update = `
 resource "opentelekomcloud_rts_stack_v1" "stack_1" {
   name = "terraform_provider_stack"
   disable_rollback= false
@@ -184,7 +179,7 @@ resource "opentelekomcloud_rts_stack_v1" "stack_1" {
     "parameters": {
       "key_name": {
         "type": "string",
-  		"default": "keysclick",
+        "default": "keysclick",
         "description": "Name of existing key pair for the instance to be created."
       }
     },
@@ -201,7 +196,7 @@ JSON
 
 }
 `
-const testAccRTSStackV1_timeout = `
+	testAccRTSStackV1Timeout = `
 resource "opentelekomcloud_rts_stack_v1" "stack_1" {
   name = "terraform_provider_stack"
   disable_rollback= true
@@ -222,7 +217,7 @@ resource "opentelekomcloud_rts_stack_v1" "stack_1" {
     "parameters": {
       "key_name": {
         "type": "string",
-  		"default": "keysclick",
+        "default": "keysclick",
         "description": "Name of existing key pair for the instance to be created."
       }
     },
@@ -243,3 +238,4 @@ JSON
   }
 }
 `
+)


### PR DESCRIPTION
## Summary of the Pull Request
Replace usages of `OS_IMAGE_ID` and `OS_NETWORK_ID` with data sources

Replace `OS_FLAVOR_ID` with `OsFlavorID`

Minor tests style fixup


## PR Checklist

* [x] Refers to: #1320
* [x] Tests added/passed.

## Acceptance Steps Performed

```
=== RUN   TestAccRTSSoftwareConfigV1DataSource_basic
--- PASS: TestAccRTSSoftwareConfigV1DataSource_basic (16.64s)
=== RUN   TestAccRTSSoftwareDeploymentV1DataSource_basic
--- PASS: TestAccRTSSoftwareDeploymentV1DataSource_basic (66.92s)
=== RUN   TestAccRTSStackResourcesV1DataSource_basic
--- PASS: TestAccRTSStackResourcesV1DataSource_basic (44.62s)
=== RUN   TestAccRTSStackV1DataSource_basic
--- PASS: TestAccRTSStackV1DataSource_basic (35.18s)
=== RUN   TestAccRTSSoftwareConfigV1_importBasic
--- PASS: TestAccRTSSoftwareConfigV1_importBasic (13.11s)
=== RUN   TestAccRTSSoftwareDeploymentV1_importBasic
--- PASS: TestAccRTSSoftwareDeploymentV1_importBasic (61.45s)
=== RUN   TestAccRTSStackV1_importBasic
--- PASS: TestAccRTSStackV1_importBasic (32.23s)
=== RUN   TestAccRTSSoftwareConfigV1_basic
--- PASS: TestAccRTSSoftwareConfigV1_basic (11.25s)
=== RUN   TestAccRTSSoftwareConfigV1_timeout
--- PASS: TestAccRTSSoftwareConfigV1_timeout (12.74s)
=== RUN   TestAccRTSSoftwareDeploymentV1_basic
--- PASS: TestAccRTSSoftwareDeploymentV1_basic (90.48s)
=== RUN   TestAccRTSSoftwareDeploymentV1_timeout
--- PASS: TestAccRTSSoftwareDeploymentV1_timeout (71.65s)
=== RUN   TestAccRTSStackV1_basic
--- PASS: TestAccRTSStackV1_basic (50.51s)
=== RUN   TestAccRTSStackV1_timeout
--- PASS: TestAccRTSStackV1_timeout (31.28s)
PASS
ok  	github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/rts	539.349s

Process finished with the exit code 0
```
