### PR TITLE
[Acceptance] Get red of IDs in `CSS`

### DIFF
--- a/opentelekomcloud/acceptance/css/data_source_opentelekomcloud_css_flavor_v1_test.go
+++ b/opentelekomcloud/acceptance/css/data_source_opentelekomcloud_css_flavor_v1_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
 )
 
+const dataFlavorName = "data.opentelekomcloud_css_flavor_v1.flavor"
+
 func TestAccCSSFlavorV1DataSource_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -18,11 +20,11 @@ func TestAccCSSFlavorV1DataSource_basic(t *testing.T) {
 			{
 				Config: testAccCSSFlavorV1DataSource,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckCSSFlavorV1DataSourceID("data.opentelekomcloud_css_flavor_v1.flavor"),
-					resource.TestCheckResourceAttrSet("data.opentelekomcloud_css_flavor_v1.flavor", "name"),
-					resource.TestCheckResourceAttrSet("data.opentelekomcloud_css_flavor_v1.flavor", "region"),
-					resource.TestCheckResourceAttrSet("data.opentelekomcloud_css_flavor_v1.flavor", "ram"),
-					resource.TestCheckResourceAttrSet("data.opentelekomcloud_css_flavor_v1.flavor", "cpu"),
+					testAccCheckCSSFlavorV1DataSourceID(dataFlavorName),
+					resource.TestCheckResourceAttrSet(dataFlavorName, "name"),
+					resource.TestCheckResourceAttrSet(dataFlavorName, "region"),
+					resource.TestCheckResourceAttrSet(dataFlavorName, "ram"),
+					resource.TestCheckResourceAttrSet(dataFlavorName, "cpu"),
 				),
 			},
 		},
@@ -37,13 +39,28 @@ func TestAccCSSFlavorV1DataSource_byName(t *testing.T) {
 			{
 				Config: testAccCSSFlavorV1DataSourceByName,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckCSSFlavorV1DataSourceID("data.opentelekomcloud_css_flavor_v1.flavor"),
-					resource.TestCheckResourceAttrSet("data.opentelekomcloud_css_flavor_v1.flavor", "name"),
-					resource.TestCheckResourceAttrSet("data.opentelekomcloud_css_flavor_v1.flavor", "region"),
+					testAccCheckCSSFlavorV1DataSourceID(dataFlavorName),
+					resource.TestCheckResourceAttrSet(dataFlavorName, "name"),
+					resource.TestCheckResourceAttrSet(dataFlavorName, "region"),
 				),
 			},
 		},
 	})
+}
+
+func testAccCheckCSSFlavorV1DataSourceID(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("can't find backup data source: %s ", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("backup data source ID not set ")
+		}
+
+		return nil
+	}
 }
 
 const (
@@ -65,18 +82,3 @@ data "opentelekomcloud_css_flavor_v1" "flavor" {
 }
 `
 )
-
-func testAccCheckCSSFlavorV1DataSourceID(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("can't find backup data source: %s ", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("backup data source ID not set ")
-		}
-
-		return nil
-	}
-}

--- a/opentelekomcloud/acceptance/css/resource_opentelekomcloud_css_cluster_v1_test.go
+++ b/opentelekomcloud/acceptance/css/resource_opentelekomcloud_css_cluster_v1_test.go
@@ -16,9 +16,10 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 )
 
+const resourceClusterName = "opentelekomcloud_css_cluster_v1.cluster"
+
 func TestAccCssClusterV1_basic(t *testing.T) {
 	name := fmt.Sprintf("css-%s", acctest.RandString(10))
-	resourceName := "opentelekomcloud_css_cluster_v1.cluster"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { acc.TestAccPreCheck(t) },
@@ -29,22 +30,22 @@ func TestAccCssClusterV1_basic(t *testing.T) {
 				Config: testAccCssClusterV1Basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCssClusterV1Exists(),
-					resource.TestCheckResourceAttr(resourceName, "nodes.#", "1"),
+					resource.TestCheckResourceAttr(resourceClusterName, "nodes.#", "1"),
 				),
 			},
 			{
-				Config: testAccCssClusterV1_extend(name),
+				Config: testAccCssClusterV1Extend(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCssClusterV1Exists(),
-					resource.TestCheckResourceAttr(resourceName, "expect_node_num", "2"),
-					resource.TestCheckResourceAttr(resourceName, "nodes.#", "2"),
+					resource.TestCheckResourceAttr(resourceClusterName, "expect_node_num", "2"),
+					resource.TestCheckResourceAttr(resourceClusterName, "nodes.#", "2"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccCssClusterV1_validateDiskandFlavor(t *testing.T) {
+func TestAccCssClusterV1_validateDiskAndFlavor(t *testing.T) {
 	name := fmt.Sprintf("css-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
@@ -77,7 +78,6 @@ func TestAccCssClusterV1_validateDiskandFlavor(t *testing.T) {
 
 func TestAccCssClusterV1_encrypted(t *testing.T) {
 	name := fmt.Sprintf("css-%s", acctest.RandString(10))
-	resourceName := "opentelekomcloud_css_cluster_v1.cluster"
 	if env.OS_KMS_ID == "" {
 		t.Skip("KMS key ID is not set")
 	}
@@ -91,216 +91,19 @@ func TestAccCssClusterV1_encrypted(t *testing.T) {
 				Config: testAccCssClusterV1Encrypted(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCssClusterV1Exists(),
-					resource.TestCheckResourceAttr(resourceName, "nodes.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "node_config.0.volume.0.encryption_key", env.OS_KMS_ID),
+					resource.TestCheckResourceAttr(resourceClusterName, "nodes.#", "1"),
+					resource.TestCheckResourceAttr(resourceClusterName, "node_config.0.volume.0.encryption_key", env.OS_KMS_ID),
 				),
 			},
 		},
 	})
 }
 
-func testAccCssClusterV1Basic(name string) string {
-	return fmt.Sprintf(`
-data "opentelekomcloud_networking_secgroup_v2" "secgroup" {
-  name = "default"
-}
-
-resource "opentelekomcloud_css_cluster_v1" "cluster" {
-  expect_node_num = 1
-  name            = "%[1]s"
-  node_config {
-    flavor = "css.medium.8"
-    network_info {
-      security_group_id = data.opentelekomcloud_networking_secgroup_v2.secgroup.id
-      network_id        = "%s"
-      vpc_id            = "%s"
-    }
-    volume {
-      volume_type = "COMMON"
-      size        = 40
-    }
-
-    availability_zone = "%s"
-  }
-  datastore {
-    version = "7.6.2"
-  }
-  enable_https     = true
-  enable_authority = true
-  admin_pass       = "QwertyUI!"
-}
-`, name, env.OS_NETWORK_ID, env.OS_VPC_ID, env.OS_AVAILABILITY_ZONE)
-}
-func testAccCssClusterV1TooSmall(name string) string {
-	return fmt.Sprintf(`
-data "opentelekomcloud_networking_secgroup_v2" "secgroup" {
-  name = "default"
-}
-
-resource "opentelekomcloud_css_cluster_v1" "cluster" {
-  expect_node_num = 1
-  name            = "%[1]s"
-  node_config {
-    flavor = "css.medium.8"
-    network_info {
-      security_group_id = data.opentelekomcloud_networking_secgroup_v2.secgroup.id
-      network_id        = "%s"
-      vpc_id            = "%s"
-    }
-    volume {
-      volume_type = "COMMON"
-      size        = 1
-    }
-
-    availability_zone = "%s"
-  }
-  datastore {
-    version = "7.6.2"
-  }
-  enable_https     = true
-  enable_authority = true
-  admin_pass       = "QwertyUI!"
-}
-`, name, env.OS_NETWORK_ID, env.OS_VPC_ID, env.OS_AVAILABILITY_ZONE)
-}
-func testAccCssClusterV1TooBig(name string) string {
-	return fmt.Sprintf(`
-data "opentelekomcloud_networking_secgroup_v2" "secgroup" {
-  name = "default"
-}
-
-resource "opentelekomcloud_css_cluster_v1" "cluster" {
-  expect_node_num = 1
-  name            = "%[1]s"
-  node_config {
-    flavor = "css.medium.8"
-    network_info {
-      security_group_id = data.opentelekomcloud_networking_secgroup_v2.secgroup.id
-      network_id        = "%s"
-      vpc_id            = "%s"
-    }
-    volume {
-      volume_type = "COMMON"
-      size        = 10000000
-    }
-
-    availability_zone = "%s"
-  }
-  datastore {
-    version = "7.6.2"
-  }
-  enable_https     = true
-  enable_authority = true
-  admin_pass       = "QwertyUI!"
-}
-`, name, env.OS_NETWORK_ID, env.OS_VPC_ID, env.OS_AVAILABILITY_ZONE)
-}
-
-func testAccCssClusterV1FlavorName(name string) string {
-	return fmt.Sprintf(`
-data "opentelekomcloud_networking_secgroup_v2" "secgroup" {
-  name = "default"
-}
-
-resource "opentelekomcloud_css_cluster_v1" "cluster" {
-  expect_node_num = 1
-  name            = "%[1]s"
-  node_config {
-    flavor = "css.large.8"
-    network_info {
-      security_group_id = data.opentelekomcloud_networking_secgroup_v2.secgroup.id
-      network_id        = "%s"
-      vpc_id            = "%s"
-    }
-    volume {
-      volume_type = "COMMON"
-      size        = 20
-    }
-
-    availability_zone = "%s"
-  }
-  datastore {
-    version = "7.6.2"
-  }
-  enable_https     = true
-  enable_authority = true
-  admin_pass       = "QwertyUI!"
-}
-`, name, env.OS_NETWORK_ID, env.OS_VPC_ID, env.OS_AVAILABILITY_ZONE)
-}
-
-func testAccCssClusterV1_extend(name string) string {
-	return fmt.Sprintf(`
-data "opentelekomcloud_networking_secgroup_v2" "secgroup" {
-  name = "default"
-}
-
-resource "opentelekomcloud_css_cluster_v1" "cluster" {
-  expect_node_num = 2
-  name            = "%[1]s"
-  node_config {
-    flavor = "css.medium.8"
-    network_info {
-      security_group_id = data.opentelekomcloud_networking_secgroup_v2.secgroup.id
-      network_id        = "%s"
-      vpc_id            = "%s"
-    }
-    volume {
-      volume_type = "COMMON"
-      size        = 40
-    }
-
-    availability_zone = "%s"
-  }
-  datastore {
-    version = "7.6.2"
-  }
-  enable_https     = true
-  enable_authority = true
-  admin_pass       = "QwertyUI!"
-}
-`, name, env.OS_NETWORK_ID, env.OS_VPC_ID, env.OS_AVAILABILITY_ZONE)
-}
-
-func testAccCssClusterV1Encrypted(name string) string {
-	return fmt.Sprintf(`
-data "opentelekomcloud_networking_secgroup_v2" "secgroup" {
-  name = "default"
-}
-
-resource "opentelekomcloud_css_cluster_v1" "cluster" {
-  expect_node_num = 1
-  name            = "%[1]s"
-  node_config {
-    flavor = "css.medium.8"
-    network_info {
-      security_group_id = data.opentelekomcloud_networking_secgroup_v2.secgroup.id
-      network_id        = "%s"
-      vpc_id            = "%s"
-    }
-    volume {
-      volume_type    = "COMMON"
-      size           = 40
-      encryption_key = "%s"
-    }
-
-    availability_zone = "%s"
-  }
-  datastore {
-    version = "7.6.2"
-  }
-  enable_https     = true
-  enable_authority = true
-  admin_pass       = "QwertyUI!"
-}
-`, name, env.OS_NETWORK_ID, env.OS_VPC_ID, env.OS_KMS_ID, env.OS_AVAILABILITY_ZONE)
-}
-
 func testAccCheckCssClusterV1Destroy(s *terraform.State) error {
 	config := acc.TestAccProvider.Meta().(*cfg.Config)
 	client, err := config.CssV1Client(env.OS_REGION_NAME)
 	if err != nil {
-		return fmt.Errorf("error creating sdk client, err=%s", err)
+		return fmt.Errorf("error creating CSSv1 client: %w", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -329,7 +132,7 @@ func testAccCheckCssClusterV1Exists() resource.TestCheckFunc {
 		config := acc.TestAccProvider.Meta().(*cfg.Config)
 		client, err := config.CssV1Client(env.OS_REGION_NAME)
 		if err != nil {
-			return fmt.Errorf("error creating sdk client, err=%s", err)
+			return fmt.Errorf("error creating CSSv1 client: %w", err)
 		}
 
 		rs, ok := s.RootModule().Resources["opentelekomcloud_css_cluster_v1.cluster"]
@@ -353,4 +156,201 @@ func testAccCheckCssClusterV1Exists() resource.TestCheckFunc {
 		}
 		return nil
 	}
+}
+
+func testAccCssClusterV1Basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+%s
+
+resource "opentelekomcloud_css_cluster_v1" "cluster" {
+  expect_node_num = 1
+  name            = "%s"
+  node_config {
+    flavor = "css.medium.8"
+    network_info {
+      security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
+      network_id        = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+      vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+    }
+    volume {
+      volume_type = "COMMON"
+      size        = 40
+    }
+
+    availability_zone = "%s"
+  }
+  datastore {
+    version = "7.6.2"
+  }
+  enable_https     = true
+  enable_authority = true
+  admin_pass       = "QwertyUI!"
+}
+`, acc.DataSourceSecGroupDefault, acc.DataSourceSubnet, name, env.OS_AVAILABILITY_ZONE)
+}
+func testAccCssClusterV1TooSmall(name string) string {
+	return fmt.Sprintf(`
+%s
+
+%s
+
+resource "opentelekomcloud_css_cluster_v1" "cluster" {
+  expect_node_num = 1
+  name            = "%s"
+  node_config {
+    flavor = "css.medium.8"
+    network_info {
+      security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
+      network_id        = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+      vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+    }
+    volume {
+      volume_type = "COMMON"
+      size        = 1
+    }
+
+    availability_zone = "%s"
+  }
+  datastore {
+    version = "7.6.2"
+  }
+  enable_https     = true
+  enable_authority = true
+  admin_pass       = "QwertyUI!"
+}
+`, acc.DataSourceSecGroupDefault, acc.DataSourceSubnet, name, env.OS_AVAILABILITY_ZONE)
+}
+func testAccCssClusterV1TooBig(name string) string {
+	return fmt.Sprintf(`
+%s
+
+%s
+
+resource "opentelekomcloud_css_cluster_v1" "cluster" {
+  expect_node_num = 1
+  name            = "%s"
+  node_config {
+    flavor = "css.medium.8"
+    network_info {
+      security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
+      network_id        = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+      vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+    }
+    volume {
+      volume_type = "COMMON"
+      size        = 10000000
+    }
+
+    availability_zone = "%s"
+  }
+  datastore {
+    version = "7.6.2"
+  }
+  enable_https     = true
+  enable_authority = true
+  admin_pass       = "QwertyUI!"
+}
+`, acc.DataSourceSecGroupDefault, acc.DataSourceSubnet, name, env.OS_AVAILABILITY_ZONE)
+}
+
+func testAccCssClusterV1FlavorName(name string) string {
+	return fmt.Sprintf(`
+%s
+
+%s
+
+resource "opentelekomcloud_css_cluster_v1" "cluster" {
+  expect_node_num = 1
+  name            = "%s"
+  node_config {
+    flavor = "css.large.8"
+    network_info {
+      security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
+      network_id        = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+      vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+    }
+    volume {
+      volume_type = "COMMON"
+      size        = 20
+    }
+
+    availability_zone = "%s"
+  }
+  datastore {
+    version = "7.6.2"
+  }
+  enable_https     = true
+  enable_authority = true
+  admin_pass       = "QwertyUI!"
+}
+`, acc.DataSourceSecGroupDefault, acc.DataSourceSubnet, name, env.OS_AVAILABILITY_ZONE)
+}
+
+func testAccCssClusterV1Extend(name string) string {
+	return fmt.Sprintf(`
+%s
+
+%s
+
+resource "opentelekomcloud_css_cluster_v1" "cluster" {
+  expect_node_num = 2
+  name            = "%s"
+  node_config {
+    flavor = "css.medium.8"
+    network_info {
+      security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
+      network_id        = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+      vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+    }
+    volume {
+      volume_type = "COMMON"
+      size        = 40
+    }
+
+    availability_zone = "%s"
+  }
+  datastore {
+    version = "7.6.2"
+  }
+  enable_https     = true
+  enable_authority = true
+  admin_pass       = "QwertyUI!"
+}
+`, acc.DataSourceSecGroupDefault, acc.DataSourceSubnet, name, env.OS_AVAILABILITY_ZONE)
+}
+
+func testAccCssClusterV1Encrypted(name string) string {
+	return fmt.Sprintf(`
+%s
+
+%s
+
+resource "opentelekomcloud_css_cluster_v1" "cluster" {
+  expect_node_num = 1
+  name            = "%s"
+  node_config {
+    flavor = "css.medium.8"
+    network_info {
+      security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
+      network_id        = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+      vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+    }
+    volume {
+      volume_type    = "COMMON"
+      size           = 40
+      encryption_key = "%s"
+    }
+
+    availability_zone = "%s"
+  }
+  datastore {
+    version = "7.6.2"
+  }
+  enable_https     = true
+  enable_authority = true
+  admin_pass       = "QwertyUI!"
+}
+`, acc.DataSourceSecGroupDefault, acc.DataSourceSubnet, name, env.OS_KMS_ID, env.OS_AVAILABILITY_ZONE)
 }

--- a/opentelekomcloud/acceptance/css/resource_opentelekomcloud_css_cluster_v1_test.go
+++ b/opentelekomcloud/acceptance/css/resource_opentelekomcloud_css_cluster_v1_test.go
@@ -190,6 +190,7 @@ resource "opentelekomcloud_css_cluster_v1" "cluster" {
 }
 `, acc.DataSourceSecGroupDefault, acc.DataSourceSubnet, name, env.OS_AVAILABILITY_ZONE)
 }
+
 func testAccCssClusterV1TooSmall(name string) string {
 	return fmt.Sprintf(`
 %s
@@ -222,6 +223,7 @@ resource "opentelekomcloud_css_cluster_v1" "cluster" {
 }
 `, acc.DataSourceSecGroupDefault, acc.DataSourceSubnet, name, env.OS_AVAILABILITY_ZONE)
 }
+
 func testAccCssClusterV1TooBig(name string) string {
 	return fmt.Sprintf(`
 %s

--- a/opentelekomcloud/acceptance/css/resource_opentelekomcloud_css_snapshot_configuration_v1_test.go
+++ b/opentelekomcloud/acceptance/css/resource_opentelekomcloud_css_snapshot_configuration_v1_test.go
@@ -46,9 +46,9 @@ var osAgency = os.Getenv("OS_AGENCY")
 
 func testResourceCSSSnapshotConfigurationV1Basic(name string) string {
 	return fmt.Sprintf(`
-data "opentelekomcloud_networking_secgroup_v2" "secgroup" {
-  name = "default"
-}
+%s
+
+%s
 
 resource "opentelekomcloud_css_cluster_v1" "cluster" {
   expect_node_num = 1
@@ -56,9 +56,9 @@ resource "opentelekomcloud_css_cluster_v1" "cluster" {
   node_config {
     flavor = "css.medium.8"
     network_info {
-      security_group_id = data.opentelekomcloud_networking_secgroup_v2.secgroup.id
-      network_id        = "%s"
-      vpc_id            = "%s"
+      security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
+      network_id        = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+      vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
     }
     volume {
       volume_type = "COMMON"
@@ -92,14 +92,13 @@ resource "opentelekomcloud_css_snapshot_configuration_v1" "config" {
     delete_auto = true
   }
 }
-`, name, env.OS_NETWORK_ID, env.OS_VPC_ID, env.OS_AVAILABILITY_ZONE, osAgency)
+`, acc.DataSourceSecGroupDefault, acc.DataSourceSubnet, name, env.OS_AVAILABILITY_ZONE, osAgency)
 }
 
 func testResourceCSSSnapshotConfigurationV1Updated(name string) string {
 	return fmt.Sprintf(`
-data "opentelekomcloud_networking_secgroup_v2" "secgroup" {
-  name = "default"
-}
+%s
+%s
 
 resource "opentelekomcloud_css_cluster_v1" "cluster" {
   expect_node_num = 1
@@ -107,9 +106,9 @@ resource "opentelekomcloud_css_cluster_v1" "cluster" {
   node_config {
     flavor = "css.medium.8"
     network_info {
-      security_group_id = data.opentelekomcloud_networking_secgroup_v2.secgroup.id
-      network_id        = "%s"
-      vpc_id            = "%s"
+      security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
+      network_id        = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+      vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
     }
     volume {
       volume_type = "COMMON"
@@ -143,5 +142,5 @@ resource "opentelekomcloud_css_snapshot_configuration_v1" "config" {
     delete_auto = true
   }
 }
-`, name, env.OS_NETWORK_ID, env.OS_VPC_ID, env.OS_AVAILABILITY_ZONE, osAgency)
+`, acc.DataSourceSecGroupDefault, acc.DataSourceSubnet, name, env.OS_AVAILABILITY_ZONE, osAgency)
 }


### PR DESCRIPTION
## Summary of the Pull Request
Replace `OS_VPC_ID` and `OS_NETWORK_ID` usages with data sources

## PR Checklist

* [x] Refers to: #1320
* [x] Tests added/passed.

## Acceptance Steps Performed

```
=== RUN   TestAccCSSFlavorV1DataSource_basic
--- PASS: TestAccCSSFlavorV1DataSource_basic (122.59s)
=== RUN   TestAccCSSFlavorV1DataSource_byName
--- PASS: TestAccCSSFlavorV1DataSource_byName (117.94s)
=== RUN   TestAccCssClusterV1_basic
--- PASS: TestAccCssClusterV1_basic (2090.80s)
=== RUN   TestAccCssClusterV1_validateDiskAndFlavor
--- PASS: TestAccCssClusterV1_validateDiskAndFlavor (147.77s)

PASS
ok  	github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/css	2482.589s
```
