### PR TITLE
[Acceptance] Get rid of IDs in `EVS`

### DIFF
--- a/opentelekomcloud/acceptance/common/data_sources.go
+++ b/opentelekomcloud/acceptance/common/data_sources.go
@@ -35,6 +35,13 @@ data "opentelekomcloud_images_image_v2" "latest_image" {
 }
 `, env.OsImageName)
 
+// DataSourceKMSKey can be referred as `data.opentelekomcloud_kms_key_v1.default_key`
+var DataSourceKMSKey = fmt.Sprintf(`
+data "opentelekomcloud_kms_key_v1" "default_key" {
+  key_alias = "%s"
+}
+`, env.OsKmsName)
+
 // DataSourceSecGroupDefault can be referred as `data.opentelekomcloud_networking_secgroup_v2.default_secgroup`
 const DataSourceSecGroupDefault = `
 data "opentelekomcloud_networking_secgroup_v2" "default_secgroup" {

--- a/opentelekomcloud/acceptance/evs/resource_opentelekomcloud_blockstorage_volume_v2_test.go
+++ b/opentelekomcloud/acceptance/evs/resource_opentelekomcloud_blockstorage_volume_v2_test.go
@@ -435,9 +435,7 @@ resource "opentelekomcloud_blockstorage_volume_v2" "volume_1" {
 `, env.OS_IMAGE_ID)
 
 var testAccBlockStorageV2VolumePolicy = fmt.Sprintf(`
-data "opentelekomcloud_kms_key_v1" key {
-  key_alias = "%s"
-}
+%s
 
 data opentelekomcloud_compute_availability_zones_v2 available {}
 
@@ -455,7 +453,7 @@ resource "opentelekomcloud_blockstorage_volume_v2" "volume" {
   }
   metadata = {
     __system__encrypted = "1"
-    __system__cmkid     = data.opentelekomcloud_kms_key_v1.key.id
+    __system__cmkid     = data.opentelekomcloud_kms_key_v1.default_key.id
     attached_mode       = "rw"
     readonly            = "False"
   }
@@ -473,4 +471,4 @@ resource "opentelekomcloud_vbs_backup_policy_v2" "vbs_policy1" {
   resources = opentelekomcloud_blockstorage_volume_v2.volume[*].id
 
 }
-`, env.OsKmsName)
+`, common.DataSourceKMSKey)

--- a/opentelekomcloud/acceptance/evs/resource_opentelekomcloud_blockstorage_volume_v2_test.go
+++ b/opentelekomcloud/acceptance/evs/resource_opentelekomcloud_blockstorage_volume_v2_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 )
 
+const resourceVolumeName = "opentelekomcloud_blockstorage_volume_v2.volume_1"
+
 func TestAccBlockStorageV2Volume_basic(t *testing.T) {
 	var volume volumes.Volume
 
@@ -26,19 +28,17 @@ func TestAccBlockStorageV2Volume_basic(t *testing.T) {
 			{
 				Config: testAccBlockStorageV2VolumeBasic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBlockStorageV2VolumeExists("opentelekomcloud_blockstorage_volume_v2.volume_1", &volume),
+					testAccCheckBlockStorageV2VolumeExists(resourceVolumeName, &volume),
 					testAccCheckBlockStorageV2VolumeMetadata(&volume, "foo", "bar"),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_blockstorage_volume_v2.volume_1", "name", "volume_1"),
+					resource.TestCheckResourceAttr(resourceVolumeName, "name", "volume_1"),
 				),
 			},
 			{
 				Config: testAccBlockStorageV2VolumeUpdate,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBlockStorageV2VolumeExists("opentelekomcloud_blockstorage_volume_v2.volume_1", &volume),
+					testAccCheckBlockStorageV2VolumeExists(resourceVolumeName, &volume),
 					testAccCheckBlockStorageV2VolumeMetadata(&volume, "foo", "bar"),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_blockstorage_volume_v2.volume_1", "name", "volume_1-updated"),
+					resource.TestCheckResourceAttr(resourceVolumeName, "name", "volume_1-updated"),
 				),
 			},
 		},
@@ -55,15 +55,15 @@ func TestAccBlockStorageV2Volume_upscaleDownScale(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBlockStorageV2VolumeBasic,
-				Check:  testAccCheckBlockStorageV2VolumeExists("opentelekomcloud_blockstorage_volume_v2.volume_1", &volume),
+				Check:  testAccCheckBlockStorageV2VolumeExists(resourceVolumeName, &volume),
 			},
 			{
 				Config: testAccBlockStorageV2VolumeBigger,
-				Check:  testAccCheckBlockStorageV2VolumeSame("opentelekomcloud_blockstorage_volume_v2.volume_1", &volume),
+				Check:  testAccCheckBlockStorageV2VolumeSame(resourceVolumeName, &volume),
 			},
 			{
 				Config: testAccBlockStorageV2VolumeBasic,
-				Check:  testAccCheckBlockStorageV2VolumeNew("opentelekomcloud_blockstorage_volume_v2.volume_1", &volume),
+				Check:  testAccCheckBlockStorageV2VolumeNew(resourceVolumeName, &volume),
 			},
 		},
 	})
@@ -78,15 +78,15 @@ func TestAccBlockStorageV2Volume_upscaleDownScaleAssigned(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBlockStorageV2VolumeAssigned(10),
-				Check:  testAccCheckBlockStorageV2VolumeExists("opentelekomcloud_blockstorage_volume_v2.volume_1", &volume),
+				Check:  testAccCheckBlockStorageV2VolumeExists(resourceVolumeName, &volume),
 			},
 			{
 				Config: testAccBlockStorageV2VolumeAssigned(12),
-				Check:  testAccCheckBlockStorageV2VolumeSame("opentelekomcloud_blockstorage_volume_v2.volume_1", &volume),
+				Check:  testAccCheckBlockStorageV2VolumeSame(resourceVolumeName, &volume),
 			},
 			{
 				Config: testAccBlockStorageV2VolumeAssigned(10),
-				Check:  testAccCheckBlockStorageV2VolumeNew("opentelekomcloud_blockstorage_volume_v2.volume_1", &volume),
+				Check:  testAccCheckBlockStorageV2VolumeNew(resourceVolumeName, &volume),
 			},
 		},
 	})
@@ -102,15 +102,15 @@ func TestAccBlockStorageV2Volume_policy(t *testing.T) {
 		CheckDestroy:      testAccCheckBlockStorageV2VolumeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBlockStorageV2VolumePolicy(os.Getenv("OS_KMS_KEY")),
+				Config: testAccBlockStorageV2VolumePolicy,
 			},
 		},
 	})
 }
 
 func testPolicyPreCheck(t *testing.T) {
-	if os.Getenv("OS_KMS_KEY") == "" {
-		t.Skipf("OS_KMS_KEY should be set for this test to existing KMS key alias")
+	if os.Getenv("OS_KMS_NAME") == "" {
+		t.Skipf("OS_KMS_NAME should be set for this test to existing KMS key alias")
 	}
 }
 
@@ -123,15 +123,15 @@ func TestAccBlockStorageV2Volume_tags(t *testing.T) {
 			{
 				Config: testAccBlockStorageV2VolumeTags,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBlockStorageV2VolumeTags("opentelekomcloud_blockstorage_volume_v2.volume_1", "foo", "bar"),
-					testAccCheckBlockStorageV2VolumeTags("opentelekomcloud_blockstorage_volume_v2.volume_1", "key", "value"),
+					testAccCheckBlockStorageV2VolumeTags(resourceVolumeName, "foo", "bar"),
+					testAccCheckBlockStorageV2VolumeTags(resourceVolumeName, "key", "value"),
 				),
 			},
 			{
 				Config: testAccBlockStorageV2VolumeTagsUpdate,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBlockStorageV2VolumeTags("opentelekomcloud_blockstorage_volume_v2.volume_1", "foo2", "bar2"),
-					testAccCheckBlockStorageV2VolumeTags("opentelekomcloud_blockstorage_volume_v2.volume_1", "key2", "value2"),
+					testAccCheckBlockStorageV2VolumeTags(resourceVolumeName, "foo2", "bar2"),
+					testAccCheckBlockStorageV2VolumeTags(resourceVolumeName, "key2", "value2"),
 				),
 			},
 		},
@@ -149,9 +149,9 @@ func TestAccBlockStorageV2Volume_image(t *testing.T) {
 			{
 				Config: testAccBlockStorageV2VolumeImage,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBlockStorageV2VolumeExists("opentelekomcloud_blockstorage_volume_v2.volume_1", &volume),
+					testAccCheckBlockStorageV2VolumeExists(resourceVolumeName, &volume),
 					resource.TestCheckResourceAttr(
-						"opentelekomcloud_blockstorage_volume_v2.volume_1", "name", "volume_1"),
+						resourceVolumeName, "name", "volume_1"),
 				),
 			},
 		},
@@ -169,7 +169,7 @@ func TestAccBlockStorageV2Volume_timeout(t *testing.T) {
 			{
 				Config: testAccBlockStorageV2VolumeTimeout,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBlockStorageV2VolumeExists("opentelekomcloud_blockstorage_volume_v2.volume_1", &volume),
+					testAccCheckBlockStorageV2VolumeExists(resourceVolumeName, &volume),
 				),
 			},
 		},
@@ -434,8 +434,7 @@ resource "opentelekomcloud_blockstorage_volume_v2" "volume_1" {
 }
 `, env.OS_IMAGE_ID)
 
-func testAccBlockStorageV2VolumePolicy(kmsKeyAlias string) string {
-	return fmt.Sprintf(`
+var testAccBlockStorageV2VolumePolicy = fmt.Sprintf(`
 data "opentelekomcloud_kms_key_v1" key {
   key_alias = "%s"
 }
@@ -474,5 +473,4 @@ resource "opentelekomcloud_vbs_backup_policy_v2" "vbs_policy1" {
   resources = opentelekomcloud_blockstorage_volume_v2.volume[*].id
 
 }
-`, kmsKeyAlias)
-}
+`, env.OsKmsName)

--- a/opentelekomcloud/acceptance/evs/resource_opentelekomcloud_evs_volume_v3_test.go
+++ b/opentelekomcloud/acceptance/evs/resource_opentelekomcloud_evs_volume_v3_test.go
@@ -277,14 +277,16 @@ resource "opentelekomcloud_evs_volume_v3" "volume_1" {
 }
 `, env.OS_AVAILABILITY_ZONE)
 	testAccEvsStorageV3VolumeImage = fmt.Sprintf(`
+%s
+
 resource "opentelekomcloud_evs_volume_v3" "volume_1" {
   name              = "volume_1"
   availability_zone = "%s"
   volume_type       = "SATA"
   size              = 12
-  image_id          = "%s"
+  image_id          = data.opentelekomcloud_images_image_v2.latest_image.id
 }
-`, env.OS_AVAILABILITY_ZONE, env.OS_IMAGE_ID)
+`, common.DataSourceImage, env.OS_AVAILABILITY_ZONE)
 	testAccEvsStorageV3VolumeTimeout = fmt.Sprintf(`
 resource "opentelekomcloud_evs_volume_v3" "volume_1" {
   name              = "volume_1"


### PR DESCRIPTION
## Summary of the Pull Request
Replace `OS_IMAGE_ID` with data source

Minor style cleanup

Add `DataSourceKMSKey` data source

## PR Checklist

* [x] Refers to: #1320
* [x] Tests added/passed.

## Acceptance Steps Performed

```
=== RUN   TestAccBlockStorageV2Volume_importBasic
--- PASS: TestAccBlockStorageV2Volume_importBasic (35.55s)
=== RUN   TestAccBlockStorageV2Volume_basic
--- PASS: TestAccBlockStorageV2Volume_basic (44.09s)
=== RUN   TestAccBlockStorageV2Volume_upscaleDownScale
--- PASS: TestAccBlockStorageV2Volume_upscaleDownScale (89.08s)
=== RUN   TestAccBlockStorageV2Volume_upscaleDownScaleAssigned
--- PASS: TestAccBlockStorageV2Volume_upscaleDownScaleAssigned (163.33s)
=== RUN   TestAccBlockStorageV2Volume_policy
--- PASS: TestAccBlockStorageV2Volume_policy (59.03s)
=== RUN   TestAccBlockStorageV2Volume_tags
--- PASS: TestAccBlockStorageV2Volume_tags (49.55s)
=== RUN   TestAccBlockStorageV2Volume_image
--- PASS: TestAccBlockStorageV2Volume_image (35.28s)
=== RUN   TestAccBlockStorageV2Volume_timeout
--- PASS: TestAccBlockStorageV2Volume_timeout (34.62s)
=== RUN   TestAccEvsStorageV3Volume_basic
--- PASS: TestAccEvsStorageV3Volume_basic (46.65s)
=== RUN   TestAccEvsStorageV3Volume_tags
--- PASS: TestAccEvsStorageV3Volume_tags (42.34s)
=== RUN   TestAccEvsStorageV3Volume_image
--- PASS: TestAccEvsStorageV3Volume_image (40.11s)
=== RUN   TestAccEvsStorageV3Volume_timeout
--- PASS: TestAccEvsStorageV3Volume_timeout (34.21s)
=== RUN   TestAccEvsStorageV3Volume_volumeType
--- PASS: TestAccEvsStorageV3Volume_volumeType (1.45s)
=== RUN   TestAccEvsStorageV3Volume_resize
--- PASS: TestAccEvsStorageV3Volume_resize (53.79s)
PASS
ok  	github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/evs	671.139s

Process finished with the exit code 0

```
