### PR TITLE
[Acceptance] Get rid of IDs in `CBR`

### DIFF
--- a/opentelekomcloud/acceptance/cbr/resource_opentelekomcloud_cbr_policy_v3_test.go
+++ b/opentelekomcloud/acceptance/cbr/resource_opentelekomcloud_cbr_policy_v3_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 )
 
+const resourcePolicyName = "opentelekomcloud_cbr_policy_v3.policy"
+
 func TestAccCBRPolicyV3_basic(t *testing.T) {
 	var cbrPolicy policies.Policy
 
@@ -22,20 +24,20 @@ func TestAccCBRPolicyV3_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckCBRPolicyV3Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testCBRPolicyV3_basic,
+				Config: testAccCBRPolicyV3Basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCBRPolicyV3Exists("opentelekomcloud_cbr_policy_v3.policy", &cbrPolicy),
-					resource.TestCheckResourceAttr("opentelekomcloud_cbr_policy_v3.policy", "name", "test-policy"),
-					resource.TestCheckResourceAttr("opentelekomcloud_cbr_policy_v3.policy", "operation_type", "backup"),
-					resource.TestCheckResourceAttr("opentelekomcloud_cbr_policy_v3.policy", "enabled", "true"),
+					testAccCheckCBRPolicyV3Exists(resourcePolicyName, &cbrPolicy),
+					resource.TestCheckResourceAttr(resourcePolicyName, "name", "test-policy"),
+					resource.TestCheckResourceAttr(resourcePolicyName, "operation_type", "backup"),
+					resource.TestCheckResourceAttr(resourcePolicyName, "enabled", "true"),
 				),
 			},
 			{
-				Config: testCBRPolicyV3_update,
+				Config: testAccCBRPolicyV3Update,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCBRPolicyV3Exists("opentelekomcloud_cbr_policy_v3.policy", &cbrPolicy),
-					resource.TestCheckResourceAttr("opentelekomcloud_cbr_policy_v3.policy", "name", "name2"),
-					resource.TestCheckResourceAttr("opentelekomcloud_cbr_policy_v3.policy", "enabled", "false"),
+					testAccCheckCBRPolicyV3Exists(resourcePolicyName, &cbrPolicy),
+					resource.TestCheckResourceAttr(resourcePolicyName, "name", "name2"),
+					resource.TestCheckResourceAttr(resourcePolicyName, "enabled", "false"),
 				),
 			},
 		},
@@ -44,7 +46,6 @@ func TestAccCBRPolicyV3_basic(t *testing.T) {
 
 func TestAccCBRPolicyV3_minConfig(t *testing.T) {
 	var cbrPolicy policies.Policy
-	policyRes := "opentelekomcloud_cbr_policy_v3.policy"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccFlavorPreCheck(t) },
@@ -52,18 +53,18 @@ func TestAccCBRPolicyV3_minConfig(t *testing.T) {
 		CheckDestroy:      testAccCheckCBRPolicyV3Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testCBRPolicyV3_minConfig,
+				Config: testAccCBRPolicyV3MinConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCBRPolicyV3Exists(policyRes, &cbrPolicy),
-					resource.TestCheckResourceAttr(policyRes, "name", "some-policy-min"),
-					resource.TestCheckResourceAttr(policyRes, "operation_type", "backup"),
-					resource.TestCheckResourceAttr(policyRes, "enabled", "true"),
+					testAccCheckCBRPolicyV3Exists(resourcePolicyName, &cbrPolicy),
+					resource.TestCheckResourceAttr(resourcePolicyName, "name", "some-policy-min"),
+					resource.TestCheckResourceAttr(resourcePolicyName, "operation_type", "backup"),
+					resource.TestCheckResourceAttr(resourcePolicyName, "enabled", "true"),
 				),
 			},
 			{
-				Config: testCBRPolicyV3_minOperationDef,
+				Config: testAccCBRPolicyV3MinOperationDef,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(policyRes, "operation_definition.0.timezone", "UTC+03:00"),
+					resource.TestCheckResourceAttr(resourcePolicyName, "operation_definition.0.timezone", "UTC+03:00"),
 				),
 			},
 		},
@@ -72,7 +73,7 @@ func TestAccCBRPolicyV3_minConfig(t *testing.T) {
 
 func testAccCheckCBRPolicyV3Destroy(s *terraform.State) error {
 	config := common.TestAccProvider.Meta().(*cfg.Config)
-	asClient, err := config.CbrV3Client(env.OS_REGION_NAME)
+	client, err := config.CbrV3Client(env.OS_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("error creating OpenTelekomCloud CBRv3 client: %s", err)
 	}
@@ -82,7 +83,7 @@ func testAccCheckCBRPolicyV3Destroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := policies.Get(asClient, rs.Primary.ID).Extract()
+		_, err := policies.Get(client, rs.Primary.ID).Extract()
 		if err == nil {
 			return fmt.Errorf("CBRv3 policy still exists")
 		}
@@ -122,7 +123,7 @@ func testAccCheckCBRPolicyV3Exists(n string, group *policies.Policy) resource.Te
 }
 
 const (
-	testCBRPolicyV3_basic = `
+	testAccCBRPolicyV3Basic = `
 resource opentelekomcloud_cbr_policy_v3 policy {
   name                 = "test-policy"
   operation_type       = "backup"
@@ -138,7 +139,7 @@ resource opentelekomcloud_cbr_policy_v3 policy {
   enabled = "true"
 }
 `
-	testCBRPolicyV3_update = `
+	testAccCBRPolicyV3Update = `
 resource opentelekomcloud_cbr_policy_v3 policy {
   name                 = "name2"
   operation_type       = "backup"
@@ -154,7 +155,7 @@ resource opentelekomcloud_cbr_policy_v3 policy {
   enabled = "false"
 }
 `
-	testCBRPolicyV3_minConfig = `
+	testAccCBRPolicyV3MinConfig = `
 resource opentelekomcloud_cbr_policy_v3 policy {
   name            = "some-policy-min"
   operation_type  = "backup"
@@ -162,12 +163,11 @@ resource opentelekomcloud_cbr_policy_v3 policy {
 }
 `
 
-	testCBRPolicyV3_minOperationDef = `
+	testAccCBRPolicyV3MinOperationDef = `
 resource opentelekomcloud_cbr_policy_v3 policy {
   name            = "some-policy-min"
   operation_type  = "backup"
   trigger_pattern = ["FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR,SA,SU;BYHOUR=14;BYMINUTE=00"]
-
 
   operation_definition {
     timezone                = "UTC+03:00"

--- a/opentelekomcloud/acceptance/cbr/resource_opentelekomcloud_cbr_vault_v3_test.go
+++ b/opentelekomcloud/acceptance/cbr/resource_opentelekomcloud_cbr_vault_v3_test.go
@@ -19,7 +19,7 @@ func TestAccCBRVaultV3_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckCBRPolicyV3Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testCBRVaultV3BasicVolumes,
+				Config: testAccCBRVaultV3BasicVolumes,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceVaultName, "resource.#", "2"),
 					resource.TestCheckResourceAttr(resourceVaultName, "resource.0.name", "cbr-test-volume"),
@@ -27,14 +27,14 @@ func TestAccCBRVaultV3_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testCBRVaultV3NoResource,
+				Config: testAccCBRVaultV3NoResource,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceVaultName, "resource.#", "0"),
 					resource.TestCheckNoResourceAttr(resourceVaultName, "backup_policy_id"),
 				),
 			},
 			{
-				Config: testCBRVaultV3NoResourceResize,
+				Config: testAccCBRVaultV3NoResourceResize,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceVaultName, "billing.0.size", "120"),
 				),
@@ -43,17 +43,17 @@ func TestAccCBRVaultV3_basic(t *testing.T) {
 	})
 }
 
-func TestAccCBRVaultV3_unassign(t *testing.T) {
+func TestAccCBRVaultV3_unAssign(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccFlavorPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckCBRPolicyV3Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testCBRVaultV3BasicVolumes,
+				Config: testAccCBRVaultV3BasicVolumes,
 			},
 			{
-				Config: testCBRVaultV3Unassign,
+				Config: testAccCBRVaultV3Unassign,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceVaultName, "backup_policy_id", ""),
 					resource.TestCheckResourceAttr(resourceVaultName, "resource.#", "0"),
@@ -70,7 +70,7 @@ func TestAccCBRVaultV3_instance(t *testing.T) {
 		CheckDestroy:      testAccCheckCBRPolicyV3Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testCBRVaultV3BasicInstance,
+				Config: testAccCBRVaultV3BasicInstance,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceVaultName, "resource.#", "1"),
 					resource.TestCheckResourceAttr(resourceVaultName, "resource.0.name", "tf-crb-test-instance"),
@@ -78,7 +78,7 @@ func TestAccCBRVaultV3_instance(t *testing.T) {
 				),
 			},
 			{
-				Config: testCBRVaultV3NoResource,
+				Config: testAccCBRVaultV3NoResource,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceVaultName, "resource.#", "0"),
 				),
@@ -88,7 +88,7 @@ func TestAccCBRVaultV3_instance(t *testing.T) {
 }
 
 var (
-	testCBRVaultV3BasicInstance = fmt.Sprintf(`
+	testAccCBRVaultV3BasicInstance = fmt.Sprintf(`
 %s
 
 %s
@@ -127,7 +127,7 @@ resource "opentelekomcloud_cbr_vault_v3" "vault" {
 )
 
 const (
-	testCBRVaultV3BasicVolumes = `
+	testAccCBRVaultV3BasicVolumes = `
 resource "opentelekomcloud_blockstorage_volume_v2" "volume" {
   name = "cbr-test-volume"
   size = 10
@@ -188,7 +188,7 @@ resource "opentelekomcloud_cbr_vault_v3" "vault" {
 }
 `
 
-	testCBRVaultV3Unassign = `
+	testAccCBRVaultV3Unassign = `
 resource "opentelekomcloud_blockstorage_volume_v2" "volume" {
   name = "cbr-test-volume"
   size = 10
@@ -233,7 +233,7 @@ resource "opentelekomcloud_cbr_vault_v3" "vault" {
 }
 `
 
-	testCBRVaultV3NoResource = `
+	testAccCBRVaultV3NoResource = `
 resource "opentelekomcloud_cbr_vault_v3" "vault" {
   name = "cbr-vault-test"
 
@@ -247,7 +247,7 @@ resource "opentelekomcloud_cbr_vault_v3" "vault" {
   }
 }
 `
-	testCBRVaultV3NoResourceResize = `
+	testAccCBRVaultV3NoResourceResize = `
 resource "opentelekomcloud_cbr_vault_v3" "vault" {
   name = "cbr-vault-test-2"
 

--- a/opentelekomcloud/acceptance/cbr/resource_opentelekomcloud_cbr_vault_v3_test.go
+++ b/opentelekomcloud/acceptance/cbr/resource_opentelekomcloud_cbr_vault_v3_test.go
@@ -5,12 +5,12 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
-	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
 )
 
-const vaultResourceName = "opentelekomcloud_cbr_vault_v3.vault"
+const resourceVaultName = "opentelekomcloud_cbr_vault_v3.vault"
 
 func TestAccCBRVaultV3_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
@@ -21,22 +21,22 @@ func TestAccCBRVaultV3_basic(t *testing.T) {
 			{
 				Config: testCBRVaultV3BasicVolumes,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(vaultResourceName, "resource.#", "2"),
-					resource.TestCheckResourceAttr(vaultResourceName, "resource.0.name", "cbr-test-volume"),
-					resource.TestCheckResourceAttrSet(vaultResourceName, "backup_policy_id"),
+					resource.TestCheckResourceAttr(resourceVaultName, "resource.#", "2"),
+					resource.TestCheckResourceAttr(resourceVaultName, "resource.0.name", "cbr-test-volume"),
+					resource.TestCheckResourceAttrSet(resourceVaultName, "backup_policy_id"),
 				),
 			},
 			{
 				Config: testCBRVaultV3NoResource,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(vaultResourceName, "resource.#", "0"),
-					resource.TestCheckNoResourceAttr(vaultResourceName, "backup_policy_id"),
+					resource.TestCheckResourceAttr(resourceVaultName, "resource.#", "0"),
+					resource.TestCheckNoResourceAttr(resourceVaultName, "backup_policy_id"),
 				),
 			},
 			{
 				Config: testCBRVaultV3NoResourceResize,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(vaultResourceName, "billing.0.size", "120"),
+					resource.TestCheckResourceAttr(resourceVaultName, "billing.0.size", "120"),
 				),
 			},
 		},
@@ -55,8 +55,8 @@ func TestAccCBRVaultV3_unassign(t *testing.T) {
 			{
 				Config: testCBRVaultV3Unassign,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(vaultResourceName, "backup_policy_id", ""),
-					resource.TestCheckResourceAttr(vaultResourceName, "resource.#", "0"),
+					resource.TestCheckResourceAttr(resourceVaultName, "backup_policy_id", ""),
+					resource.TestCheckResourceAttr(resourceVaultName, "resource.#", "0"),
 				),
 			},
 		},
@@ -72,15 +72,15 @@ func TestAccCBRVaultV3_instance(t *testing.T) {
 			{
 				Config: testCBRVaultV3BasicInstance,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(vaultResourceName, "resource.#", "1"),
-					resource.TestCheckResourceAttr(vaultResourceName, "resource.0.name", "tf-crb-test-instance"),
-					resource.TestCheckResourceAttr(vaultResourceName, "billing.0.size", "100"),
+					resource.TestCheckResourceAttr(resourceVaultName, "resource.#", "1"),
+					resource.TestCheckResourceAttr(resourceVaultName, "resource.0.name", "tf-crb-test-instance"),
+					resource.TestCheckResourceAttr(resourceVaultName, "billing.0.size", "100"),
 				),
 			},
 			{
 				Config: testCBRVaultV3NoResource,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(vaultResourceName, "resource.#", "0"),
+					resource.TestCheckResourceAttr(resourceVaultName, "resource.#", "0"),
 				),
 			},
 		},
@@ -89,14 +89,18 @@ func TestAccCBRVaultV3_instance(t *testing.T) {
 
 var (
 	testCBRVaultV3BasicInstance = fmt.Sprintf(`
+%s
+
+%s
+
 resource "opentelekomcloud_compute_instance_v2" "instance" {
   name = "tf-crb-test-instance"
 
-  image_id    = "%s"
+  image_id    = data.opentelekomcloud_images_image_v2.latest_image.id
   flavor_name = "%s"
 
   network {
-    uuid = "%s"
+    uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
 }
 
@@ -119,7 +123,7 @@ resource "opentelekomcloud_cbr_vault_v3" "vault" {
     type = "OS::Nova::Server"
   }
 }
-`, env.OS_IMAGE_ID, env.OS_FLAVOR_NAME, env.OS_NETWORK_ID)
+`, common.DataSourceImage, common.DataSourceSubnet, env.OsFlavorID)
 )
 
 const (


### PR DESCRIPTION
## Summary of the Pull Request
Replace `OS_NETWORK_ID`, `OS_VPC_ID` with data sources

## PR Checklist

* [x] Refers to: #1320
* [x] Tests added/passed.

## Acceptance Steps Performed

```
=== RUN   TestAccCBRPolicyV3_basic
--- PASS: TestAccCBRPolicyV3_basic (182.78s)
=== RUN   TestAccCBRPolicyV3_minConfig
--- PASS: TestAccCBRPolicyV3_minConfig (175.25s)
=== RUN   TestAccCBRVaultV3_basic
--- PASS: TestAccCBRVaultV3_basic (286.87s)
=== RUN   TestAccCBRVaultV3_unassign
--- PASS: TestAccCBRVaultV3_unassign (223.95s)
=== RUN   TestAccCBRVaultV3_instance
--- PASS: TestAccCBRVaultV3_instance (235.18s)
PASS
ok  	github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/cbr	1106.782s
```
