### PR TITLE
Fix panic creating read replica w/o `public_ips`

### DIFF
--- a/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_read_replica_v3_test.go
+++ b/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_read_replica_v3_test.go
@@ -29,6 +29,15 @@ func TestAccRdsReadReplicaV3Basic(t *testing.T) {
 		CheckDestroy:      testAccCheckRdsInstanceV3Destroy,
 		Steps: []resource.TestStep{
 			{
+				Config: testAccRdsReadReplicaV3BasicNoIP(postfix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRdsInstanceV3Exists(resName, &rdsInstance),
+					resource.TestCheckResourceAttr(resName, "availability_zone", secondAZ),
+					resource.TestCheckResourceAttr(resName, "volume.0.size", "40"),
+					resource.TestCheckResourceAttr(resName, "public_ips.#", "0"),
+				),
+			},
+			{
 				Config: testAccRdsReadReplicaV3Basic(postfix),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRdsInstanceV3Exists(resName, &rdsInstance),
@@ -43,15 +52,6 @@ func TestAccRdsReadReplicaV3Basic(t *testing.T) {
 					testAccCheckRdsInstanceV3Exists(resName, &rdsInstance),
 					resource.TestCheckResourceAttr(resName, "availability_zone", secondAZ),
 					resource.TestCheckResourceAttr(resName, "volume.0.size", "40"),
-				),
-			},
-			{ // and assign it back
-				Config: testAccRdsReadReplicaV3Basic(postfix),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRdsInstanceV3Exists(resName, &rdsInstance),
-					resource.TestCheckResourceAttr(resName, "availability_zone", secondAZ),
-					resource.TestCheckResourceAttr(resName, "volume.0.size", "40"),
-					resource.TestCheckResourceAttr(resName, "public_ips.#", "1"),
 				),
 			},
 		},

--- a/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_read_replica_v3.go
+++ b/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_read_replica_v3.go
@@ -193,7 +193,11 @@ func resourceRdsReadReplicaV3Create(ctx context.Context, d *schema.ResourceData,
 }
 
 func getReplicaPublicIP(d *schema.ResourceData) string {
-	return d.Get("public_ips").(*schema.Set).List()[0].(string)
+	ips := d.Get("public_ips").(*schema.Set)
+	if ips.Len() == 0 {
+		return ""
+	}
+	return ips.List()[0].(string)
 }
 
 func getReplicaPrivateIP(d *schema.ResourceData) string {

--- a/releasenotes/notes/fix-rds-rr-659c927b3edd5907.yaml
+++ b/releasenotes/notes/fix-rds-rr-659c927b3edd5907.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[RDS]** Fix panic when creating ``resource/opentelekomcloud_rds_read_replica_v3`` with empty ``public_ips`` (`#1398 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1398>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Fix possible panic in `rds_read_replica_v3` creation

Fix #1397 

## PR Checklist

* [x] Refers to: #1397
* [x] Tests added/passed.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccRdsReadReplicaV3Basic
--- PASS: TestAccRdsReadReplicaV3Basic (934.59s)
PASS

Process finished with the exit code 0

```
