### PR TITLE
[VPC] Fix broken delete of `vpc_subnet_v1`

### DIFF
--- a/releasenotes/notes/fix-subnet-deletion-99362ef7e310dadc.yaml
+++ b/releasenotes/notes/fix-subnet-deletion-99362ef7e310dadc.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[VPC]** Fix broken delete in ``resource/opentelekomcloud_vpc_subnet_v1`` (`#1394 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1394>`_)


### PR DESCRIPTION
## Summary of the Pull Request

Fix broken delete of `resource/opentelekomcloud_vpc_subnet_v1`
Fixes: #1393

## PR Checklist

* [x] Refers to: #1393
* [x] Tests added/passed.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccRdsInstanceV3Delete
--- PASS: TestAccRdsInstanceV3Delete (587.78s)
PASS

Process finished with the exit code 0
```
