### PR TITLE
[DNS] Refactoring `zone_v2`

### DIFF
--- a/docs/data-sources/dns_zone_v2.md
+++ b/docs/data-sources/dns_zone_v2.md
@@ -43,8 +43,6 @@ In addition to all arguments above, the following attributes are exported:
 
 * `updated_at` - The time the zone was last updated.
 
-* `version` - The version of the zone.
-
 * `serial` - The serial number of the zone.
 
 * `pool_id` - The ID of the pool hosting the zone.

--- a/docs/data-sources/dns_zone_v2.md
+++ b/docs/data-sources/dns_zone_v2.md
@@ -10,15 +10,16 @@ Use this data source to get the ID of an available OpenStack DNS zone.
 
 ```hcl
 data "opentelekomcloud_dns_zone_v2" "zone_1" {
-  name = "example.com"
+  name = "example.com."
 }
 ```
 
 ## Argument Reference
 
-* `zone_type` - (Optional) The type of the zone: `private` or `public`. This argument is required to match private zones.
+* `zone_type` - (Optional) The type of the zone: `private` or `public`.
+  This argument is **required** to match `private` zones.
 
-* `name` - (Optional) The name of the zone.
+* `name` - (Optional) The name of the zone. A fuzzy search will be performed.
 
 * `description` - (Optional) A description of the zone.
 
@@ -34,20 +35,18 @@ data "opentelekomcloud_dns_zone_v2" "zone_1" {
 
 ## Attributes Reference
 
-`id` is set to the ID of the found zone. In addition, the following attributes
-are exported:
+In addition to all arguments above, the following attributes are exported:
 
-* `region` - See Argument Reference above.
-* `name` - See Argument Reference above.
-* `email` - See Argument Reference above.
-* `zone_type` - See Argument Reference above.
-* `ttl` - See Argument Reference above.
-* `description` - See Argument Reference above.
-* `status` - See Argument Reference above.
 * `masters` - An array of master DNS servers.
+
 * `created_at` - The time the zone was created.
+
 * `updated_at` - The time the zone was last updated.
+
 * `version` - The version of the zone.
+
 * `serial` - The serial number of the zone.
+
 * `pool_id` - The ID of the pool hosting the zone.
+
 * `project_id` - The project ID that owns the zone.

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/jinzhu/copier v0.2.3
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.5.2-0.20210920092602-29ce3f5aae5b
+	github.com/opentelekomcloud/gophertelekomcloud v0.5.2-0.20210924153237-014b19bba497
 	github.com/unknwon/com v1.0.1
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -287,8 +287,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.5.2-0.20210920092602-29ce3f5aae5b h1:ZJxFAqQmw157wBTC/JdPzoFEXpMXuiK8fNGG8JdA9a4=
-github.com/opentelekomcloud/gophertelekomcloud v0.5.2-0.20210920092602-29ce3f5aae5b/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
+github.com/opentelekomcloud/gophertelekomcloud v0.5.2-0.20210924153237-014b19bba497 h1:n4/aMTV1OPDqtax1qga+1oy0vh5tQaG7tqSEdGfAxZo=
+github.com/opentelekomcloud/gophertelekomcloud v0.5.2-0.20210924153237-014b19bba497/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/opentelekomcloud/acceptance/dns/data_source_opentelekomcloud_dns_zone_v2_test.go
+++ b/opentelekomcloud/acceptance/dns/data_source_opentelekomcloud_dns_zone_v2_test.go
@@ -64,6 +64,27 @@ func TestAccOpenStackDNSZoneV2DataSource_byTag(t *testing.T) {
 	})
 }
 
+func TestAccOpenStackDNSZoneV2DataSource_private(t *testing.T) {
+	zone1 := randomZoneName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheckRequiredEnvVars(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDNSV2ZoneDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDNSV2ZonePrivate(zone1),
+			},
+			{
+				Config: testAccOpenStackDNSZoneV2DataSourcePrivate(zone1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDNSZoneV2DataSourceID(dataZoneName),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckDNSZoneV2DataSourceID(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -136,4 +157,16 @@ data "opentelekomcloud_dns_zone_v2" "z1" {
   }
 }
 `, base, zoneTagValue)
+}
+
+func testAccOpenStackDNSZoneV2DataSourcePrivate(zoneName string) string {
+	base := testAccDNSV2ZonePrivate(zoneName)
+	return fmt.Sprintf(`
+%s
+
+data "opentelekomcloud_dns_zone_v2" "z1" {
+  name      = "%s"
+  zone_type = "private"
+}
+`, base, zoneName)
 }

--- a/opentelekomcloud/services/dns/common.go
+++ b/opentelekomcloud/services/dns/common.go
@@ -1,0 +1,5 @@
+package dns
+
+const (
+	errCreationClient = "error creating OpenTelekomCloud DNSv2 client: %w"
+)

--- a/opentelekomcloud/services/dns/data_source_opentelekomcloud_dns_zone_v2.go
+++ b/opentelekomcloud/services/dns/data_source_opentelekomcloud_dns_zone_v2.go
@@ -31,12 +31,10 @@ func DataSourceDNSZoneV2() *schema.Resource {
 			},
 			"pool_id": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 			"project_id": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 			"email": {
@@ -61,28 +59,23 @@ func DataSourceDNSZoneV2() *schema.Resource {
 			},
 			"serial": {
 				Type:     schema.TypeInt,
-				Optional: true,
 				Computed: true,
 			},
 			"created_at": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 			"updated_at": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 			"masters": {
 				Type:     schema.TypeSet,
-				Optional: true,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"links": {
 				Type:     schema.TypeMap,
-				Optional: true,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},

--- a/opentelekomcloud/services/dns/data_source_opentelekomcloud_dns_zone_v2.go
+++ b/opentelekomcloud/services/dns/data_source_opentelekomcloud_dns_zone_v2.go
@@ -2,15 +2,11 @@ package dns
 
 import (
 	"context"
-	"fmt"
 	"log"
-	"strings"
-	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/dns/v2/zones"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
@@ -26,130 +22,83 @@ func DataSourceDNSZoneV2() *schema.Resource {
 			"name": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
-
 			"zone_type": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
-
 			"pool_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
-
 			"project_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
-
 			"email": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
-
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
-
 			"status": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
-
 			"ttl": {
-				Type:     schema.TypeInt,
-				Optional: true,
-			},
-
-			"version": {
 				Type:     schema.TypeInt,
 				Optional: true,
 				Computed: true,
 			},
-
 			"serial": {
 				Type:     schema.TypeInt,
 				Optional: true,
 				Computed: true,
 			},
-
 			"created_at": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
-
 			"updated_at": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
-
-			"transferred_at": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-
-			"attributes": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Computed: true,
-			},
-
 			"masters": {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-
 			"links": {
 				Type:     schema.TypeMap,
 				Optional: true,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-
 			"tags": common.TagsSchema(),
 		},
 	}
 }
 
-type TaggedListOpts struct {
-	zones.ListOpts
-
-	Tags string `q:"tags"`
-}
-
-func (opts TaggedListOpts) ToZoneListQuery() (string, error) {
-	q, err := golangsdk.BuildQueryString(opts)
-	if err != nil {
-		return "", err
-	}
-	return q.String(), err
-}
-
-func tagsAsString(tags map[string]interface{}) string {
-	tagList := make([]string, 0, len(tags))
-	for tag, value := range tags {
-		tagList = append(tagList, fmt.Sprintf("%s,%s", tag, value))
-	}
-	return strings.Join(tagList, "|")
-}
-
 func dataSourceDNSZoneV2Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	dnsClient, err := config.DnsV2Client(config.GetRegion(d))
+	client, err := config.DnsV2Client(config.GetRegion(d))
 	if err != nil {
-		return diag.FromErr(err)
+		return fmterr.Errorf(errCreationClient, err)
 	}
 
-	listOpts := TaggedListOpts{}
+	listOpts := zones.ListOpts{}
 
 	if v, ok := d.GetOk("name"); ok {
 		listOpts.Name = v.(string)
@@ -176,27 +125,28 @@ func dataSourceDNSZoneV2Read(_ context.Context, d *schema.ResourceData, meta int
 	}
 
 	if v, ok := d.GetOk("tags"); ok {
-		listOpts.Tags = tagsAsString(v.(map[string]interface{}))
+		tags := v.(map[string]interface{})
+		listOpts.Tags = common.ExpandResourceTags(tags)
 	}
 
-	pages, err := zones.List(dnsClient, listOpts).AllPages()
+	pages, err := zones.List(client, listOpts).AllPages()
 	if err != nil {
-		return fmterr.Errorf("unable to retrieve zones: %s", err)
+		return fmterr.Errorf("unable to retrieve zones: %w", err)
 	}
 
 	allZones, err := zones.ExtractZones(pages)
 	if err != nil {
-		return fmterr.Errorf("unable to extract zones: %s", err)
+		return fmterr.Errorf("unable to extract zones: %w", err)
 	}
 
 	if len(allZones) < 1 {
-		return fmterr.Errorf("your query returned no results." +
+		return fmterr.Errorf("your query returned no results. " +
 			"Please change your search criteria and try again")
 	}
 
 	if len(allZones) > 1 {
-		return fmterr.Errorf("your query returned more than one result." +
-			" Please try a more specific search criteria")
+		return fmterr.Errorf("your query returned more than one result. " +
+			"Please try a more specific search criteria")
 	}
 
 	zone := allZones[0]
@@ -204,39 +154,21 @@ func dataSourceDNSZoneV2Read(_ context.Context, d *schema.ResourceData, meta int
 	log.Printf("[DEBUG] Retrieved DNS Zone %s: %+v", zone.ID, zone)
 	d.SetId(zone.ID)
 
-	me := &multierror.Error{}
-	// strings
-	me = multierror.Append(me,
+	mErr := multierror.Append(
 		d.Set("name", zone.Name),
 		d.Set("pool_id", zone.PoolID),
 		d.Set("email", zone.Email),
 		d.Set("description", zone.Description),
 		d.Set("status", zone.Status),
 		d.Set("zone_type", zone.ZoneType),
-
-		// ints
 		d.Set("ttl", zone.TTL),
-		d.Set("version", zone.Version),
 		d.Set("serial", zone.Serial),
-
-		// time.Times
-		d.Set("created_at", zone.CreatedAt.Format(time.RFC3339)),
-		d.Set("updated_at", zone.UpdatedAt.Format(time.RFC3339)),
+		d.Set("created_at", zone.CreatedAt),
+		d.Set("updated_at", zone.UpdatedAt),
+		d.Set("links", zone.Links),
+		d.Set("masters", zone.Masters),
 	)
-	if err := me.ErrorOrNil(); err != nil {
-		return diag.FromErr(err)
-	}
-
-	// maps
-	err = d.Set("links", zone.Links)
-	if err != nil {
-		log.Printf("[DEBUG] Unable to set links: %s", err)
-		return diag.FromErr(err)
-	}
-	// slices
-	err = d.Set("masters", zone.Masters)
-	if err != nil {
-		log.Printf("[DEBUG] Unable to set masters: %s", err)
+	if err := mErr.ErrorOrNil(); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/releasenotes/notes/fix-d-dns-zone-64876419d2acfc73.yaml
+++ b/releasenotes/notes/fix-d-dns-zone-64876419d2acfc73.yaml
@@ -1,0 +1,4 @@
+---
+other:
+  - |
+    **[DNS]** Remove redundant fields ``transferred_at``, ``attributes`` and `version` in ``data_source/opentelekomcloud_dns_zone_v2`` (`#1424 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1424>`_)


### PR DESCRIPTION
## Summary of the Pull Request
* Refactoring `data_source/opentelekomcloud_dns_zone_v2`
* Remove redundant fields `transferred_at`, `attributes` and `version`

Fixes: #1421

## PR Checklist

* [x] Refers to: #1421
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccOpenStackDNSZoneV2DataSource_basic
--- PASS: TestAccOpenStackDNSZoneV2DataSource_basic (103.63s)
=== RUN   TestAccOpenStackDNSZoneV2DataSource_byTag
--- PASS: TestAccOpenStackDNSZoneV2DataSource_byTag (80.90s)
=== RUN   TestAccOpenStackDNSZoneV2DataSource_private
--- PASS: TestAccOpenStackDNSZoneV2DataSource_private (91.30s)
PASS

Process finished with the exit code 0
```
