### PR TITLE
[Acceptance] Get rid of IDs in `ECS`

### DIFF
--- a/opentelekomcloud/acceptance/ecs/data_source_opentelekomcloud_compute_availability_zones_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/data_source_opentelekomcloud_compute_availability_zones_v2_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
 )
 
+const dataAzName = "data.opentelekomcloud_compute_availability_zones_v2.zones"
+
 func TestAccOpenStackAvailabilityZonesV2_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -17,7 +19,7 @@ func TestAccOpenStackAvailabilityZonesV2_basic(t *testing.T) {
 			{
 				Config: testAccOpenStackAvailabilityZonesConfig,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr("data.opentelekomcloud_compute_availability_zones_v2.zones", "names.#", regexp.MustCompile(`[1-9]\d*`)),
+					resource.TestMatchResourceAttr(dataAzName, "names.#", regexp.MustCompile(`[1-9]\d*`)),
 				),
 			},
 		},

--- a/opentelekomcloud/acceptance/ecs/import_opentelekomcloud_compute_floatingip_associate_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/import_opentelekomcloud_compute_floatingip_associate_v2_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
 )
 
-func TestAccComputeV2FloatingIPAssociate_importBasic(t *testing.T) {
-	resourceName := "opentelekomcloud_compute_floatingip_associate_v2.fip_1"
+const resourceFloatingIpAssociateName = "opentelekomcloud_compute_floatingip_associate_v2.fip_1"
 
+func TestAccComputeV2FloatingIPAssociate_importBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
@@ -19,9 +19,8 @@ func TestAccComputeV2FloatingIPAssociate_importBasic(t *testing.T) {
 			{
 				Config: testAccComputeV2FloatingIPAssociateBasic,
 			},
-
 			{
-				ResourceName:      resourceName,
+				ResourceName:      resourceFloatingIpAssociateName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},

--- a/opentelekomcloud/acceptance/ecs/import_opentelekomcloud_compute_floatingip_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/import_opentelekomcloud_compute_floatingip_v2_test.go
@@ -9,19 +9,16 @@ import (
 )
 
 func TestAccComputeV2FloatingIP_importBasic(t *testing.T) {
-	resourceName := "opentelekomcloud_compute_floatingip_v2.fip_1"
-
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckComputeV2FloatingIPDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeV2FloatingIP_basic,
+				Config: testAccComputeV2FloatingIPBasic,
 			},
-
 			{
-				ResourceName:      resourceName,
+				ResourceName:      resourceFloatingIpName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},

--- a/opentelekomcloud/acceptance/ecs/import_opentelekomcloud_compute_instance_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/import_opentelekomcloud_compute_instance_v2_test.go
@@ -9,8 +9,6 @@ import (
 )
 
 func TestAccComputeV2InstanceImportBasic(t *testing.T) {
-	resourceName := "opentelekomcloud_compute_instance_v2.instance_1"
-
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
@@ -20,7 +18,7 @@ func TestAccComputeV2InstanceImportBasic(t *testing.T) {
 				Config: testAccComputeV2InstanceBasic,
 			},
 			{
-				ResourceName:      resourceName,
+				ResourceName:      resourceInstanceV2Name,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
@@ -33,8 +31,6 @@ func TestAccComputeV2InstanceImportBasic(t *testing.T) {
 }
 
 func TestAccComputeV2InstanceImportBootFromVolumeImage(t *testing.T) {
-	resourceName := "opentelekomcloud_compute_instance_v2.instance_1"
-
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
@@ -44,7 +40,7 @@ func TestAccComputeV2InstanceImportBootFromVolumeImage(t *testing.T) {
 				Config: testAccComputeV2InstanceBootFromVolumeImage,
 			},
 			{
-				ResourceName:      resourceName,
+				ResourceName:      resourceInstanceV2Name,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{

--- a/opentelekomcloud/acceptance/ecs/import_opentelekomcloud_compute_keypair_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/import_opentelekomcloud_compute_keypair_v2_test.go
@@ -9,19 +9,17 @@ import (
 )
 
 func TestAccComputeV2Keypair_importBasic(t *testing.T) {
-	resourceName := "opentelekomcloud_compute_keypair_v2.kp_1"
-
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckComputeV2KeypairDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeV2Keypair_basic,
+				Config: testAccComputeV2KeypairBasic,
 			},
 
 			{
-				ResourceName:      resourceName,
+				ResourceName:      resourceKeyPairName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},

--- a/opentelekomcloud/acceptance/ecs/import_opentelekomcloud_compute_secgroup_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/import_opentelekomcloud_compute_secgroup_v2_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestAccComputeV2SecGroup_importBasic(t *testing.T) {
-
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,

--- a/opentelekomcloud/acceptance/ecs/import_opentelekomcloud_compute_secgroup_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/import_opentelekomcloud_compute_secgroup_v2_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestAccComputeV2SecGroup_importBasic(t *testing.T) {
-	resourceName := "opentelekomcloud_compute_secgroup_v2.sg_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -19,9 +18,8 @@ func TestAccComputeV2SecGroup_importBasic(t *testing.T) {
 			{
 				Config: testAccComputeV2SecGroupBasicOrig,
 			},
-
 			{
-				ResourceName:      resourceName,
+				ResourceName:      resourceSecGroupName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},

--- a/opentelekomcloud/acceptance/ecs/import_opentelekomcloud_compute_servergroup_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/import_opentelekomcloud_compute_servergroup_v2_test.go
@@ -17,7 +17,7 @@ func TestAccComputeV2ServerGroup_importBasic(t *testing.T) {
 		CheckDestroy:      testAccCheckComputeV2ServerGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeV2ServerGroup_basic,
+				Config: testAccComputeV2ServerGroupBasic,
 			},
 
 			{

--- a/opentelekomcloud/acceptance/ecs/import_opentelekomcloud_compute_volume_attach_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/import_opentelekomcloud_compute_volume_attach_v2_test.go
@@ -9,8 +9,6 @@ import (
 )
 
 func TestAccComputeV2VolumeAttach_importBasic(t *testing.T) {
-	resourceName := "opentelekomcloud_compute_volume_attach_v2.va_1"
-
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
@@ -21,7 +19,7 @@ func TestAccComputeV2VolumeAttach_importBasic(t *testing.T) {
 			},
 
 			{
-				ResourceName:      resourceName,
+				ResourceName:      resourceVolumeAttach,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},

--- a/opentelekomcloud/acceptance/ecs/import_opentelekomcloud_ecs_instance_v1_test.go
+++ b/opentelekomcloud/acceptance/ecs/import_opentelekomcloud_ecs_instance_v1_test.go
@@ -9,8 +9,6 @@ import (
 )
 
 func TestAccEcsV1Instance_importBasic(t *testing.T) {
-	resourceName := "opentelekomcloud_ecs_instance_v1.instance_1"
-
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
@@ -21,7 +19,7 @@ func TestAccEcsV1Instance_importBasic(t *testing.T) {
 			},
 
 			{
-				ResourceName:      resourceName,
+				ResourceName:      resourceInstanceV1Name,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{

--- a/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_floatingip_associate_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_floatingip_associate_v2_test.go
@@ -22,6 +22,7 @@ import (
 func TestAccComputeV2FloatingIPAssociate_basic(t *testing.T) {
 	var instance servers.Server
 	var fip floatingips.FloatingIP
+	resourceNwFloatingIpName := "opentelekomcloud_networking_floatingip_v2.fip_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -32,7 +33,7 @@ func TestAccComputeV2FloatingIPAssociate_basic(t *testing.T) {
 				Config: testAccComputeV2FloatingIPAssociateBasic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeV2InstanceExists(resourceInstanceV2Name, &instance),
-					vpc.TestAccCheckNetworkingV2FloatingIPExists(resourceFloatingIpName, &fip),
+					vpc.TestAccCheckNetworkingV2FloatingIPExists(resourceNwFloatingIpName, &fip),
 					testAccCheckComputeV2FloatingIPAssociateAssociated(&fip, &instance, 1),
 				),
 			},
@@ -43,6 +44,7 @@ func TestAccComputeV2FloatingIPAssociate_basic(t *testing.T) {
 func TestAccComputeV2FloatingIPAssociate_fixedIP(t *testing.T) {
 	var instance servers.Server
 	var fip floatingips.FloatingIP
+	resourceNwFloatingIpName := "opentelekomcloud_networking_floatingip_v2.fip_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -53,7 +55,7 @@ func TestAccComputeV2FloatingIPAssociate_fixedIP(t *testing.T) {
 				Config: testAccComputeV2FloatingIPAssociateFixedIP,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeV2InstanceExists(resourceInstanceV2Name, &instance),
-					vpc.TestAccCheckNetworkingV2FloatingIPExists(resourceFloatingIpName, &fip),
+					vpc.TestAccCheckNetworkingV2FloatingIPExists(resourceNwFloatingIpName, &fip),
 					testAccCheckComputeV2FloatingIPAssociateAssociated(&fip, &instance, 1),
 				),
 			},
@@ -64,6 +66,7 @@ func TestAccComputeV2FloatingIPAssociate_fixedIP(t *testing.T) {
 func TestAccComputeV2FloatingIPAssociate_attachToFirstNetwork(t *testing.T) {
 	var instance servers.Server
 	var fip floatingips.FloatingIP
+	resourceNwFloatingIpName := "opentelekomcloud_networking_floatingip_v2.fip_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -74,7 +77,7 @@ func TestAccComputeV2FloatingIPAssociate_attachToFirstNetwork(t *testing.T) {
 				Config: testAccComputeV2FloatingIPAssociateAttachToFirstNetwork,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeV2InstanceExists(resourceInstanceV2Name, &instance),
-					vpc.TestAccCheckNetworkingV2FloatingIPExists(resourceFloatingIpName, &fip),
+					vpc.TestAccCheckNetworkingV2FloatingIPExists(resourceNwFloatingIpName, &fip),
 					testAccCheckComputeV2FloatingIPAssociateAssociated(&fip, &instance, 1),
 				),
 			},
@@ -86,7 +89,8 @@ func TestAccComputeV2FloatingIPAssociate_attachNew(t *testing.T) {
 	var instance servers.Server
 	var fip1 floatingips.FloatingIP
 	var fip2 floatingips.FloatingIP
-	resourceFloatingIp2Name := "opentelekomcloud_networking_floatingip_v2.fip_2"
+	resourceNwFloatingIpName := "opentelekomcloud_networking_floatingip_v2.fip_1"
+	resourceNwFloatingIp2Name := "opentelekomcloud_networking_floatingip_v2.fip_2"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -97,8 +101,8 @@ func TestAccComputeV2FloatingIPAssociate_attachNew(t *testing.T) {
 				Config: testAccComputeV2FloatingIPAssociateAttachNew1,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeV2InstanceExists(resourceInstanceV2Name, &instance),
-					vpc.TestAccCheckNetworkingV2FloatingIPExists(resourceFloatingIpName, &fip1),
-					vpc.TestAccCheckNetworkingV2FloatingIPExists(resourceFloatingIp2Name, &fip2),
+					vpc.TestAccCheckNetworkingV2FloatingIPExists(resourceNwFloatingIpName, &fip1),
+					vpc.TestAccCheckNetworkingV2FloatingIPExists(resourceNwFloatingIp2Name, &fip2),
 					testAccCheckComputeV2FloatingIPAssociateAssociated(&fip1, &instance, 1),
 				),
 			},
@@ -106,8 +110,8 @@ func TestAccComputeV2FloatingIPAssociate_attachNew(t *testing.T) {
 				Config: testAccComputeV2FloatingIPAssociateAttachNew2,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeV2InstanceExists(resourceInstanceV2Name, &instance),
-					vpc.TestAccCheckNetworkingV2FloatingIPExists(resourceFloatingIpName, &fip1),
-					vpc.TestAccCheckNetworkingV2FloatingIPExists(resourceFloatingIp2Name, &fip2),
+					vpc.TestAccCheckNetworkingV2FloatingIPExists(resourceNwFloatingIpName, &fip1),
+					vpc.TestAccCheckNetworkingV2FloatingIPExists(resourceNwFloatingIp2Name, &fip2),
 					testAccCheckComputeV2FloatingIPAssociateAssociated(&fip2, &instance, 1),
 				),
 			},

--- a/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_floatingip_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_floatingip_v2_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 )
 
+const resourceFloatingIpName = "opentelekomcloud_compute_floatingip_v2.fip_1"
+
 func TestAccComputeV2FloatingIP_basic(t *testing.T) {
 	var fip floatingips.FloatingIP
 
@@ -23,9 +25,9 @@ func TestAccComputeV2FloatingIP_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckComputeV2FloatingIPDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeV2FloatingIP_basic,
+				Config: testAccComputeV2FloatingIPBasic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2FloatingIPExists("opentelekomcloud_compute_floatingip_v2.fip_1", &fip),
+					testAccCheckComputeV2FloatingIPExists(resourceFloatingIpName, &fip),
 				),
 			},
 		},
@@ -34,9 +36,9 @@ func TestAccComputeV2FloatingIP_basic(t *testing.T) {
 
 func testAccCheckComputeV2FloatingIPDestroy(s *terraform.State) error {
 	config := common.TestAccProvider.Meta().(*cfg.Config)
-	computeClient, err := config.ComputeV2Client(env.OS_REGION_NAME)
+	client, err := config.ComputeV2Client(env.OS_REGION_NAME)
 	if err != nil {
-		return fmt.Errorf("error creating OpenTelekomCloud compute client: %s", err)
+		return fmt.Errorf("error creating OpenTelekomCloud ComputeV2 client: %s", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -44,7 +46,7 @@ func testAccCheckComputeV2FloatingIPDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := floatingips.Get(computeClient, rs.Primary.ID).Extract()
+		_, err := floatingips.Get(client, rs.Primary.ID).Extract()
 		if err == nil {
 			return fmt.Errorf("floatingIP still exists")
 		}
@@ -65,12 +67,12 @@ func testAccCheckComputeV2FloatingIPExists(n string, kp *floatingips.FloatingIP)
 		}
 
 		config := common.TestAccProvider.Meta().(*cfg.Config)
-		computeClient, err := config.ComputeV2Client(env.OS_REGION_NAME)
+		client, err := config.ComputeV2Client(env.OS_REGION_NAME)
 		if err != nil {
-			return fmt.Errorf("error creating OpenTelekomCloud compute client: %s", err)
+			return fmt.Errorf("error creating OpenTelekomCloud ComputeV2 client: %s", err)
 		}
 
-		found, err := floatingips.Get(computeClient, rs.Primary.ID).Extract()
+		found, err := floatingips.Get(client, rs.Primary.ID).Extract()
 		if err != nil {
 			return err
 		}
@@ -85,6 +87,6 @@ func testAccCheckComputeV2FloatingIPExists(n string, kp *floatingips.FloatingIP)
 	}
 }
 
-const testAccComputeV2FloatingIP_basic = `
+const testAccComputeV2FloatingIPBasic = `
 resource "opentelekomcloud_compute_floatingip_v2" "fip_1" {}
 `

--- a/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_instance_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_instance_v2_test.go
@@ -18,9 +18,10 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 )
 
+const resourceInstanceV2Name = "opentelekomcloud_compute_instance_v2.instance_1"
+
 func TestAccComputeV2Instance_basic(t *testing.T) {
 	var instance servers.Server
-	resourceName := "opentelekomcloud_compute_instance_v2.instance_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -30,20 +31,20 @@ func TestAccComputeV2Instance_basic(t *testing.T) {
 			{
 				Config: testAccComputeV2InstanceBasic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2InstanceExists(resourceName, &instance),
+					testAccCheckComputeV2InstanceExists(resourceInstanceV2Name, &instance),
 					testAccCheckComputeV2InstanceMetadata(&instance, "foo", "bar"),
-					resource.TestCheckResourceAttr(resourceName, "all_metadata.foo", "bar"),
-					resource.TestCheckResourceAttr(resourceName, "name", "instance_1"),
-					resource.TestCheckResourceAttr(resourceName, "availability_zone", env.OS_AVAILABILITY_ZONE),
-					resource.TestCheckResourceAttr(resourceName, "tags.muh", "value-create"),
+					resource.TestCheckResourceAttr(resourceInstanceV2Name, "all_metadata.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceInstanceV2Name, "name", "instance_1"),
+					resource.TestCheckResourceAttr(resourceInstanceV2Name, "availability_zone", env.OS_AVAILABILITY_ZONE),
+					resource.TestCheckResourceAttr(resourceInstanceV2Name, "tags.muh", "value-create"),
 				),
 			},
 			{
 				Config: testAccComputeV2InstanceUpdate,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2InstanceExists(resourceName, &instance),
-					resource.TestCheckResourceAttr(resourceName, "name", "instance_2"),
-					resource.TestCheckResourceAttr(resourceName, "tags.muh", "value-update"),
+					testAccCheckComputeV2InstanceExists(resourceInstanceV2Name, &instance),
+					resource.TestCheckResourceAttr(resourceInstanceV2Name, "name", "instance_2"),
+					resource.TestCheckResourceAttr(resourceInstanceV2Name, "tags.muh", "value-update"),
 				),
 			},
 		},
@@ -53,7 +54,6 @@ func TestAccComputeV2Instance_basic(t *testing.T) {
 func TestAccComputeV2Instance_multiSecgroup(t *testing.T) {
 	var instance servers.Server
 	var secGroup1, secGroup2 secgroups.SecurityGroup
-	resourceName := "opentelekomcloud_compute_instance_v2.instance_1"
 	secGroupName1 := "opentelekomcloud_compute_secgroup_v2.secgroup_1"
 	secGroupName2 := "opentelekomcloud_compute_secgroup_v2.secgroup_2"
 
@@ -67,7 +67,7 @@ func TestAccComputeV2Instance_multiSecgroup(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeV2SecGroupExists(secGroupName1, &secGroup1),
 					testAccCheckComputeV2SecGroupExists(secGroupName2, &secGroup2),
-					testAccCheckComputeV2InstanceExists(resourceName, &instance),
+					testAccCheckComputeV2InstanceExists(resourceInstanceV2Name, &instance),
 				),
 			},
 			{
@@ -75,7 +75,7 @@ func TestAccComputeV2Instance_multiSecgroup(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeV2SecGroupExists(secGroupName1, &secGroup1),
 					testAccCheckComputeV2SecGroupExists(secGroupName2, &secGroup2),
-					testAccCheckComputeV2InstanceExists(resourceName, &instance),
+					testAccCheckComputeV2InstanceExists(resourceInstanceV2Name, &instance),
 				),
 			},
 		},
@@ -84,7 +84,6 @@ func TestAccComputeV2Instance_multiSecgroup(t *testing.T) {
 
 func TestAccComputeV2Instance_bootFromImage(t *testing.T) {
 	var instance servers.Server
-	resourceName := "opentelekomcloud_compute_instance_v2.instance_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -94,7 +93,7 @@ func TestAccComputeV2Instance_bootFromImage(t *testing.T) {
 			{
 				Config: testAccComputeV2InstanceBootFromVolumeImage,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2InstanceExists(resourceName, &instance),
+					testAccCheckComputeV2InstanceExists(resourceInstanceV2Name, &instance),
 					testAccCheckComputeV2InstanceBootVolumeAttachment(&instance),
 				),
 			},
@@ -104,7 +103,6 @@ func TestAccComputeV2Instance_bootFromImage(t *testing.T) {
 
 func TestAccComputeV2Instance_bootFromVolume(t *testing.T) {
 	var instance servers.Server
-	resourceName := "opentelekomcloud_compute_instance_v2.instance_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -114,7 +112,7 @@ func TestAccComputeV2Instance_bootFromVolume(t *testing.T) {
 			{
 				Config: testAccComputeV2InstanceBootFromVolume,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2InstanceExists(resourceName, &instance),
+					testAccCheckComputeV2InstanceExists(resourceInstanceV2Name, &instance),
 				),
 			},
 		},
@@ -132,8 +130,7 @@ func TestAccComputeV2Instance_changeFixedIP(t *testing.T) {
 			{
 				Config: testAccComputeV2InstanceFixedIP,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2InstanceExists(
-						"opentelekomcloud_compute_instance_v2.instance_1", &instance),
+					testAccCheckComputeV2InstanceExists(resourceInstanceV2Name, &instance),
 				),
 			},
 		},
@@ -142,7 +139,6 @@ func TestAccComputeV2Instance_changeFixedIP(t *testing.T) {
 
 func TestAccComputeV2Instance_bootFromVolumeVolume(t *testing.T) {
 	var instance servers.Server
-	resourceName := "opentelekomcloud_compute_instance_v2.instance_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -152,7 +148,7 @@ func TestAccComputeV2Instance_bootFromVolumeVolume(t *testing.T) {
 			{
 				Config: testAccComputeV2InstanceBootFromVolumeVolume,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2InstanceExists(resourceName, &instance),
+					testAccCheckComputeV2InstanceExists(resourceInstanceV2Name, &instance),
 					testAccCheckComputeV2InstanceBootVolumeAttachment(&instance),
 				),
 			},
@@ -162,7 +158,6 @@ func TestAccComputeV2Instance_bootFromVolumeVolume(t *testing.T) {
 
 func TestAccComputeV2Instance_stopBeforeDestroy(t *testing.T) {
 	var instance servers.Server
-	resourceName := "opentelekomcloud_compute_instance_v2.instance_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -172,7 +167,7 @@ func TestAccComputeV2Instance_stopBeforeDestroy(t *testing.T) {
 			{
 				Config: testAccComputeV2InstanceStopBeforeDestroy,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2InstanceExists(resourceName, &instance),
+					testAccCheckComputeV2InstanceExists(resourceInstanceV2Name, &instance),
 				),
 			},
 		},
@@ -181,7 +176,6 @@ func TestAccComputeV2Instance_stopBeforeDestroy(t *testing.T) {
 
 func TestAccComputeV2Instance_metadata(t *testing.T) {
 	var instance servers.Server
-	resourceName := "opentelekomcloud_compute_instance_v2.instance_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -191,22 +185,22 @@ func TestAccComputeV2Instance_metadata(t *testing.T) {
 			{
 				Config: testAccComputeV2InstanceMetadata,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2InstanceExists(resourceName, &instance),
+					testAccCheckComputeV2InstanceExists(resourceInstanceV2Name, &instance),
 					testAccCheckComputeV2InstanceMetadata(&instance, "foo", "bar"),
 					testAccCheckComputeV2InstanceMetadata(&instance, "abc", "def"),
-					resource.TestCheckResourceAttr(resourceName, "all_metadata.foo", "bar"),
-					resource.TestCheckResourceAttr(resourceName, "all_metadata.abc", "def"),
+					resource.TestCheckResourceAttr(resourceInstanceV2Name, "all_metadata.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceInstanceV2Name, "all_metadata.abc", "def"),
 				),
 			},
 			{
 				Config: testAccComputeV2InstanceMetadataUpdate,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2InstanceExists(resourceName, &instance),
+					testAccCheckComputeV2InstanceExists(resourceInstanceV2Name, &instance),
 					testAccCheckComputeV2InstanceMetadata(&instance, "foo", "bar"),
 					testAccCheckComputeV2InstanceMetadata(&instance, "ghi", "jkl"),
 					testAccCheckComputeV2InstanceNoMetadataKey(&instance, "abc"),
-					resource.TestCheckResourceAttr(resourceName, "all_metadata.foo", "bar"),
-					resource.TestCheckResourceAttr(resourceName, "all_metadata.ghi", "jkl"),
+					resource.TestCheckResourceAttr(resourceInstanceV2Name, "all_metadata.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceInstanceV2Name, "all_metadata.ghi", "jkl"),
 				),
 			},
 		},
@@ -215,7 +209,6 @@ func TestAccComputeV2Instance_metadata(t *testing.T) {
 
 func TestAccComputeV2Instance_timeout(t *testing.T) {
 	var instance servers.Server
-	resourceName := "opentelekomcloud_compute_instance_v2.instance_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -225,7 +218,7 @@ func TestAccComputeV2Instance_timeout(t *testing.T) {
 			{
 				Config: testAccComputeV2InstanceTimeout,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2InstanceExists(resourceName, &instance),
+					testAccCheckComputeV2InstanceExists(resourceInstanceV2Name, &instance),
 				),
 			},
 		},
@@ -234,7 +227,6 @@ func TestAccComputeV2Instance_timeout(t *testing.T) {
 
 func TestAccComputeV2Instance_autoRecovery(t *testing.T) {
 	var instance servers.Server
-	resourceName := "opentelekomcloud_compute_instance_v2.instance_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -244,15 +236,15 @@ func TestAccComputeV2Instance_autoRecovery(t *testing.T) {
 			{
 				Config: testAccComputeV2InstanceBasic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2InstanceExists(resourceName, &instance),
-					resource.TestCheckResourceAttr(resourceName, "auto_recovery", "true"),
+					testAccCheckComputeV2InstanceExists(resourceInstanceV2Name, &instance),
+					resource.TestCheckResourceAttr(resourceInstanceV2Name, "auto_recovery", "true"),
 				),
 			},
 			{
 				Config: testAccComputeV2InstanceAutoRecovery,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2InstanceExists(resourceName, &instance),
-					resource.TestCheckResourceAttr(resourceName, "auto_recovery", "false"),
+					testAccCheckComputeV2InstanceExists(resourceInstanceV2Name, &instance),
+					resource.TestCheckResourceAttr(resourceInstanceV2Name, "auto_recovery", "false"),
 				),
 			},
 		},
@@ -261,7 +253,6 @@ func TestAccComputeV2Instance_autoRecovery(t *testing.T) {
 
 func TestAccComputeV2Instance_crazyNICs(t *testing.T) {
 	var instance servers.Server
-	resourceName := "opentelekomcloud_compute_instance_v2.instance_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -271,7 +262,7 @@ func TestAccComputeV2Instance_crazyNICs(t *testing.T) {
 			{
 				Config: testAccComputeV2InstanceCrazyNICs,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2InstanceExists(resourceName, &instance),
+					testAccCheckComputeV2InstanceExists(resourceInstanceV2Name, &instance),
 				),
 			},
 		},
@@ -291,27 +282,24 @@ func TestAccComputeV2Instance_initialStateActive(t *testing.T) {
 			{
 				Config: testAccComputeV2InstanceActive,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2InstanceExists("opentelekomcloud_compute_instance_v2.instance_1", &instance),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_compute_instance_v2.instance_1", "power_state", "active"),
+					testAccCheckComputeV2InstanceExists(resourceInstanceV2Name, &instance),
+					resource.TestCheckResourceAttr(resourceInstanceV2Name, "power_state", "active"),
 					testAccCheckComputeV2InstanceState(&instance, "active"),
 				),
 			},
 			{
 				Config: testAccComputeV2InstanceShutoff,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2InstanceExists("opentelekomcloud_compute_instance_v2.instance_1", &instance),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_compute_instance_v2.instance_1", "power_state", "shutoff"),
+					testAccCheckComputeV2InstanceExists(resourceInstanceV2Name, &instance),
+					resource.TestCheckResourceAttr(resourceInstanceV2Name, "power_state", "shutoff"),
 					testAccCheckComputeV2InstanceState(&instance, "shutoff"),
 				),
 			},
 			{
 				Config: testAccComputeV2InstanceActive,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2InstanceExists("opentelekomcloud_compute_instance_v2.instance_1", &instance),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_compute_instance_v2.instance_1", "power_state", "active"),
+					testAccCheckComputeV2InstanceExists(resourceInstanceV2Name, &instance),
+					resource.TestCheckResourceAttr(resourceInstanceV2Name, "power_state", "active"),
 					testAccCheckComputeV2InstanceState(&instance, "active"),
 				),
 			},
@@ -332,27 +320,24 @@ func TestAccComputeV2Instance_initialStateShutoff(t *testing.T) {
 			{
 				Config: testAccComputeV2InstanceShutoff,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2InstanceExists("opentelekomcloud_compute_instance_v2.instance_1", &instance),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_compute_instance_v2.instance_1", "power_state", "shutoff"),
+					testAccCheckComputeV2InstanceExists(resourceInstanceV2Name, &instance),
+					resource.TestCheckResourceAttr(resourceInstanceV2Name, "power_state", "shutoff"),
 					testAccCheckComputeV2InstanceState(&instance, "shutoff"),
 				),
 			},
 			{
 				Config: testAccComputeV2InstanceActive,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2InstanceExists("opentelekomcloud_compute_instance_v2.instance_1", &instance),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_compute_instance_v2.instance_1", "power_state", "active"),
+					testAccCheckComputeV2InstanceExists(resourceInstanceV2Name, &instance),
+					resource.TestCheckResourceAttr(resourceInstanceV2Name, "power_state", "active"),
 					testAccCheckComputeV2InstanceState(&instance, "active"),
 				),
 			},
 			{
 				Config: testAccComputeV2InstanceShutoff,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2InstanceExists("opentelekomcloud_compute_instance_v2.instance_1", &instance),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_compute_instance_v2.instance_1", "power_state", "shutoff"),
+					testAccCheckComputeV2InstanceExists(resourceInstanceV2Name, &instance),
+					resource.TestCheckResourceAttr(resourceInstanceV2Name, "power_state", "shutoff"),
 					testAccCheckComputeV2InstanceState(&instance, "shutoff"),
 				),
 			},
@@ -433,12 +418,12 @@ func testAccCheckComputeV2InstanceBootVolumeAttachment(instance *servers.Server)
 		var attachments []volumeattach.VolumeAttachment
 
 		config := common.TestAccProvider.Meta().(*cfg.Config)
-		computeClient, err := config.ComputeV2Client(env.OS_REGION_NAME)
+		client, err := config.ComputeV2Client(env.OS_REGION_NAME)
 		if err != nil {
-			return err
+			return fmt.Errorf("error creating OpenTelekomCloud ComputeV2 client: %s", err)
 		}
 
-		err = volumeattach.List(computeClient, instance.ID).EachPage(
+		err = volumeattach.List(client, instance.ID).EachPage(
 			func(page pagination.Page) (bool, error) {
 				actual, err := volumeattach.ExtractVolumeAttachments(page)
 				if err != nil {
@@ -461,6 +446,8 @@ func testAccCheckComputeV2InstanceBootVolumeAttachment(instance *servers.Server)
 }
 
 var testAccComputeV2InstanceBasic = fmt.Sprintf(`
+%s
+
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name              = "instance_1"
   availability_zone = "%s"
@@ -468,7 +455,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
     foo = "bar"
   }
   network {
-    uuid = "%s"
+    uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
 
   tags = {
@@ -476,25 +463,29 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
     kuh = "value-create"
   }
 }
-`, env.OS_AVAILABILITY_ZONE, env.OS_NETWORK_ID)
+`, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE)
 
 var testAccComputeV2InstanceUpdate = fmt.Sprintf(`
+%s
+
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name              = "instance_2"
   security_groups   = ["default"]
   availability_zone = "%s"
 
   network {
-    uuid = "%s"
+    uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
 
   tags = {
     muh = "value-update"
   }
 }
-`, env.OS_AVAILABILITY_ZONE, env.OS_NETWORK_ID)
+`, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE)
 
 var testAccComputeV2InstanceMultiSecgroup = fmt.Sprintf(`
+%s
+
 resource "opentelekomcloud_compute_secgroup_v2" "secgroup_1" {
   name        = "secgroup_1"
   description = "a security group"
@@ -521,12 +512,14 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
   network {
-    uuid = "%s"
+    uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
 }
-`, env.OS_NETWORK_ID)
+`, common.DataSourceSubnet)
 
 var testAccComputeV2InstanceMultiSecgroupUpdate = fmt.Sprintf(`
+%s
+
 resource "opentelekomcloud_compute_secgroup_v2" "secgroup_1" {
   name        = "secgroup_1"
   description = "a security group"
@@ -554,24 +547,28 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   security_groups = [
     "default",
     opentelekomcloud_compute_secgroup_v2.secgroup_1.name,
-    opentelekomcloud_compute_secgroup_v2.secgroup_2.name,
+    opentelekomcloud_compute_secgroup_v2.secgroup_2.name
   ]
   network {
-    uuid = "%s"
+    uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
 }
-`, env.OS_NETWORK_ID)
+`, common.DataSourceSubnet)
 
 var testAccComputeV2InstanceBootFromVolumeImage = fmt.Sprintf(`
+%s
+
+%s
+
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name              = "instance_1"
   security_groups   = ["default"]
   availability_zone = "%s"
   network {
-    uuid = "%s"
+    uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
   block_device {
-    uuid                  = "%s"
+    uuid                  = data.opentelekomcloud_images_image_v2.latest_image.id
     source_type           = "image"
     volume_size           = 50
     boot_index            = 0
@@ -579,20 +576,24 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
     delete_on_termination = true
   }
 }
-`, env.OS_AVAILABILITY_ZONE, env.OS_NETWORK_ID, env.OS_IMAGE_ID)
+`, common.DataSourceImage, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE)
 
 var testAccComputeV2InstanceBootFromVolumeVolume = fmt.Sprintf(`
+%s
+
+%s
+
 resource "opentelekomcloud_blockstorage_volume_v2" "vol_1" {
   name     = "vol_1"
   size     = 50
-  image_id = "%s"
+  image_id = data.opentelekomcloud_images_image_v2.latest_image.id
 }
 
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
   network {
-    uuid = "%s"
+    uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
   block_device {
     uuid                  = opentelekomcloud_blockstorage_volume_v2.vol_1.id
@@ -602,17 +603,21 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
     delete_on_termination = true
   }
 }
-`, env.OS_IMAGE_ID, env.OS_NETWORK_ID)
+`, common.DataSourceImage, common.DataSourceSubnet)
 
 var testAccComputeV2InstanceBootFromVolume = fmt.Sprintf(`
+%s
+
+%s
+
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
   network {
-    uuid = "%s"
+    uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
   block_device {
-    uuid                  = "%s"
+    uuid                  = data.opentelekomcloud_images_image_v2.latest_image.id
     source_type           = "image"
     volume_size           = 50
     boot_index            = 0
@@ -620,73 +625,85 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
     delete_on_termination = true
   }
 }
-`, env.OS_NETWORK_ID, env.OS_IMAGE_ID)
+`, common.DataSourceImage, common.DataSourceSubnet)
 
 var testAccComputeV2InstanceFixedIP = fmt.Sprintf(`
+%s
+
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
   network {
-    uuid        = "%s"
+    uuid        = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
     fixed_ip_v4 = "192.168.0.24"
   }
 }
-`, env.OS_NETWORK_ID)
+`, common.DataSourceSubnet)
 
 var testAccComputeV2InstanceStopBeforeDestroy = fmt.Sprintf(`
+%s
+
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
   network {
-    uuid = "%s"
+    uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
   stop_before_destroy = true
 }
-`, env.OS_NETWORK_ID)
+`, common.DataSourceSubnet)
 
 var testAccComputeV2InstanceMetadata = fmt.Sprintf(`
+%s
+
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
   network {
-    uuid = "%s"
+    uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
   metadata = {
     foo = "bar"
     abc = "def"
   }
 }
-`, env.OS_NETWORK_ID)
+`, common.DataSourceSubnet)
 
 var testAccComputeV2InstanceMetadataUpdate = fmt.Sprintf(`
+%s
+
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
   network {
-    uuid = "%s"
+    uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
   metadata = {
     foo = "bar"
     ghi = "jkl"
   }
 }
-`, env.OS_NETWORK_ID)
+`, common.DataSourceSubnet)
 
 var testAccComputeV2InstanceTimeout = fmt.Sprintf(`
+%s
+
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
   network {
-    uuid = "%s"
+    uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
 
   timeouts {
     create = "10m"
   }
 }
-`, env.OS_NETWORK_ID)
+`, common.DataSourceSubnet)
 
 var testAccComputeV2InstanceAutoRecovery = fmt.Sprintf(`
+%s
+
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name              = "instance_1"
   security_groups   = ["default"]
@@ -695,13 +712,15 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
     foo = "bar"
   }
   network {
-    uuid = "%s"
+    uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
   auto_recovery = false
 }
-`, env.OS_AVAILABILITY_ZONE, env.OS_NETWORK_ID)
+`, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE)
 
 var testAccComputeV2InstanceCrazyNICs = fmt.Sprintf(`
+%s
+
 resource "opentelekomcloud_networking_network_v2" "network_1" {
   name = "network_1"
 }
@@ -764,14 +783,12 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   depends_on = [
     "opentelekomcloud_networking_subnet_v2.subnet_1",
     "opentelekomcloud_networking_subnet_v2.subnet_2",
-    "opentelekomcloud_networking_port_v2.port_1",
-    "opentelekomcloud_networking_port_v2.port_2",
   ]
   name            = "instance_1"
   security_groups = ["default"]
 
   network {
-    uuid = "%s"
+    uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
   network {
     uuid        = opentelekomcloud_networking_network_v2.network_1.id
@@ -802,29 +819,33 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
     port = opentelekomcloud_networking_port_v2.port_4.id
   }
 }
-`, env.OS_NETWORK_ID)
+`, common.DataSourceSubnet)
 
 var testAccComputeV2InstanceActive = fmt.Sprintf(`
+%s
+
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
-  name = "instance_1"
+  name            = "instance_1"
   security_groups = ["default"]
-  power_state = "active"
+  power_state     = "active"
   network {
-    uuid = "%s"
+    uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
 }
-`, env.OS_NETWORK_ID)
+`, common.DataSourceSubnet)
 
 var testAccComputeV2InstanceShutoff = fmt.Sprintf(`
+%s
+
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
-  name = "instance_1"
+  name            = "instance_1"
   security_groups = ["default"]
-  power_state = "shutoff"
+  power_state     = "shutoff"
   network {
-    uuid = "%s"
+    uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
 }
-`, env.OS_NETWORK_ID)
+`, common.DataSourceSubnet)
 
 func testAccCheckComputeV2InstanceState(
 	instance *servers.Server, state string) resource.TestCheckFunc {

--- a/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_keypair_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_keypair_v2_test.go
@@ -14,9 +14,10 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 )
 
+const resourceKeyPairName = "opentelekomcloud_compute_keypair_v2.kp_1"
+
 func TestAccComputeV2Keypair_basic(t *testing.T) {
 	var keypair keypairs.KeyPair
-	resourceName := "opentelekomcloud_compute_keypair_v2.kp_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -24,9 +25,9 @@ func TestAccComputeV2Keypair_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckComputeV2KeypairDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeV2Keypair_basic,
+				Config: testAccComputeV2KeypairBasic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2KeypairExists(resourceName, &keypair),
+					testAccCheckComputeV2KeypairExists(resourceKeyPairName, &keypair),
 				),
 			},
 		},
@@ -35,7 +36,6 @@ func TestAccComputeV2Keypair_basic(t *testing.T) {
 
 func TestAccComputeV2Keypair_shared(t *testing.T) {
 	var keypair keypairs.KeyPair
-	resourceName1 := "opentelekomcloud_compute_keypair_v2.kp_1"
 	resourceName2 := "opentelekomcloud_compute_keypair_v2.kp_2"
 
 	resource.Test(t, resource.TestCase{
@@ -44,15 +44,15 @@ func TestAccComputeV2Keypair_shared(t *testing.T) {
 		CheckDestroy:      testAccCheckComputeV2KeypairDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeV2Keypair_basic,
+				Config: testAccComputeV2KeypairBasic,
 			},
 			{
-				Config: testAccComputeV2Keypair_shared,
+				Config: testAccComputeV2KeypairShared,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2KeypairExists(resourceName1, &keypair),
+					testAccCheckComputeV2KeypairExists(resourceKeyPairName, &keypair),
 					testAccCheckComputeV2KeypairExists(resourceName2, &keypair),
 					resource.TestCheckResourceAttr(resourceName2, "shared", "true"),
-					resource.TestCheckResourceAttr(resourceName1, "shared", "false"),
+					resource.TestCheckResourceAttr(resourceKeyPairName, "shared", "false"),
 				),
 			},
 		},
@@ -61,7 +61,6 @@ func TestAccComputeV2Keypair_shared(t *testing.T) {
 
 func TestAccComputeV2Keypair_private(t *testing.T) {
 	var keypair keypairs.KeyPair
-	resourceName := "opentelekomcloud_compute_keypair_v2.kp_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -69,10 +68,10 @@ func TestAccComputeV2Keypair_private(t *testing.T) {
 		CheckDestroy:      testAccCheckComputeV2KeypairDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeV2Keypair_private,
+				Config: testAccComputeV2KeypairPrivate,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2KeypairExists(resourceName, &keypair),
-					resource.TestCheckResourceAttrSet(resourceName, "private_key"),
+					testAccCheckComputeV2KeypairExists(resourceKeyPairName, &keypair),
+					resource.TestCheckResourceAttrSet(resourceKeyPairName, "private_key"),
 				),
 			},
 		},
@@ -83,7 +82,7 @@ func testAccCheckComputeV2KeypairDestroy(s *terraform.State) error {
 	config := common.TestAccProvider.Meta().(*cfg.Config)
 	client, err := config.ComputeV2Client(env.OS_REGION_NAME)
 	if err != nil {
-		return fmt.Errorf("error creating OpenTelekomCloud ComputeV2 client: %s", err)
+		return fmt.Errorf("error creating OpenTelekomCloud ComputeV2 client: %w", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -132,14 +131,14 @@ func testAccCheckComputeV2KeypairExists(n string, kp *keypairs.KeyPair) resource
 	}
 }
 
-const testAccComputeV2Keypair_basic = `
+const testAccComputeV2KeypairBasic = `
 resource "opentelekomcloud_compute_keypair_v2" "kp_1" {
   name       = "kp_1"
   public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDAjpC1hwiOCCmKEWxJ4qzTTsJbKzndLo1BCz5PcwtUnflmU+gHJtWMZKpuEGVi29h0A/+ydKek1O18k10Ff+4tyFjiHDQAT9+OfgWf7+b1yK+qDip3X1C0UPMbwHlTfSGWLGZquwhvEFx9k3h/M+VtMvwR1lJ9LUyTAImnNjWG7TAIPmui30HvM2UiFEmqkr4ijq45MyX2+fLIePLRIFuu1p4whjHAQYufqyno3BS48icQb4p6iVEZPo4AE2o9oIyQvj2mx4dk5Y8CgSETOZTYDOR3rU2fZTRDRgPJDH9FWvQjF5tA0p3d9CoWWd2s6GKKbfoUIi8R/Db1BSPJwkqB jrp-hp-pc"
 }
 `
 
-const testAccComputeV2Keypair_shared = `
+const testAccComputeV2KeypairShared = `
 locals {
   public_name = "kp_1"
   public_key  = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDAjpC1hwiOCCmKEWxJ4qzTTsJbKzndLo1BCz5PcwtUnflmU+gHJtWMZKpuEGVi29h0A/+ydKek1O18k10Ff+4tyFjiHDQAT9+OfgWf7+b1yK+qDip3X1C0UPMbwHlTfSGWLGZquwhvEFx9k3h/M+VtMvwR1lJ9LUyTAImnNjWG7TAIPmui30HvM2UiFEmqkr4ijq45MyX2+fLIePLRIFuu1p4whjHAQYufqyno3BS48icQb4p6iVEZPo4AE2o9oIyQvj2mx4dk5Y8CgSETOZTYDOR3rU2fZTRDRgPJDH9FWvQjF5tA0p3d9CoWWd2s6GKKbfoUIi8R/Db1BSPJwkqB jrp-hp-pc"
@@ -158,7 +157,7 @@ resource "opentelekomcloud_compute_keypair_v2" "kp_2" {
 }
 `
 
-const testAccComputeV2Keypair_private = `
+const testAccComputeV2KeypairPrivate = `
 resource "opentelekomcloud_compute_keypair_v2" "kp_1" {
   name = "kp_1"
 }

--- a/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_secgroup_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_secgroup_v2_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 )
 
+const resourceSecGroupName = "opentelekomcloud_compute_secgroup_v2.sg_1"
+
 func TestAccComputeV2SecGroup_basic(t *testing.T) {
 	var secGroup secgroups.SecurityGroup
 
@@ -25,7 +27,7 @@ func TestAccComputeV2SecGroup_basic(t *testing.T) {
 			{
 				Config: testAccComputeV2SecGroupBasicOrig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2SecGroupExists("opentelekomcloud_compute_secgroup_v2.sg_1", &secGroup),
+					testAccCheckComputeV2SecGroupExists(resourceSecGroupName, &secGroup),
 				),
 			},
 		},
@@ -43,13 +45,13 @@ func TestAccComputeV2SecGroup_update(t *testing.T) {
 			{
 				Config: testAccComputeV2SecGroupBasicOrig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2SecGroupExists("opentelekomcloud_compute_secgroup_v2.sg_1", &secGroup),
+					testAccCheckComputeV2SecGroupExists(resourceSecGroupName, &secGroup),
 				),
 			},
 			{
 				Config: testAccComputeV2SecGroupBasicUpdate,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2SecGroupExists("opentelekomcloud_compute_secgroup_v2.sg_1", &secGroup),
+					testAccCheckComputeV2SecGroupExists(resourceSecGroupName, &secGroup),
 					testAccCheckComputeV2SecGroupRuleCount(&secGroup, 2),
 				),
 			},
@@ -59,6 +61,8 @@ func TestAccComputeV2SecGroup_update(t *testing.T) {
 
 func TestAccComputeV2SecGroup_groupID(t *testing.T) {
 	var secgroup1, secGroup2, secgroup3 secgroups.SecurityGroup
+	resourceSecGroup2Name := "opentelekomcloud_compute_secgroup_v2.sg_2"
+	resourceSecGroup3Name := "opentelekomcloud_compute_secgroup_v2.sg_3"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -68,18 +72,18 @@ func TestAccComputeV2SecGroup_groupID(t *testing.T) {
 			{
 				Config: testAccComputeV2SecGroupGroupIDOrig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2SecGroupExists("opentelekomcloud_compute_secgroup_v2.sg_1", &secgroup1),
-					testAccCheckComputeV2SecGroupExists("opentelekomcloud_compute_secgroup_v2.sg_2", &secGroup2),
-					testAccCheckComputeV2SecGroupExists("opentelekomcloud_compute_secgroup_v2.sg_3", &secgroup3),
+					testAccCheckComputeV2SecGroupExists(resourceSecGroupName, &secgroup1),
+					testAccCheckComputeV2SecGroupExists(resourceSecGroup2Name, &secGroup2),
+					testAccCheckComputeV2SecGroupExists(resourceSecGroup3Name, &secgroup3),
 					testAccCheckComputeV2SecGroupGroupIDMatch(&secgroup1, &secgroup3),
 				),
 			},
 			{
 				Config: testAccComputeV2SecGroupGroupIDUpdate,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2SecGroupExists("opentelekomcloud_compute_secgroup_v2.sg_1", &secgroup1),
-					testAccCheckComputeV2SecGroupExists("opentelekomcloud_compute_secgroup_v2.sg_2", &secGroup2),
-					testAccCheckComputeV2SecGroupExists("opentelekomcloud_compute_secgroup_v2.sg_3", &secgroup3),
+					testAccCheckComputeV2SecGroupExists(resourceSecGroupName, &secgroup1),
+					testAccCheckComputeV2SecGroupExists(resourceSecGroup2Name, &secGroup2),
+					testAccCheckComputeV2SecGroupExists(resourceSecGroup3Name, &secgroup3),
 					testAccCheckComputeV2SecGroupGroupIDMatch(&secGroup2, &secgroup3),
 				),
 			},
@@ -98,12 +102,10 @@ func TestAccComputeV2SecGroup_self(t *testing.T) {
 			{
 				Config: testAccComputeV2SecGroupSelf,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2SecGroupExists("opentelekomcloud_compute_secgroup_v2.sg_1", &secGroup),
+					testAccCheckComputeV2SecGroupExists(resourceSecGroupName, &secGroup),
 					testAccCheckComputeV2SecGroupGroupIDMatch(&secGroup, &secGroup),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_compute_secgroup_v2.sg_1", "rule.3170486100.self", "true"),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_compute_secgroup_v2.sg_1", "rule.3170486100.from_group_id", ""),
+					resource.TestCheckResourceAttr(resourceSecGroupName, "rule.3170486100.self", "true"),
+					resource.TestCheckResourceAttr(resourceSecGroupName, "rule.3170486100.from_group_id", ""),
 				),
 			},
 		},
@@ -121,7 +123,7 @@ func TestAccComputeV2SecGroup_icmpZero(t *testing.T) {
 			{
 				Config: testAccComputeV2SecGroupIcmpZero,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2SecGroupExists("opentelekomcloud_compute_secgroup_v2.sg_1", &secGroup),
+					testAccCheckComputeV2SecGroupExists(resourceSecGroupName, &secGroup),
 				),
 			},
 		},
@@ -139,7 +141,7 @@ func TestAccComputeV2SecGroup_timeout(t *testing.T) {
 			{
 				Config: testAccComputeV2SecGroupTimeout,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2SecGroupExists("opentelekomcloud_compute_secgroup_v2.sg_1", &secGroup),
+					testAccCheckComputeV2SecGroupExists(resourceSecGroupName, &secGroup),
 				),
 			},
 		},
@@ -148,9 +150,9 @@ func TestAccComputeV2SecGroup_timeout(t *testing.T) {
 
 func testAccCheckComputeV2SecGroupDestroy(s *terraform.State) error {
 	config := common.TestAccProvider.Meta().(*cfg.Config)
-	computeClient, err := config.ComputeV2Client(env.OS_REGION_NAME)
+	client, err := config.ComputeV2Client(env.OS_REGION_NAME)
 	if err != nil {
-		return fmt.Errorf("error creating OpenTelekomCloud compute client: %s", err)
+		return fmt.Errorf("error creating OpenTelekomCloud ComputeV2 client: %s", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -158,7 +160,7 @@ func testAccCheckComputeV2SecGroupDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := secgroups.Get(computeClient, rs.Primary.ID).Extract()
+		_, err := secgroups.Get(client, rs.Primary.ID).Extract()
 		if err == nil {
 			return fmt.Errorf("security group still exists")
 		}
@@ -179,12 +181,12 @@ func testAccCheckComputeV2SecGroupExists(n string, secgroup *secgroups.SecurityG
 		}
 
 		config := common.TestAccProvider.Meta().(*cfg.Config)
-		computeClient, err := config.ComputeV2Client(env.OS_REGION_NAME)
+		client, err := config.ComputeV2Client(env.OS_REGION_NAME)
 		if err != nil {
-			return fmt.Errorf("error creating OpenTelekomCloud compute client: %s", err)
+			return fmt.Errorf("error creating OpenTelekomCloud ComputeV2 client: %s", err)
 		}
 
-		found, err := secgroups.Get(computeClient, rs.Primary.ID).Extract()
+		found, err := secgroups.Get(client, rs.Primary.ID).Extract()
 		if err != nil {
 			return err
 		}
@@ -202,7 +204,7 @@ func testAccCheckComputeV2SecGroupExists(n string, secgroup *secgroups.SecurityG
 func testAccCheckComputeV2SecGroupRuleCount(secgroup *secgroups.SecurityGroup, count int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if len(secgroup.Rules) != count {
-			return fmt.Errorf("security group rule count does not match. Expected %d, got %d", count, len(secgroup.Rules))
+			return fmt.Errorf("SG rule count does not match. Expected %d, got %d", count, len(secgroup.Rules))
 		}
 
 		return nil


### PR DESCRIPTION
## Summary of the Pull Request
Replace `OS_NETWORK_ID`, `OS_VPC_ID`, `OS_IMAGE_ID` with data sources

## PR Checklist

* [x] Refers to: #1320
* [x] Tests added/passed.

## Acceptance Steps Performed

```
=== RUN   TestAccOpenStackAvailabilityZonesV2_basic
--- PASS: TestAccOpenStackAvailabilityZonesV2_basic (116.59s)
=== RUN   TestAccComputeV2FlavorDataSource_basic
--- PASS: TestAccComputeV2FlavorDataSource_basic (140.12s)
=== RUN   TestAccComputeV2FlavorDataSource_testQueries
--- PASS: TestAccComputeV2FlavorDataSource_testQueries (484.79s)
=== RUN   TestAccComputeV2FloatingIPAssociate_importBasic
--- PASS: TestAccComputeV2FloatingIPAssociate_importBasic (345.22s)
=== RUN   TestAccComputeV2FloatingIP_importBasic
--- PASS: TestAccComputeV2FloatingIP_importBasic (169.56s)
=== RUN   TestAccComputeV2InstanceImportBasic
--- PASS: TestAccComputeV2InstanceImportBasic (338.55s)
=== RUN   TestAccComputeV2InstanceImportBootFromVolumeImage
--- PASS: TestAccComputeV2InstanceImportBootFromVolumeImage (222.00s)
=== RUN   TestAccComputeV2Keypair_importBasic
--- PASS: TestAccComputeV2Keypair_importBasic (154.56s)
=== RUN   TestAccComputeV2SecGroup_importBasic
--- PASS: TestAccComputeV2SecGroup_importBasic (171.12s)
=== RUN   TestAccComputeV2ServerGroup_importBasic
--- PASS: TestAccComputeV2ServerGroup_importBasic (155.72s)
=== RUN   TestAccComputeV2VolumeAttach_importBasic
--- PASS: TestAccComputeV2VolumeAttach_importBasic (460.63s)
=== RUN   TestAccEcsV1Instance_importBasic
--- PASS: TestAccEcsV1Instance_importBasic (312.25s)
=== RUN   TestAccComputeV2FloatingIPAssociate_basic
--- PASS: TestAccComputeV2FloatingIPAssociate_basic (308.36s)
=== RUN   TestAccComputeV2FloatingIPAssociate_fixedIP
--- PASS: TestAccComputeV2FloatingIPAssociate_fixedIP (308.62s)
=== RUN   TestAccComputeV2FloatingIPAssociate_attachToFirstNetwork
--- PASS: TestAccComputeV2FloatingIPAssociate_attachToFirstNetwork (311.38s)
=== RUN   TestAccComputeV2FloatingIPAssociate_attachNew
--- PASS: TestAccComputeV2FloatingIPAssociate_attachNew (442.69s)
=== RUN   TestAccComputeV2FloatingIP_basic
--- PASS: TestAccComputeV2FloatingIP_basic (131.10s)
=== RUN   TestAccComputeV2Instance_basic
--- PASS: TestAccComputeV2Instance_basic (447.28s)
=== RUN   TestAccComputeV2Instance_multiSecgroup
--- PASS: TestAccComputeV2Instance_multiSecgroup (442.73s)
=== RUN   TestAccComputeV2Instance_bootFromImage
--- PASS: TestAccComputeV2Instance_bootFromImage (179.98s)
=== RUN   TestAccComputeV2Instance_bootFromVolume
--- PASS: TestAccComputeV2Instance_bootFromVolume (172.39s)
=== RUN   TestAccComputeV2Instance_changeFixedIP
--- PASS: TestAccComputeV2Instance_changeFixedIP (300.00s)
=== RUN   TestAccComputeV2Instance_bootFromVolumeVolume
--- PASS: TestAccComputeV2Instance_bootFromVolumeVolume (190.23s)
=== RUN   TestAccComputeV2Instance_stopBeforeDestroy
--- PASS: TestAccComputeV2Instance_stopBeforeDestroy (292.55s)
```
