### PR TITLE
[RDS] Add validations for `flavor` and network part in `instance_v3`

### DIFF
--- a/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
+++ b/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
@@ -453,9 +453,9 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
     type     = "PostgreSQL"
     version  = "10"
   }
-  security_group_id = opentelekomcloud_networking_secgroup_v2.sg.id
-  subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
-  vpc_id            = data.opentelekomcloud_vpc_v1.shared_vpc.id
+  security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
+  subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
   volume {
     type = "COMMON"
     size = 100
@@ -465,7 +465,6 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
     start_time = "10:00-11:00"
     keep_days  = 5
   }
-
 }
 `, common.DataSourceSecGroupDefault, common.DataSourceSubnet, postfix, env.OS_AVAILABILITY_ZONE)
 }

--- a/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
+++ b/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
@@ -196,6 +196,23 @@ func TestAccRdsInstanceV3InvalidDBVersion(t *testing.T) {
 	})
 }
 
+func TestAccRdsInstanceV3InvalidFlavor(t *testing.T) {
+	postfix := acctest.RandString(3)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckRdsInstanceV3Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccRdsInstanceV3InvalidFlavor(postfix),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`can't find flavor.+`),
+			},
+		},
+	})
+}
+
 func TestAccRdsInstanceV3_configurationParameters(t *testing.T) {
 	postfix := acctest.RandString(3)
 	var rdsInstance instances.RdsInstanceResponse
@@ -618,6 +635,31 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
   parameters = {
     max_connections = "37",
   }
+}
+`, common.DataSourceSecGroupDefault, common.DataSourceSubnet, postfix, env.OS_AVAILABILITY_ZONE)
+}
+
+func testAccRdsInstanceV3InvalidFlavor(postfix string) string {
+	return fmt.Sprintf(`
+%s
+%s
+
+resource "opentelekomcloud_rds_instance_v3" "instance" {
+  name              = "tf_rds_instance_%s"
+  availability_zone = ["%s"]
+  db {
+    password = "Postgres!120521"
+    type     = "PostgreSQL"
+    version  = "10"
+  }
+  security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
+  subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  volume {
+    type = "COMMON"
+    size = 40
+  }
+  flavor = "bla.bla.rds"
 }
 `, common.DataSourceSecGroupDefault, common.DataSourceSubnet, postfix, env.OS_AVAILABILITY_ZONE)
 }

--- a/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_instance_v3.go
+++ b/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_instance_v3.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/tags"
@@ -43,7 +44,10 @@ func ResourceRdsInstanceV3() *schema.Resource {
 			Update: schema.DefaultTimeout(30 * time.Minute),
 		},
 
-		CustomizeDiff: validateRDSv3Version("db"),
+		CustomizeDiff: customdiff.All(
+			validateRDSv3Version("db"),
+			validateRDSv3Flavor("flavor"),
+		),
 
 		Schema: map[string]*schema.Schema{
 			"availability_zone": {
@@ -93,7 +97,6 @@ func ResourceRdsInstanceV3() *schema.Resource {
 			"flavor": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: false,
 			},
 			"name": {
 				Type:     schema.TypeString,
@@ -314,7 +317,7 @@ func resourceRdsInstanceV3Create(ctx context.Context, d *schema.ResourceData, me
 	config := meta.(*cfg.Config)
 	client, err := config.RdsV3Client(config.GetRegion(d))
 	if err != nil {
-		return fmterr.Errorf("error creating RDSv3 client: %s", err)
+		return fmterr.Errorf(errCreateClient, err)
 	}
 
 	dbInfo := resourceRDSDbInfo(d)
@@ -641,7 +644,7 @@ func resourceRdsInstanceV3Update(ctx context.Context, d *schema.ResourceData, me
 	config := meta.(*cfg.Config)
 	client, err := config.RdsV3Client(config.GetRegion(d))
 	if err != nil {
-		return fmterr.Errorf("error creating OpenTelekomCloud RDSv3 Client: %s", err)
+		return fmterr.Errorf(errCreateClient, err)
 	}
 	var updateBackupOpts backups.UpdateOpts
 
@@ -705,41 +708,15 @@ func resourceRdsInstanceV3Update(ctx context.Context, d *schema.ResourceData, me
 	if d.HasChange("flavor") {
 		_, newFlavor := d.GetChange("flavor")
 
-		// Fetch flavor id
-		db := resourceRDSDbInfo(d)
-		datastoreType := db["type"].(string)
-		datastoreVersion := db["version"].(string)
-
-		dbFlavorsOpts := flavors.ListOpts{
-			VersionName: datastoreVersion,
-		}
-		flavorsPages, err := flavors.List(client, dbFlavorsOpts, datastoreType).AllPages()
-		if err != nil {
-			return fmterr.Errorf("unable to retrieve flavors all pages: %s", err)
-		}
-		flavorsList, err := flavors.ExtractDbFlavors(flavorsPages)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-		if len(flavorsList) < 1 {
-			return fmterr.Errorf("no flavors returned")
-		}
-		var rdsFlavor flavors.Flavor
-		for _, flavor := range flavorsList {
-			if flavor.SpecCode == newFlavor.(string) {
-				rdsFlavor = flavor
-				break
-			}
-		}
 		updateFlavorOpts := instances.ResizeFlavorOpts{
 			ResizeFlavor: &instances.SpecCode{
-				Speccode: rdsFlavor.SpecCode,
+				Speccode: newFlavor.(string),
 			},
 		}
 
 		log.Printf("Update flavor could be done only in status `available`")
 		if err := instances.WaitForStateAvailable(client, 1200, d.Id()); err != nil {
-			log.Printf("Status available wasn't present")
+			return diag.FromErr(err)
 		}
 
 		log.Printf("[DEBUG] Update flavor: %s", newFlavor.(string))
@@ -750,7 +727,7 @@ func resourceRdsInstanceV3Update(ctx context.Context, d *schema.ResourceData, me
 
 		log.Printf("Waiting for RDSv3 become in status `available`")
 		if err := instances.WaitForStateAvailable(client, 1200, d.Id()); err != nil {
-			log.Printf("Status available wasn't present")
+			return diag.FromErr(err)
 		}
 
 		log.Printf("[DEBUG] Successfully updated instance %s flavor: %s", d.Id(), d.Get("flavor").(string))
@@ -775,14 +752,14 @@ func resourceRdsInstanceV3Update(ctx context.Context, d *schema.ResourceData, me
 
 		log.Printf("Update volume size could be done only in status `available`")
 		if err := instances.WaitForStateAvailable(client, 1200, d.Id()); err != nil {
-			log.Printf("Status available wasn't present")
+			return diag.FromErr(err)
 		}
 
 		updateResult, err := instances.EnlargeVolume(client, updateOpts, d.Id()).ExtractJobResponse()
 		if err != nil {
 			return fmterr.Errorf("error updating instance volume from result: %s", err)
 		}
-		timeout := d.Timeout(schema.TimeoutCreate)
+		timeout := d.Timeout(schema.TimeoutUpdate)
 		if err := instances.WaitForJobCompleted(client, int(timeout.Seconds()), updateResult.JobID); err != nil {
 			return diag.FromErr(err)
 		}
@@ -877,7 +854,7 @@ func resourceRdsInstanceV3Read(_ context.Context, d *schema.ResourceData, meta i
 	config := meta.(*cfg.Config)
 	client, err := config.RdsV3Client(config.GetRegion(d))
 	if err != nil {
-		return fmterr.Errorf("error creating RDSv3 client: %s", err)
+		return fmterr.Errorf(errCreateClient, err)
 	}
 
 	rdsInstance, err := GetRdsInstance(client, d.Id())
@@ -1039,7 +1016,7 @@ func resourceRdsInstanceV3Delete(_ context.Context, d *schema.ResourceData, meta
 	config := meta.(*cfg.Config)
 	client, err := config.RdsV3Client(config.GetRegion(d))
 	if err != nil {
-		return fmterr.Errorf("error creating OpenTelekomCloud RDSv3 client: %s", err)
+		return fmterr.Errorf(errCreateClient, err)
 	}
 
 	log.Printf("[DEBUG] Deleting Instance %s", d.Id())
@@ -1060,13 +1037,13 @@ func validateRDSv3Version(argumentName string) schema.CustomizeDiffFunc {
 			return fmt.Errorf("error retreiving configuration: can't convert %v to Config", meta)
 		}
 
-		rdsClient, err := config.RdsV3Client(config.GetRegion(d))
+		client, err := config.RdsV3Client(config.GetRegion(d))
 		if err != nil {
-			return fmt.Errorf("error creating OpenTelekomCloud RDSv3 Client: %s", err)
+			return fmt.Errorf(errCreateClient, err)
 		}
 
 		dataStoreInfo := d.Get(argumentName).([]interface{})[0].(map[string]interface{})
-		datastoreVersions, err := getRdsV3VersionList(rdsClient, dataStoreInfo["type"].(string))
+		datastoreVersions, err := getRdsV3VersionList(client, dataStoreInfo["type"].(string))
 		if err != nil {
 			return fmt.Errorf("unable to get datastore versions: %s", err)
 		}
@@ -1084,6 +1061,49 @@ func validateRDSv3Version(argumentName string) schema.CustomizeDiffFunc {
 
 		return nil
 	}
+}
+
+func validateRDSv3Flavor(argName string) schema.CustomizeDiffFunc {
+	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+		config, ok := meta.(*cfg.Config)
+		if !ok {
+			return fmt.Errorf("error retreiving configuration: can't convert %v to Config", meta)
+		}
+
+		client, err := config.RdsV3Client(config.GetRegion(d))
+		if err != nil {
+			return fmt.Errorf(errCreateClient, err)
+		}
+		dataStoreInfo := d.Get("db").([]interface{})[0].(map[string]interface{})
+		flavor := d.Get(argName).(string)
+
+		listOpts := flavors.ListOpts{
+			VersionName: dataStoreInfo["version"].(string),
+		}
+		flavorPages, err := flavors.List(client, listOpts, dataStoreInfo["type"].(string)).AllPages()
+		if err != nil {
+			return fmt.Errorf("unable to get flavor pages: %w", err)
+		}
+		flavorList, err := flavors.ExtractDbFlavors(flavorPages)
+		if err != nil {
+			return fmt.Errorf("error extracting flavors: %w", err)
+		}
+		var matches = false
+		for _, flavorItem := range flavorList {
+			if flavorItem.SpecCode == flavor {
+				matches = true
+				break
+			}
+		}
+
+		if !matches {
+			return fmt.Errorf("can't find flavor `%s`", flavor)
+		}
+
+		return nil
+
+	}
+
 }
 
 func updateInstanceParameters(d *schema.ResourceData, client *golangsdk.ServiceClient) (bool, error) {

--- a/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_instance_v3.go
+++ b/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_instance_v3.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/tags"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v1/subnets"
@@ -47,6 +48,8 @@ func ResourceRdsInstanceV3() *schema.Resource {
 		CustomizeDiff: customdiff.All(
 			validateRDSv3Version("db"),
 			validateRDSv3Flavor("flavor"),
+			common.ValidateSubnet("subnet_id"),
+			common.ValidateVPC("vpc_id"),
 		),
 
 		Schema: map[string]*schema.Schema{
@@ -75,6 +78,9 @@ func ResourceRdsInstanceV3() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 							ForceNew: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"PostgreSQL", "MySQL", "SQLServer",
+							}, false),
 						},
 						"version": {
 							Type:     schema.TypeString,
@@ -1101,9 +1107,7 @@ func validateRDSv3Flavor(argName string) schema.CustomizeDiffFunc {
 		}
 
 		return nil
-
 	}
-
 }
 
 func updateInstanceParameters(d *schema.ResourceData, client *golangsdk.ServiceClient) (bool, error) {

--- a/releasenotes/notes/validate-rds-cb8350246eaa5e4d.yaml
+++ b/releasenotes/notes/validate-rds-cb8350246eaa5e4d.yaml
@@ -1,0 +1,4 @@
+---
+other:
+  - |
+    **[RDS]** Add validation for ``flavor``, ``subnet_id`` and ``vpc_id`` in ``resource/opentelekomcloud_rds_instance_v3`` (`#1410 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1410>`_)


### PR DESCRIPTION
## Summary of the Pull Request
* Add validation for `flavor` in `resource/opentelekomcloud_rds_instance_v3`
* Add validations for `subnet_id` and `vpc_id` in `resource/opentelekomcloud_rds_instance_v3`

## PR Checklist

* [x] Tests added/passed.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccRdsInstanceV3Basic
--- PASS: TestAccRdsInstanceV3Basic (842.47s)
=== RUN   TestAccRdsInstanceV3ElasticIP
--- PASS: TestAccRdsInstanceV3ElasticIP (500.94s)
=== RUN   TestAccRdsInstanceV3OptionalParams
--- PASS: TestAccRdsInstanceV3OptionalParams (439.45s)
=== RUN   TestAccRdsInstanceV3Backup
--- PASS: TestAccRdsInstanceV3Backup (417.72s)
=== RUN   TestAccRdsInstanceV3TemplateConfig
--- PASS: TestAccRdsInstanceV3TemplateConfig (560.09s)
=== RUN   TestAccRdsInstanceV3InvalidDBVersion
--- PASS: TestAccRdsInstanceV3InvalidDBVersion (14.62s)
=== RUN   TestAccRdsInstanceV3InvalidFlavor
--- PASS: TestAccRdsInstanceV3InvalidFlavor (14.23s)
=== RUN   TestAccRdsInstanceV3_configurationParameters
--- PASS: TestAccRdsInstanceV3_configurationParameters (924.45s)
PASS

Process finished with the exit code 0
```
