### PR TITLE
Acceptance: make EVS tests run in parallel

### DIFF
--- a/opentelekomcloud/acceptance/common/quotas/quotas.go
+++ b/opentelekomcloud/acceptance/common/quotas/quotas.go
@@ -103,6 +103,13 @@ var (
 	FloatingIP = FromEnv("OS_FLOATING_IP_QUOTA", 3)
 	// Router - shared router(VPC) quota
 	Router = FromEnv("OS_ROUTER_QUOTA", 10)
+
+	// Volumes
+
+	// Volume - quota for block storage volumes
+	Volume = FromEnv("OS_VOLUME_QUOTA", 50)
+	// VolumeSize - quota for block storage total size, GB
+	VolumeSize = FromEnv("OS_VOLUME_SIZE_QUOTA", 12500)
 )
 
 // ExpectedQuota is a simple container of quota + count used for `Multiple` operations

--- a/opentelekomcloud/acceptance/evs/import_opentelekomcloud_blockstorage_volume_v2_test.go
+++ b/opentelekomcloud/acceptance/evs/import_opentelekomcloud_blockstorage_volume_v2_test.go
@@ -2,13 +2,20 @@ package acceptance
 
 import (
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 )
 
 func TestAccBlockStorageV2Volume_importBasic(t *testing.T) {
+	t.Parallel()
+	qts := []*quotas.ExpectedQuota{{Q: quotas.Volume, Count: 1}, {Q: quotas.VolumeSize, Count: 1}}
+	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
+	defer quotas.ReleaseMultipleQuotas(qts)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,

--- a/opentelekomcloud/acceptance/evs/resource_opentelekomcloud_blockstorage_volume_v2_test.go
+++ b/opentelekomcloud/acceptance/evs/resource_opentelekomcloud_blockstorage_volume_v2_test.go
@@ -4,11 +4,14 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/blockstorage/v2/volumes"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/evs/v2/tags"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
@@ -19,6 +22,10 @@ const resourceVolumeV2Name = "opentelekomcloud_blockstorage_volume_v2.volume_1"
 
 func TestAccBlockStorageV2Volume_basic(t *testing.T) {
 	var volume volumes.Volume
+	t.Parallel()
+	qts := []*quotas.ExpectedQuota{{Q: quotas.Volume, Count: 1}, {Q: quotas.VolumeSize, Count: 1}}
+	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
+	defer quotas.ReleaseMultipleQuotas(qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -47,6 +54,10 @@ func TestAccBlockStorageV2Volume_basic(t *testing.T) {
 
 func TestAccBlockStorageV2Volume_upscaleDownScale(t *testing.T) {
 	var volume volumes.Volume
+	t.Parallel()
+	qts := []*quotas.ExpectedQuota{{Q: quotas.Volume, Count: 1}, {Q: quotas.VolumeSize, Count: 2}}
+	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
+	defer quotas.ReleaseMultipleQuotas(qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -70,6 +81,10 @@ func TestAccBlockStorageV2Volume_upscaleDownScale(t *testing.T) {
 }
 func TestAccBlockStorageV2Volume_upscaleDownScaleAssigned(t *testing.T) {
 	var volume volumes.Volume
+	t.Parallel()
+	qts := []*quotas.ExpectedQuota{{Q: quotas.Volume, Count: 1}, {Q: quotas.VolumeSize, Count: 12}}
+	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
+	defer quotas.ReleaseMultipleQuotas(qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -93,6 +108,10 @@ func TestAccBlockStorageV2Volume_upscaleDownScaleAssigned(t *testing.T) {
 }
 
 func TestAccBlockStorageV2Volume_policy(t *testing.T) {
+	t.Parallel()
+	qts := []*quotas.ExpectedQuota{{Q: quotas.Volume, Count: 1}, {Q: quotas.VolumeSize, Count: 40}}
+	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
+	defer quotas.ReleaseMultipleQuotas(qts)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			common.TestAccPreCheck(t)
@@ -115,6 +134,7 @@ func testPolicyPreCheck(t *testing.T) {
 }
 
 func TestAccBlockStorageV2Volume_tags(t *testing.T) {
+	t.Parallel()
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
@@ -140,6 +160,10 @@ func TestAccBlockStorageV2Volume_tags(t *testing.T) {
 
 func TestAccBlockStorageV2Volume_image(t *testing.T) {
 	var volume volumes.Volume
+	t.Parallel()
+	qts := []*quotas.ExpectedQuota{{Q: quotas.Volume, Count: 1}, {Q: quotas.VolumeSize, Count: 12}}
+	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
+	defer quotas.ReleaseMultipleQuotas(qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -160,6 +184,10 @@ func TestAccBlockStorageV2Volume_image(t *testing.T) {
 
 func TestAccBlockStorageV2Volume_timeout(t *testing.T) {
 	var volume volumes.Volume
+	t.Parallel()
+	qts := []*quotas.ExpectedQuota{{Q: quotas.Volume, Count: 1}, {Q: quotas.VolumeSize, Count: 1}}
+	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
+	defer quotas.ReleaseMultipleQuotas(qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },

--- a/opentelekomcloud/acceptance/evs/resource_opentelekomcloud_evs_volume_v3_test.go
+++ b/opentelekomcloud/acceptance/evs/resource_opentelekomcloud_evs_volume_v3_test.go
@@ -4,9 +4,12 @@ import (
 	"fmt"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/evs/v3/volumes"
 
@@ -19,6 +22,10 @@ const resourceVolumeV3Name = "opentelekomcloud_evs_volume_v3.volume_1"
 
 func TestAccEvsStorageV3Volume_basic(t *testing.T) {
 	var volume volumes.Volume
+	t.Parallel()
+	qts := []*quotas.ExpectedQuota{{Q: quotas.Volume, Count: 1}, {Q: quotas.VolumeSize, Count: 12}}
+	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
+	defer quotas.ReleaseMultipleQuotas(qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -44,6 +51,11 @@ func TestAccEvsStorageV3Volume_basic(t *testing.T) {
 }
 
 func TestAccEvsStorageV3Volume_tags(t *testing.T) {
+	t.Parallel()
+	qts := []*quotas.ExpectedQuota{{Q: quotas.Volume, Count: 1}, {Q: quotas.VolumeSize, Count: 12}}
+	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
+	defer quotas.ReleaseMultipleQuotas(qts)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
@@ -67,6 +79,10 @@ func TestAccEvsStorageV3Volume_tags(t *testing.T) {
 
 func TestAccEvsStorageV3Volume_image(t *testing.T) {
 	var volume volumes.Volume
+	t.Parallel()
+	qts := []*quotas.ExpectedQuota{{Q: quotas.Volume, Count: 1}, {Q: quotas.VolumeSize, Count: 12}}
+	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
+	defer quotas.ReleaseMultipleQuotas(qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -86,6 +102,10 @@ func TestAccEvsStorageV3Volume_image(t *testing.T) {
 
 func TestAccEvsStorageV3Volume_timeout(t *testing.T) {
 	var volume volumes.Volume
+	t.Parallel()
+	qts := []*quotas.ExpectedQuota{{Q: quotas.Volume, Count: 1}, {Q: quotas.VolumeSize, Count: 12}}
+	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
+	defer quotas.ReleaseMultipleQuotas(qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -103,6 +123,11 @@ func TestAccEvsStorageV3Volume_timeout(t *testing.T) {
 }
 
 func TestAccEvsStorageV3Volume_volumeType(t *testing.T) {
+	t.Parallel()
+	qts := []*quotas.ExpectedQuota{{Q: quotas.Volume, Count: 1}, {Q: quotas.VolumeSize, Count: 12}}
+	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
+	defer quotas.ReleaseMultipleQuotas(qts)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
@@ -120,6 +145,10 @@ func TestAccEvsStorageV3Volume_volumeType(t *testing.T) {
 func TestAccEvsStorageV3Volume_resize(t *testing.T) {
 	var volume volumes.Volume
 	var volumeUpScaled volumes.Volume
+	t.Parallel()
+	qts := []*quotas.ExpectedQuota{{Q: quotas.Volume, Count: 1}, {Q: quotas.VolumeSize, Count: 20}}
+	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
+	defer quotas.ReleaseMultipleQuotas(qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },


### PR DESCRIPTION
## Summary of the Pull Request
Parallelize EVS acceptance tests

Add `Volume` and `VolumeSize` shared quotas

## Acceptance Steps Performed

```
=== RUN   TestAccBlockStorageV2Volume_importBasic
=== PAUSE TestAccBlockStorageV2Volume_importBasic
=== CONT  TestAccBlockStorageV2Volume_importBasic
--- PASS: TestAccBlockStorageV2Volume_importBasic (58.10s)
=== RUN   TestAccBlockStorageV2Volume_basic
=== PAUSE TestAccBlockStorageV2Volume_basic
=== CONT  TestAccBlockStorageV2Volume_basic
--- PASS: TestAccBlockStorageV2Volume_basic (76.09s)
=== RUN   TestAccBlockStorageV2Volume_upscaleDownScale
=== PAUSE TestAccBlockStorageV2Volume_upscaleDownScale
=== CONT  TestAccBlockStorageV2Volume_upscaleDownScale
--- PASS: TestAccBlockStorageV2Volume_upscaleDownScale (129.83s)
=== RUN   TestAccBlockStorageV2Volume_upscaleDownScaleAssigned
=== PAUSE TestAccBlockStorageV2Volume_upscaleDownScaleAssigned
=== CONT  TestAccBlockStorageV2Volume_upscaleDownScaleAssigned
--- PASS: TestAccBlockStorageV2Volume_upscaleDownScaleAssigned (220.58s)
=== RUN   TestAccBlockStorageV2Volume_policy
=== PAUSE TestAccBlockStorageV2Volume_policy
=== CONT  TestAccBlockStorageV2Volume_policy
=== CONT  TestAccBlockStorageV2Volume_policy
    resource_opentelekomcloud_blockstorage_volume_v2_test.go:132: OS_KMS_NAME should be set for this test to existing KMS key alias
--- SKIP: TestAccBlockStorageV2Volume_policy (0.00s)

Test ignored.
=== RUN   TestAccBlockStorageV2Volume_tags
=== PAUSE TestAccBlockStorageV2Volume_tags
=== CONT  TestAccBlockStorageV2Volume_tags
--- PASS: TestAccBlockStorageV2Volume_tags (78.70s)
=== RUN   TestAccBlockStorageV2Volume_image
=== PAUSE TestAccBlockStorageV2Volume_image
=== CONT  TestAccBlockStorageV2Volume_image
--- PASS: TestAccBlockStorageV2Volume_image (56.42s)
=== RUN   TestAccBlockStorageV2Volume_timeout
=== PAUSE TestAccBlockStorageV2Volume_timeout
=== CONT  TestAccBlockStorageV2Volume_timeout
--- PASS: TestAccBlockStorageV2Volume_timeout (52.64s)
=== RUN   TestAccEvsStorageV3Volume_basic
=== PAUSE TestAccEvsStorageV3Volume_basic
=== CONT  TestAccEvsStorageV3Volume_basic
--- PASS: TestAccEvsStorageV3Volume_basic (77.86s)
=== RUN   TestAccEvsStorageV3Volume_tags
=== PAUSE TestAccEvsStorageV3Volume_tags
=== CONT  TestAccEvsStorageV3Volume_tags
--- PASS: TestAccEvsStorageV3Volume_tags (71.31s)
=== RUN   TestAccEvsStorageV3Volume_image
=== PAUSE TestAccEvsStorageV3Volume_image
=== CONT  TestAccEvsStorageV3Volume_image
--- PASS: TestAccEvsStorageV3Volume_image (59.06s)
=== RUN   TestAccEvsStorageV3Volume_timeout
=== PAUSE TestAccEvsStorageV3Volume_timeout
=== CONT  TestAccEvsStorageV3Volume_timeout
--- PASS: TestAccEvsStorageV3Volume_timeout (46.36s)
=== RUN   TestAccEvsStorageV3Volume_volumeType
=== PAUSE TestAccEvsStorageV3Volume_volumeType
=== CONT  TestAccEvsStorageV3Volume_volumeType
--- PASS: TestAccEvsStorageV3Volume_volumeType (19.97s)
=== RUN   TestAccEvsStorageV3Volume_resize
=== PAUSE TestAccEvsStorageV3Volume_resize
=== CONT  TestAccEvsStorageV3Volume_resize
--- PASS: TestAccEvsStorageV3Volume_resize (83.46s)
PASS
ok  	github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/evs	221.640s

Process finished with the exit code 0

```
