### PR TITLE
[Acceptance] Get rid of IDs in `DCS`

### DIFF
--- a/opentelekomcloud/acceptance/dcs/data_source_opentelekomcloud_dcs_az_v1_test.go
+++ b/opentelekomcloud/acceptance/dcs/data_source_opentelekomcloud_dcs_az_v1_test.go
@@ -11,17 +11,18 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
 )
 
+const dataAzName = "data.opentelekomcloud_dcs_az_v1.az1"
+
 func TestAccDcsAZV1DataSource_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDcsAZV1DataSource_basic,
+				Config: testAccDcsAZV1DataSourceBasic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDcsAZV1DataSourceID("data.opentelekomcloud_dcs_az_v1.az1"),
-					resource.TestCheckResourceAttr(
-						"data.opentelekomcloud_dcs_az_v1.az1", "port", "8002"),
+					testAccCheckDcsAZV1DataSourceID(dataAzName),
+					resource.TestCheckResourceAttr(dataAzName, "port", "8002"),
 				),
 			},
 		},
@@ -32,18 +33,18 @@ func testAccCheckDcsAZV1DataSourceID(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("can't find Dcs az data source: %s", n)
+			return fmt.Errorf("can't find DCS AZ data source: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("dcs az data source ID not set")
+			return fmt.Errorf("dcs AZ data source ID not set")
 		}
 
 		return nil
 	}
 }
 
-var testAccDcsAZV1DataSource_basic = fmt.Sprintf(`
+var testAccDcsAZV1DataSourceBasic = fmt.Sprintf(`
 data "opentelekomcloud_dcs_az_v1" "az1" {
   code = "%s"
   port = "8002"

--- a/opentelekomcloud/acceptance/dcs/data_source_opentelekomcloud_dcs_maintainwindow_v1_test.go
+++ b/opentelekomcloud/acceptance/dcs/data_source_opentelekomcloud_dcs_maintainwindow_v1_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
 )
 
+const dataMaintainWindowName = "data.opentelekomcloud_dcs_maintainwindow_v1.maintainwindow1"
+
 func TestAccDcsMaintainWindowV1DataSource_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -18,11 +20,9 @@ func TestAccDcsMaintainWindowV1DataSource_basic(t *testing.T) {
 			{
 				Config: testAccDcsMaintainWindowV1DataSourceBasic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDcsMaintainWindowV1DataSourceID("data.opentelekomcloud_dcs_maintainwindow_v1.maintainwindow1"),
-					resource.TestCheckResourceAttr(
-						"data.opentelekomcloud_dcs_maintainwindow_v1.maintainwindow1", "seq", "1"),
-					resource.TestCheckResourceAttr(
-						"data.opentelekomcloud_dcs_maintainwindow_v1.maintainwindow1", "begin", "22"),
+					testAccCheckDcsMaintainWindowV1DataSourceID(dataMaintainWindowName),
+					resource.TestCheckResourceAttr(dataMaintainWindowName, "seq", "1"),
+					resource.TestCheckResourceAttr(dataMaintainWindowName, "begin", "22"),
 				),
 			},
 		},
@@ -33,7 +33,7 @@ func testAccCheckDcsMaintainWindowV1DataSourceID(n string) resource.TestCheckFun
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("can't find Dcs maintainwindow data source: %s", n)
+			return fmt.Errorf("can't find DCS maintainwindow data source: %s", n)
 		}
 
 		if rs.Primary.ID == "" {

--- a/opentelekomcloud/acceptance/dcs/data_source_opentelekomcloud_dcs_product_v1_test.go
+++ b/opentelekomcloud/acceptance/dcs/data_source_opentelekomcloud_dcs_product_v1_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
 )
 
+const dataProductName = "data.opentelekomcloud_dcs_product_v1.product1"
+
 func TestAccDcsProductV1DataSource_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -18,9 +20,8 @@ func TestAccDcsProductV1DataSource_basic(t *testing.T) {
 			{
 				Config: testAccDcsProductV1DataSourceBasic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDcsProductV1DataSourceID("data.opentelekomcloud_dcs_product_v1.product1"),
-					resource.TestCheckResourceAttr(
-						"data.opentelekomcloud_dcs_product_v1.product1", "spec_code", "dcs.single_node"),
+					testAccCheckDcsProductV1DataSourceID(dataProductName),
+					resource.TestCheckResourceAttr(dataProductName, "spec_code", "dcs.single_node"),
 				),
 			},
 		},
@@ -31,11 +32,11 @@ func testAccCheckDcsProductV1DataSourceID(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("can't find Dcs product data source: %s", n)
+			return fmt.Errorf("can't find DCS product data source: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("DCS product data source ID not set")
+			return fmt.Errorf("dcs product data source ID not set")
 		}
 
 		return nil

--- a/opentelekomcloud/acceptance/dcs/resource_opentelekomcloud_dcs_instance_v1_test.go
+++ b/opentelekomcloud/acceptance/dcs/resource_opentelekomcloud_dcs_instance_v1_test.go
@@ -127,7 +127,7 @@ resource "opentelekomcloud_dcs_instance_v1" "instance_1" {
   engine            = "Redis"
   capacity          = 2
   vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
-  security_group_id = opentelekomcloud_networking_secgroup_v2.secgroup_1.id
+  security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
   subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   available_zones   = [data.opentelekomcloud_dcs_az_v1.az_1.id]
   product_id        = data.opentelekomcloud_dcs_product_v1.product_1.id
@@ -169,7 +169,7 @@ resource "opentelekomcloud_dcs_instance_v1" "instance_1" {
   engine            = "Redis"
   capacity          = 2
   vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
-  security_group_id = opentelekomcloud_networking_secgroup_v2.secgroup_1.id
+  security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
   subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   available_zones   = [data.opentelekomcloud_dcs_az_v1.az_1.id]
   product_id        = data.opentelekomcloud_dcs_product_v1.product_1.id
@@ -212,7 +212,7 @@ resource "opentelekomcloud_dcs_instance_v1" "instance_1" {
   engine            = "Redis"
   capacity          = 2
   vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
-  security_group_id = opentelekomcloud_networking_secgroup_v2.secgroup_1.id
+  security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
   subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   available_zones   = [data.opentelekomcloud_dcs_az_v1.az_1.id]
   product_id        = data.opentelekomcloud_dcs_product_v1.product_1.id

--- a/opentelekomcloud/acceptance/dcs/resource_opentelekomcloud_dcs_instance_v1_test.go
+++ b/opentelekomcloud/acceptance/dcs/resource_opentelekomcloud_dcs_instance_v1_test.go
@@ -15,10 +15,11 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 )
 
+const resourceInstanceName = "opentelekomcloud_dcs_instance_v1.instance_1"
+
 func TestAccDcsInstancesV1_basic(t *testing.T) {
 	var instance instances.Instance
 	var instanceName = fmt.Sprintf("dcs_instance_%s", acctest.RandString(5))
-	resourceName := "opentelekomcloud_dcs_instance_v1.instance_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -28,26 +29,26 @@ func TestAccDcsInstancesV1_basic(t *testing.T) {
 			{
 				Config: testAccDcsV1InstanceBasic(instanceName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDcsV1InstanceExists(resourceName, instance),
-					resource.TestCheckResourceAttr(resourceName, "name", instanceName),
-					resource.TestCheckResourceAttr(resourceName, "engine", "Redis"),
+					testAccCheckDcsV1InstanceExists(resourceInstanceName, instance),
+					resource.TestCheckResourceAttr(resourceInstanceName, "name", instanceName),
+					resource.TestCheckResourceAttr(resourceInstanceName, "engine", "Redis"),
 				),
 			},
 			{
 				Config: testAccDcsV1InstanceUpdated(instanceName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "backup_policy.0.begin_at", "01:00-02:00"),
-					resource.TestCheckResourceAttr(resourceName, "backup_policy.0.save_days", "2"),
-					resource.TestCheckResourceAttr(resourceName, "backup_policy.0.backup_at.#", "3"),
+					resource.TestCheckResourceAttr(resourceInstanceName, "backup_policy.0.begin_at", "01:00-02:00"),
+					resource.TestCheckResourceAttr(resourceInstanceName, "backup_policy.0.save_days", "2"),
+					resource.TestCheckResourceAttr(resourceInstanceName, "backup_policy.0.backup_at.#", "3"),
 				),
 			},
 			{
 				Config: testAccDcsV1InstanceSingle(instanceName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDcsV1InstanceExists(resourceName, instance),
-					resource.TestCheckResourceAttr(resourceName, "name", instanceName),
-					resource.TestCheckResourceAttr(resourceName, "engine", "Redis"),
-					resource.TestCheckResourceAttr(resourceName, "resource_spec_code", "dcs.single_node"),
+					testAccCheckDcsV1InstanceExists(resourceInstanceName, instance),
+					resource.TestCheckResourceAttr(resourceInstanceName, "name", instanceName),
+					resource.TestCheckResourceAttr(resourceInstanceName, "engine", "Redis"),
+					resource.TestCheckResourceAttr(resourceInstanceName, "resource_spec_code", "dcs.single_node"),
 				),
 			},
 		},
@@ -106,14 +107,15 @@ func testAccCheckDcsV1InstanceExists(n string, instance instances.Instance) reso
 
 func testAccDcsV1InstanceBasic(instanceName string) string {
 	return fmt.Sprintf(`
-resource "opentelekomcloud_networking_secgroup_v2" "secgroup_1" {
-  name        = "secgroup_1"
-  description = "secgroup_1"
-}
+%s
+
+%s
+
 data "opentelekomcloud_dcs_az_v1" "az_1" {
   port = "8002"
   code = "%s"
 }
+
 data "opentelekomcloud_dcs_product_v1" "product_1" {
   spec_code = "dcs.master_standby"
 }
@@ -124,9 +126,9 @@ resource "opentelekomcloud_dcs_instance_v1" "instance_1" {
   password          = "Hungarian_rapsody"
   engine            = "Redis"
   capacity          = 2
-  vpc_id            = "%s"
+  vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
   security_group_id = opentelekomcloud_networking_secgroup_v2.secgroup_1.id
-  subnet_id         = "%s"
+  subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   available_zones   = [data.opentelekomcloud_dcs_az_v1.az_1.id]
   product_id        = data.opentelekomcloud_dcs_product_v1.product_1.id
   backup_policy {
@@ -143,30 +145,32 @@ resource "opentelekomcloud_dcs_instance_v1" "instance_1" {
     parameter_value = "100"
   }
 }
-`, env.OS_AVAILABILITY_ZONE, instanceName, env.OS_VPC_ID, env.OS_NETWORK_ID)
+`, common.DataSourceSecGroupDefault, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, instanceName)
 }
 func testAccDcsV1InstanceUpdated(instanceName string) string {
 	return fmt.Sprintf(`
-resource "opentelekomcloud_networking_secgroup_v2" "secgroup_1" {
-  name        = "secgroup_1"
-  description = "secgroup_1"
-}
+%s
+
+%s
+
 data "opentelekomcloud_dcs_az_v1" "az_1" {
   port = "8002"
   code = "%s"
 }
+
 data "opentelekomcloud_dcs_product_v1" "product_1" {
   spec_code = "dcs.master_standby"
 }
+
 resource "opentelekomcloud_dcs_instance_v1" "instance_1" {
   name              = "%s"
   engine_version    = "3.0"
   password          = "Hungarian_rapsody"
   engine            = "Redis"
   capacity          = 2
-  vpc_id            = "%s"
+  vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
   security_group_id = opentelekomcloud_networking_secgroup_v2.secgroup_1.id
-  subnet_id         = "%s"
+  subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   available_zones   = [data.opentelekomcloud_dcs_az_v1.az_1.id]
   product_id        = data.opentelekomcloud_dcs_product_v1.product_1.id
   backup_policy {
@@ -183,33 +187,35 @@ resource "opentelekomcloud_dcs_instance_v1" "instance_1" {
     parameter_value = "200"
   }
 }
-`, env.OS_AVAILABILITY_ZONE, instanceName, env.OS_VPC_ID, env.OS_NETWORK_ID)
+`, common.DataSourceSecGroupDefault, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, instanceName)
 }
 
 func testAccDcsV1InstanceSingle(instanceName string) string {
 	return fmt.Sprintf(`
-resource "opentelekomcloud_networking_secgroup_v2" "secgroup_1" {
-  name        = "secgroup_1"
-  description = "secgroup_1"
-}
+%s
+
+%s
+
 data "opentelekomcloud_dcs_az_v1" "az_1" {
   port = "8002"
   code = "%s"
 }
+
 data "opentelekomcloud_dcs_product_v1" "product_1" {
   spec_code = "dcs.single_node"
 }
+
 resource "opentelekomcloud_dcs_instance_v1" "instance_1" {
   name              = "%s"
   engine_version    = "3.0.7"
   password          = "Hungarian_rapsody"
   engine            = "Redis"
   capacity          = 2
-  vpc_id            = "%s"
+  vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
   security_group_id = opentelekomcloud_networking_secgroup_v2.secgroup_1.id
-  subnet_id         = "%s"
+  subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   available_zones   = [data.opentelekomcloud_dcs_az_v1.az_1.id]
   product_id        = data.opentelekomcloud_dcs_product_v1.product_1.id
 }
-`, env.OS_AVAILABILITY_ZONE, instanceName, env.OS_VPC_ID, env.OS_NETWORK_ID)
+`, common.DataSourceSecGroupDefault, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, instanceName)
 }


### PR DESCRIPTION
## Summary of the Pull Request
Replace `OS_NETWORK_ID` and `OS_VPC_ID` with data sources

## PR Checklist

* [x] Refers to: #1320
* [x] Tests added/passed.

## Acceptance Steps Performed

```
=== RUN   TestAccDcsAZV1DataSource_basic
--- PASS: TestAccDcsAZV1DataSource_basic (116.20s)
=== RUN   TestAccDcsMaintainWindowV1DataSource_basic
--- PASS: TestAccDcsMaintainWindowV1DataSource_basic (113.45s)
=== RUN   TestAccDcsProductV1DataSource_basic
--- PASS: TestAccDcsProductV1DataSource_basic (111.00s)
=== RUN   TestAccDcsInstancesV1_basic        
--- PASS: TestAccDcsInstancesV1_basic (649.29s)

PASS
PASS github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/dcs	993.362s
```
