### PR TITLE
[DCS] Fix creation of single-node instance

### DIFF
--- a/opentelekomcloud/acceptance/dcs/resource_opentelekomcloud_dcs_instance_v1_test.go
+++ b/opentelekomcloud/acceptance/dcs/resource_opentelekomcloud_dcs_instance_v1_test.go
@@ -42,6 +42,19 @@ func TestAccDcsInstancesV1_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceInstanceName, "backup_policy.0.backup_at.#", "3"),
 				),
 			},
+		},
+	})
+}
+
+func TestAccDcsInstancesV1_basicSingleInstance(t *testing.T) {
+	var instance instances.Instance
+	var instanceName = fmt.Sprintf("dcs_instance_%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDcsV1InstanceDestroy,
+		Steps: []resource.TestStep{
 			{
 				Config: testAccDcsV1InstanceSingle(instanceName),
 				Check: resource.ComposeTestCheckFunc(

--- a/opentelekomcloud/services/dcs/resource_opentelekomcloud_dcs_instance_v1.go
+++ b/opentelekomcloud/services/dcs/resource_opentelekomcloud_dcs_instance_v1.go
@@ -263,6 +263,9 @@ func getInstanceBackupPolicy(d *schema.ResourceData) *instances.InstanceBackupPo
 	var instanceBackupPolicy *instances.InstanceBackupPolicy
 	if _, ok := d.GetOk("backup_policy"); !ok { // deprecated branch
 		backupAts := d.Get("backup_at").([]interface{})
+		if len(backupAts) == 0 {
+			return nil
+		}
 		instanceBackupPolicy = &instances.InstanceBackupPolicy{
 			SaveDays:   d.Get("save_days").(int),
 			BackupType: d.Get("backup_type").(string),

--- a/releasenotes/notes/dcs-single-dad2a4e5a7a1589c.yaml
+++ b/releasenotes/notes/dcs-single-dad2a4e5a7a1589c.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[DCS]** Fix not creating single-node ``resource/opentelekomcloud_dcs_instance_v1`` (`#1415 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1415>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Fix instance backup policy populated when not needed in create request

Separate DCS single-node test

## PR Checklist

* [x] Refers to: #1371
* [x] Tests added/passed.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccDcsInstancesV1_basic
--- PASS: TestAccDcsInstancesV1_basic (379.63s)
=== RUN   TestAccDcsInstancesV1_basicSingleInstance
--- PASS: TestAccDcsInstancesV1_basicSingleInstance (316.63s)
PASS

Process finished with the exit code 0

```
