### PR TITLE
[Acceptance] Get rid of IDs in `CSBS`

### DIFF
--- a/opentelekomcloud/acceptance/csbs/data_source_opentelekomcloud_csbs_backup_policy_v1_test.go
+++ b/opentelekomcloud/acceptance/csbs/data_source_opentelekomcloud_csbs_backup_policy_v1_test.go
@@ -11,17 +11,19 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
 )
 
+const dataPolicyName = "data.opentelekomcloud_csbs_backup_policy_v1.csbs_policy"
+
 func TestAccCSBSBackupPolicyV1DataSource_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCSBSBackupPolicyV1DataSource_basic,
+				Config: testAccCSBSBackupPolicyV1DataSourceBasic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCSBSBackupPolicyV1DataSourceID("data.opentelekomcloud_csbs_backup_policy_v1.csbs_policy"),
-					resource.TestCheckResourceAttr("data.opentelekomcloud_csbs_backup_policy_v1.csbs_policy", "name", "backup-policy"),
-					resource.TestCheckResourceAttr("data.opentelekomcloud_csbs_backup_policy_v1.csbs_policy", "status", "suspended"),
+					testAccCheckCSBSBackupPolicyV1DataSourceID(dataPolicyName),
+					resource.TestCheckResourceAttr(dataPolicyName, "name", "backup-policy"),
+					resource.TestCheckResourceAttr(dataPolicyName, "status", "suspended"),
 				),
 			},
 		},
@@ -36,17 +38,21 @@ func testAccCheckCSBSBackupPolicyV1DataSourceID(n string) resource.TestCheckFunc
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("backup data source ID not set ")
+			return fmt.Errorf("backup data source ID not set")
 		}
 
 		return nil
 	}
 }
 
-var testAccCSBSBackupPolicyV1DataSource_basic = fmt.Sprintf(`
+var testAccCSBSBackupPolicyV1DataSourceBasic = fmt.Sprintf(`
+%s
+
+%s
+
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name              = "instance_1"
-  image_id          = "%s"
+  image_id          = data.opentelekomcloud_images_image_v2.latest_image.id
   security_groups   = ["default"]
   availability_zone = "%s"
   flavor_id         = "%s"
@@ -54,9 +60,10 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
     foo = "bar"
   }
   network {
-    uuid = "%s"
+    uuid = data.opentelekomcloud_images_image_v2.latest_image.network_id
   }
 }
+
 resource "opentelekomcloud_csbs_backup_policy_v1" "backup_policy_v1" {
   name = "backup-policy"
   resource {
@@ -76,4 +83,4 @@ resource "opentelekomcloud_csbs_backup_policy_v1" "backup_policy_v1" {
 data "opentelekomcloud_csbs_backup_policy_v1" "csbs_policy" {
   id = opentelekomcloud_csbs_backup_policy_v1.backup_policy_v1.id
 }
-`, env.OS_IMAGE_ID, env.OS_AVAILABILITY_ZONE, env.OS_FLAVOR_ID, env.OS_NETWORK_ID)
+`, common.DataSourceImage, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, env.OsFlavorID)

--- a/opentelekomcloud/acceptance/csbs/data_source_opentelekomcloud_csbs_backup_policy_v1_test.go
+++ b/opentelekomcloud/acceptance/csbs/data_source_opentelekomcloud_csbs_backup_policy_v1_test.go
@@ -60,7 +60,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
     foo = "bar"
   }
   network {
-    uuid = data.opentelekomcloud_images_image_v2.latest_image.network_id
+    uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
 }
 

--- a/opentelekomcloud/acceptance/csbs/data_source_opentelekomcloud_csbs_backup_v1_test.go
+++ b/opentelekomcloud/acceptance/csbs/data_source_opentelekomcloud_csbs_backup_v1_test.go
@@ -11,17 +11,19 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
 )
 
+const dataBackupName = "data.opentelekomcloud_csbs_backup_v1.csbs"
+
 func TestAccCSBSBackupV1DataSource_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCSBSBackupV1DataSource_basic,
+				Config: testAccCSBSBackupV1DataSourceBasic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCSBSBackupV1DataSourceID("data.opentelekomcloud_csbs_backup_v1.csbs"),
-					resource.TestCheckResourceAttr("data.opentelekomcloud_csbs_backup_v1.csbs", "backup_name", "csbs-test"),
-					resource.TestCheckResourceAttr("data.opentelekomcloud_csbs_backup_v1.csbs", "resource_name", "instance_1"),
+					testAccCheckCSBSBackupV1DataSourceID(dataBackupName),
+					resource.TestCheckResourceAttr(dataBackupName, "backup_name", "csbs-test"),
+					resource.TestCheckResourceAttr(dataBackupName, "resource_name", "instance_1"),
 				),
 			},
 		},
@@ -43,10 +45,14 @@ func testAccCheckCSBSBackupV1DataSourceID(n string) resource.TestCheckFunc {
 	}
 }
 
-var testAccCSBSBackupV1DataSource_basic = fmt.Sprintf(`
+var testAccCSBSBackupV1DataSourceBasic = fmt.Sprintf(`
+%s
+
+%s
+
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name              = "instance_1"
-  image_id          = "%s"
+  image_id          = data.opentelekomcloud_images_image_v2.latest_image.id
   security_groups   = ["default"]
   availability_zone = "%s"
   flavor_id         = "%s"
@@ -54,7 +60,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
     foo = "bar"
   }
   network {
-    uuid = "%s"
+    uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
 }
 resource "opentelekomcloud_csbs_backup_v1" "csbs" {
@@ -66,4 +72,4 @@ resource "opentelekomcloud_csbs_backup_v1" "csbs" {
 data "opentelekomcloud_csbs_backup_v1" "csbs" {
   id = opentelekomcloud_csbs_backup_v1.csbs.id
 }
-`, env.OS_IMAGE_ID, env.OS_AVAILABILITY_ZONE, env.OS_FLAVOR_ID, env.OS_NETWORK_ID)
+`, common.DataSourceImage, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, env.OsFlavorID)

--- a/opentelekomcloud/acceptance/csbs/import_opentelekomcloud_csbs_backup_policy_v1_test.go
+++ b/opentelekomcloud/acceptance/csbs/import_opentelekomcloud_csbs_backup_policy_v1_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestAccCSBSBackupPolicyV1_importWeekMonth(t *testing.T) {
-	resourceName := "opentelekomcloud_csbs_backup_policy_v1.backup_policy_v1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -17,10 +16,10 @@ func TestAccCSBSBackupPolicyV1_importWeekMonth(t *testing.T) {
 		CheckDestroy:      testAccCheckCSBSBackupPolicyV1Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCSBSBackupPolicyV1_weekMonth,
+				Config: testAccCSBSBackupPolicyV1WeekMonth,
 			},
 			{
-				ResourceName:      resourceName,
+				ResourceName:      resourcePolicyName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{

--- a/opentelekomcloud/acceptance/csbs/import_opentelekomcloud_csbs_backup_policy_v1_test.go
+++ b/opentelekomcloud/acceptance/csbs/import_opentelekomcloud_csbs_backup_policy_v1_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestAccCSBSBackupPolicyV1_importWeekMonth(t *testing.T) {
-
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,

--- a/opentelekomcloud/acceptance/csbs/import_opentelekomcloud_csbs_backup_v1_test.go
+++ b/opentelekomcloud/acceptance/csbs/import_opentelekomcloud_csbs_backup_v1_test.go
@@ -9,19 +9,16 @@ import (
 )
 
 func TestAccCSBSBackupV1_importBasic(t *testing.T) {
-	resourceName := "opentelekomcloud_csbs_backup_v1.csbs"
-
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCSBSBackupV1Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCSBSBackupV1_basic,
+				Config: testAccCSBSBackupV1Basic,
 			},
-
 			{
-				ResourceName:      resourceName,
+				ResourceName:      resourceBackupName,
 				ImportState:       true,
 				ImportStateVerify: false,
 			},


### PR DESCRIPTION
## Summary of the Pull Request
Replace usages of `OS_IMAGE_ID` and `OS_NETWORK_ID` with data sources
Replace `OS_FLAVOR_ID` with `OsFlavorID`
Minor tests style fixup

## PR Checklist

* [x] Refers to: #1320
* [x] Tests added/passed.

## Acceptance Steps Performed

```
=== RUN   TestAccCSBSBackupPolicyV1DataSource_basic
--- PASS: TestAccCSBSBackupPolicyV1DataSource_basic (239.23s)
=== RUN   TestAccCSBSBackupPolicyV1_importWeekMonth
--- PASS: TestAccCSBSBackupPolicyV1_importWeekMonth (311.45s)
=== RUN   TestAccCSBSBackupPolicyV1_basic
--- PASS: TestAccCSBSBackupPolicyV1_basic (366.81s)
=== RUN   TestAccCSBSBackupPolicyV1_timeout
--- PASS: TestAccCSBSBackupPolicyV1_timeout (217.04s)
=== RUN   TestAccCSBSBackupPolicyV1_weekMonth
--- PASS: TestAccCSBSBackupPolicyV1_weekMonth (277.13s)
=== RUN   TestAccCSBSBackupV1_basic
    resource_opentelekomcloud_csbs_backup_v1_test.go:22: Step 1/1 error: Error running apply: exit status 1
        
        Error: Error waiting for Backup (8b4fb0bd-1715-4381-aec1-82f1958a5598) to become available: json: cannot unmarshal number 29.9 into Go struct field .checkpoint_item of type int
        
          with opentelekomcloud_csbs_backup_v1.csbs,
          on terraform_plugin_test.tf line 28, in resource "opentelekomcloud_csbs_backup_v1" "csbs":
          28: resource "opentelekomcloud_csbs_backup_v1" "csbs" {
        
    testing_new.go:70: Error running post-test destroy, there may be dangling resources: exit status 1
        
        Error: error deleting csbs backup: json: cannot unmarshal number 29.9 into Go struct field .checkpoint_item of type int
        
--- FAIL: TestAccCSBSBackupV1_basic (545.97s)
```
