### PR TITLE
[IAM] Fix error reading `role_assignment_v3`

### DIFF
--- a/opentelekomcloud/services/iam/resource_opentelekomcloud_identity_role_assignment_v3.go
+++ b/opentelekomcloud/services/iam/resource_opentelekomcloud_identity_role_assignment_v3.go
@@ -113,7 +113,6 @@ func resourceIdentityRoleAssignmentV3Read(_ context.Context, d *schema.ResourceD
 		d.Set("group_id", groupID),
 		d.Set("user_id", userID),
 		d.Set("role_id", roleAssignment.ID),
-		d.Set("region", config.GetRegion(d)),
 	)
 	if err := mErr.ErrorOrNil(); err != nil {
 		return diag.FromErr(err)

--- a/releasenotes/notes/fix-iam-role-assignment-90fb763da1a5d79a.yaml
+++ b/releasenotes/notes/fix-iam-role-assignment-90fb763da1a5d79a.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[IAM]** Fix error reading ``resource/opentelekomcloud_identity_role_assignment_v3`` (`#1389 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1389>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Remove setting `region` in `identity_role_assignment_v3` resource

Fix #1386 

## PR Checklist

* [x] Refers to: #1386
* [x] Tests added/passed.
* [x] Release notes added.

## Acceptance Steps Performed
Tested using `microstack`:
```
=== RUN   TestAccIdentityV3RoleAssignment_basic
    testing_new.go:70: Error running post-test destroy, there may be dangling resources: exit status 1
        
        Error: error deleting OpenStack project: Expected HTTP response code [200] when accessing [DELETE http://192.168.1.35:5000/v3/projects/a84e5cb0ba264f988a1a4952a6bb012a], but got 204 instead
        
        
--- FAIL: TestAccIdentityV3RoleAssignment_basic (3.75s)

FAIL

Process finished with the exit code 1
```
(THIS IS OK) 