### PR TITLE
[Acceptance] Get rid IDs in `RDS`

### DIFF
--- a/opentelekomcloud/acceptance/rds/data_source_opentelekomcloud_rds_flavors_v1_test.go
+++ b/opentelekomcloud/acceptance/rds/data_source_opentelekomcloud_rds_flavors_v1_test.go
@@ -11,21 +11,20 @@ import (
 	vpc "github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/vpc"
 )
 
+const flavorDataName = "data.opentelekomcloud_rds_flavors_v1.flavor"
+
 func TestAccOpenTelekomCloudRdsFlavorV1DataSource_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccOpenTelekomCloudRdsFlavorV1DataSource_basic,
+				Config: testAccOpenTelekomCloudRdsFlavorV1DataSourceBasic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRdsFlavorV1DataSourceID("data.opentelekomcloud_rds_flavors_v1.flavor"),
-					resource.TestCheckResourceAttrSet(
-						"data.opentelekomcloud_rds_flavors_v1.flavor", "name"),
-					resource.TestCheckResourceAttrSet(
-						"data.opentelekomcloud_rds_flavors_v1.flavor", "id"),
-					resource.TestCheckResourceAttrSet(
-						"data.opentelekomcloud_rds_flavors_v1.flavor", "speccode"),
+					testAccCheckRdsFlavorV1DataSourceID(flavorDataName),
+					resource.TestCheckResourceAttrSet(flavorDataName, "name"),
+					resource.TestCheckResourceAttrSet(flavorDataName, "id"),
+					resource.TestCheckResourceAttrSet(flavorDataName, "speccode"),
 				),
 			},
 		},
@@ -38,13 +37,11 @@ func TestAccOpenTelekomCloudRdsFlavorV1DataSource_speccode(t *testing.T) {
 		ProviderFactories: common.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccOpenTelekomCloudRdsFlavorV1DataSource_speccode,
+				Config: testAccOpenTelekomCloudRdsFlavorV1DataSourceSpeccode,
 				Check: resource.ComposeTestCheckFunc(
-					vpc.TestAccCheckNetworkingNetworkV2DataSourceID("data.opentelekomcloud_rds_flavors_v1.flavor"),
-					resource.TestCheckResourceAttr(
-						"data.opentelekomcloud_rds_flavors_v1.flavor", "name", "OTC_PGCM_XLARGE"),
-					resource.TestCheckResourceAttr(
-						"data.opentelekomcloud_rds_flavors_v1.flavor", "speccode", "rds.pg.s1.xlarge"),
+					vpc.TestAccCheckNetworkingNetworkV2DataSourceID(flavorDataName),
+					resource.TestCheckResourceAttr(flavorDataName, "name", "OTC_PGCM_XLARGE"),
+					resource.TestCheckResourceAttr(flavorDataName, "speccode", "rds.pg.s1.xlarge"),
 				),
 			},
 		},
@@ -66,21 +63,19 @@ func testAccCheckRdsFlavorV1DataSourceID(n string) resource.TestCheckFunc {
 	}
 }
 
-var testAccOpenTelekomCloudRdsFlavorV1DataSource_basic = `
-
+const testAccOpenTelekomCloudRdsFlavorV1DataSourceBasic = `
 data "opentelekomcloud_rds_flavors_v1" "flavor" {
-    region = "eu-de"
-	datastore_name = "PostgreSQL"
-    datastore_version = "9.5.5"
+  region            = "eu-de"
+  datastore_name    = "PostgreSQL"
+  datastore_version = "9.5.5"
 }
 `
 
-var testAccOpenTelekomCloudRdsFlavorV1DataSource_speccode = `
-
+const testAccOpenTelekomCloudRdsFlavorV1DataSourceSpeccode = `
 data "opentelekomcloud_rds_flavors_v1" "flavor" {
-    region = "eu-de"
-	datastore_name = "PostgreSQL"
-    datastore_version = "9.5.5"
-    speccode = "rds.pg.s1.xlarge"
+  region            = "eu-de"
+  datastore_name    = "PostgreSQL"
+  datastore_version = "9.5.5"
+  speccode          = "rds.pg.s1.xlarge"
 }
 `

--- a/opentelekomcloud/acceptance/rds/data_source_opentelekomcloud_rds_flavors_v3_test.go
+++ b/opentelekomcloud/acceptance/rds/data_source_opentelekomcloud_rds_flavors_v3_test.go
@@ -16,7 +16,7 @@ func TestAccOpenTelekomCloudRdsFlavorV3DataSource_basic(t *testing.T) {
 		ProviderFactories: common.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccOpenTelekomCloudRdsFlavorV3DataSource_basic,
+				Config: testAccOpenTelekomCloudRdsFlavorV3DataSourceBasic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRdsFlavorV3DataSourceID("data.opentelekomcloud_rds_flavors_v3.flavor"),
 				),
@@ -40,7 +40,7 @@ func testAccCheckRdsFlavorV3DataSourceID(n string) resource.TestCheckFunc {
 	}
 }
 
-var testAccOpenTelekomCloudRdsFlavorV3DataSource_basic = `
+const testAccOpenTelekomCloudRdsFlavorV3DataSourceBasic = `
 
 data "opentelekomcloud_rds_flavors_v3" "flavor" {
   db_type = "PostgreSQL"

--- a/opentelekomcloud/acceptance/rds/data_source_opentelekomcloud_rds_versions_v3_test.go
+++ b/opentelekomcloud/acceptance/rds/data_source_opentelekomcloud_rds_versions_v3_test.go
@@ -14,7 +14,7 @@ func TestRDSVersionsV3_basic(t *testing.T) {
 		ProviderFactories: common.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testRDSVersionsV3_basic,
+				Config: testRDSVersionsV3Basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRdsFlavorV3DataSourceID("data.opentelekomcloud_rds_versions_v3.sqls_versions"),
 					testAccCheckRdsFlavorV3DataSourceID("data.opentelekomcloud_rds_versions_v3.mysql_versions"),
@@ -25,7 +25,7 @@ func TestRDSVersionsV3_basic(t *testing.T) {
 	})
 }
 
-var testRDSVersionsV3_basic = `
+const testRDSVersionsV3Basic = `
 data "opentelekomcloud_rds_versions_v3" "sqls_versions" {
   database_name = "sqlserver"
 }

--- a/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v1_test.go
+++ b/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v1_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 )
 
+const instanceV1ResourceName = "opentelekomcloud_rds_instance_v1.instance"
+
 func TestAccRDSV1Instance_basic(t *testing.T) {
 	var instance instances.Instance
 
@@ -25,13 +27,10 @@ func TestAccRDSV1Instance_basic(t *testing.T) {
 			{
 				Config: testAccSInstanceV1ConfigBasic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRDSV1InstanceExists("opentelekomcloud_rds_instance_v1.instance", &instance),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_rds_instance_v1.instance", "status", "ACTIVE"),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_rds_instance_v1.instance", "region", "eu-de"),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_rds_instance_v1.instance", "availabilityzone", "eu-de-01"),
+					testAccCheckRDSV1InstanceExists(instanceV1ResourceName, &instance),
+					resource.TestCheckResourceAttr(instanceV1ResourceName, "status", "ACTIVE"),
+					resource.TestCheckResourceAttr(instanceV1ResourceName, "region", "eu-de"),
+					resource.TestCheckResourceAttr(instanceV1ResourceName, "availabilityzone", "eu-de-01"),
 					testAccCheckRDSV1InstanceTag(&instance, "foo", "bar"),
 					testAccCheckRDSV1InstanceTag(&instance, "key", "value"),
 				),
@@ -39,7 +38,7 @@ func TestAccRDSV1Instance_basic(t *testing.T) {
 			{
 				Config: testAccSInstanceV1ConfigUpdatetag,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRDSV1InstanceExists("opentelekomcloud_rds_instance_v1.instance", &instance),
+					testAccCheckRDSV1InstanceExists(instanceV1ResourceName, &instance),
 					testAccCheckRDSV1InstanceTag(&instance, "foo2", "bar2"),
 					testAccCheckRDSV1InstanceTag(&instance, "key", "value2"),
 				),
@@ -47,14 +46,14 @@ func TestAccRDSV1Instance_basic(t *testing.T) {
 			{
 				Config: testAccSInstanceV1ConfigNoTags,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRDSV1InstanceExists("opentelekomcloud_rds_instance_v1.instance", &instance),
+					testAccCheckRDSV1InstanceExists(instanceV1ResourceName, &instance),
 					testAccCheckRDSV1InstanceNoTag(&instance),
 				),
 			},
 			{
 				Config: testAccSInstanceV1ConfigBasic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRDSV1InstanceExists("opentelekomcloud_rds_instance_v1.instance", &instance),
+					testAccCheckRDSV1InstanceExists(instanceV1ResourceName, &instance),
 					testAccCheckRDSV1InstanceTag(&instance, "foo", "bar"),
 					testAccCheckRDSV1InstanceTag(&instance, "key", "value"),
 				),
@@ -171,6 +170,9 @@ func testAccCheckRDSV1InstanceNoTag(
 }
 
 var testAccSInstanceV1ConfigBasic = fmt.Sprintf(`
+%s
+%s
+
 data "opentelekomcloud_rds_flavors_v1" "flavor" {
     region = "eu-de"
     datastore_name = "PostgreSQL"
@@ -195,9 +197,9 @@ resource "opentelekomcloud_rds_instance_v1" "instance" {
   }
   region = "eu-de"
   availabilityzone = "eu-de-01"
-  vpc = "%s"
+  vpc = data.opentelekomcloud_vpc_v1.shared_vpc.id
   nics {
-    subnetid = "%s"
+    subnetid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
   }
   securitygroup {
     id = opentelekomcloud_networking_secgroup_v2.sg.id
@@ -217,9 +219,12 @@ resource "opentelekomcloud_rds_instance_v1" "instance" {
     key = "value"
   }
   depends_on = ["opentelekomcloud_networking_secgroup_v2.sg"]
-}`, env.OS_VPC_ID, env.OS_NETWORK_ID)
+}`, common.DataSourceVPC, common.DataSourceSubnet)
 
 var testAccSInstanceV1ConfigUpdatetag = fmt.Sprintf(`
+%s
+%s
+
 data "opentelekomcloud_rds_flavors_v1" "flavor" {
     region = "eu-de"
     datastore_name = "PostgreSQL"
@@ -244,9 +249,9 @@ resource "opentelekomcloud_rds_instance_v1" "instance" {
   }
   region = "eu-de"
   availabilityzone = "eu-de-01"
-  vpc = "%s"
+  vpc = data.opentelekomcloud_vpc_v1.shared_vpc.id
   nics {
-    subnetid = "%s"
+    subnetid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
   }
   securitygroup {
     id = opentelekomcloud_networking_secgroup_v2.sg.id
@@ -266,9 +271,12 @@ resource "opentelekomcloud_rds_instance_v1" "instance" {
     key = "value2"
   }
   depends_on = ["opentelekomcloud_networking_secgroup_v2.sg"]
-}`, env.OS_VPC_ID, env.OS_NETWORK_ID)
+}`, common.DataSourceVPC, common.DataSourceSubnet)
 
 var testAccSInstanceV1ConfigNoTags = fmt.Sprintf(`
+%s
+%s
+
 data "opentelekomcloud_rds_flavors_v1" "flavor" {
     region = "eu-de"
     datastore_name = "PostgreSQL"
@@ -293,9 +301,9 @@ resource "opentelekomcloud_rds_instance_v1" "instance" {
   }
   region = "eu-de"
   availabilityzone = "eu-de-01"
-  vpc = "%s"
+  vpc = data.opentelekomcloud_vpc_v1.shared_vpc.id
   nics {
-    subnetid = "%s"
+    subnetid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
   }
   securitygroup {
     id = opentelekomcloud_networking_secgroup_v2.sg.id
@@ -311,4 +319,4 @@ resource "opentelekomcloud_rds_instance_v1" "instance" {
     replicationmode = "async"
   }
   depends_on = ["opentelekomcloud_networking_secgroup_v2.sg"]
-}`, env.OS_VPC_ID, env.OS_NETWORK_ID)
+}`, common.DataSourceVPC, common.DataSourceSubnet)

--- a/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
+++ b/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/services/rds"
 )
 
-const resourceName = "opentelekomcloud_rds_instance_v3.instance"
+const instanceV3ResourceName = "opentelekomcloud_rds_instance_v3.instance"
 
 func TestAccRdsInstanceV3Basic(t *testing.T) {
 	postfix := acctest.RandString(3)
@@ -32,23 +32,23 @@ func TestAccRdsInstanceV3Basic(t *testing.T) {
 			{
 				Config: testAccRdsInstanceV3Basic(postfix),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRdsInstanceV3Exists(resourceName, &rdsInstance),
-					resource.TestCheckResourceAttr(resourceName, "flavor", "rds.pg.c2.medium"),
-					resource.TestCheckResourceAttr(resourceName, "db.0.port", "8635"),
-					resource.TestCheckResourceAttr(resourceName, "name", "tf_rds_instance_"+postfix),
-					resource.TestCheckResourceAttr(resourceName, "db.0.type", "PostgreSQL"),
-					resource.TestCheckResourceAttr(resourceName, "volume.0.size", "40"),
-					resource.TestCheckResourceAttr(resourceName, "backup_strategy.0.keep_days", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.muh", "value-create"),
-					resource.TestCheckResourceAttr(resourceName, "tags.kuh", "value-create"),
+					testAccCheckRdsInstanceV3Exists(instanceV3ResourceName, &rdsInstance),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "flavor", "rds.pg.c2.medium"),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "db.0.port", "8635"),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "name", "tf_rds_instance_"+postfix),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "db.0.type", "PostgreSQL"),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "volume.0.size", "40"),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "backup_strategy.0.keep_days", "1"),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "tags.muh", "value-create"),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "tags.kuh", "value-create"),
 				),
 			},
 			{
 				Config: testAccRdsInstanceV3Update(postfix),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "flavor", "rds.pg.c2.large"),
-					resource.TestCheckResourceAttr(resourceName, "volume.0.size", "100"),
-					resource.TestCheckResourceAttr(resourceName, "tags.muh", "value-update"),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "flavor", "rds.pg.c2.large"),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "volume.0.size", "100"),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "tags.muh", "value-update"),
 				),
 			},
 		},
@@ -67,17 +67,17 @@ func TestAccRdsInstanceV3ElasticIP(t *testing.T) {
 			{
 				Config: testAccRdsInstanceV3ElasticIP(postfix),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRdsInstanceV3Exists(resourceName, &rdsInstance),
-					resource.TestCheckResourceAttr(resourceName, "name", "tf_rds_instance_"+postfix),
-					resource.TestCheckResourceAttr(resourceName, "db.0.version", "10"),
-					resource.TestCheckResourceAttr(resourceName, "public_ips.#", "1"),
+					testAccCheckRdsInstanceV3Exists(instanceV3ResourceName, &rdsInstance),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "name", "tf_rds_instance_"+postfix),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "db.0.version", "10"),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "public_ips.#", "1"),
 				),
 			},
 			{
 				Config: testAccRdsInstanceV3Basic(postfix),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "db.0.version", "10"),
-					resource.TestCheckResourceAttr(resourceName, "public_ips.#", "0"),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "db.0.version", "10"),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "public_ips.#", "0"),
 				),
 			},
 		},
@@ -101,11 +101,11 @@ func TestAccRdsInstanceV3HA(t *testing.T) {
 			{
 				Config: testAccRdsInstanceV3HA(postfix, availabilityZone2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRdsInstanceV3Exists(resourceName, &rdsInstance),
-					resource.TestCheckResourceAttr(resourceName, "name", "tf_rds_instance_"+postfix),
-					resource.TestCheckResourceAttr(resourceName, "ha_replication_mode", "semisync"),
-					resource.TestCheckResourceAttr(resourceName, "volume.0.type", "ULTRAHIGH"),
-					resource.TestCheckResourceAttr(resourceName, "db.0.type", "MySQL"),
+					testAccCheckRdsInstanceV3Exists(instanceV3ResourceName, &rdsInstance),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "name", "tf_rds_instance_"+postfix),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "ha_replication_mode", "semisync"),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "volume.0.type", "ULTRAHIGH"),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "db.0.type", "MySQL"),
 				),
 			},
 		},
@@ -124,8 +124,8 @@ func TestAccRdsInstanceV3OptionalParams(t *testing.T) {
 			{
 				Config: testAccRdsInstanceV3OptionalParams(postfix),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRdsInstanceV3Exists(resourceName, &rdsInstance),
-					resource.TestCheckResourceAttr(resourceName, "name", "tf_rds_instance_"+postfix),
+					testAccCheckRdsInstanceV3Exists(instanceV3ResourceName, &rdsInstance),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "name", "tf_rds_instance_"+postfix),
 				),
 			},
 		},
@@ -144,8 +144,8 @@ func TestAccRdsInstanceV3Backup(t *testing.T) {
 			{
 				Config: testAccRdsInstanceV3Backup(postfix),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRdsInstanceV3Exists(resourceName, &rdsInstance),
-					resource.TestCheckResourceAttr(resourceName, "name", "tf_rds_instance_"+postfix),
+					testAccCheckRdsInstanceV3Exists(instanceV3ResourceName, &rdsInstance),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "name", "tf_rds_instance_"+postfix),
 				),
 			},
 		},
@@ -164,15 +164,15 @@ func TestAccRdsInstanceV3TemplateConfig(t *testing.T) {
 			{
 				Config: testAccRdsInstanceV3ConfigTemplateBasic(postfix),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRdsInstanceV3Exists(resourceName, &rdsInstance),
-					resource.TestCheckResourceAttr(resourceName, "name", "tf_rds_instance_"+postfix),
+					testAccCheckRdsInstanceV3Exists(instanceV3ResourceName, &rdsInstance),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "name", "tf_rds_instance_"+postfix),
 				),
 			},
 			{
 				Config: testAccRdsInstanceV3ConfigTemplateUpdate(postfix),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRdsInstanceV3Exists(resourceName, &rdsInstance),
-					resource.TestCheckResourceAttr(resourceName, "name", "tf_rds_instance_"+postfix),
+					testAccCheckRdsInstanceV3Exists(instanceV3ResourceName, &rdsInstance),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "name", "tf_rds_instance_"+postfix),
 				),
 			},
 		},
@@ -208,8 +208,8 @@ func TestAccRdsInstanceV3_configurationParameters(t *testing.T) {
 			{
 				Config: testAccRdsInstanceV3ConfigurationOverride(postfix),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRdsInstanceV3Exists(resourceName, &rdsInstance),
-					resource.TestCheckResourceAttr(resourceName, "parameters.max_connections", "37"),
+					testAccCheckRdsInstanceV3Exists(instanceV3ResourceName, &rdsInstance),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "parameters.max_connections", "37"),
 				),
 			},
 		},
@@ -268,6 +268,9 @@ func testAccCheckRdsInstanceV3Exists(n string, rdsInstance *instances.RdsInstanc
 
 func testAccRdsInstanceV3Basic(postfix string) string {
 	return fmt.Sprintf(`
+%s
+%s
+
 resource "opentelekomcloud_networking_secgroup_v2" "sg" {
   name = "sg-rds-test"
 }
@@ -282,8 +285,8 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
     port     = "8635"
   }
   security_group_id = opentelekomcloud_networking_secgroup_v2.sg.id
-  subnet_id         = "%s"
-  vpc_id            = "%s"
+  subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
+  vpc_id            = data.opentelekomcloud_vpc_v1.shared_vpc.id
   volume {
     type = "COMMON"
     size = 40
@@ -298,11 +301,14 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
     kuh = "value-create"
   }
 }
-`, postfix, env.OS_AVAILABILITY_ZONE, env.OS_NETWORK_ID, env.OS_VPC_ID)
+`, common.DataSourceVPC, common.DataSourceSubnet, postfix, env.OS_AVAILABILITY_ZONE)
 }
 
 func testAccRdsInstanceV3Update(postfix string) string {
 	return fmt.Sprintf(`
+%s
+%s
+
 resource opentelekomcloud_networking_secgroup_v2 sg {
   name = "sg-rds-test"
 }
@@ -317,8 +323,8 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
     port     = "8635"
   }
   security_group_id = opentelekomcloud_networking_secgroup_v2.sg.id
-  subnet_id         = "%s"
-  vpc_id            = "%s"
+  subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
+  vpc_id            = data.opentelekomcloud_vpc_v1.shared_vpc.id
   volume {
     type = "COMMON"
     size = 100
@@ -332,11 +338,14 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
     muh = "value-update"
   }
 }
-`, postfix, env.OS_AVAILABILITY_ZONE, env.OS_NETWORK_ID, env.OS_VPC_ID)
+`, common.DataSourceVPC, common.DataSourceSubnet, postfix, env.OS_AVAILABILITY_ZONE)
 }
 
 func testAccRdsInstanceV3ElasticIP(postfix string) string {
 	return fmt.Sprintf(`
+%s
+%s
+
 resource "opentelekomcloud_networking_floatingip_v2" "fip_1" {}
 
 resource "opentelekomcloud_networking_secgroup_v2" "sg" {
@@ -353,8 +362,8 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
     port     = "8635"
   }
   security_group_id = opentelekomcloud_networking_secgroup_v2.sg.id
-  subnet_id         = "%s"
-  vpc_id            = "%s"
+  subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
+  vpc_id            = data.opentelekomcloud_vpc_v1.shared_vpc.id
   volume {
     type = "COMMON"
     size = 40
@@ -367,11 +376,14 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
 
   public_ips = [opentelekomcloud_networking_floatingip_v2.fip_1.address]
 }
-`, postfix, env.OS_AVAILABILITY_ZONE, env.OS_NETWORK_ID, env.OS_VPC_ID)
+`, common.DataSourceVPC, common.DataSourceSubnet, postfix, env.OS_AVAILABILITY_ZONE)
 }
 
 func testAccRdsInstanceV3HA(postfix string, az2 string) string {
 	return fmt.Sprintf(`
+%s
+%s
+
 resource "opentelekomcloud_networking_secgroup_v2" "sg" {
   name = "sg-rds-test"
 }
@@ -386,8 +398,8 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
     port     = "8635"
   }
   security_group_id = opentelekomcloud_networking_secgroup_v2.sg.id
-  subnet_id         = "%s"
-  vpc_id            = "%s"
+  subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
+  vpc_id            = data.opentelekomcloud_vpc_v1.shared_vpc.id
   volume {
     type = "ULTRAHIGH"
     size = 100
@@ -399,11 +411,14 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
   }
   ha_replication_mode = "semisync"
 }
-`, postfix, env.OS_AVAILABILITY_ZONE, az2, env.OS_NETWORK_ID, env.OS_VPC_ID)
+`, common.DataSourceVPC, common.DataSourceSubnet, postfix, env.OS_AVAILABILITY_ZONE, az2)
 }
 
 func testAccRdsInstanceV3OptionalParams(postfix string) string {
 	return fmt.Sprintf(`
+%s
+%s
+
 resource "opentelekomcloud_networking_secgroup_v2" "sg" {
   name = "sg-rds-test"
 }
@@ -417,19 +432,22 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
     version  = "10"
   }
   security_group_id = opentelekomcloud_networking_secgroup_v2.sg.id
-  subnet_id         = "%s"
-  vpc_id            = "%s"
+  subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
+  vpc_id            = data.opentelekomcloud_vpc_v1.shared_vpc.id
   volume {
     type = "COMMON"
     size = 100
   }
   flavor = "rds.pg.c2.medium"
 }
-`, postfix, env.OS_AVAILABILITY_ZONE, env.OS_NETWORK_ID, env.OS_VPC_ID)
+`, common.DataSourceVPC, common.DataSourceSubnet, postfix, env.OS_AVAILABILITY_ZONE)
 }
 
 func testAccRdsInstanceV3Backup(postfix string) string {
 	return fmt.Sprintf(`
+%s
+%s
+
 resource "opentelekomcloud_networking_secgroup_v2" "sg" {
   name = "sg-rds-test"
 }
@@ -443,8 +461,8 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
     version  = "10"
   }
   security_group_id = opentelekomcloud_networking_secgroup_v2.sg.id
-  subnet_id         = "%s"
-  vpc_id            = "%s"
+  subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
+  vpc_id            = data.opentelekomcloud_vpc_v1.shared_vpc.id
   volume {
     type = "COMMON"
     size = 100
@@ -456,15 +474,18 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
   }
 
 }
-`, postfix, env.OS_AVAILABILITY_ZONE, env.OS_NETWORK_ID, env.OS_VPC_ID)
+`, common.DataSourceVPC, common.DataSourceSubnet, postfix, env.OS_AVAILABILITY_ZONE)
 }
 
 func testAccRdsInstanceV3ConfigTemplateBasic(postfix string) string {
 	return fmt.Sprintf(`
+%s
+%s
+
 resource "opentelekomcloud_rds_parametergroup_v3" "pg" {
   name = "pg-rds-test"
   values = {
-    max_connections = "100"
+    max_connections = "1200"
     autocommit      = "OFF"
   }
   datastore {
@@ -476,7 +497,7 @@ resource "opentelekomcloud_rds_parametergroup_v3" "pg" {
 resource "opentelekomcloud_rds_parametergroup_v3" "pg2" {
   name = "pg-rds-test-2"
   values = {
-    max_connections = "100"
+    max_connections = "1200"
     autocommit      = "OFF"
   }
   datastore {
@@ -498,8 +519,8 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
     version  = "12"
   }
   security_group_id = opentelekomcloud_networking_secgroup_v2.sg.id
-  subnet_id         = "%s"
-  vpc_id            = "%s"
+  subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
+  vpc_id            = data.opentelekomcloud_vpc_v1.shared_vpc.id
   volume {
     type = "COMMON"
     size = 40
@@ -507,15 +528,18 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
   flavor         = "rds.pg.c2.medium"
   param_group_id = opentelekomcloud_rds_parametergroup_v3.pg.id
 }
-`, postfix, env.OS_AVAILABILITY_ZONE, env.OS_NETWORK_ID, env.OS_VPC_ID)
+`, common.DataSourceVPC, common.DataSourceSubnet, postfix, env.OS_AVAILABILITY_ZONE)
 }
 
 func testAccRdsInstanceV3ConfigTemplateUpdate(postfix string) string {
 	return fmt.Sprintf(`
+%s
+%s
+
 resource "opentelekomcloud_rds_parametergroup_v3" "pg" {
   name = "pg-rds-test"
   values = {
-    max_connections = "100"
+    max_connections = "1200"
     autocommit      = "OFF"
   }
   datastore {
@@ -527,12 +551,12 @@ resource "opentelekomcloud_rds_parametergroup_v3" "pg" {
 resource "opentelekomcloud_rds_parametergroup_v3" "pg2" {
   name = "pg-rds-test-2"
   values = {
-    max_connections = "100"
+    max_connections = "1200"
     autocommit      = "OFF"
   }
   datastore {
     type    = "postgresql"
-    version = "10"
+    version = "12"
   }
 }
 
@@ -549,8 +573,8 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
     version  = "12"
   }
   security_group_id = opentelekomcloud_networking_secgroup_v2.sg.id
-  subnet_id         = "%s"
-  vpc_id            = "%s"
+  subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
+  vpc_id            = data.opentelekomcloud_vpc_v1.shared_vpc.id
   volume {
     type = "COMMON"
     size = 40
@@ -558,11 +582,14 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
   flavor         = "rds.pg.c2.medium"
   param_group_id = opentelekomcloud_rds_parametergroup_v3.pg2.id
 }
-`, postfix, env.OS_AVAILABILITY_ZONE, env.OS_NETWORK_ID, env.OS_VPC_ID)
+`, common.DataSourceVPC, common.DataSourceSubnet, postfix, env.OS_AVAILABILITY_ZONE)
 }
 
 func testAccRdsInstanceV3InvalidDBVersion(postfix string) string {
 	return fmt.Sprintf(`
+%s
+%s
+
 resource "opentelekomcloud_networking_secgroup_v2" "sg" {
   name = "sg-rds-test"
 }
@@ -577,19 +604,22 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
     port     = "8635"
   }
   security_group_id = opentelekomcloud_networking_secgroup_v2.sg.id
-  subnet_id         = "%s"
-  vpc_id            = "%s"
+  subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
+  vpc_id            = data.opentelekomcloud_vpc_v1.shared_vpc.id
   volume {
     type = "COMMON"
     size = 40
   }
   flavor = "rds.pg.c2.medium"
 }
-`, postfix, env.OS_AVAILABILITY_ZONE, env.OS_NETWORK_ID, env.OS_VPC_ID)
+`, common.DataSourceVPC, common.DataSourceSubnet, postfix, env.OS_AVAILABILITY_ZONE)
 }
 
 func testAccRdsInstanceV3ConfigurationOverride(postfix string) string {
 	return fmt.Sprintf(`
+%s
+%s
+
 resource "opentelekomcloud_networking_secgroup_v2" "sg" {
   name = "sg-rds-test"
 }
@@ -617,8 +647,8 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
   }
 
   security_group_id = opentelekomcloud_networking_secgroup_v2.sg.id
-  subnet_id         = "%s"
-  vpc_id            = "%s"
+  subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
+  vpc_id            = data.opentelekomcloud_vpc_v1.shared_vpc.id
   flavor            = "rds.pg.c2.medium"
   volume {
     type = "COMMON"
@@ -629,5 +659,5 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
     max_connections = "37",
   }
 }
-`, postfix, env.OS_AVAILABILITY_ZONE, env.OS_NETWORK_ID, env.OS_VPC_ID)
+`, common.DataSourceVPC, common.DataSourceSubnet, postfix, env.OS_AVAILABILITY_ZONE)
 }

--- a/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_parametergroup_v3_test.go
+++ b/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_parametergroup_v3_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 )
 
+const pgResourceName = "opentelekomcloud_rds_parametergroup_v3.pg_1"
+
 func TestAccRdsConfigurationV3_basic(t *testing.T) {
 	var config configurations.Configuration
 
@@ -24,23 +26,19 @@ func TestAccRdsConfigurationV3_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckRdsConfigV3Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRdsConfigV3_basic,
+				Config: testAccRdsConfigV3Basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRdsConfigV3Exists("opentelekomcloud_rds_parametergroup_v3.pg_1", &config),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_rds_parametergroup_v3.pg_1", "name", "pg_create"),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_rds_parametergroup_v3.pg_1", "description", "some description"),
+					testAccCheckRdsConfigV3Exists(pgResourceName, &config),
+					resource.TestCheckResourceAttr(pgResourceName, "name", "pg_create"),
+					resource.TestCheckResourceAttr(pgResourceName, "description", "some description"),
 				),
 			},
 			{
-				Config: testAccRdsConfigV3_update,
+				Config: testAccRdsConfigV3Update,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRdsConfigV3Exists("opentelekomcloud_rds_parametergroup_v3.pg_1", &config),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_rds_parametergroup_v3.pg_1", "name", "pg_update"),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_rds_parametergroup_v3.pg_1", "description", "updated description"),
+					testAccCheckRdsConfigV3Exists(pgResourceName, &config),
+					resource.TestCheckResourceAttr(pgResourceName, "name", "pg_update"),
+					resource.TestCheckResourceAttr(pgResourceName, "description", "updated description"),
 				),
 			},
 		},
@@ -54,7 +52,7 @@ func TestAccRdsConfigurationV3_invalidDbVersion(t *testing.T) {
 		CheckDestroy:      testAccCheckRdsConfigV3Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccRdsConfigV3_invalidDataStoreVersion,
+				Config:      testAccRdsConfigV3InvalidDataStoreVersion,
 				PlanOnly:    true,
 				ExpectError: regexp.MustCompile(`can't find version.+`),
 			},
@@ -115,7 +113,8 @@ func testAccCheckRdsConfigV3Exists(n string, configuration *configurations.Confi
 	}
 }
 
-const testAccRdsConfigV3_basic = `
+const (
+	testAccRdsConfigV3Basic = `
 resource "opentelekomcloud_rds_parametergroup_v3" "pg_1" {
   name        = "pg_create"
   description = "some description"
@@ -131,8 +130,7 @@ resource "opentelekomcloud_rds_parametergroup_v3" "pg_1" {
   }
 }
 `
-
-const testAccRdsConfigV3_update = `
+	testAccRdsConfigV3Update = `
 resource "opentelekomcloud_rds_parametergroup_v3" "pg_1" {
   name        = "pg_update"
   description = "updated description"
@@ -148,8 +146,7 @@ resource "opentelekomcloud_rds_parametergroup_v3" "pg_1" {
   }
 }
 `
-
-const testAccRdsConfigV3_invalidDataStoreVersion = `
+	testAccRdsConfigV3InvalidDataStoreVersion = `
 resource "opentelekomcloud_rds_parametergroup_v3" "pg_1" {
   name        = "pg_update"
   description = "updated description"
@@ -165,3 +162,4 @@ resource "opentelekomcloud_rds_parametergroup_v3" "pg_1" {
   }
 }
 `
+)

--- a/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_read_replica_v3_test.go
+++ b/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_read_replica_v3_test.go
@@ -60,14 +60,16 @@ func TestAccRdsReadReplicaV3Basic(t *testing.T) {
 
 func testAccRdsReadReplicaV3Basic(postfix string) string {
 	return fmt.Sprintf(`
+%s
+%s
+
 resource "opentelekomcloud_networking_secgroup_v2" "sg" {
   name = "sg-rds-replica-test"
 }
 
 resource "opentelekomcloud_rds_instance_v3" "instance" {
   name = "tf_rds_instance_%s"
-  availability_zone = [
-  "%s"]
+  availability_zone = ["%s"]
   db {
     password = "Postgres!120521"
     type     = "PostgreSQL"
@@ -75,8 +77,8 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
     port     = "8635"
   }
   security_group_id = opentelekomcloud_networking_secgroup_v2.sg.id
-  subnet_id         = "%s"
-  vpc_id            = "%s"
+  subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
+  vpc_id            = data.opentelekomcloud_vpc_v1.shared_vpc.id
   volume {
     type = "COMMON"
     size = 40
@@ -108,11 +110,14 @@ resource "opentelekomcloud_rds_read_replica_v3" "replica" {
   }
 }
 
-`, postfix, env.OS_AVAILABILITY_ZONE, env.OS_NETWORK_ID, env.OS_VPC_ID)
+`, common.DataSourceVPC, common.DataSourceSubnet, postfix, env.OS_AVAILABILITY_ZONE)
 }
 
 func testAccRdsReadReplicaV3BasicNoIP(postfix string) string {
 	return fmt.Sprintf(`
+%s
+%s
+
 resource "opentelekomcloud_networking_secgroup_v2" "sg" {
   name = "sg-rds-replica-test"
 }
@@ -127,8 +132,8 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
     port     = "8635"
   }
   security_group_id = opentelekomcloud_networking_secgroup_v2.sg.id
-  subnet_id         = "%s"
-  vpc_id            = "%s"
+  subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
+  vpc_id            = data.opentelekomcloud_vpc_v1.shared_vpc.id
   volume {
     type = "COMMON"
     size = 40
@@ -159,5 +164,5 @@ resource "opentelekomcloud_rds_read_replica_v3" "replica" {
     type = "COMMON"
   }
 }
-`, postfix, env.OS_AVAILABILITY_ZONE, env.OS_NETWORK_ID, env.OS_VPC_ID)
+`, common.DataSourceVPC, common.DataSourceSubnet, postfix, env.OS_AVAILABILITY_ZONE)
 }


### PR DESCRIPTION
## Summary of the Pull Request
Replace `OS_VPC_ID` and `OS_NETWORK_ID` usages with data sources


## PR Checklist

* [x] Refers to: #1320
* [x] Tests added/passed.

## Acceptance Steps Performed

```
=== RUN   TestAccRDSV1Instance_basic
--- PASS: TestAccRDSV1Instance_basic (695.64s)
PASS

Process finished with the exit code 0

=== RUN   TestAccRdsConfigurationV3_basic
--- PASS: TestAccRdsConfigurationV3_basic (54.06s)
=== RUN   TestAccRdsConfigurationV3_invalidDbVersion
--- PASS: TestAccRdsConfigurationV3_invalidDbVersion (2.20s)
PASS

Process finished with the exit code 0


=== RUN   TestAccRdsInstanceV3Basic
--- PASS: TestAccRdsInstanceV3Basic (1153.93s)
=== RUN   TestAccRdsInstanceV3ElasticIP
--- PASS: TestAccRdsInstanceV3ElasticIP (774.16s)
=== RUN   TestAccRdsInstanceV3HA
--- PASS: TestAccRdsInstanceV3HA (506.53s)
=== RUN   TestAccRdsInstanceV3OptionalParams
--- PASS: TestAccRdsInstanceV3OptionalParams (642.60s)
=== RUN   TestAccRdsInstanceV3Backup
--- PASS: TestAccRdsInstanceV3Backup (638.79s)
=== RUN   TestAccRdsInstanceV3TemplateConfig
--- PASS: TestAccRdsInstanceV3TemplateConfig (832.69s)
=== RUN   TestAccRdsInstanceV3InvalidDBVersion
--- PASS: TestAccRdsInstanceV3InvalidDBVersion (3.69s)
=== RUN   TestAccRdsInstanceV3_configurationParameters
--- PASS: TestAccRdsInstanceV3_configurationParameters (639.10s)
PASS

Process finished with the exit code 0

=== RUN   TestAccRdsReadReplicaV3Basic
--- PASS: TestAccRdsReadReplicaV3Basic (1143.61s)
PASS

Process finished with the exit code 0

```
