### PR TITLE
Fix redundant `network` setter in `bms_server_v2`

### DIFF
--- a/opentelekomcloud/services/bms/data_source_opentelekomcloud_compute_bms_server_v2.go
+++ b/opentelekomcloud/services/bms/data_source_opentelekomcloud_compute_bms_server_v2.go
@@ -209,7 +209,6 @@ func dataSourceBMSServersV2Read(_ context.Context, d *schema.ResourceData, meta 
 		d.Set("host_status", server.HostStatus),
 		d.Set("host_id", server.HostID),
 		d.Set("flavor_id", server.Flavor.ID),
-		d.Set("network", server.Addresses),
 		d.Set("metadata", server.Metadata),
 		d.Set("tenant_id", server.TenantID),
 		d.Set("image_id", server.Image.ID),


### PR DESCRIPTION
## Summary of the Pull Request
Remove duplicated broken setter of `network` field of `bms_server_v2` data source

## PR Checklist

* [x] Refers to: #1408 
