### PR TITLE
[ELB] Fix certificate deletion logic

### DIFF
--- a/releasenotes/notes/fix-lb-cert-7f550a1b8eb67d5c.yaml
+++ b/releasenotes/notes/fix-lb-cert-7f550a1b8eb67d5c.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[ELB]** Fix timeout during deletion of ``resource/opentelekomcloud_lb_certificate_v2`` bound to a listener (`#1377 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1377>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Fix too early wait during certification deletion.

The wait was expiring a context before trying to unassign a cert from the listeners.

Fix #1376

## PR Checklist

* [x] Refers to: #1376
* [x] Tests added/passed.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccLBV2Listener_basic
--- PASS: TestAccLBV2Listener_basic (87.43s)
=== RUN   TestAccLBV2Listener_tls
--- PASS: TestAccLBV2Listener_tls (88.44s)
=== RUN   TestAccLBV2ListenerSni
--- PASS: TestAccLBV2ListenerSni (121.52s)
PASS

Process finished with the exit code 0


=== RUN   TestAccLBV2Certificate_basic
--- PASS: TestAccLBV2Certificate_basic (81.57s)
PASS

Process finished with the exit code 0

```
