### PR TITLE
[CSBS] Fix incorrect setter in `data/csbs_backup_v1`

### DIFF
--- a/opentelekomcloud/services/csbs/data_source_opentelekomcloud_csbs_backup_v1.go
+++ b/opentelekomcloud/services/csbs/data_source_opentelekomcloud_csbs_backup_v1.go
@@ -67,7 +67,7 @@ func DataSourceCSBSBackupV1() *schema.Resource {
 				Computed: true,
 			},
 			"average_speed": {
-				Type:     schema.TypeInt,
+				Type:     schema.TypeFloat,
 				Computed: true,
 			},
 			"size": {

--- a/releasenotes/notes/setters-csbs-backup-99511766b8157a55.yaml
+++ b/releasenotes/notes/setters-csbs-backup-99511766b8157a55.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[CSBS]** Change type of the ``average_speed`` field of the ``data_source/opentelekomcloud_csbs_backup_v1`` to ``float`` (`#1411 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1411>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Make `average_speed` a float for `csbs_backup_v1` data source

## PR Checklist

* [x] Refers to: #1408
* [x] Tests added/passed.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccCSBSBackupV1DataSource_basic
--- PASS: TestAccCSBSBackupV1DataSource_basic (808.03s)
PASS

Process finished with the exit code 0

```
