### PR TITLE
[VPC] Fix `route_v2` data source query by `id`

### DIFF
--- a/opentelekomcloud/acceptance/vpc/data_source_opentelekomcloud_vpc_route_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/data_source_opentelekomcloud_vpc_route_v2_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
 )
 
@@ -15,6 +14,9 @@ func TestAccVpcRouteV2DataSource_basic(t *testing.T) {
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceRouteV2Res,
+			},
 			{
 				Config: testAccDataSourceRouteV2Config,
 				Check: resource.ComposeTestCheckFunc(
@@ -49,35 +51,100 @@ func testAccCheckRouteV2DataSourceID(n string) resource.TestCheckFunc {
 	}
 }
 
-const testAccDataSourceRouteV2Config = `
+const testAccDataSourceRouteV2Res = `
 resource "opentelekomcloud_vpc_v1" "vpc_1" {
-name = "vpc_test"
-cidr = "192.168.0.0/16"
+  name = "vpc_test_route_ds"
+  cidr = "192.168.0.0/16"
 }
 
 resource "opentelekomcloud_vpc_v1" "vpc_2" {
-		name = "vpc_test1"
-        cidr = "192.168.0.0/16"
+  name = "vpc_test_route_ds1"
+  cidr = "192.168.0.0/16"
+}
+
+resource "opentelekomcloud_vpc_v1" "vpc_3" {
+  name = "vpc_test_route_ds2"
+  cidr = "192.168.0.0/16"
 }
 
 resource "opentelekomcloud_vpc_peering_connection_v2" "peering_1" {
-		name = "opentelekomcloud_peering"
-		vpc_id = opentelekomcloud_vpc_v1.vpc_1.id
-		peer_vpc_id = opentelekomcloud_vpc_v1.vpc_2.id
+  name        = "opentelekomcloud_peering_ds_1"
+  vpc_id      = opentelekomcloud_vpc_v1.vpc_1.id
+  peer_vpc_id = opentelekomcloud_vpc_v1.vpc_2.id
+}
+
+resource "opentelekomcloud_vpc_peering_connection_v2" "peering_2" {
+  name        = "opentelekomcloud_peering_ds_2"
+  vpc_id      = opentelekomcloud_vpc_v1.vpc_2.id
+  peer_vpc_id = opentelekomcloud_vpc_v1.vpc_3.id
 }
 
 resource "opentelekomcloud_vpc_route_v2" "route_1" {
-   type = "peering"
-  nexthop = opentelekomcloud_vpc_peering_connection_v2.peering_1.id
+  type        = "peering"
+  nexthop     = opentelekomcloud_vpc_peering_connection_v2.peering_1.id
   destination = "192.168.0.0/16"
-  vpc_id =opentelekomcloud_vpc_v1.vpc_1.id
+  vpc_id      = opentelekomcloud_vpc_v1.vpc_1.id
+}
+
+resource "opentelekomcloud_vpc_route_v2" "route_2" {
+  type        = "peering"
+  nexthop     = opentelekomcloud_vpc_peering_connection_v2.peering_1.id
+  destination = "192.168.0.0/16"
+  vpc_id      = opentelekomcloud_vpc_v1.vpc_2.id
+}
+`
+
+const testAccDataSourceRouteV2Config = `
+resource "opentelekomcloud_vpc_v1" "vpc_1" {
+  name = "vpc_test_route_ds"
+  cidr = "192.168.0.0/16"
+}
+
+resource "opentelekomcloud_vpc_v1" "vpc_2" {
+  name = "vpc_test_route_ds1"
+  cidr = "192.168.0.0/16"
+}
+
+resource "opentelekomcloud_vpc_v1" "vpc_3" {
+  name = "vpc_test_route_ds2"
+  cidr = "192.168.0.0/16"
+}
+
+resource "opentelekomcloud_vpc_peering_connection_v2" "peering_1" {
+  name        = "opentelekomcloud_peering_ds_1"
+  vpc_id      = opentelekomcloud_vpc_v1.vpc_1.id
+  peer_vpc_id = opentelekomcloud_vpc_v1.vpc_2.id
+}
+
+resource "opentelekomcloud_vpc_peering_connection_v2" "peering_2" {
+  name        = "opentelekomcloud_peering_ds_2"
+  vpc_id      = opentelekomcloud_vpc_v1.vpc_2.id
+  peer_vpc_id = opentelekomcloud_vpc_v1.vpc_3.id
+}
+
+resource "opentelekomcloud_vpc_route_v2" "route_1" {
+  type        = "peering"
+  nexthop     = opentelekomcloud_vpc_peering_connection_v2.peering_1.id
+  destination = "192.168.0.0/16"
+  vpc_id      = opentelekomcloud_vpc_v1.vpc_1.id
+}
+
+resource "opentelekomcloud_vpc_route_v2" "route_2" {
+  type        = "peering"
+  nexthop     = opentelekomcloud_vpc_peering_connection_v2.peering_1.id
+  destination = "192.168.0.0/16"
+  vpc_id      = opentelekomcloud_vpc_v1.vpc_2.id
 }
 
 data "opentelekomcloud_vpc_route_v2" "by_id" {
-		id = opentelekomcloud_vpc_route_v2.route_1.id
+  id = opentelekomcloud_vpc_route_v2.route_1.id
+
+  depends_on = [opentelekomcloud_vpc_route_v2.route_1]
 }
 
 data "opentelekomcloud_vpc_route_v2" "by_vpc_id" {
-		vpc_id = opentelekomcloud_vpc_route_v2.route_1.vpc_id
+  vpc_id      = opentelekomcloud_vpc_route_v2.route_1.vpc_id
+
+  depends_on = [opentelekomcloud_vpc_route_v2.route_1]
 }
 `

--- a/opentelekomcloud/services/vpc/data_source_opentelekomcloud_vpc_route_v2.go
+++ b/opentelekomcloud/services/vpc/data_source_opentelekomcloud_vpc_route_v2.go
@@ -65,7 +65,7 @@ func dataSourceVpcRouteV2Read(_ context.Context, d *schema.ResourceData, meta in
 		Destination: d.Get("destination").(string),
 		VPC_ID:      d.Get("vpc_id").(string),
 		Tenant_Id:   d.Get("tenant_id").(string),
-		RouteID:     d.Id(),
+		RouteID:     d.Get("id").(string), // d.Id() will return an empty string
 	}
 
 	pages, err := routes.List(vpcRouteClient, listOpts).AllPages()
@@ -87,17 +87,17 @@ func dataSourceVpcRouteV2Read(_ context.Context, d *schema.ResourceData, meta in
 			" Please try a more specific search criteria")
 	}
 
-	Route := refinedRoutes[0]
+	route := refinedRoutes[0]
 
-	log.Printf("[INFO] Retrieved Vpc Route using given filter %s: %+v", Route.RouteID, Route)
-	d.SetId(Route.RouteID)
+	log.Printf("[INFO] Retrieved Vpc Route using given filter %s: %+v", route.RouteID, route)
+	d.SetId(route.RouteID)
 
 	mErr := multierror.Append(
-		d.Set("type", Route.Type),
-		d.Set("nexthop", Route.NextHop),
-		d.Set("destination", Route.Destination),
-		d.Set("tenant_id", Route.Tenant_Id),
-		d.Set("vpc_id", Route.VPC_ID),
+		d.Set("type", route.Type),
+		d.Set("nexthop", route.NextHop),
+		d.Set("destination", route.Destination),
+		d.Set("tenant_id", route.Tenant_Id),
+		d.Set("vpc_id", route.VPC_ID),
 		d.Set("region", config.GetRegion(d)),
 	)
 	if err := mErr.ErrorOrNil(); err != nil {

--- a/releasenotes/notes/vpc-route-data-78a50e2f1eee90d9.yaml
+++ b/releasenotes/notes/vpc-route-data-78a50e2f1eee90d9.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[VPC]** Fix not working search by `id` in `data_source/opentelekomcloud_vpc_route_v2` (`#1452 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1452>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Fix reading `id` argument in `data/opentelekomcloud_vpc_route_v2`

Fixes #1451

## PR Checklist

* [x] Refers to: #1451.
* [x] Tests added/passed.
* [x] Release notes.

## Acceptance Steps Performed

```
=== RUN   TestAccVpcRouteV2DataSource_basic
--- PASS: TestAccVpcRouteV2DataSource_basic (91.17s)
PASS

Process finished with the exit code 0

```
