### PR TITLE
[VPC] Fix peering data source querying by `id`

### DIFF
--- a/opentelekomcloud/acceptance/vpc/data_source_opentelekomcloud_vpc_peering_connection_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/data_source_opentelekomcloud_vpc_peering_connection_v2_test.go
@@ -6,8 +6,13 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+)
+
+const (
+	dataSourceVpcPeeringNameID        = "data.opentelekomcloud_vpc_peering_connection_v2.by_id"
+	dataSourceVpcPeeringNameVpcID     = "data.opentelekomcloud_vpc_peering_connection_v2.by_vpc_id"
+	dataSourceVpcPeeringNamePeerVpcID = "data.opentelekomcloud_vpc_peering_connection_v2.by_peer_vpc_id"
 )
 
 func TestAccVpcPeeringConnectionV2DataSource_basic(t *testing.T) {
@@ -18,26 +23,18 @@ func TestAccVpcPeeringConnectionV2DataSource_basic(t *testing.T) {
 			{
 				Config: testAccDataSourceOTCVpcPeeringConnectionV2Config,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckVpcPeeringConnectionV2DataSourceID("data.opentelekomcloud_vpc_peering_connection_v2.by_id"),
-					resource.TestCheckResourceAttr(
-						"data.opentelekomcloud_vpc_peering_connection_v2.by_id", "name", "opentelekomcloud_peering"),
-					resource.TestCheckResourceAttr(
-						"data.opentelekomcloud_vpc_peering_connection_v2.by_id", "status", "ACTIVE"),
-					testAccCheckVpcPeeringConnectionV2DataSourceID("data.opentelekomcloud_vpc_peering_connection_v2.by_vpc_id"),
-					resource.TestCheckResourceAttr(
-						"data.opentelekomcloud_vpc_peering_connection_v2.by_vpc_id", "name", "opentelekomcloud_peering"),
-					resource.TestCheckResourceAttr(
-						"data.opentelekomcloud_vpc_peering_connection_v2.by_vpc_id", "status", "ACTIVE"),
-					testAccCheckVpcPeeringConnectionV2DataSourceID("data.opentelekomcloud_vpc_peering_connection_v2.by_peer_vpc_id"),
-					resource.TestCheckResourceAttr(
-						"data.opentelekomcloud_vpc_peering_connection_v2.by_peer_vpc_id", "name", "opentelekomcloud_peering"),
-					resource.TestCheckResourceAttr(
-						"data.opentelekomcloud_vpc_peering_connection_v2.by_peer_vpc_id", "status", "ACTIVE"),
-					testAccCheckVpcPeeringConnectionV2DataSourceID("data.opentelekomcloud_vpc_peering_connection_v2.by_vpc_ids"),
-					resource.TestCheckResourceAttr(
-						"data.opentelekomcloud_vpc_peering_connection_v2.by_vpc_ids", "name", "opentelekomcloud_peering"),
-					resource.TestCheckResourceAttr(
-						"data.opentelekomcloud_vpc_peering_connection_v2.by_vpc_ids", "status", "ACTIVE"),
+					testAccCheckVpcPeeringConnectionV2DataSourceID(dataSourceVpcPeeringNameID),
+					resource.TestCheckResourceAttr(dataSourceVpcPeeringNameID, "name", "opentelekomcloud_peering_ds"),
+					resource.TestCheckResourceAttr(dataSourceVpcPeeringNameID, "status", "ACTIVE"),
+					testAccCheckVpcPeeringConnectionV2DataSourceID(dataSourceVpcPeeringNameVpcID),
+					resource.TestCheckResourceAttr(dataSourceVpcPeeringNameVpcID, "name", "opentelekomcloud_peering_ds"),
+					resource.TestCheckResourceAttr(dataSourceVpcPeeringNameVpcID, "status", "ACTIVE"),
+					testAccCheckVpcPeeringConnectionV2DataSourceID(dataSourceVpcPeeringNamePeerVpcID),
+					resource.TestCheckResourceAttr(dataSourceVpcPeeringNameVpcID, "name", "opentelekomcloud_peering_ds"),
+					resource.TestCheckResourceAttr(dataSourceVpcPeeringNameVpcID, "status", "ACTIVE"),
+					testAccCheckVpcPeeringConnectionV2DataSourceID(dataSourceVpcPeeringNameVpcID),
+					resource.TestCheckResourceAttr(dataSourceVpcPeeringNameVpcID, "name", "opentelekomcloud_peering_ds"),
+					resource.TestCheckResourceAttr(dataSourceVpcPeeringNameVpcID, "status", "ACTIVE"),
 				),
 			},
 		},
@@ -61,35 +58,46 @@ func testAccCheckVpcPeeringConnectionV2DataSourceID(n string) resource.TestCheck
 
 const testAccDataSourceOTCVpcPeeringConnectionV2Config = `
 resource "opentelekomcloud_vpc_v1" "vpc_1" {
-		name = "vpc_test"
-		cidr = "192.168.0.0/16"
+  name = "vpc_test_ds_peer"
+  cidr = "192.168.0.0/16"
 }
 
 resource "opentelekomcloud_vpc_v1" "vpc_2" {
-		name = "vpc_test1"
-        cidr = "192.168.0.0/16"
+  name = "vpc_test_ds_peer1"
+  cidr = "192.168.0.0/16"
+}
+
+resource "opentelekomcloud_vpc_v1" "vpc_3" {
+  name = "vpc_test_ds_peer_other"
+  cidr = "192.168.0.0/16"
 }
 
 resource "opentelekomcloud_vpc_peering_connection_v2" "peering_1" {
-		name = "opentelekomcloud_peering"
-		vpc_id = opentelekomcloud_vpc_v1.vpc_1.id
-		peer_vpc_id = opentelekomcloud_vpc_v1.vpc_2.id
+  name        = "opentelekomcloud_peering_ds"
+  vpc_id      = opentelekomcloud_vpc_v1.vpc_1.id
+  peer_vpc_id = opentelekomcloud_vpc_v1.vpc_2.id
+}
+
+resource "opentelekomcloud_vpc_peering_connection_v2" "peering_other" {
+  name        = "opentelekomcloud_peering_ds_other"
+  vpc_id      = opentelekomcloud_vpc_v1.vpc_2.id
+  peer_vpc_id = opentelekomcloud_vpc_v1.vpc_3.id
 }
 
 data "opentelekomcloud_vpc_peering_connection_v2" "by_id" {
-		id = opentelekomcloud_vpc_peering_connection_v2.peering_1.id
+  id = opentelekomcloud_vpc_peering_connection_v2.peering_1.id
 }
 
 data "opentelekomcloud_vpc_peering_connection_v2" "by_vpc_id" {
-		vpc_id = opentelekomcloud_vpc_peering_connection_v2.peering_1.vpc_id
+  vpc_id = opentelekomcloud_vpc_peering_connection_v2.peering_1.vpc_id
 }
 
 data "opentelekomcloud_vpc_peering_connection_v2" "by_peer_vpc_id" {
-		peer_vpc_id = opentelekomcloud_vpc_peering_connection_v2.peering_1.peer_vpc_id
+  peer_vpc_id = opentelekomcloud_vpc_peering_connection_v2.peering_1.peer_vpc_id
 }
 
 data "opentelekomcloud_vpc_peering_connection_v2" "by_vpc_ids" {
-		vpc_id = opentelekomcloud_vpc_peering_connection_v2.peering_1.vpc_id
-		peer_vpc_id = opentelekomcloud_vpc_peering_connection_v2.peering_1.peer_vpc_id
+  vpc_id      = opentelekomcloud_vpc_peering_connection_v2.peering_1.vpc_id
+  peer_vpc_id = opentelekomcloud_vpc_peering_connection_v2.peering_1.peer_vpc_id
 }
 `

--- a/opentelekomcloud/services/vpc/data_source_opentelekomcloud_vpc_peering_connection_v2.go
+++ b/opentelekomcloud/services/vpc/data_source_opentelekomcloud_vpc_peering_connection_v2.go
@@ -62,7 +62,7 @@ func dataSourceVpcPeeringConnectionV2Read(_ context.Context, d *schema.ResourceD
 	}
 
 	listOpts := peerings.ListOpts{
-		ID:         d.Id(),
+		ID:         d.Get("id").(string),
 		Name:       d.Get("name").(string),
 		Status:     d.Get("status").(string),
 		TenantId:   d.Get("peer_tenant_id").(string),

--- a/releasenotes/notes/vpc-peering-data-845d4850e56c72a6.yaml
+++ b/releasenotes/notes/vpc-peering-data-845d4850e56c72a6.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[VPC]** Fix not working search by `id` in `data_source/opentelekomcloud_vpc_peering_connection_v2` (`#1455 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1455>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Fix #1454 

## PR Checklist

* [x] Refers to: #1454
* [x] Tests added/passed.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccVpcPeeringConnectionV2DataSource_basic
--- PASS: TestAccVpcPeeringConnectionV2DataSource_basic (63.43s)
PASS

Process finished with the exit code 0
```
