### PR TITLE
Acceptance: make `ECS` tests parallel

### DIFF
--- a/opentelekomcloud/acceptance/ecs/data_source_opentelekomcloud_compute_availability_zones_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/data_source_opentelekomcloud_compute_availability_zones_v2_test.go
@@ -12,6 +12,8 @@ import (
 const dataAzName = "data.opentelekomcloud_compute_availability_zones_v2.zones"
 
 func TestAccOpenStackAvailabilityZonesV2_basic(t *testing.T) {
+	t.Parallel()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,

--- a/opentelekomcloud/acceptance/ecs/data_source_opentelekomcloud_compute_flavor_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/data_source_opentelekomcloud_compute_flavor_v2_test.go
@@ -12,6 +12,8 @@ import (
 const dataFlavorName = "data.opentelekomcloud_compute_flavor_v2.flavor_1"
 
 func TestAccComputeV2FlavorDataSource_basic(t *testing.T) {
+	t.Parallel()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,

--- a/opentelekomcloud/acceptance/ecs/import_opentelekomcloud_compute_floatingip_associate_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/import_opentelekomcloud_compute_floatingip_associate_v2_test.go
@@ -2,8 +2,11 @@ package acceptance
 
 import (
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
 )
@@ -11,6 +14,11 @@ import (
 const resourceFloatingIpAssociateName = "opentelekomcloud_compute_floatingip_associate_v2.fip_1"
 
 func TestAccComputeV2FloatingIPAssociate_importBasic(t *testing.T) {
+	t.Parallel()
+	qts := simpleServerWithIPQuotas(1)
+	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
+	defer quotas.ReleaseMultipleQuotas(qts)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,

--- a/opentelekomcloud/acceptance/ecs/import_opentelekomcloud_compute_floatingip_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/import_opentelekomcloud_compute_floatingip_v2_test.go
@@ -4,11 +4,17 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
 )
 
 func TestAccComputeV2FloatingIP_importBasic(t *testing.T) {
+	t.Parallel()
+	th.AssertNoErr(t, quotas.FloatingIP.Acquire())
+	defer quotas.FloatingIP.Release()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,

--- a/opentelekomcloud/acceptance/ecs/import_opentelekomcloud_compute_instance_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/import_opentelekomcloud_compute_instance_v2_test.go
@@ -2,13 +2,22 @@ package acceptance
 
 import (
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
 )
 
 func TestAccComputeV2InstanceImportBasic(t *testing.T) {
+	qts := serverQuotas(4, env.OsFlavorID)
+	t.Parallel()
+	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
+	defer quotas.ReleaseMultipleQuotas(qts)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,

--- a/opentelekomcloud/acceptance/ecs/import_opentelekomcloud_compute_keypair_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/import_opentelekomcloud_compute_keypair_v2_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccComputeV2Keypair_importBasic(t *testing.T) {
+	t.Parallel()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,

--- a/opentelekomcloud/acceptance/ecs/import_opentelekomcloud_compute_secgroup_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/import_opentelekomcloud_compute_secgroup_v2_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccComputeV2SecGroup_importBasic(t *testing.T) {
+	t.Parallel()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,

--- a/opentelekomcloud/acceptance/ecs/import_opentelekomcloud_compute_servergroup_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/import_opentelekomcloud_compute_servergroup_v2_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestAccComputeV2ServerGroup_importBasic(t *testing.T) {
 	resourceName := "opentelekomcloud_compute_servergroup_v2.sg_1"
+	t.Parallel()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },

--- a/opentelekomcloud/acceptance/ecs/import_opentelekomcloud_compute_volume_attach_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/import_opentelekomcloud_compute_volume_attach_v2_test.go
@@ -2,13 +2,21 @@ package acceptance
 
 import (
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
 )
 
 func TestAccComputeV2VolumeAttach_importBasic(t *testing.T) {
+	t.Parallel()
+	qts := serverQuotas(1+4, "s2.medium.1")
+	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
+	defer quotas.ReleaseMultipleQuotas(qts)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,

--- a/opentelekomcloud/acceptance/ecs/import_opentelekomcloud_ecs_instance_v1_test.go
+++ b/opentelekomcloud/acceptance/ecs/import_opentelekomcloud_ecs_instance_v1_test.go
@@ -2,13 +2,21 @@ package acceptance
 
 import (
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
 )
 
 func TestAccEcsV1Instance_importBasic(t *testing.T) {
+	t.Parallel()
+	qts := serverQuotas(10+4, "s2.medium.1")
+	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
+	defer quotas.ReleaseMultipleQuotas(qts)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
@@ -24,6 +32,7 @@ func TestAccEcsV1Instance_importBasic(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"password",
+					"delete_disks_on_termination",
 				},
 			},
 		},

--- a/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_floatingip_associate_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_floatingip_associate_v2_test.go
@@ -3,8 +3,11 @@ package acceptance
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/compute/v2/servers"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/layer3/floatingips"
@@ -23,6 +26,10 @@ func TestAccComputeV2FloatingIPAssociate_basic(t *testing.T) {
 	var instance servers.Server
 	var fip floatingips.FloatingIP
 	resourceNwFloatingIpName := "opentelekomcloud_networking_floatingip_v2.fip_1"
+	t.Parallel()
+	qts := simpleServerWithIPQuotas(1)
+	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
+	defer quotas.ReleaseMultipleQuotas(qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -45,6 +52,10 @@ func TestAccComputeV2FloatingIPAssociate_fixedIP(t *testing.T) {
 	var instance servers.Server
 	var fip floatingips.FloatingIP
 	resourceNwFloatingIpName := "opentelekomcloud_networking_floatingip_v2.fip_1"
+	t.Parallel()
+	qts := simpleServerWithIPQuotas(1)
+	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
+	defer quotas.ReleaseMultipleQuotas(qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -67,6 +78,10 @@ func TestAccComputeV2FloatingIPAssociate_attachToFirstNetwork(t *testing.T) {
 	var instance servers.Server
 	var fip floatingips.FloatingIP
 	resourceNwFloatingIpName := "opentelekomcloud_networking_floatingip_v2.fip_1"
+	t.Parallel()
+	qts := simpleServerWithIPQuotas(1)
+	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
+	defer quotas.ReleaseMultipleQuotas(qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -91,6 +106,10 @@ func TestAccComputeV2FloatingIPAssociate_attachNew(t *testing.T) {
 	var fip2 floatingips.FloatingIP
 	resourceNwFloatingIpName := "opentelekomcloud_networking_floatingip_v2.fip_1"
 	resourceNwFloatingIp2Name := "opentelekomcloud_networking_floatingip_v2.fip_2"
+	t.Parallel()
+	qts := simpleServerWithIPQuotas(2)
+	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
+	defer quotas.ReleaseMultipleQuotas(qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },

--- a/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_floatingip_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_floatingip_v2_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/compute/v2/extensions/floatingips"
 
@@ -18,6 +20,9 @@ const resourceFloatingIpName = "opentelekomcloud_compute_floatingip_v2.fip_1"
 
 func TestAccComputeV2FloatingIP_basic(t *testing.T) {
 	var fip floatingips.FloatingIP
+
+	th.AssertNoErr(t, quotas.FloatingIP.Acquire())
+	defer quotas.FloatingIP.Release()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },

--- a/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_instance_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_instance_v2_test.go
@@ -4,9 +4,12 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/compute/v2/extensions/secgroups"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/compute/v2/extensions/volumeattach"
@@ -22,6 +25,10 @@ const resourceInstanceV2Name = "opentelekomcloud_compute_instance_v2.instance_1"
 
 func TestAccComputeV2Instance_basic(t *testing.T) {
 	var instance servers.Server
+	qts := serverQuotas(4, env.OsFlavorID)
+	t.Parallel()
+	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
+	defer quotas.ReleaseMultipleQuotas(qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -56,6 +63,10 @@ func TestAccComputeV2Instance_multiSecgroup(t *testing.T) {
 	var secGroup1, secGroup2 secgroups.SecurityGroup
 	secGroupName1 := "opentelekomcloud_compute_secgroup_v2.secgroup_1"
 	secGroupName2 := "opentelekomcloud_compute_secgroup_v2.secgroup_2"
+	qts := serverQuotas(4, env.OsFlavorID)
+	t.Parallel()
+	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
+	defer quotas.ReleaseMultipleQuotas(qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -84,6 +95,10 @@ func TestAccComputeV2Instance_multiSecgroup(t *testing.T) {
 
 func TestAccComputeV2Instance_bootFromImage(t *testing.T) {
 	var instance servers.Server
+	qts := serverQuotas(50, env.OsFlavorID)
+	t.Parallel()
+	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
+	defer quotas.ReleaseMultipleQuotas(qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -103,6 +118,10 @@ func TestAccComputeV2Instance_bootFromImage(t *testing.T) {
 
 func TestAccComputeV2Instance_bootFromVolume(t *testing.T) {
 	var instance servers.Server
+	qts := serverQuotas(50, env.OsFlavorID)
+	t.Parallel()
+	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
+	defer quotas.ReleaseMultipleQuotas(qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -121,6 +140,10 @@ func TestAccComputeV2Instance_bootFromVolume(t *testing.T) {
 
 func TestAccComputeV2Instance_changeFixedIP(t *testing.T) {
 	var instance servers.Server
+	qts := serverQuotas(4, env.OsFlavorID)
+	t.Parallel()
+	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
+	defer quotas.ReleaseMultipleQuotas(qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -139,6 +162,10 @@ func TestAccComputeV2Instance_changeFixedIP(t *testing.T) {
 
 func TestAccComputeV2Instance_bootFromVolumeVolume(t *testing.T) {
 	var instance servers.Server
+	qts := serverQuotas(50, env.OsFlavorID)
+	t.Parallel()
+	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
+	defer quotas.ReleaseMultipleQuotas(qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -158,6 +185,10 @@ func TestAccComputeV2Instance_bootFromVolumeVolume(t *testing.T) {
 
 func TestAccComputeV2Instance_stopBeforeDestroy(t *testing.T) {
 	var instance servers.Server
+	qts := serverQuotas(4, env.OsFlavorID)
+	t.Parallel()
+	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
+	defer quotas.ReleaseMultipleQuotas(qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -176,6 +207,10 @@ func TestAccComputeV2Instance_stopBeforeDestroy(t *testing.T) {
 
 func TestAccComputeV2Instance_metadata(t *testing.T) {
 	var instance servers.Server
+	qts := serverQuotas(4, env.OsFlavorID)
+	t.Parallel()
+	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
+	defer quotas.ReleaseMultipleQuotas(qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -209,6 +244,10 @@ func TestAccComputeV2Instance_metadata(t *testing.T) {
 
 func TestAccComputeV2Instance_timeout(t *testing.T) {
 	var instance servers.Server
+	qts := serverQuotas(4, env.OsFlavorID)
+	t.Parallel()
+	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
+	defer quotas.ReleaseMultipleQuotas(qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -227,6 +266,10 @@ func TestAccComputeV2Instance_timeout(t *testing.T) {
 
 func TestAccComputeV2Instance_autoRecovery(t *testing.T) {
 	var instance servers.Server
+	qts := serverQuotas(4, env.OsFlavorID)
+	t.Parallel()
+	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
+	defer quotas.ReleaseMultipleQuotas(qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -253,6 +296,10 @@ func TestAccComputeV2Instance_autoRecovery(t *testing.T) {
 
 func TestAccComputeV2Instance_crazyNICs(t *testing.T) {
 	var instance servers.Server
+	qts := serverQuotas(4, env.OsFlavorID)
+	t.Parallel()
+	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
+	defer quotas.ReleaseMultipleQuotas(qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -271,6 +318,10 @@ func TestAccComputeV2Instance_crazyNICs(t *testing.T) {
 
 func TestAccComputeV2Instance_initialStateActive(t *testing.T) {
 	var instance servers.Server
+	qts := serverQuotas(4, env.OsFlavorID)
+	t.Parallel()
+	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
+	defer quotas.ReleaseMultipleQuotas(qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -309,6 +360,10 @@ func TestAccComputeV2Instance_initialStateActive(t *testing.T) {
 
 func TestAccComputeV2Instance_initialStateShutoff(t *testing.T) {
 	var instance servers.Server
+	qts := serverQuotas(4, env.OsFlavorID)
+	t.Parallel()
+	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
+	defer quotas.ReleaseMultipleQuotas(qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {

--- a/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_keypair_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_keypair_v2_test.go
@@ -18,6 +18,7 @@ const resourceKeyPairName = "opentelekomcloud_compute_keypair_v2.kp_1"
 
 func TestAccComputeV2Keypair_basic(t *testing.T) {
 	var keypair keypairs.KeyPair
+	t.Parallel()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -37,6 +38,7 @@ func TestAccComputeV2Keypair_basic(t *testing.T) {
 func TestAccComputeV2Keypair_shared(t *testing.T) {
 	var keypair keypairs.KeyPair
 	resourceName2 := "opentelekomcloud_compute_keypair_v2.kp_2"
+	t.Parallel()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -44,7 +46,7 @@ func TestAccComputeV2Keypair_shared(t *testing.T) {
 		CheckDestroy:      testAccCheckComputeV2KeypairDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeV2KeypairBasic,
+				Config: testAccComputeV2KeypairSharedPre,
 			},
 			{
 				Config: testAccComputeV2KeypairShared,
@@ -61,6 +63,7 @@ func TestAccComputeV2Keypair_shared(t *testing.T) {
 
 func TestAccComputeV2Keypair_private(t *testing.T) {
 	var keypair keypairs.KeyPair
+	t.Parallel()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -134,14 +137,26 @@ func testAccCheckComputeV2KeypairExists(n string, kp *keypairs.KeyPair) resource
 const testAccComputeV2KeypairBasic = `
 resource "opentelekomcloud_compute_keypair_v2" "kp_1" {
   name       = "kp_1"
-  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDAjpC1hwiOCCmKEWxJ4qzTTsJbKzndLo1BCz5PcwtUnflmU+gHJtWMZKpuEGVi29h0A/+ydKek1O18k10Ff+4tyFjiHDQAT9+OfgWf7+b1yK+qDip3X1C0UPMbwHlTfSGWLGZquwhvEFx9k3h/M+VtMvwR1lJ9LUyTAImnNjWG7TAIPmui30HvM2UiFEmqkr4ijq45MyX2+fLIePLRIFuu1p4whjHAQYufqyno3BS48icQb4p6iVEZPo4AE2o9oIyQvj2mx4dk5Y8CgSETOZTYDOR3rU2fZTRDRgPJDH9FWvQjF5tA0p3d9CoWWd2s6GKKbfoUIi8R/Db1BSPJwkqB jrp-hp-pc"
+  public_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIALRzbIOR9HUYNwfKtII/et98eGXDJhf8YxHf9BtRdAU"
+}
+`
+
+const testAccComputeV2KeypairSharedPre = `
+locals {
+  public_name = "kp_1-shared"
+  public_key  = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINnnG9HsMplxW056UKoJWeiWYEMBZ0fKQoMOaPFRA5Zp"
+}
+
+resource "opentelekomcloud_compute_keypair_v2" "kp_1" {
+  name       = local.public_name
+  public_key = local.public_key
 }
 `
 
 const testAccComputeV2KeypairShared = `
 locals {
-  public_name = "kp_1"
-  public_key  = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDAjpC1hwiOCCmKEWxJ4qzTTsJbKzndLo1BCz5PcwtUnflmU+gHJtWMZKpuEGVi29h0A/+ydKek1O18k10Ff+4tyFjiHDQAT9+OfgWf7+b1yK+qDip3X1C0UPMbwHlTfSGWLGZquwhvEFx9k3h/M+VtMvwR1lJ9LUyTAImnNjWG7TAIPmui30HvM2UiFEmqkr4ijq45MyX2+fLIePLRIFuu1p4whjHAQYufqyno3BS48icQb4p6iVEZPo4AE2o9oIyQvj2mx4dk5Y8CgSETOZTYDOR3rU2fZTRDRgPJDH9FWvQjF5tA0p3d9CoWWd2s6GKKbfoUIi8R/Db1BSPJwkqB jrp-hp-pc"
+  public_name = "kp_1-shared"
+  public_key  = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINnnG9HsMplxW056UKoJWeiWYEMBZ0fKQoMOaPFRA5Zp"
 }
 
 resource "opentelekomcloud_compute_keypair_v2" "kp_1" {
@@ -159,6 +174,6 @@ resource "opentelekomcloud_compute_keypair_v2" "kp_2" {
 
 const testAccComputeV2KeypairPrivate = `
 resource "opentelekomcloud_compute_keypair_v2" "kp_1" {
-  name = "kp_1"
+  name = "kp_1-private"
 }
 `

--- a/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_secgroup_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_secgroup_v2_test.go
@@ -18,6 +18,7 @@ const resourceSecGroupName = "opentelekomcloud_compute_secgroup_v2.sg_1"
 
 func TestAccComputeV2SecGroup_basic(t *testing.T) {
 	var secGroup secgroups.SecurityGroup
+	t.Parallel()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -36,6 +37,7 @@ func TestAccComputeV2SecGroup_basic(t *testing.T) {
 
 func TestAccComputeV2SecGroup_update(t *testing.T) {
 	var secGroup secgroups.SecurityGroup
+	t.Parallel()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -60,9 +62,12 @@ func TestAccComputeV2SecGroup_update(t *testing.T) {
 }
 
 func TestAccComputeV2SecGroup_groupID(t *testing.T) {
+	t.Skip("this test is not a stable one")
+
 	var secgroup1, secGroup2, secgroup3 secgroups.SecurityGroup
 	resourceSecGroup2Name := "opentelekomcloud_compute_secgroup_v2.sg_2"
 	resourceSecGroup3Name := "opentelekomcloud_compute_secgroup_v2.sg_3"
+	t.Parallel()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -104,8 +109,8 @@ func TestAccComputeV2SecGroup_self(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeV2SecGroupExists(resourceSecGroupName, &secGroup),
 					testAccCheckComputeV2SecGroupGroupIDMatch(&secGroup, &secGroup),
-					resource.TestCheckResourceAttr(resourceSecGroupName, "rule.3170486100.self", "true"),
-					resource.TestCheckResourceAttr(resourceSecGroupName, "rule.3170486100.from_group_id", ""),
+					resource.TestCheckResourceAttr(resourceSecGroupName, "rule.0.self", "true"),
+					resource.TestCheckResourceAttr(resourceSecGroupName, "rule.0.from_group_id", ""),
 				),
 			},
 		},
@@ -114,6 +119,7 @@ func TestAccComputeV2SecGroup_self(t *testing.T) {
 
 func TestAccComputeV2SecGroup_icmpZero(t *testing.T) {
 	var secGroup secgroups.SecurityGroup
+	t.Parallel()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -132,6 +138,7 @@ func TestAccComputeV2SecGroup_icmpZero(t *testing.T) {
 
 func TestAccComputeV2SecGroup_timeout(t *testing.T) {
 	var secGroup secgroups.SecurityGroup
+	t.Parallel()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },

--- a/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_volume_attach_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_volume_attach_v2_test.go
@@ -3,9 +3,12 @@ package acceptance
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/compute/v2/extensions/volumeattach"
 
@@ -19,6 +22,10 @@ const resourceVolumeAttach = "opentelekomcloud_compute_volume_attach_v2.va_1"
 
 func TestAccComputeV2VolumeAttach_basic(t *testing.T) {
 	var va volumeattach.VolumeAttachment
+	qts := serverQuotas(4+1, "s2.medium.1")
+	t.Parallel()
+	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
+	defer quotas.ReleaseMultipleQuotas(qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -37,6 +44,10 @@ func TestAccComputeV2VolumeAttach_basic(t *testing.T) {
 
 func TestAccComputeV2VolumeAttach_device(t *testing.T) {
 	var va volumeattach.VolumeAttachment
+	qts := serverQuotas(4+1, "s2.medium.1")
+	t.Parallel()
+	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
+	defer quotas.ReleaseMultipleQuotas(qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -56,6 +67,10 @@ func TestAccComputeV2VolumeAttach_device(t *testing.T) {
 
 func TestAccComputeV2VolumeAttach_timeout(t *testing.T) {
 	var va volumeattach.VolumeAttachment
+	qts := serverQuotas(4+1, "s2.medium.1")
+	t.Parallel()
+	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
+	defer quotas.ReleaseMultipleQuotas(qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },

--- a/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_ecs_instance_v1_test.go
+++ b/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_ecs_instance_v1_test.go
@@ -4,9 +4,12 @@ import (
 	"fmt"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/ecs/v1/cloudservers"
 
@@ -19,6 +22,10 @@ const resourceInstanceV1Name = "opentelekomcloud_ecs_instance_v1.instance_1"
 
 func TestAccEcsV1InstanceBasic(t *testing.T) {
 	var instance cloudservers.CloudServer
+	qts := serverQuotas(10+4, "s2.medium.1")
+	t.Parallel()
+	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
+	defer quotas.ReleaseMultipleQuotas(qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -50,6 +57,7 @@ func TestAccEcsV1InstanceBasic(t *testing.T) {
 }
 
 func TestAccEcsV1InstanceDiskTypeValidation(t *testing.T) {
+	t.Parallel()
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
@@ -74,6 +82,11 @@ func TestAccEcsV1InstanceDiskTypeValidation(t *testing.T) {
 }
 
 func TestAccEcsV1InstanceVPCValidation(t *testing.T) {
+	qts := serverQuotas(4, "s2.medium.1")
+	t.Parallel()
+	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
+	defer quotas.ReleaseMultipleQuotas(qts)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
@@ -92,6 +105,10 @@ func TestAccEcsV1InstanceVPCValidation(t *testing.T) {
 
 func TestAccEcsV1InstanceEncryption(t *testing.T) {
 	var instance cloudservers.CloudServer
+	qts := serverQuotas(10+4, "s2.medium.1")
+	t.Parallel()
+	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
+	defer quotas.ReleaseMultipleQuotas(qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -186,6 +203,7 @@ resource "opentelekomcloud_ecs_instance_v1" "instance_1" {
   password          = "Password@123"
   availability_zone = "%s"
   auto_recovery     = true
+  delete_disks_on_termination = true
 
   tags = {
     muh = "value-create"
@@ -304,6 +322,7 @@ resource "opentelekomcloud_ecs_instance_v1" "instance_1" {
     size = 10
     type = "invalid"
   }
+  delete_disks_on_termination = true
 
   password          = "Password@123"
   availability_zone = "eu-de-03"
@@ -406,5 +425,6 @@ resource "opentelekomcloud_ecs_instance_v1" "instance_1" {
     type   = "SAS"
     kms_id = "%s"
   }
+  delete_disks_on_termination = true
 }
 `, common.DataSourceImage, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, env.OS_KMS_ID)

--- a/opentelekomcloud/acceptance/ecs/utils.go
+++ b/opentelekomcloud/acceptance/ecs/utils.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/compute/v2/flavors"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/compute/v2/servers"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
@@ -32,4 +34,69 @@ func TestAccCheckComputeV2InstanceDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func getFlavors() (map[string][]*quotas.ExpectedQuota, error) {
+	config := common.TestAccProvider.Meta().(*cfg.Config)
+	client, err := config.ComputeV2Client(env.OS_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating OpenTelekomCloud ComputeV2 client: %s", err)
+	}
+	pgs, err := flavors.ListDetail(client, flavors.ListOpts{}).AllPages()
+	if err != nil {
+		return nil, fmt.Errorf("error listing flavors pages: %w", err)
+	}
+	flavs, err := flavors.ExtractFlavors(pgs)
+	if err != nil {
+		return nil, fmt.Errorf("error extracting flavors pages: %w", err)
+	}
+	resultsQ := map[string][]*quotas.ExpectedQuota{}
+	for _, flv := range flavs {
+		exp := []*quotas.ExpectedQuota{
+			{
+				Q:     quotas.CPU,
+				Count: int64(flv.VCPUs),
+			},
+			{
+				Q:     quotas.RAM,
+				Count: int64(flv.RAM),
+			},
+		}
+		resultsQ[flv.ID] = exp
+	}
+	return resultsQ, nil
+}
+
+var flavorsQuota map[string][]*quotas.ExpectedQuota
+
+func init() {
+	qs, err := getFlavors()
+	if err != nil {
+		panic("failed to get server flavors")
+	}
+	flavorsQuota = qs
+}
+
+func quotasForFlavor(flavorRef string) []*quotas.ExpectedQuota {
+	var qts []*quotas.ExpectedQuota
+	qts = append(qts,
+		flavorsQuota[flavorRef]...,
+	)
+	return qts
+}
+
+func serverQuotas(volume int64, flavor string) []*quotas.ExpectedQuota {
+	qts := []*quotas.ExpectedQuota{
+		{Q: quotas.Volume, Count: 1},
+		{Q: quotas.VolumeSize, Count: volume},
+		{Q: quotas.Server, Count: 1},
+	}
+	qts = append(qts, quotasForFlavor(flavor)...)
+	return qts
+}
+
+func simpleServerWithIPQuotas(eipCount int64) []*quotas.ExpectedQuota {
+	qts := serverQuotas(4, env.OsFlavorID)
+	qts = append(qts, &quotas.ExpectedQuota{Q: quotas.FloatingIP, Count: eipCount})
+	return qts
 }

--- a/opentelekomcloud/acceptance/ecs/utils.go
+++ b/opentelekomcloud/acceptance/ecs/utils.go
@@ -2,6 +2,7 @@ package acceptance
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/compute/v2/flavors"
@@ -70,11 +71,13 @@ func getFlavors() (map[string][]*quotas.ExpectedQuota, error) {
 var flavorsQuota map[string][]*quotas.ExpectedQuota
 
 func init() {
-	qs, err := getFlavors()
-	if err != nil {
-		panic("failed to get server flavors")
+	if os.Getenv("TF_ACC") != "" { // this can be done only in acceptance
+		qs, err := getFlavors()
+		if err != nil {
+			panic("failed to get server flavors")
+		}
+		flavorsQuota = qs
 	}
-	flavorsQuota = qs
 }
 
 func quotasForFlavor(flavorRef string) []*quotas.ExpectedQuota {


### PR DESCRIPTION
## Summary of the Pull Request
Parallelize ECS v1 and v2 tests execution

## PR Checklist

* [x] Tests added/passed.

## Acceptance Steps Performed

```
=== RUN   TestAccOpenStackAvailabilityZonesV2_basic
=== PAUSE TestAccOpenStackAvailabilityZonesV2_basic
=== CONT  TestAccOpenStackAvailabilityZonesV2_basic
--- PASS: TestAccOpenStackAvailabilityZonesV2_basic (23.06s)
=== RUN   TestAccComputeV2FlavorDataSource_basic
=== PAUSE TestAccComputeV2FlavorDataSource_basic
=== CONT  TestAccComputeV2FlavorDataSource_basic
--- PASS: TestAccComputeV2FlavorDataSource_basic (32.24s)
=== RUN   TestAccComputeV2FlavorDataSource_testQueries
--- PASS: TestAccComputeV2FlavorDataSource_testQueries (117.39s)
=== RUN   TestAccComputeV2FloatingIPAssociate_importBasic
=== PAUSE TestAccComputeV2FloatingIPAssociate_importBasic
=== CONT  TestAccComputeV2FloatingIPAssociate_importBasic
--- PASS: TestAccComputeV2FloatingIPAssociate_importBasic (274.44s)
=== RUN   TestAccComputeV2FloatingIP_importBasic
=== PAUSE TestAccComputeV2FloatingIP_importBasic
=== CONT  TestAccComputeV2FloatingIP_importBasic
--- PASS: TestAccComputeV2FloatingIP_importBasic (40.91s)
=== RUN   TestAccComputeV2InstanceImportBasic
=== PAUSE TestAccComputeV2InstanceImportBasic
=== CONT  TestAccComputeV2InstanceImportBasic
--- PASS: TestAccComputeV2InstanceImportBasic (86.58s)
=== RUN   TestAccComputeV2InstanceImportBootFromVolumeImage
--- PASS: TestAccComputeV2InstanceImportBootFromVolumeImage (82.34s)
=== RUN   TestAccComputeV2Keypair_importBasic
=== PAUSE TestAccComputeV2Keypair_importBasic
=== CONT  TestAccComputeV2Keypair_importBasic
--- PASS: TestAccComputeV2Keypair_importBasic (29.12s)
=== RUN   TestAccComputeV2SecGroup_importBasic
=== PAUSE TestAccComputeV2SecGroup_importBasic
=== CONT  TestAccComputeV2SecGroup_importBasic
--- PASS: TestAccComputeV2SecGroup_importBasic (50.05s)
=== RUN   TestAccComputeV2ServerGroup_importBasic
=== PAUSE TestAccComputeV2ServerGroup_importBasic
=== CONT  TestAccComputeV2ServerGroup_importBasic
--- PASS: TestAccComputeV2ServerGroup_importBasic (27.22s)
=== RUN   TestAccComputeV2VolumeAttach_importBasic
=== PAUSE TestAccComputeV2VolumeAttach_importBasic
=== CONT  TestAccComputeV2VolumeAttach_importBasic
--- PASS: TestAccComputeV2VolumeAttach_importBasic (147.57s)
=== RUN   TestAccEcsV1Instance_importBasic
=== PAUSE TestAccEcsV1Instance_importBasic
=== CONT  TestAccEcsV1Instance_importBasic
--- PASS: TestAccEcsV1Instance_importBasic (173.28s)
=== RUN   TestAccComputeV2FloatingIPAssociate_basic
=== PAUSE TestAccComputeV2FloatingIPAssociate_basic
=== CONT  TestAccComputeV2FloatingIPAssociate_basic
--- PASS: TestAccComputeV2FloatingIPAssociate_basic (77.62s)
=== RUN   TestAccComputeV2FloatingIPAssociate_fixedIP
=== PAUSE TestAccComputeV2FloatingIPAssociate_fixedIP
=== CONT  TestAccComputeV2FloatingIPAssociate_fixedIP
--- PASS: TestAccComputeV2FloatingIPAssociate_fixedIP (80.22s)
=== RUN   TestAccComputeV2FloatingIPAssociate_attachToFirstNetwork
=== PAUSE TestAccComputeV2FloatingIPAssociate_attachToFirstNetwork
=== CONT  TestAccComputeV2FloatingIPAssociate_attachToFirstNetwork
--- PASS: TestAccComputeV2FloatingIPAssociate_attachToFirstNetwork (77.02s)
=== RUN   TestAccComputeV2FloatingIPAssociate_attachNew
=== PAUSE TestAccComputeV2FloatingIPAssociate_attachNew
=== CONT  TestAccComputeV2FloatingIPAssociate_attachNew
--- PASS: TestAccComputeV2FloatingIPAssociate_attachNew (124.89s)
=== RUN   TestAccComputeV2FloatingIP_basic
--- PASS: TestAccComputeV2FloatingIP_basic (38.53s)
=== RUN   TestAccComputeV2Instance_basic
=== PAUSE TestAccComputeV2Instance_basic
=== CONT  TestAccComputeV2Instance_basic
--- PASS: TestAccComputeV2Instance_basic (115.21s)
=== RUN   TestAccComputeV2Instance_multiSecgroup
=== PAUSE TestAccComputeV2Instance_multiSecgroup
=== CONT  TestAccComputeV2Instance_multiSecgroup
--- PASS: TestAccComputeV2Instance_multiSecgroup (133.36s)
=== RUN   TestAccComputeV2Instance_bootFromImage
=== PAUSE TestAccComputeV2Instance_bootFromImage
=== CONT  TestAccComputeV2Instance_bootFromImage
--- PASS: TestAccComputeV2Instance_bootFromImage (68.83s)
=== RUN   TestAccComputeV2Instance_bootFromVolume
=== PAUSE TestAccComputeV2Instance_bootFromVolume
=== CONT  TestAccComputeV2Instance_bootFromVolume
--- PASS: TestAccComputeV2Instance_bootFromVolume (149.79s)
=== RUN   TestAccComputeV2Instance_changeFixedIP
=== PAUSE TestAccComputeV2Instance_changeFixedIP
=== CONT  TestAccComputeV2Instance_changeFixedIP
--- PASS: TestAccComputeV2Instance_changeFixedIP (75.60s)
=== RUN   TestAccComputeV2Instance_bootFromVolumeVolume
=== PAUSE TestAccComputeV2Instance_bootFromVolumeVolume
=== CONT  TestAccComputeV2Instance_bootFromVolumeVolume
--- PASS: TestAccComputeV2Instance_bootFromVolumeVolume (88.98s)
=== RUN   TestAccComputeV2Instance_stopBeforeDestroy
=== PAUSE TestAccComputeV2Instance_stopBeforeDestroy
=== CONT  TestAccComputeV2Instance_stopBeforeDestroy
--- PASS: TestAccComputeV2Instance_stopBeforeDestroy (83.48s)
=== RUN   TestAccComputeV2Instance_metadata
=== PAUSE TestAccComputeV2Instance_metadata
=== CONT  TestAccComputeV2Instance_metadata
--- PASS: TestAccComputeV2Instance_metadata (247.05s)
=== RUN   TestAccComputeV2Instance_timeout
=== PAUSE TestAccComputeV2Instance_timeout
=== CONT  TestAccComputeV2Instance_timeout
--- PASS: TestAccComputeV2Instance_timeout (77.23s)
=== RUN   TestAccComputeV2Instance_autoRecovery
=== PAUSE TestAccComputeV2Instance_autoRecovery
=== CONT  TestAccComputeV2Instance_autoRecovery
--- PASS: TestAccComputeV2Instance_autoRecovery (114.34s)
=== RUN   TestAccComputeV2Instance_crazyNICs
=== PAUSE TestAccComputeV2Instance_crazyNICs
=== CONT  TestAccComputeV2Instance_crazyNICs
--- PASS: TestAccComputeV2Instance_crazyNICs (199.34s)
=== RUN   TestAccComputeV2Instance_initialStateActive
=== PAUSE TestAccComputeV2Instance_initialStateActive
=== CONT  TestAccComputeV2Instance_initialStateActive
--- PASS: TestAccComputeV2Instance_initialStateActive (183.44s)
=== RUN   TestAccComputeV2Instance_initialStateShutoff
=== PAUSE TestAccComputeV2Instance_initialStateShutoff
=== CONT  TestAccComputeV2Instance_initialStateShutoff
--- PASS: TestAccComputeV2Instance_initialStateShutoff (436.37s)
=== RUN   TestAccComputeV2Keypair_basic
=== PAUSE TestAccComputeV2Keypair_basic
=== CONT  TestAccComputeV2Keypair_basic
--- PASS: TestAccComputeV2Keypair_basic (24.32s)
=== RUN   TestAccComputeV2Keypair_shared
=== PAUSE TestAccComputeV2Keypair_shared
=== CONT  TestAccComputeV2Keypair_shared
--- PASS: TestAccComputeV2Keypair_shared (44.73s)
=== RUN   TestAccComputeV2Keypair_private
=== PAUSE TestAccComputeV2Keypair_private
=== CONT  TestAccComputeV2Keypair_private
--- PASS: TestAccComputeV2Keypair_private (23.45s)
=== RUN   TestAccComputeV2SecGroup_basic
=== PAUSE TestAccComputeV2SecGroup_basic
=== CONT  TestAccComputeV2SecGroup_basic
--- PASS: TestAccComputeV2SecGroup_basic (41.46s)
=== RUN   TestAccComputeV2SecGroup_update
=== PAUSE TestAccComputeV2SecGroup_update
=== CONT  TestAccComputeV2SecGroup_update
--- PASS: TestAccComputeV2SecGroup_update (65.30s)
=== RUN   TestAccComputeV2SecGroup_groupID
    resource_opentelekomcloud_compute_secgroup_v2_test.go:65: this test is not a stable one
--- SKIP: TestAccComputeV2SecGroup_groupID (0.00s)

Test ignored.
=== RUN   TestAccComputeV2SecGroup_self
--- PASS: TestAccComputeV2SecGroup_self (39.49s)
=== RUN   TestAccComputeV2SecGroup_icmpZero
=== PAUSE TestAccComputeV2SecGroup_icmpZero
=== CONT  TestAccComputeV2SecGroup_icmpZero
--- PASS: TestAccComputeV2SecGroup_icmpZero (39.05s)
=== RUN   TestAccComputeV2SecGroup_timeout
=== PAUSE TestAccComputeV2SecGroup_timeout
=== CONT  TestAccComputeV2SecGroup_timeout
--- PASS: TestAccComputeV2SecGroup_timeout (39.51s)
=== RUN   TestAccComputeV2ServerGroup_basic
=== PAUSE TestAccComputeV2ServerGroup_basic
=== CONT  TestAccComputeV2ServerGroup_basic
--- PASS: TestAccComputeV2ServerGroup_basic (23.22s)
=== RUN   TestAccComputeV2ServerGroup_affinity
=== PAUSE TestAccComputeV2ServerGroup_affinity
=== CONT  TestAccComputeV2ServerGroup_affinity
--- PASS: TestAccComputeV2ServerGroup_affinity (292.88s)
=== RUN   TestAccComputeV2VolumeAttach_basic
=== PAUSE TestAccComputeV2VolumeAttach_basic
=== CONT  TestAccComputeV2VolumeAttach_basic
--- PASS: TestAccComputeV2VolumeAttach_basic (165.02s)
=== RUN   TestAccComputeV2VolumeAttach_device
=== PAUSE TestAccComputeV2VolumeAttach_device
=== CONT  TestAccComputeV2VolumeAttach_device
--- PASS: TestAccComputeV2VolumeAttach_device (386.43s)
=== RUN   TestAccComputeV2VolumeAttach_timeout
=== PAUSE TestAccComputeV2VolumeAttach_timeout
=== CONT  TestAccComputeV2VolumeAttach_timeout
--- PASS: TestAccComputeV2VolumeAttach_timeout (136.36s)
=== RUN   TestAccEcsV1InstanceBasic
=== PAUSE TestAccEcsV1InstanceBasic
=== CONT  TestAccEcsV1InstanceBasic
--- PASS: TestAccEcsV1InstanceBasic (211.46s)
=== RUN   TestAccEcsV1InstanceDiskTypeValidation
=== PAUSE TestAccEcsV1InstanceDiskTypeValidation
=== CONT  TestAccEcsV1InstanceDiskTypeValidation
--- PASS: TestAccEcsV1InstanceDiskTypeValidation (16.99s)
=== RUN   TestAccEcsV1InstanceVPCValidation
=== PAUSE TestAccEcsV1InstanceVPCValidation
=== CONT  TestAccEcsV1InstanceVPCValidation
--- PASS: TestAccEcsV1InstanceVPCValidation (201.23s)
=== RUN   TestAccEcsV1InstanceEncryption
=== PAUSE TestAccEcsV1InstanceEncryption
=== CONT  TestAccEcsV1InstanceEncryption
--- PASS: TestAccEcsV1InstanceEncryption (163.93s)
PASS

Process finished with the exit code 0
```
