### PR TITLE
Fix panic in `rds_instance_v1`

### DIFF
--- a/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_instance_v1.go
+++ b/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_instance_v1.go
@@ -3,6 +3,7 @@ package rds
 import (
 	"context"
 	"log"
+	"strconv"
 	"strings"
 	"time"
 
@@ -448,7 +449,7 @@ func resourceInstanceRead(_ context.Context, d *schema.ResourceData, meta interf
 			"[DEBUG] Error saving volume to Rds instance (%s): %s", d.Id(), err)
 	}
 
-	mErr = multierror.Append(mErr, d.Set("dbport", instance.DbPort))
+	mErr = multierror.Append(mErr, d.Set("dbport", strconv.Itoa(instance.DbPort)))
 
 	datastoreList := make([]map[string]interface{}, 0, 1)
 	datastore := map[string]interface{}{

--- a/releasenotes/notes/fix-rds-v1-015fcf5224d0d250.yaml
+++ b/releasenotes/notes/fix-rds-v1-015fcf5224d0d250.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[RDS]** Fix panic when using ``resource/opentelekomcloud_rds_instance_v1`` (`#1354 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1354>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Fix incorrect setting of `dbport` attribute

Fix #1353

## PR Checklist

* [x] Refers to: #1353
* [x] Tests added/passed.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccRDSV1Instance_basic
--- PASS: TestAccRDSV1Instance_basic (662.02s)
PASS

Process finished with the exit code 0
```
