### PR TITLE
Fix remaining loose setters

### DIFF
--- a/opentelekomcloud/services/bms/data_source_opentelekomcloud_compute_bms_server_v2.go
+++ b/opentelekomcloud/services/bms/data_source_opentelekomcloud_compute_bms_server_v2.go
@@ -203,7 +203,6 @@ func dataSourceBMSServersV2Read(_ context.Context, d *schema.ResourceData, meta 
 	}
 
 	mErr := multierror.Append(
-		d.Set("server_id", server.ID),
 		d.Set("user_id", server.UserID),
 		d.Set("name", server.Name),
 		d.Set("status", server.Status),

--- a/opentelekomcloud/services/deh/resource_opentelekomcloud_deh_host_v1.go
+++ b/opentelekomcloud/services/deh/resource_opentelekomcloud_deh_host_v1.go
@@ -184,7 +184,6 @@ func resourceDeHHostV1Read(_ context.Context, d *schema.ResourceData, meta inter
 	mErr := multierror.Append(
 		d.Set("name", n.Name),
 		d.Set("status", n.State),
-		d.Set("dedicated_host_id", n.ID),
 		d.Set("auto_placement", n.AutoPlacement),
 		d.Set("availability_zone", n.Az),
 		d.Set("available_vcpus", n.AvailableVcpus),

--- a/opentelekomcloud/services/elb/resource_opentelekomcloud_lb_listener_v2.go
+++ b/opentelekomcloud/services/elb/resource_opentelekomcloud_lb_listener_v2.go
@@ -77,12 +77,6 @@ func ResourceListenerV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			/*"connection_limit": &schema.Schema{
-				Type:     schema.TypeInt,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			}, */
 			// new feature 2020 to support https2
 			"http2_enable": {
 				Type:     schema.TypeBool,
@@ -152,11 +146,6 @@ func resourceListenerV2Create(ctx context.Context, d *schema.ResourceData, meta 
 		AdminStateUp:           &adminStateUp,
 	}
 
-	/*if v, ok := d.GetOk("connection_limit"); ok {
-		connectionLimit := v.(int)
-		createOpts.ConnLimit = &connectionLimit
-	} */
-
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)
 
 	// Wait for LoadBalancer to become active before continuing
@@ -223,7 +212,6 @@ func resourceListenerV2Read(_ context.Context, d *schema.ResourceData, meta inte
 		d.Set("http2_enable", listener.Http2Enable),
 		d.Set("default_tls_container_ref", listener.DefaultTlsContainerRef),
 		d.Set("client_ca_tls_container_ref", listener.CAContainerRef),
-		// d.Set("connection_limit", listener.ConnLimit),
 		d.Set("sni_container_refs", listener.SniContainerRefs),
 		d.Set("tls_ciphers_policy", listener.TlsCiphersPolicy),
 		d.Set("admin_state_up", listener.AdminStateUp),
@@ -260,10 +248,6 @@ func resourceListenerV2Update(ctx context.Context, d *schema.ResourceData, meta 
 	if d.HasChange("description") {
 		updateOpts.Description = d.Get("description").(string)
 	}
-	/*if d.HasChange("connection_limit") {
-		connLimit := d.Get("connection_limit").(int)
-		updateOpts.ConnLimit = &connLimit
-	} */
 	if d.HasChange("http2_enable") {
 		http2Enable := d.Get("http2_enable").(bool)
 		updateOpts.Http2Enable = &http2Enable

--- a/releasenotes/notes/fix-assignments-f6c51099b42318c6.yaml
+++ b/releasenotes/notes/fix-assignments-f6c51099b42318c6.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    **[BMS]** Fix potential panic in ``data_source/opentelekomcloud_compute_bms_server_v2`` (`#1396 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1396>`_)
+  - |
+    **[DEH]** Fix potential panic in ``resource/opentelekomcloud_deh_host_v1`` (`#1396 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1396>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Get rid of remaining incorrect `d.Set` calls

Remove commented out lines from `resource/opentelekomcloud_lb_listener_v2`

Fix #1395

## PR Checklist

* [x] Refers to: #1395
* [x] ~Tests added/passed.~ Impossible (DEH and BMS)
* [x] Release notes added.
