### PR TITLE
[Acceptance] Get rid of IDs in `DNS`

### DIFF
--- a/opentelekomcloud/acceptance/dns/data_source_opentelekomcloud_dns_zone_v2_test.go
+++ b/opentelekomcloud/acceptance/dns/data_source_opentelekomcloud_dns_zone_v2_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
 )
 
+const dataZoneName = "data.opentelekomcloud_dns_zone_v2.z1"
+
 func TestAccOpenStackDNSZoneV2DataSource_basic(t *testing.T) {
 	zone := randomZoneName()
 	randZoneTag := fmt.Sprintf("value-%s", acctest.RandString(5))
@@ -26,13 +28,10 @@ func TestAccOpenStackDNSZoneV2DataSource_basic(t *testing.T) {
 			{
 				Config: testAccOpenStackDNSZoneV2DataSourceBasic(zone, randZoneTag),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDNSZoneV2DataSourceID("data.opentelekomcloud_dns_zone_v2.z1"),
-					resource.TestCheckResourceAttr(
-						"data.opentelekomcloud_dns_zone_v2.z1", "name", zone),
-					resource.TestCheckResourceAttr(
-						"data.opentelekomcloud_dns_zone_v2.z1", "ttl", "3000"),
-					resource.TestCheckResourceAttr(
-						"data.opentelekomcloud_dns_zone_v2.z1", "zone_type", "public"),
+					testAccCheckDNSZoneV2DataSourceID(dataZoneName),
+					resource.TestCheckResourceAttr(dataZoneName, "name", zone),
+					resource.TestCheckResourceAttr(dataZoneName, "ttl", "3000"),
+					resource.TestCheckResourceAttr(dataZoneName, "zone_type", "public"),
 				),
 			},
 			{
@@ -58,7 +57,7 @@ func TestAccOpenStackDNSZoneV2DataSource_byTag(t *testing.T) {
 			{
 				Config: testAccOpenStackDNSZoneV2DataSourceByTag(zone1, zone2, randZoneTag),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDNSZoneV2DataSourceID("data.opentelekomcloud_dns_zone_v2.z1"),
+					testAccCheckDNSZoneV2DataSourceID(dataZoneName),
 				),
 			},
 		},
@@ -94,7 +93,8 @@ resource "opentelekomcloud_dns_zone_v2" "zone_1" {
 }
 `
 
-const zoneTemplateNoTags = `resource "opentelekomcloud_dns_zone_v2" "zone_2" {
+const zoneTemplateNoTags = `
+resource "opentelekomcloud_dns_zone_v2" "zone_2" {
   name        = "%s"
   email       = "email1@example.com"
   description = "a public zone"

--- a/opentelekomcloud/acceptance/dns/import_opentelekomcloud_dns_recordset_v2_test.go
+++ b/opentelekomcloud/acceptance/dns/import_opentelekomcloud_dns_recordset_v2_test.go
@@ -10,7 +10,6 @@ import (
 
 func TestAccDNSV2RecordSet_importBasic(t *testing.T) {
 	zoneName := randomZoneName()
-	resourceName := "opentelekomcloud_dns_recordset_v2.recordset_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -18,10 +17,10 @@ func TestAccDNSV2RecordSet_importBasic(t *testing.T) {
 		CheckDestroy:      testAccCheckDNSV2RecordSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDNSV2RecordSet_basic(zoneName),
+				Config: testAccDNSV2RecordSetBasic(zoneName),
 			},
 			{
-				ResourceName:      resourceName,
+				ResourceName:      resourceRecordSetName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},

--- a/opentelekomcloud/acceptance/dns/import_opentelekomcloud_dns_zone_v2_test.go
+++ b/opentelekomcloud/acceptance/dns/import_opentelekomcloud_dns_zone_v2_test.go
@@ -12,7 +12,6 @@ import (
 
 func TestAccDNSV2Zone_importBasic(t *testing.T) {
 	var zoneName = fmt.Sprintf("accepttest%s.com.", acctest.RandString(5))
-	resourceName := "opentelekomcloud_dns_zone_v2.zone_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -20,11 +19,11 @@ func TestAccDNSV2Zone_importBasic(t *testing.T) {
 		CheckDestroy:      testAccCheckDNSV2ZoneDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDNSV2Zone_basic(zoneName),
+				Config: testAccDNSV2ZoneBasic(zoneName),
 			},
 
 			{
-				ResourceName:      resourceName,
+				ResourceName:      resourceZoneName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},

--- a/opentelekomcloud/acceptance/dns/resource_opentelekomcloud_dns_ptrrecord_v2_test.go
+++ b/opentelekomcloud/acceptance/dns/resource_opentelekomcloud_dns_ptrrecord_v2_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 )
 
+const resourcePtrRecordName = "opentelekomcloud_dns_ptrrecord_v2.ptr_1"
+
 func TestAccDNSV2PtrRecord_basic(t *testing.T) {
 	var ptr ptrrecords.Ptr
 	ptrName := fmt.Sprintf("acc-test-%s.com.", acctest.RandString(3))
@@ -25,30 +27,26 @@ func TestAccDNSV2PtrRecord_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckDNSV2PtrRecordDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDNSV2PtrRecord_basic(ptrName),
+				Config: testAccDNSV2PtrRecordBasic(ptrName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDNSV2PtrRecordExists("opentelekomcloud_dns_ptrrecord_v2.ptr_1", &ptr),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_dns_ptrrecord_v2.ptr_1", "description", "a ptr record"),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_dns_ptrrecord_v2.ptr_1", "tags.muh", "value-create"),
+					testAccCheckDNSV2PtrRecordExists(resourcePtrRecordName, &ptr),
+					resource.TestCheckResourceAttr(resourcePtrRecordName, "description", "a ptr record"),
+					resource.TestCheckResourceAttr(resourcePtrRecordName, "tags.muh", "value-create"),
 				),
 			},
 			{
-				Config: testAccDNSV2PtrRecord_update(ptrName),
+				Config: testAccDNSV2PtrRecordUpdate(ptrName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDNSV2PtrRecordExists("opentelekomcloud_dns_ptrrecord_v2.ptr_1", &ptr),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_dns_ptrrecord_v2.ptr_1", "description", "ptr record updated"),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_dns_ptrrecord_v2.ptr_1", "tags.muh", "value-update"),
+					testAccCheckDNSV2PtrRecordExists(resourcePtrRecordName, &ptr),
+					resource.TestCheckResourceAttr(resourcePtrRecordName, "description", "ptr record updated"),
+					resource.TestCheckResourceAttr(resourcePtrRecordName, "tags.muh", "value-update"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccDNSV2PtrRecord_undotted(t *testing.T) {
+func TestAccDNSV2PtrRecord_unDotted(t *testing.T) {
 	zoneName := randomZoneName()
 	zoneName = strings.TrimSuffix(zoneName, ".")
 	resource.Test(t, resource.TestCase{
@@ -57,7 +55,7 @@ func TestAccDNSV2PtrRecord_undotted(t *testing.T) {
 		CheckDestroy:      testAccCheckDNSV2PtrRecordDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDNSV2PtrRecord_basic(zoneName),
+				Config: testAccDNSV2PtrRecordBasic(zoneName),
 			},
 		},
 	})
@@ -116,7 +114,7 @@ func testAccCheckDNSV2PtrRecordExists(n string, ptr *ptrrecords.Ptr) resource.Te
 	}
 }
 
-func testAccDNSV2PtrRecord_basic(ptrName string) string {
+func testAccDNSV2PtrRecordBasic(ptrName string) string {
 	return fmt.Sprintf(`
 resource "opentelekomcloud_networking_floatingip_v2" "fip_1" {}
 
@@ -133,7 +131,7 @@ resource "opentelekomcloud_dns_ptrrecord_v2" "ptr_1" {
 `, ptrName)
 }
 
-func testAccDNSV2PtrRecord_update(ptrName string) string {
+func testAccDNSV2PtrRecordUpdate(ptrName string) string {
 	return fmt.Sprintf(`
 resource "opentelekomcloud_networking_floatingip_v2" "fip_1" {}
 

--- a/opentelekomcloud/acceptance/dns/resource_opentelekomcloud_dns_recordset_v2_test.go
+++ b/opentelekomcloud/acceptance/dns/resource_opentelekomcloud_dns_recordset_v2_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/services/dns"
 )
 
+const resourceRecordSetName = "opentelekomcloud_dns_recordset_v2.recordset_1"
+
 func randomZoneName() string {
 	// TODO: why does back-end convert name to lowercase?
 	return fmt.Sprintf("acpttest-zone-%s.com.", acctest.RandString(5))
@@ -33,38 +35,29 @@ func TestAccDNSV2RecordSet_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckDNSV2RecordSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDNSV2RecordSet_basic(zoneName),
+				Config: testAccDNSV2RecordSetBasic(zoneName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDNSV2RecordSetExists(
-						"opentelekomcloud_dns_recordset_v2.recordset_1", &recordset),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_dns_recordset_v2.recordset_1", "name", zoneName),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_dns_recordset_v2.recordset_1", "description", "a record set"),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_dns_recordset_v2.recordset_1", "type", "A"),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_dns_recordset_v2.recordset_1", "ttl", "3000"),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_dns_recordset_v2.recordset_1", "tags.key", "value"),
+					testAccCheckDNSV2RecordSetExists(resourceRecordSetName, &recordset),
+					resource.TestCheckResourceAttr(resourceRecordSetName, "name", zoneName),
+					resource.TestCheckResourceAttr(resourceRecordSetName, "description", "a record set"),
+					resource.TestCheckResourceAttr(resourceRecordSetName, "type", "A"),
+					resource.TestCheckResourceAttr(resourceRecordSetName, "ttl", "3000"),
+					resource.TestCheckResourceAttr(resourceRecordSetName, "tags.key", "value"),
 				),
 			},
 			{
-				Config: testAccDNSV2RecordSet_update(zoneName),
+				Config: testAccDNSV2RecordSetUpdate(zoneName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_dns_recordset_v2.recordset_1", "ttl", "6000"),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_dns_recordset_v2.recordset_1", "tags.key", "value_updated"),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_dns_recordset_v2.recordset_1", "description", "an updated record set"),
+					resource.TestCheckResourceAttr(resourceRecordSetName, "ttl", "6000"),
+					resource.TestCheckResourceAttr(resourceRecordSetName, "tags.key", "value_updated"),
+					resource.TestCheckResourceAttr(resourceRecordSetName, "description", "an updated record set"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccDNSV2RecordSet_undotted(t *testing.T) {
+func TestAccDNSV2RecordSet_unDotted(t *testing.T) {
 	zoneName := randomZoneName()
 	zoneName = strings.TrimSuffix(zoneName, ".")
 	resource.Test(t, resource.TestCase{
@@ -73,7 +66,7 @@ func TestAccDNSV2RecordSet_undotted(t *testing.T) {
 		CheckDestroy:      testAccCheckDNSV2RecordSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDNSV2RecordSet_basic(zoneName),
+				Config: testAccDNSV2RecordSetBasic(zoneName),
 			},
 		},
 	})
@@ -88,10 +81,10 @@ func TestAccDNSV2RecordSet_childFirst(t *testing.T) {
 		CheckDestroy:      testAccCheckDNSV2RecordSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDNSV2RecordSet_childFirst1(zoneName),
+				Config: testAccDNSV2RecordSetChildFirst1(zoneName),
 			},
 			{
-				Config: testAccDNSV2RecordSet_childFirst2(zoneName),
+				Config: testAccDNSV2RecordSetChildFirst2(zoneName),
 			},
 		},
 	})
@@ -107,11 +100,10 @@ func TestAccDNSV2RecordSet_readTTL(t *testing.T) {
 		CheckDestroy:      testAccCheckDNSV2RecordSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDNSV2RecordSet_readTTL(zoneName),
+				Config: testAccDNSV2RecordSetReadTTL(zoneName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDNSV2RecordSetExists("opentelekomcloud_dns_recordset_v2.recordset_1", &recordset),
-					resource.TestMatchResourceAttr(
-						"opentelekomcloud_dns_recordset_v2.recordset_1", "ttl", regexp.MustCompile("^[0-9]+$")),
+					testAccCheckDNSV2RecordSetExists(resourceRecordSetName, &recordset),
+					resource.TestMatchResourceAttr(resourceRecordSetName, "ttl", regexp.MustCompile("^[0-9]+$")),
 				),
 			},
 		},
@@ -128,9 +120,9 @@ func TestAccDNSV2RecordSet_timeout(t *testing.T) {
 		CheckDestroy:      testAccCheckDNSV2RecordSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDNSV2RecordSet_timeout(zoneName),
+				Config: testAccDNSV2RecordSetTimeout(zoneName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDNSV2RecordSetExists("opentelekomcloud_dns_recordset_v2.recordset_1", &recordset),
+					testAccCheckDNSV2RecordSetExists(resourceRecordSetName, &recordset),
 				),
 			},
 		},
@@ -139,6 +131,7 @@ func TestAccDNSV2RecordSet_timeout(t *testing.T) {
 
 func TestAccDNSV2RecordSet_shared(t *testing.T) {
 	zoneName := randomZoneName()
+	resourceRecordSet2Name := "opentelekomcloud_dns_recordset_v2.recordset_2"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -146,23 +139,20 @@ func TestAccDNSV2RecordSet_shared(t *testing.T) {
 		CheckDestroy:      testAccCheckDNSV2RecordSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDNSV2RecordSet_basic(zoneName),
+				Config: testAccDNSV2RecordSetBasic(zoneName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_dns_recordset_v2.recordset_1", "shared", "false"),
+					resource.TestCheckResourceAttr(resourceRecordSetName, "shared", "false"),
 				),
 			},
 			{
-				Config: testAccDNSV2RecordSet_reuse(zoneName),
+				Config: testAccDNSV2RecordSetReuse(zoneName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_dns_recordset_v2.recordset_1", "shared", "false"),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_dns_recordset_v2.recordset_2", "shared", "true"),
+					resource.TestCheckResourceAttr(resourceRecordSetName, "shared", "false"),
+					resource.TestCheckResourceAttr(resourceRecordSet2Name, "shared", "true"),
 				),
 			},
 			{
-				Config: testAccDNSV2RecordSet_basic(zoneName),
+				Config: testAccDNSV2RecordSetBasic(zoneName),
 			},
 		},
 	})
@@ -170,7 +160,7 @@ func TestAccDNSV2RecordSet_shared(t *testing.T) {
 
 func testAccCheckDNSV2RecordSetDestroy(s *terraform.State) error {
 	config := common.TestAccProvider.Meta().(*cfg.Config)
-	dnsClient, err := config.DnsV2Client(env.OS_REGION_NAME)
+	client, err := config.DnsV2Client(env.OS_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("error creating OpenTelekomCloud DNS client: %s", err)
 	}
@@ -185,7 +175,7 @@ func testAccCheckDNSV2RecordSetDestroy(s *terraform.State) error {
 			return err
 		}
 
-		_, err = recordsets.Get(dnsClient, zoneID, recordsetID).Extract()
+		_, err = recordsets.Get(client, zoneID, recordsetID).Extract()
 		if err == nil {
 			return fmt.Errorf("record set still exists")
 		}
@@ -206,7 +196,7 @@ func testAccCheckDNSV2RecordSetExists(n string, recordset *recordsets.RecordSet)
 		}
 
 		config := common.TestAccProvider.Meta().(*cfg.Config)
-		dnsClient, err := config.DnsV2Client(env.OS_REGION_NAME)
+		client, err := config.DnsV2Client(env.OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("error creating OpenTelekomCloud DNS client: %s", err)
 		}
@@ -216,7 +206,7 @@ func testAccCheckDNSV2RecordSetExists(n string, recordset *recordsets.RecordSet)
 			return err
 		}
 
-		found, err := recordsets.Get(dnsClient, zoneID, recordsetID).Extract()
+		found, err := recordsets.Get(client, zoneID, recordsetID).Extract()
 		if err != nil {
 			return err
 		}
@@ -231,7 +221,7 @@ func testAccCheckDNSV2RecordSetExists(n string, recordset *recordsets.RecordSet)
 	}
 }
 
-func testAccDNSV2RecordSet_basic(zoneName string) string {
+func testAccDNSV2RecordSetBasic(zoneName string) string {
 	return fmt.Sprintf(`
 resource "opentelekomcloud_dns_zone_v2" "zone_1" {
   name        = "%[1]s"
@@ -256,7 +246,7 @@ resource "opentelekomcloud_dns_recordset_v2" "recordset_1" {
 `, zoneName)
 }
 
-func testAccDNSV2RecordSet_update(zoneName string) string {
+func testAccDNSV2RecordSetUpdate(zoneName string) string {
 	return fmt.Sprintf(`
 resource "opentelekomcloud_dns_zone_v2" "zone_1" {
   name        = "%s"
@@ -281,7 +271,7 @@ resource "opentelekomcloud_dns_recordset_v2" "recordset_1" {
 `, zoneName, zoneName)
 }
 
-func testAccDNSV2RecordSet_readTTL(zoneName string) string {
+func testAccDNSV2RecordSetReadTTL(zoneName string) string {
 	return fmt.Sprintf(`
 resource "opentelekomcloud_dns_zone_v2" "zone_1" {
   name        = "%[1]s"
@@ -299,7 +289,7 @@ resource "opentelekomcloud_dns_recordset_v2" "recordset_1" {
 `, zoneName)
 }
 
-func testAccDNSV2RecordSet_timeout(zoneName string) string {
+func testAccDNSV2RecordSetTimeout(zoneName string) string {
 	return fmt.Sprintf(`
 resource "opentelekomcloud_dns_zone_v2" "zone_1" {
   name        = "%[1]s"
@@ -324,7 +314,7 @@ resource "opentelekomcloud_dns_recordset_v2" "recordset_1" {
 `, zoneName)
 }
 
-func testAccDNSV2RecordSet_reuse(zoneName string) string {
+func testAccDNSV2RecordSetReuse(zoneName string) string {
 	return fmt.Sprintf(`
 resource "opentelekomcloud_dns_zone_v2" "zone_1" {
   name        = "%[1]s"
@@ -363,7 +353,7 @@ resource "opentelekomcloud_dns_recordset_v2" "recordset_2" {
 `, zoneName)
 }
 
-func testAccDNSV2RecordSet_childFirst1(zoneName string) string {
+func testAccDNSV2RecordSetChildFirst1(zoneName string) string {
 	return fmt.Sprintf(`
 resource "opentelekomcloud_dns_zone_v2" "zone_1" {
   name        = "%[1]s"
@@ -388,7 +378,7 @@ resource "opentelekomcloud_dns_recordset_v2" "recordset" {
 `, zoneName)
 }
 
-func testAccDNSV2RecordSet_childFirst2(zoneName string) string {
+func testAccDNSV2RecordSetChildFirst2(zoneName string) string {
 	return fmt.Sprintf(`
 resource "opentelekomcloud_dns_zone_v2" "zone_1" {
   name        = "%[1]s"

--- a/opentelekomcloud/acceptance/dns/resource_opentelekomcloud_dns_zone_v2_test.go
+++ b/opentelekomcloud/acceptance/dns/resource_opentelekomcloud_dns_zone_v2_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 )
 
+const resourceZoneName = "opentelekomcloud_dns_zone_v2.zone_1"
+
 func TestAccDNSV2Zone_basic(t *testing.T) {
 	var zone zones.Zone
 	// TODO: Why does it lowercase names in back-end?
@@ -28,36 +30,31 @@ func TestAccDNSV2Zone_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckDNSV2ZoneDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDNSV2Zone_basic(zoneName),
+				Config: testAccDNSV2ZoneBasic(zoneName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDNSV2ZoneExists("opentelekomcloud_dns_zone_v2.zone_1", &zone),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_dns_zone_v2.zone_1", "description", "a public zone"),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_dns_zone_v2.zone_1", "tags.foo", "bar"),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_dns_zone_v2.zone_1", "tags.key", "value"),
+					testAccCheckDNSV2ZoneExists(resourceZoneName, &zone),
+					resource.TestCheckResourceAttr(resourceZoneName, "description", "a public zone"),
+					resource.TestCheckResourceAttr(resourceZoneName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceZoneName, "tags.key", "value"),
 				),
 			},
 			{
-				Config: testAccDNSV2Zone_update(zoneName),
+				Config: testAccDNSV2ZoneUpdate(zoneName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("opentelekomcloud_dns_zone_v2.zone_1", "name", zoneName),
-					resource.TestCheckResourceAttr("opentelekomcloud_dns_zone_v2.zone_1", "email", "email2@example.com"),
-					resource.TestCheckResourceAttr("opentelekomcloud_dns_zone_v2.zone_1", "ttl", "6000"),
+					resource.TestCheckResourceAttr(resourceZoneName, "name", zoneName),
+					resource.TestCheckResourceAttr(resourceZoneName, "email", "email2@example.com"),
+					resource.TestCheckResourceAttr(resourceZoneName, "ttl", "6000"),
 					// TODO: research why this is blank...
-					// resource.TestCheckResourceAttr("opentelekomcloud_dns_zone_v2.zone_1", "type", "PRIMARY"),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_dns_zone_v2.zone_1", "description", "an updated zone"),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_dns_zone_v2.zone_1", "tags.key", "value_updated"),
+					// resource.TestCheckResourceAttr(resourceZoneName, "type", "PRIMARY"),
+					resource.TestCheckResourceAttr(resourceZoneName, "description", "an updated zone"),
+					resource.TestCheckResourceAttr(resourceZoneName, "tags.key", "value_updated"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccDNSV2Zone_undotted(t *testing.T) {
+func TestAccDNSV2Zone_unDotted(t *testing.T) {
 	zoneName := randomZoneName()
 	zoneName = strings.TrimSuffix(zoneName, ".")
 	resource.Test(t, resource.TestCase{
@@ -66,7 +63,7 @@ func TestAccDNSV2Zone_undotted(t *testing.T) {
 		CheckDestroy:      testAccCheckDNSV2ZoneDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDNSV2Zone_basic(zoneName),
+				Config: testAccDNSV2ZoneBasic(zoneName),
 			},
 		},
 	})
@@ -83,18 +80,14 @@ func TestAccDNSV2Zone_private(t *testing.T) {
 		CheckDestroy:      testAccCheckDNSV2ZoneDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDNSV2Zone_private(zoneName),
+				Config: testAccDNSV2ZonePrivate(zoneName),
 				// ExpectNonEmptyPlan: true,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDNSV2ZoneExists("opentelekomcloud_dns_zone_v2.zone_1", &zone),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_dns_zone_v2.zone_1", "description", "a private zone"),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_dns_zone_v2.zone_1", "type", "private"),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_dns_zone_v2.zone_1", "tags.foo", "bar"),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_dns_zone_v2.zone_1", "tags.key", "value"),
+					testAccCheckDNSV2ZoneExists(resourceZoneName, &zone),
+					resource.TestCheckResourceAttr(resourceZoneName, "description", "a private zone"),
+					resource.TestCheckResourceAttr(resourceZoneName, "type", "private"),
+					resource.TestCheckResourceAttr(resourceZoneName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceZoneName, "tags.key", "value"),
 				),
 			},
 		},
@@ -111,13 +104,12 @@ func TestAccDNSV2Zone_readTTL(t *testing.T) {
 		CheckDestroy:      testAccCheckDNSV2ZoneDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:             testAccDNSV2Zone_readTTL(zoneName),
+				Config:             testAccDNSV2ZoneReadTTL(zoneName),
 				ExpectNonEmptyPlan: true,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDNSV2ZoneExists("opentelekomcloud_dns_zone_v2.zone_1", &zone),
-					// resource.TestCheckResourceAttr("opentelekomcloud_dns_zone_v2.zone_1", "type", "PRIMARY"),
-					resource.TestMatchResourceAttr(
-						"opentelekomcloud_dns_zone_v2.zone_1", "ttl", regexp.MustCompile("^[0-9]+$")),
+					testAccCheckDNSV2ZoneExists(resourceZoneName, &zone),
+					// resource.TestCheckResourceAttr(resourceZoneName, "type", "PRIMARY"),
+					resource.TestMatchResourceAttr(resourceZoneName, "ttl", regexp.MustCompile("^[0-9]+$")),
 				),
 			},
 		},
@@ -134,10 +126,10 @@ func TestAccDNSV2Zone_timeout(t *testing.T) {
 		CheckDestroy:      testAccCheckDNSV2ZoneDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:             testAccDNSV2Zone_timeout(zoneName),
+				Config:             testAccDNSV2ZoneTimeout(zoneName),
 				ExpectNonEmptyPlan: true,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDNSV2ZoneExists("opentelekomcloud_dns_zone_v2.zone_1", &zone),
+					testAccCheckDNSV2ZoneExists(resourceZoneName, &zone),
 				),
 			},
 		},
@@ -146,7 +138,7 @@ func TestAccDNSV2Zone_timeout(t *testing.T) {
 
 func testAccCheckDNSV2ZoneDestroy(s *terraform.State) error {
 	config := common.TestAccProvider.Meta().(*cfg.Config)
-	dnsClient, err := config.DnsV2Client(env.OS_REGION_NAME)
+	client, err := config.DnsV2Client(env.OS_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("error creating OpenTelekomCloud DNS client: %s", err)
 	}
@@ -156,7 +148,7 @@ func testAccCheckDNSV2ZoneDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := zones.Get(dnsClient, rs.Primary.ID).Extract()
+		_, err := zones.Get(client, rs.Primary.ID).Extract()
 		if err == nil {
 			return fmt.Errorf("zone still exists")
 		}
@@ -177,12 +169,12 @@ func testAccCheckDNSV2ZoneExists(n string, zone *zones.Zone) resource.TestCheckF
 		}
 
 		config := common.TestAccProvider.Meta().(*cfg.Config)
-		dnsClient, err := config.DnsV2Client(env.OS_REGION_NAME)
+		client, err := config.DnsV2Client(env.OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("error creating OpenTelekomCloud DNS client: %s", err)
 		}
 
-		found, err := zones.Get(dnsClient, rs.Primary.ID).Extract()
+		found, err := zones.Get(client, rs.Primary.ID).Extract()
 		if err != nil {
 			return err
 		}
@@ -197,7 +189,7 @@ func testAccCheckDNSV2ZoneExists(n string, zone *zones.Zone) resource.TestCheckF
 	}
 }
 
-func testAccDNSV2Zone_basic(zoneName string) string {
+func testAccDNSV2ZoneBasic(zoneName string) string {
 	return fmt.Sprintf(`
 resource "opentelekomcloud_dns_zone_v2" "zone_1" {
   name        = "%s"
@@ -214,8 +206,10 @@ resource "opentelekomcloud_dns_zone_v2" "zone_1" {
 `, zoneName)
 }
 
-func testAccDNSV2Zone_private(zoneName string) string {
+func testAccDNSV2ZonePrivate(zoneName string) string {
 	return fmt.Sprintf(`
+%s
+
 resource "opentelekomcloud_dns_zone_v2" "zone_1" {
   name        = "%s"
   email       = "email1@example.com"
@@ -224,7 +218,7 @@ resource "opentelekomcloud_dns_zone_v2" "zone_1" {
   type        = "private"
 
   router {
-    router_id     = "%s"
+    router_id     = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
     router_region = "%s"
   }
   tags = {
@@ -232,10 +226,10 @@ resource "opentelekomcloud_dns_zone_v2" "zone_1" {
     key = "value"
   }
 }
-`, zoneName, env.OS_VPC_ID, env.OS_REGION_NAME)
+`, common.DataSourceSubnet, zoneName, env.OS_REGION_NAME)
 }
 
-func testAccDNSV2Zone_update(zoneName string) string {
+func testAccDNSV2ZoneUpdate(zoneName string) string {
 	return fmt.Sprintf(`
 resource "opentelekomcloud_dns_zone_v2" "zone_1" {
   name        = "%s"
@@ -252,7 +246,7 @@ resource "opentelekomcloud_dns_zone_v2" "zone_1" {
 `, zoneName)
 }
 
-func testAccDNSV2Zone_readTTL(zoneName string) string {
+func testAccDNSV2ZoneReadTTL(zoneName string) string {
 	return fmt.Sprintf(`
 resource "opentelekomcloud_dns_zone_v2" "zone_1" {
   name  = "%s"
@@ -261,7 +255,7 @@ resource "opentelekomcloud_dns_zone_v2" "zone_1" {
 `, zoneName)
 }
 
-func testAccDNSV2Zone_timeout(zoneName string) string {
+func testAccDNSV2ZoneTimeout(zoneName string) string {
 	return fmt.Sprintf(`
 resource "opentelekomcloud_dns_zone_v2" "zone_1" {
   name  = "%s"


### PR DESCRIPTION
## Summary of the Pull Request
Replace `OS_VPC_ID` with data sources

## PR Checklist

* [x] Refers to: #1320
* [x] Tests added/passed.

## Acceptance Steps Performed

```
=== RUN   TestAccOpenStackDNSZoneV2DataSource_basic
--- PASS: TestAccOpenStackDNSZoneV2DataSource_basic (353.40s)
=== RUN   TestAccOpenStackDNSZoneV2DataSource_byTag
--- PASS: TestAccOpenStackDNSZoneV2DataSource_byTag (261.14s)
=== RUN   TestAccDNSV2RecordSet_importBasic
--- PASS: TestAccDNSV2RecordSet_importBasic (203.37s)
=== RUN   TestAccDNSV2Zone_importBasic
--- PASS: TestAccDNSV2Zone_importBasic (177.04s)
=== RUN   TestAccDNSV2PtrRecord_basic
--- PASS: TestAccDNSV2PtrRecord_basic (280.02s)
=== RUN   TestAccDNSV2PtrRecord_unDotted
--- PASS: TestAccDNSV2PtrRecord_unDotted (159.57s)
=== RUN   TestAccDNSV2RecordSet_basic
--- PASS: TestAccDNSV2RecordSet_basic (297.13s)
=== RUN   TestAccDNSV2RecordSet_unDotted
--- PASS: TestAccDNSV2RecordSet_unDotted (163.84s)
=== RUN   TestAccDNSV2RecordSet_childFirst
--- PASS: TestAccDNSV2RecordSet_childFirst (292.26s)
=== RUN   TestAccDNSV2RecordSet_readTTL
--- PASS: TestAccDNSV2RecordSet_readTTL (178.66s)
=== RUN   TestAccDNSV2RecordSet_timeout
--- PASS: TestAccDNSV2RecordSet_timeout (172.08s)
=== RUN   TestAccDNSV2RecordSet_shared
--- PASS: TestAccDNSV2RecordSet_shared (245.71s)
=== RUN   TestAccDNSV2Zone_basic
--- PASS: TestAccDNSV2Zone_basic (268.63s)
=== RUN   TestAccDNSV2Zone_unDotted
--- PASS: TestAccDNSV2Zone_unDotted (144.82s)
=== RUN   TestAccDNSV2Zone_private
--- PASS: TestAccDNSV2Zone_private (171.39s)
=== RUN   TestAccDNSV2Zone_readTTL
--- PASS: TestAccDNSV2Zone_readTTL (162.06s)
=== RUN   TestAccDNSV2Zone_timeout
--- PASS: TestAccDNSV2Zone_timeout (148.07s)
PASS
PASS github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/dns	3683.039s
```
