### PR TITLE
[Acceptance] Get rid of IDs in `DDS`

### DIFF
--- a/opentelekomcloud/acceptance/dds/data_source_opentelekomcloud_dds_flavors_v3_test.go
+++ b/opentelekomcloud/acceptance/dds/data_source_opentelekomcloud_dds_flavors_v3_test.go
@@ -10,16 +10,18 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
 )
 
+const dataFlavorName = "data.opentelekomcloud_dds_flavors_v3.flavor"
+
 func TestAccDDSFlavorV3DataSource_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDDSFlavorV3DataSource_basic,
+				Config: testAccDDSFlavorV3DataSourceBasic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDDSFlavorV3DataSourceID("data.opentelekomcloud_dds_flavors_v3.flavor"),
-					resource.TestCheckResourceAttrSet("data.opentelekomcloud_dds_flavors_v3.flavor", "flavors.#"),
+					testAccCheckDDSFlavorV3DataSourceID(dataFlavorName),
+					resource.TestCheckResourceAttrSet(dataFlavorName, "flavors.#"),
 				),
 			},
 		},
@@ -41,7 +43,7 @@ func testAccCheckDDSFlavorV3DataSourceID(n string) resource.TestCheckFunc {
 	}
 }
 
-var testAccDDSFlavorV3DataSource_basic = `
+var testAccDDSFlavorV3DataSourceBasic = `
 data "opentelekomcloud_dds_flavors_v3" "flavor" {
   engine_name = "DDS-Community"
   vcpus       = 8

--- a/opentelekomcloud/acceptance/dds/data_source_opentelekomcloud_dds_instance_v3_test.go
+++ b/opentelekomcloud/acceptance/dds/data_source_opentelekomcloud_dds_instance_v3_test.go
@@ -11,19 +11,21 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
 )
 
+const dataInstanceName = "data.opentelekomcloud_dds_instance_v3.instances"
+
 func TestAccDDSInstanceV3DataSource_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDDSInstanceV3DataSource_basic,
+				Config: testAccDDSInstanceV3DataSourceBasic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDDSInstanceV3DataSourceID("data.opentelekomcloud_dds_instance_v3.instances"),
-					resource.TestCheckResourceAttr("data.opentelekomcloud_dds_instance_v3.instances", "name", "dds-instance"),
-					resource.TestCheckResourceAttr("data.opentelekomcloud_dds_instance_v3.instances", "vpc_id", env.OS_VPC_ID),
-					resource.TestCheckResourceAttr("data.opentelekomcloud_dds_instance_v3.instances", "mode", "ReplicaSet"),
-					resource.TestCheckResourceAttr("data.opentelekomcloud_dds_instance_v3.instances", "datastore.0.type", "DDS-Community"),
+					testAccCheckDDSInstanceV3DataSourceID(dataInstanceName),
+					resource.TestCheckResourceAttr(dataInstanceName, "name", "dds-instance"),
+					resource.TestCheckResourceAttrSet(dataInstanceName, "vpc_id"),
+					resource.TestCheckResourceAttr(dataInstanceName, "mode", "ReplicaSet"),
+					resource.TestCheckResourceAttr(dataInstanceName, "datastore.0.type", "DDS-Community"),
 				),
 			},
 		},
@@ -45,10 +47,11 @@ func testAccCheckDDSInstanceV3DataSourceID(n string) resource.TestCheckFunc {
 	}
 }
 
-var testAccDDSInstanceV3DataSource_basic = fmt.Sprintf(`
-resource "opentelekomcloud_networking_secgroup_v2" "sg_acc" {
-  name = "secgroup_acc"
-}
+var testAccDDSInstanceV3DataSourceBasic = fmt.Sprintf(`
+%s
+
+%s
+
 resource "opentelekomcloud_dds_instance_v3" "instance_1" {
   name              = "dds-instance"
   availability_zone = "%s"
@@ -57,9 +60,9 @@ resource "opentelekomcloud_dds_instance_v3" "instance_1" {
     version        = "3.4"
     storage_engine = "wiredTiger"
   }
-  vpc_id            = "%s"
-  subnet_id         = "%s"
-  security_group_id = opentelekomcloud_networking_secgroup_v2.sg_acc.id
+  vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
   password          = "5ecuredPa55w0rd@"
   mode              = "ReplicaSet"
   flavor {
@@ -73,4 +76,4 @@ resource "opentelekomcloud_dds_instance_v3" "instance_1" {
 data "opentelekomcloud_dds_instance_v3" "instances" {
   instance_id = opentelekomcloud_dds_instance_v3.instance_1.id
 }
-`, env.OS_AVAILABILITY_ZONE, env.OS_VPC_ID, env.OS_NETWORK_ID)
+`, common.DataSourceSecGroupDefault, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE)

--- a/opentelekomcloud/acceptance/dds/import_opentelekomcloud_dds_instance_v3_test.go
+++ b/opentelekomcloud/acceptance/dds/import_opentelekomcloud_dds_instance_v3_test.go
@@ -9,18 +9,16 @@ import (
 )
 
 func TestAccDDSInstanceV3_importBasic(t *testing.T) {
-	resourceName := "opentelekomcloud_dds_instance_v3.instance"
-
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckDDSV3InstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: TestAccDDSInstanceV3Config_basic,
+				Config: TestAccDDSInstanceV3ConfigBasic,
 			},
 			{
-				ResourceName:      resourceName,
+				ResourceName:      resourceInstanceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{

--- a/opentelekomcloud/acceptance/dds/resource_opentelekomcloud_dds_instance_v3_test.go
+++ b/opentelekomcloud/acceptance/dds/resource_opentelekomcloud_dds_instance_v3_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 )
 
+const resourceInstanceName = "opentelekomcloud_dds_instance_v3.instance"
+
 func TestAccDDSV3Instance_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -20,12 +22,12 @@ func TestAccDDSV3Instance_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckDDSV3InstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: TestAccDDSInstanceV3Config_basic,
+				Config: TestAccDDSInstanceV3ConfigBasic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDDSV3InstanceExists("opentelekomcloud_dds_instance_v3.instance"),
-					resource.TestCheckResourceAttr("opentelekomcloud_dds_instance_v3.instance", "name", "dds-instance"),
-					resource.TestCheckResourceAttr("opentelekomcloud_dds_instance_v3.instance", "mode", "ReplicaSet"),
-					resource.TestCheckResourceAttr("opentelekomcloud_dds_instance_v3.instance", "ssl", "true"),
+					testAccCheckDDSV3InstanceExists(resourceInstanceName),
+					resource.TestCheckResourceAttr(resourceInstanceName, "name", "dds-instance"),
+					resource.TestCheckResourceAttr(resourceInstanceName, "mode", "ReplicaSet"),
+					resource.TestCheckResourceAttr(resourceInstanceName, "ssl", "true"),
 				),
 			},
 		},
@@ -39,9 +41,9 @@ func TestAccDDSV3Instance_minConfig(t *testing.T) {
 		CheckDestroy:      testAccCheckDDSV3InstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: TestAccDDSInstanceV3Config_minConfig,
+				Config: TestAccDDSInstanceV3ConfigMinConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDDSV3InstanceExists("opentelekomcloud_dds_instance_v3.instance"),
+					testAccCheckDDSV3InstanceExists(resourceInstanceName),
 				),
 			},
 		},
@@ -115,22 +117,22 @@ func testAccCheckDDSV3InstanceExists(n string) resource.TestCheckFunc {
 	}
 }
 
-var TestAccDDSInstanceV3Config_basic = fmt.Sprintf(`
-resource "opentelekomcloud_networking_secgroup_v2" "sg_acc" {
-  name = "secgroup_acc"
-}
+var TestAccDDSInstanceV3ConfigBasic = fmt.Sprintf(`
+%s
+
+%s
+
 resource "opentelekomcloud_dds_instance_v3" "instance" {
   name              = "dds-instance"
   availability_zone = "%s"
-  region            = "%s"
   datastore {
     type           = "DDS-Community"
     version        = "3.4"
     storage_engine = "wiredTiger"
   }
-  vpc_id            = "%s"
-  subnet_id         = "%s"
-  security_group_id = opentelekomcloud_networking_secgroup_v2.sg_acc.id
+  vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
   password          = "5ecuredPa55w0rd@"
   mode              = "ReplicaSet"
   flavor {
@@ -144,12 +146,13 @@ resource "opentelekomcloud_dds_instance_v3" "instance" {
     start_time = "08:00-09:00"
     keep_days = "1"
   }
-}`, env.OS_AVAILABILITY_ZONE, env.OS_REGION_NAME, env.OS_VPC_ID, env.OS_NETWORK_ID)
+}`, common.DataSourceSecGroupDefault, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE)
 
-var TestAccDDSInstanceV3Config_minConfig = fmt.Sprintf(`
-resource "opentelekomcloud_networking_secgroup_v2" "sg_acc" {
-  name = "secgroup_acc"
-}
+var TestAccDDSInstanceV3ConfigMinConfig = fmt.Sprintf(`
+%s
+
+%s
+
 resource "opentelekomcloud_dds_instance_v3" "instance" {
   name              = "dds-instance"
   availability_zone = "%s"
@@ -158,9 +161,9 @@ resource "opentelekomcloud_dds_instance_v3" "instance" {
     version        = "3.4"
     storage_engine = "wiredTiger"
   }
-  vpc_id            = "%s"
-  subnet_id         = "%s"
-  security_group_id = opentelekomcloud_networking_secgroup_v2.sg_acc.id
+  vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
   password          = "5ecuredPa55w0rd@"
   mode              = "ReplicaSet"
   flavor {
@@ -169,4 +172,4 @@ resource "opentelekomcloud_dds_instance_v3" "instance" {
     size = 20
     spec_code = "dds.mongodb.s2.medium.4.repset"
   }
-}`, env.OS_AVAILABILITY_ZONE, env.OS_VPC_ID, env.OS_NETWORK_ID)
+}`, common.DataSourceSecGroupDefault, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE)


### PR DESCRIPTION
## Summary of the Pull Request
Replace `OS_NETWORK_ID`, `OS_VPC_ID` with data sources

## PR Checklist

* [x] Refers to: #1320
* [x] Tests added/passed.

## Acceptance Steps Performed

```
=== RUN   TestAccDDSFlavorV3DataSource_basic
--- PASS: TestAccDDSFlavorV3DataSource_basic (93.90s)
=== RUN   TestAccDDSInstanceV3DataSource_basic
--- PASS: TestAccDDSInstanceV3DataSource_basic (753.80s)
=== RUN   TestAccDDSInstanceV3_importBasic
--- PASS: TestAccDDSInstanceV3_importBasic (658.07s)
=== RUN   TestAccDDSV3Instance_basic
--- PASS: TestAccDDSV3Instance_basic (661.15s)
=== RUN   TestAccDDSV3Instance_minConfig
--- PASS: TestAccDDSV3Instance_minConfig (641.70s)
PASS
ok  	github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/dds	2811.454s

Process finished with the exit code 0
```
