### PR TITLE
[Acceptance] Get rid of IDs in `EVS`

### DIFF
--- a/opentelekomcloud/acceptance/evs/import_opentelekomcloud_blockstorage_volume_v2_test.go
+++ b/opentelekomcloud/acceptance/evs/import_opentelekomcloud_blockstorage_volume_v2_test.go
@@ -9,8 +9,6 @@ import (
 )
 
 func TestAccBlockStorageV2Volume_importBasic(t *testing.T) {
-	resourceName := "opentelekomcloud_blockstorage_volume_v2.volume_1"
-
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
@@ -19,9 +17,8 @@ func TestAccBlockStorageV2Volume_importBasic(t *testing.T) {
 			{
 				Config: testAccBlockStorageV2VolumeBasic,
 			},
-
 			{
-				ResourceName:      resourceName,
+				ResourceName:      resourceVolumeV2Name,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{

--- a/opentelekomcloud/acceptance/evs/resource_opentelekomcloud_blockstorage_volume_v2_test.go
+++ b/opentelekomcloud/acceptance/evs/resource_opentelekomcloud_blockstorage_volume_v2_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 )
 
-const resourceVolumeName = "opentelekomcloud_blockstorage_volume_v2.volume_1"
+const resourceVolumeV2Name = "opentelekomcloud_blockstorage_volume_v2.volume_1"
 
 func TestAccBlockStorageV2Volume_basic(t *testing.T) {
 	var volume volumes.Volume
@@ -28,17 +28,17 @@ func TestAccBlockStorageV2Volume_basic(t *testing.T) {
 			{
 				Config: testAccBlockStorageV2VolumeBasic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBlockStorageV2VolumeExists(resourceVolumeName, &volume),
+					testAccCheckBlockStorageV2VolumeExists(resourceVolumeV2Name, &volume),
 					testAccCheckBlockStorageV2VolumeMetadata(&volume, "foo", "bar"),
-					resource.TestCheckResourceAttr(resourceVolumeName, "name", "volume_1"),
+					resource.TestCheckResourceAttr(resourceVolumeV2Name, "name", "volume_1"),
 				),
 			},
 			{
 				Config: testAccBlockStorageV2VolumeUpdate,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBlockStorageV2VolumeExists(resourceVolumeName, &volume),
+					testAccCheckBlockStorageV2VolumeExists(resourceVolumeV2Name, &volume),
 					testAccCheckBlockStorageV2VolumeMetadata(&volume, "foo", "bar"),
-					resource.TestCheckResourceAttr(resourceVolumeName, "name", "volume_1-updated"),
+					resource.TestCheckResourceAttr(resourceVolumeV2Name, "name", "volume_1-updated"),
 				),
 			},
 		},
@@ -55,15 +55,15 @@ func TestAccBlockStorageV2Volume_upscaleDownScale(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBlockStorageV2VolumeBasic,
-				Check:  testAccCheckBlockStorageV2VolumeExists(resourceVolumeName, &volume),
+				Check:  testAccCheckBlockStorageV2VolumeExists(resourceVolumeV2Name, &volume),
 			},
 			{
 				Config: testAccBlockStorageV2VolumeBigger,
-				Check:  testAccCheckBlockStorageV2VolumeSame(resourceVolumeName, &volume),
+				Check:  testAccCheckBlockStorageV2VolumeSame(resourceVolumeV2Name, &volume),
 			},
 			{
 				Config: testAccBlockStorageV2VolumeBasic,
-				Check:  testAccCheckBlockStorageV2VolumeNew(resourceVolumeName, &volume),
+				Check:  testAccCheckBlockStorageV2VolumeNew(resourceVolumeV2Name, &volume),
 			},
 		},
 	})
@@ -78,15 +78,15 @@ func TestAccBlockStorageV2Volume_upscaleDownScaleAssigned(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBlockStorageV2VolumeAssigned(10),
-				Check:  testAccCheckBlockStorageV2VolumeExists(resourceVolumeName, &volume),
+				Check:  testAccCheckBlockStorageV2VolumeExists(resourceVolumeV2Name, &volume),
 			},
 			{
 				Config: testAccBlockStorageV2VolumeAssigned(12),
-				Check:  testAccCheckBlockStorageV2VolumeSame(resourceVolumeName, &volume),
+				Check:  testAccCheckBlockStorageV2VolumeSame(resourceVolumeV2Name, &volume),
 			},
 			{
 				Config: testAccBlockStorageV2VolumeAssigned(10),
-				Check:  testAccCheckBlockStorageV2VolumeNew(resourceVolumeName, &volume),
+				Check:  testAccCheckBlockStorageV2VolumeNew(resourceVolumeV2Name, &volume),
 			},
 		},
 	})
@@ -123,15 +123,15 @@ func TestAccBlockStorageV2Volume_tags(t *testing.T) {
 			{
 				Config: testAccBlockStorageV2VolumeTags,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBlockStorageV2VolumeTags(resourceVolumeName, "foo", "bar"),
-					testAccCheckBlockStorageV2VolumeTags(resourceVolumeName, "key", "value"),
+					testAccCheckBlockStorageV2VolumeTags(resourceVolumeV2Name, "foo", "bar"),
+					testAccCheckBlockStorageV2VolumeTags(resourceVolumeV2Name, "key", "value"),
 				),
 			},
 			{
 				Config: testAccBlockStorageV2VolumeTagsUpdate,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBlockStorageV2VolumeTags(resourceVolumeName, "foo2", "bar2"),
-					testAccCheckBlockStorageV2VolumeTags(resourceVolumeName, "key2", "value2"),
+					testAccCheckBlockStorageV2VolumeTags(resourceVolumeV2Name, "foo2", "bar2"),
+					testAccCheckBlockStorageV2VolumeTags(resourceVolumeV2Name, "key2", "value2"),
 				),
 			},
 		},
@@ -149,9 +149,9 @@ func TestAccBlockStorageV2Volume_image(t *testing.T) {
 			{
 				Config: testAccBlockStorageV2VolumeImage,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBlockStorageV2VolumeExists(resourceVolumeName, &volume),
+					testAccCheckBlockStorageV2VolumeExists(resourceVolumeV2Name, &volume),
 					resource.TestCheckResourceAttr(
-						resourceVolumeName, "name", "volume_1"),
+						resourceVolumeV2Name, "name", "volume_1"),
 				),
 			},
 		},
@@ -169,7 +169,7 @@ func TestAccBlockStorageV2Volume_timeout(t *testing.T) {
 			{
 				Config: testAccBlockStorageV2VolumeTimeout,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBlockStorageV2VolumeExists(resourceVolumeName, &volume),
+					testAccCheckBlockStorageV2VolumeExists(resourceVolumeV2Name, &volume),
 				),
 			},
 		},
@@ -327,17 +327,21 @@ func testAccCheckBlockStorageV2VolumeNew(n string, volume *volumes.Volume) resou
 
 func testAccBlockStorageV2VolumeAssigned(size int) string {
 	return fmt.Sprintf(`
+%s
+
+%s
+
 resource "opentelekomcloud_blockstorage_volume_v2" "volume_1" {
   name     = "volume_1"
   size     = %d
-  image_id = "%s"
+  image_id = data.opentelekomcloud_images_image_v2.latest_image.id
 }
 
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
   network {
-    uuid = "%s"
+    uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
   block_device {
     uuid                  = opentelekomcloud_blockstorage_volume_v2.volume_1.id
@@ -347,13 +351,13 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
     delete_on_termination = true
   }
 }
-`, size, env.OS_IMAGE_ID, env.OS_NETWORK_ID)
+`, common.DataSourceImage, common.DataSourceSubnet, size)
 }
 
 const (
 	testAccBlockStorageV2VolumeUpdate = `
 resource "opentelekomcloud_blockstorage_volume_v2" "volume_1" {
-  name = "volume_1-updated"
+  name        = "volume_1-updated"
   description = "first test volume"
   metadata = {
     foo = "bar"
@@ -363,7 +367,7 @@ resource "opentelekomcloud_blockstorage_volume_v2" "volume_1" {
 `
 	testAccBlockStorageV2VolumeTags = `
 resource "opentelekomcloud_blockstorage_volume_v2" "volume_1" {
-  name = "volume_1"
+  name        = "volume_1"
   description = "first test volume"
   metadata = {
     foo = "bar"
@@ -378,7 +382,7 @@ resource "opentelekomcloud_blockstorage_volume_v2" "volume_1" {
 
 	testAccBlockStorageV2VolumeTagsUpdate = `
 resource "opentelekomcloud_blockstorage_volume_v2" "volume_1" {
-  name = "volume_1-updated"
+  name        = "volume_1-updated"
   description = "first test volume"
   metadata = {
     foo = "bar"
@@ -392,7 +396,7 @@ resource "opentelekomcloud_blockstorage_volume_v2" "volume_1" {
 `
 	testAccBlockStorageV2VolumeTimeout = `
 resource "opentelekomcloud_blockstorage_volume_v2" "volume_1" {
-  name = "volume_1"
+  name        = "volume_1"
   description = "first test volume"
   size = 1
   device_type = "SCSI"
@@ -405,7 +409,7 @@ resource "opentelekomcloud_blockstorage_volume_v2" "volume_1" {
 `
 	testAccBlockStorageV2VolumeBasic = `
 resource "opentelekomcloud_blockstorage_volume_v2" "volume_1" {
-  name = "volume_1"
+  name        = "volume_1"
   description = "first test volume"
   metadata = {
     foo = "bar"
@@ -416,7 +420,7 @@ resource "opentelekomcloud_blockstorage_volume_v2" "volume_1" {
 
 	testAccBlockStorageV2VolumeBigger = `
 resource "opentelekomcloud_blockstorage_volume_v2" "volume_1" {
-  name = "volume_1"
+  name        = "volume_1"
   description = "first test volume"
   metadata = {
     foo = "bar"
@@ -427,12 +431,13 @@ resource "opentelekomcloud_blockstorage_volume_v2" "volume_1" {
 )
 
 var testAccBlockStorageV2VolumeImage = fmt.Sprintf(`
+%s
 resource "opentelekomcloud_blockstorage_volume_v2" "volume_1" {
-  name = "volume_1"
-  size = 12
-  image_id = "%s"
+  name     = "volume_1"
+  size     = 12
+  image_id = data.opentelekomcloud_images_image_v2.latest_image.id
 }
-`, env.OS_IMAGE_ID)
+`, common.DataSourceImage)
 
 var testAccBlockStorageV2VolumePolicy = fmt.Sprintf(`
 %s

--- a/opentelekomcloud/acceptance/evs/resource_opentelekomcloud_evs_volume_v3_test.go
+++ b/opentelekomcloud/acceptance/evs/resource_opentelekomcloud_evs_volume_v3_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 )
 
-const resourceName = "opentelekomcloud_evs_volume_v3.volume_1"
+const resourceVolumeV3Name = "opentelekomcloud_evs_volume_v3.volume_1"
 
 func TestAccEvsStorageV3Volume_basic(t *testing.T) {
 	var volume volumes.Volume
@@ -28,15 +28,15 @@ func TestAccEvsStorageV3Volume_basic(t *testing.T) {
 			{
 				Config: testAccEvsStorageV3VolumeBasic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEvsStorageV3VolumeExists(resourceName, &volume),
-					resource.TestCheckResourceAttr(resourceName, "name", "volume_1"),
+					testAccCheckEvsStorageV3VolumeExists(resourceVolumeV3Name, &volume),
+					resource.TestCheckResourceAttr(resourceVolumeV3Name, "name", "volume_1"),
 				),
 			},
 			{
 				Config: testAccEvsStorageV3VolumeUpdate,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEvsStorageV3VolumeExists(resourceName, &volume),
-					resource.TestCheckResourceAttr(resourceName, "name", "volume_1-updated"),
+					testAccCheckEvsStorageV3VolumeExists(resourceVolumeV3Name, &volume),
+					resource.TestCheckResourceAttr(resourceVolumeV3Name, "name", "volume_1-updated"),
 				),
 			},
 		},
@@ -52,13 +52,13 @@ func TestAccEvsStorageV3Volume_tags(t *testing.T) {
 			{
 				Config: testAccEvsStorageV3VolumeTags,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "tags.muh", "value-create"),
+					resource.TestCheckResourceAttr(resourceVolumeV3Name, "tags.muh", "value-create"),
 				),
 			},
 			{
 				Config: testAccEvsStorageV3VolumeTagsUpdate,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "tags.muh", "value-update"),
+					resource.TestCheckResourceAttr(resourceVolumeV3Name, "tags.muh", "value-update"),
 				),
 			},
 		},
@@ -76,8 +76,8 @@ func TestAccEvsStorageV3Volume_image(t *testing.T) {
 			{
 				Config: testAccEvsStorageV3VolumeImage,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEvsStorageV3VolumeExists(resourceName, &volume),
-					resource.TestCheckResourceAttr(resourceName, "name", "volume_1"),
+					testAccCheckEvsStorageV3VolumeExists(resourceVolumeV3Name, &volume),
+					resource.TestCheckResourceAttr(resourceVolumeV3Name, "name", "volume_1"),
 				),
 			},
 		},
@@ -95,7 +95,7 @@ func TestAccEvsStorageV3Volume_timeout(t *testing.T) {
 			{
 				Config: testAccEvsStorageV3VolumeTimeout,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEvsStorageV3VolumeExists(resourceName, &volume),
+					testAccCheckEvsStorageV3VolumeExists(resourceVolumeV3Name, &volume),
 				),
 			},
 		},
@@ -119,7 +119,7 @@ func TestAccEvsStorageV3Volume_volumeType(t *testing.T) {
 
 func TestAccEvsStorageV3Volume_resize(t *testing.T) {
 	var volume volumes.Volume
-	var volumeUpscaled volumes.Volume
+	var volumeUpScaled volumes.Volume
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -129,15 +129,15 @@ func TestAccEvsStorageV3Volume_resize(t *testing.T) {
 			{
 				Config: testAccEvsStorageV3VolumeBasic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEvsStorageV3VolumeExists(resourceName, &volume),
-					resource.TestCheckResourceAttr(resourceName, "name", "volume_1"),
+					testAccCheckEvsStorageV3VolumeExists(resourceVolumeV3Name, &volume),
+					resource.TestCheckResourceAttr(resourceVolumeV3Name, "name", "volume_1"),
 				),
 			},
 			{
 				Config: testAccEvsStorageV3VolumeUpscale,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEvsStorageV3VolumePersists(resourceName, &volumeUpscaled, &volume),
-					resource.TestCheckResourceAttr(resourceName, "size", "20"),
+					testAccCheckEvsStorageV3VolumePersists(resourceVolumeV3Name, &volumeUpScaled, &volume),
+					resource.TestCheckResourceAttr(resourceVolumeV3Name, "size", "20"),
 				),
 			},
 		},
@@ -146,9 +146,9 @@ func TestAccEvsStorageV3Volume_resize(t *testing.T) {
 
 func testAccCheckEvsStorageV3VolumeDestroy(s *terraform.State) error {
 	config := common.TestAccProvider.Meta().(*cfg.Config)
-	blockStorageClient, err := config.BlockStorageV3Client(env.OS_REGION_NAME)
+	client, err := config.BlockStorageV3Client(env.OS_REGION_NAME)
 	if err != nil {
-		return fmt.Errorf("error creating OpenTelekomCloud evs storage client: %s", err)
+		return fmt.Errorf("error creating OpenTelekomCloud BlockStorageV3 client: %s", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -156,7 +156,7 @@ func testAccCheckEvsStorageV3VolumeDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := volumes.Get(blockStorageClient, rs.Primary.ID).Extract()
+		_, err := volumes.Get(client, rs.Primary.ID).Extract()
 		if err == nil {
 			return fmt.Errorf("volume still exists")
 		}
@@ -177,12 +177,12 @@ func testAccCheckEvsStorageV3VolumeExists(n string, volume *volumes.Volume) reso
 		}
 
 		config := common.TestAccProvider.Meta().(*cfg.Config)
-		blockStorageClient, err := config.BlockStorageV3Client(env.OS_REGION_NAME)
+		client, err := config.BlockStorageV3Client(env.OS_REGION_NAME)
 		if err != nil {
-			return fmt.Errorf("error creating OpenTelekomCloud evs storage client: %s", err)
+			return fmt.Errorf("error creating OpenTelekomCloud BlockStorageV3 client: %s", err)
 		}
 
-		found, err := volumes.Get(blockStorageClient, rs.Primary.ID).Extract()
+		found, err := volumes.Get(client, rs.Primary.ID).Extract()
 		if err != nil {
 			return err
 		}
@@ -210,7 +210,7 @@ func testAccCheckEvsStorageV3VolumePersists(n string, volume, oldVolume *volumes
 		config := common.TestAccProvider.Meta().(*cfg.Config)
 		client, err := config.BlockStorageV3Client(env.OS_REGION_NAME)
 		if err != nil {
-			return fmt.Errorf("error creating OpenTelekomCloud evs storage client: %s", err)
+			return fmt.Errorf("error creating OpenTelekomCloud BlockStorageV3 client: %s", err)
 		}
 
 		found, err := volumes.Get(client, rs.Primary.ID).Extract()


### PR DESCRIPTION
## Summary of the Pull Request
Replace `OS_NETWORK_ID`, `OS_IMAGE_ID` with data sources

## PR Checklist

* [x] Refers to: #1320
* [x] Tests added/passed.

## Acceptance Steps Performed

```
=== RUN   TestAccBlockStorageV2Volume_importBasic
--- PASS: TestAccBlockStorageV2Volume_importBasic (145.44s)
=== RUN   TestAccBlockStorageV2Volume_basic
--- PASS: TestAccBlockStorageV2Volume_basic (194.82s)
=== RUN   TestAccBlockStorageV2Volume_upscaleDownScale
--- PASS: TestAccBlockStorageV2Volume_upscaleDownScale (301.68s)
=== RUN   TestAccBlockStorageV2Volume_upscaleDownScaleAssigned
--- PASS: TestAccBlockStorageV2Volume_upscaleDownScaleAssigned (400.09s)
=== RUN   TestAccBlockStorageV2Volume_tags
--- PASS: TestAccBlockStorageV2Volume_tags (197.84s)
=== RUN   TestAccBlockStorageV2Volume_image
--- PASS: TestAccBlockStorageV2Volume_image (124.74s)
=== RUN   TestAccBlockStorageV2Volume_timeout
--- PASS: TestAccBlockStorageV2Volume_timeout (119.14s)
=== RUN   TestAccEvsStorageV3Volume_basic
--- PASS: TestAccEvsStorageV3Volume_basic (192.49s)
=== RUN   TestAccEvsStorageV3Volume_tags
--- PASS: TestAccEvsStorageV3Volume_tags (190.98s)
=== RUN   TestAccEvsStorageV3Volume_image
--- PASS: TestAccEvsStorageV3Volume_image (132.95s)
=== RUN   TestAccEvsStorageV3Volume_timeout
--- PASS: TestAccEvsStorageV3Volume_timeout (117.86s)
=== RUN   TestAccEvsStorageV3Volume_volumeType
--- PASS: TestAccEvsStorageV3Volume_volumeType (22.63s)
=== RUN   TestAccEvsStorageV3Volume_resize
--- PASS: TestAccEvsStorageV3Volume_resize (198.91s)
PASS
ok  	github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/evs	2342.643s

```
