### PR TITLE
[Acceptance] Get rid of IDs in `IMS`

### DIFF
--- a/opentelekomcloud/acceptance/ims/resource_opentelekomcloud_ims_data_image_v2_test.go
+++ b/opentelekomcloud/acceptance/ims/resource_opentelekomcloud_ims_data_image_v2_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/services/ims"
 )
 
+const resourceDataImageName = "opentelekomcloud_ims_data_image_v2.image_1"
+
 func TestAccImsDataImageV2_basic(t *testing.T) {
 	var image cloudimages.Image
 
@@ -24,24 +26,22 @@ func TestAccImsDataImageV2_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckImsDataImageV2Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccImsDataImageV2_basic,
+				Config: testAccImsDataImageV2Basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckImsDataImageV2Exists("opentelekomcloud_ims_data_image_v2.image_1", &image),
-					testAccCheckImsImageV2Tags("opentelekomcloud_ims_data_image_v2.image_1", "foo", "bar"),
-					testAccCheckImsImageV2Tags("opentelekomcloud_ims_data_image_v2.image_1", "key", "value"),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_ims_data_image_v2.image_1", "name", "TFTest_data_image"),
+					testAccCheckImsDataImageV2Exists(resourceDataImageName, &image),
+					testAccCheckImsImageV2Tags(resourceDataImageName, "foo", "bar"),
+					testAccCheckImsImageV2Tags(resourceDataImageName, "key", "value"),
+					resource.TestCheckResourceAttr(resourceDataImageName, "name", "TFTest_data_image"),
 				),
 			},
 			{
-				Config: testAccImsDataImageV2_update,
+				Config: testAccImsDataImageV2Update,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckImsDataImageV2Exists("opentelekomcloud_ims_data_image_v2.image_1", &image),
-					testAccCheckImsImageV2Tags("opentelekomcloud_ims_data_image_v2.image_1", "foo", "bar"),
-					testAccCheckImsImageV2Tags("opentelekomcloud_ims_data_image_v2.image_1", "key", "value1"),
-					testAccCheckImsImageV2Tags("opentelekomcloud_ims_data_image_v2.image_1", "key2", "value2"),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_ims_data_image_v2.image_1", "name", "TFTest_data_image_update"),
+					testAccCheckImsDataImageV2Exists(resourceDataImageName, &image),
+					testAccCheckImsImageV2Tags(resourceDataImageName, "foo", "bar"),
+					testAccCheckImsImageV2Tags(resourceDataImageName, "key", "value1"),
+					testAccCheckImsImageV2Tags(resourceDataImageName, "key2", "value2"),
+					resource.TestCheckResourceAttr(resourceDataImageName, "name", "TFTest_data_image_update"),
 				),
 			},
 		},
@@ -96,81 +96,87 @@ func testAccCheckImsDataImageV2Exists(n string, image *cloudimages.Image) resour
 	}
 }
 
-var testAccImsDataImageV2_basic = fmt.Sprintf(`
+var testAccImsDataImageV2Basic = fmt.Sprintf(`
+%s
+%s
+
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
-  name = "instance_1"
-  security_groups = ["default"]
+  name              = "instance_1"
+  security_groups   = ["default"]
   availability_zone = "%s"
   metadata = {
     foo = "bar"
   }
   network {
-    uuid = "%s"
+    uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
   block_device {
-    boot_index = 0
+    boot_index            = 0
     delete_on_termination = true
-    destination_type = "volume"
-	volume_size = 40
-    source_type = "image"
-    uuid = "%s"
+    destination_type      = "volume"
+    volume_size           = 40
+    source_type           = "image"
+    uuid                  = data.opentelekomcloud_images_image_v2.latest_image.id
   }
   block_device {
-    boot_index = 1
+    boot_index            = 1
     delete_on_termination = true
-    destination_type = "volume"
-    source_type = "blank"
-    volume_size = 1
+    destination_type      = "volume"
+    source_type           = "blank"
+    volume_size           = 1
   }
 }
 
 resource "opentelekomcloud_ims_data_image_v2" "image_1" {
-  name   = "TFTest_data_image"
+  name        = "TFTest_data_image"
   description = "created by TerraformAccTest"
-  volume_id = opentelekomcloud_compute_instance_v2.instance_1.volume_attached.1.id
+  volume_id   = opentelekomcloud_compute_instance_v2.instance_1.volume_attached.1.id
   tags = {
     foo = "bar"
     key = "value"
   }
 }
-`, env.OS_AVAILABILITY_ZONE, env.OS_NETWORK_ID, env.OS_IMAGE_ID)
+`, common.DataSourceSubnet, common.DataSourceImage, env.OS_AVAILABILITY_ZONE)
 
-var testAccImsDataImageV2_update = fmt.Sprintf(`
+var testAccImsDataImageV2Update = fmt.Sprintf(`
+%s
+%s
+
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
-  name = "instance_1"
-  security_groups = ["default"]
+  name              = "instance_1"
+  security_groups   = ["default"]
   availability_zone = "%s"
   metadata = {
     foo = "bar"
   }
   network {
-    uuid = "%s"
+    uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
   block_device {
-    boot_index = 0
+    boot_index            = 0
     delete_on_termination = true
-    destination_type = "volume"
-	volume_size = 40
-    source_type = "image"
-    uuid = "%s"
+    destination_type      = "volume"
+    volume_size           = 40
+    source_type           = "image"
+    uuid                  = data.opentelekomcloud_images_image_v2.latest_image.id
   }
   block_device {
-    boot_index = 1
+    boot_index            = 1
     delete_on_termination = true
-    destination_type = "volume"
-    source_type = "blank"
-    volume_size = 1
+    destination_type      = "volume"
+    source_type           = "blank"
+    volume_size           = 1
   }
 }
 
 resource "opentelekomcloud_ims_data_image_v2" "image_1" {
-  name   = "TFTest_data_image_update"
+  name        = "TFTest_data_image_update"
   description = "created by TerraformAccTest"
-  volume_id = opentelekomcloud_compute_instance_v2.instance_1.volume_attached.1.id
+  volume_id   = opentelekomcloud_compute_instance_v2.instance_1.volume_attached.1.id
   tags = {
     foo  = "bar"
     key  = "value1"
     key2 = "value2"
   }
 }
-`, env.OS_AVAILABILITY_ZONE, env.OS_NETWORK_ID, env.OS_IMAGE_ID)
+`, common.DataSourceSubnet, common.DataSourceImage, env.OS_AVAILABILITY_ZONE)

--- a/opentelekomcloud/acceptance/ims/resource_opentelekomcloud_ims_image_v2_test.go
+++ b/opentelekomcloud/acceptance/ims/resource_opentelekomcloud_ims_image_v2_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/services/ims"
 )
 
+const resourceImageName = "opentelekomcloud_ims_image_v2.image_1"
+
 func TestAccImsImageV2_basic(t *testing.T) {
 	var image cloudimages.Image
 
@@ -25,24 +27,22 @@ func TestAccImsImageV2_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckImsImageV2Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccImsImageV2_basic,
+				Config: testAccImsImageV2Basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckImsImageV2Exists("opentelekomcloud_ims_image_v2.image_1", &image),
-					testAccCheckImsImageV2Tags("opentelekomcloud_ims_image_v2.image_1", "foo", "bar"),
-					testAccCheckImsImageV2Tags("opentelekomcloud_ims_image_v2.image_1", "key", "value"),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_ims_image_v2.image_1", "name", "TFTest_image"),
+					testAccCheckImsImageV2Exists(resourceImageName, &image),
+					testAccCheckImsImageV2Tags(resourceImageName, "foo", "bar"),
+					testAccCheckImsImageV2Tags(resourceImageName, "key", "value"),
+					resource.TestCheckResourceAttr(resourceImageName, "name", "TFTest_image"),
 				),
 			},
 			{
-				Config: testAccImsImageV2_update,
+				Config: testAccImsImageV2Update,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckImsImageV2Exists("opentelekomcloud_ims_image_v2.image_1", &image),
-					testAccCheckImsImageV2Tags("opentelekomcloud_ims_image_v2.image_1", "foo", "bar"),
-					testAccCheckImsImageV2Tags("opentelekomcloud_ims_image_v2.image_1", "key", "value1"),
-					testAccCheckImsImageV2Tags("opentelekomcloud_ims_image_v2.image_1", "key2", "value2"),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_ims_image_v2.image_1", "name", "TFTest_image_update"),
+					testAccCheckImsImageV2Exists(resourceImageName, &image),
+					testAccCheckImsImageV2Tags(resourceImageName, "foo", "bar"),
+					testAccCheckImsImageV2Tags(resourceImageName, "key", "value1"),
+					testAccCheckImsImageV2Tags(resourceImageName, "key2", "value2"),
+					resource.TestCheckResourceAttr(resourceImageName, "name", "TFTest_image_update"),
 				),
 			},
 		},
@@ -137,21 +137,23 @@ func testAccCheckImsImageV2Tags(n string, k string, v string) resource.TestCheck
 	}
 }
 
-var testAccImsImageV2_basic = fmt.Sprintf(`
+var testAccImsImageV2Basic = fmt.Sprintf(`
+%s
+
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
-  name = "instance_1"
-  security_groups = ["default"]
+  name              = "instance_1"
+  security_groups   = ["default"]
   availability_zone = "%s"
   metadata = {
     foo = "bar"
   }
   network {
-    uuid = "%s"
+    uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
 }
 
 resource "opentelekomcloud_ims_image_v2" "image_1" {
-  name   = "TFTest_image"
+  name        = "TFTest_image"
   instance_id = opentelekomcloud_compute_instance_v2.instance_1.id
   description = "created by TerraformAccTest"
   tags = {
@@ -159,23 +161,25 @@ resource "opentelekomcloud_ims_image_v2" "image_1" {
     key = "value"
   }
 }
-`, env.OS_AVAILABILITY_ZONE, env.OS_NETWORK_ID)
+`, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE)
 
-var testAccImsImageV2_update = fmt.Sprintf(`
+var testAccImsImageV2Update = fmt.Sprintf(`
+%s
+
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
-  name = "instance_1"
-  security_groups = ["default"]
+  name              = "instance_1"
+  security_groups   = ["default"]
   availability_zone = "%s"
   metadata = {
     foo = "bar"
   }
   network {
-    uuid = "%s"
+    uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
 }
 
 resource "opentelekomcloud_ims_image_v2" "image_1" {
-  name   = "TFTest_image_update"
+  name        = "TFTest_image_update"
   instance_id = opentelekomcloud_compute_instance_v2.instance_1.id
   description = "created by TerraformAccTest"
   tags = {
@@ -184,4 +188,4 @@ resource "opentelekomcloud_ims_image_v2" "image_1" {
     key2 = "value2"
   }
 }
-`, env.OS_AVAILABILITY_ZONE, env.OS_NETWORK_ID)
+`, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE)


### PR DESCRIPTION
## Summary of the Pull Request
Replace `OS_NETWORK_ID` and `OS_IMAGE_ID` with data sources

Minor style fixes

## PR Checklist

* [x] Refers to: #1320
* [x] Tests added/passed.

## Acceptance Steps Performed

```
=== RUN   TestAccImsDataImageV2_basic
--- PASS: TestAccImsDataImageV2_basic (202.08s)
PASS

Process finished with the exit code 0

=== RUN   TestAccImsImageV2_basic
--- PASS: TestAccImsImageV2_basic (178.04s)
PASS

Process finished with the exit code 0
```
