### PR TITLE
Fix panic using `ims_image_v2`

### DIFF
--- a/docs/resources/ims_image_v2.md
+++ b/docs/resources/ims_image_v2.md
@@ -121,6 +121,8 @@ The following attributes are exported:
 
 * `image_size` - The size(bytes) of the image file format.
 
+* `file` - The URL for uploading and downloading the image file.
+
 ## Import
 
 Images can be imported using the `id`, e.g.

--- a/opentelekomcloud/services/ims/resource_opentelekomcloud_ims_image_v2.go
+++ b/opentelekomcloud/services/ims/resource_opentelekomcloud_ims_image_v2.go
@@ -124,6 +124,10 @@ func ResourceImsImageV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"file": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -259,7 +263,6 @@ func resourceImsImageV2Read(_ context.Context, d *schema.ResourceData, meta inte
 		d.Set("name", img.Name),
 		d.Set("visibility", img.Visibility),
 		d.Set("file", img.File),
-		d.Set("schema", img.Schema),
 		d.Set("data_origin", img.DataOrigin),
 		d.Set("disk_format", img.DiskFormat),
 		d.Set("image_size", img.ImageSize),

--- a/releasenotes/notes/fix-ims-image-9a16fbd4e945f46b.yaml
+++ b/releasenotes/notes/fix-ims-image-9a16fbd4e945f46b.yaml
@@ -1,0 +1,7 @@
+---
+enhancements:
+  - |
+    **[IMS]** Add `file` attribute to ``resource/opentelekomcloud_ims_image_v2`` (`#1366 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1366>`_)
+fixes:
+  - |
+    **[IMS]** Fix panic using ``resource/opentelekomcloud_ims_image_v2`` (`#1366 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1366>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Add `file` field to `ims_image_v2` resource schema

Remove setting value to not existing `schema` field

Fix #1365 

## PR Checklist

* [x] Refers to: #1365
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccImsImageV2_basic
--- PASS: TestAccImsImageV2_basic (178.04s)
PASS

Process finished with the exit code 0

```
