### PR TITLE
Acceptance: allow quota multiplication

### DIFF
--- a/opentelekomcloud/acceptance/common/quotas/quotas.go
+++ b/opentelekomcloud/acceptance/common/quotas/quotas.go
@@ -132,6 +132,25 @@ type ExpectedQuota struct {
 	Count int64
 }
 
+// X multiples quota returning new `ExpectedQuota` instance
+func (q ExpectedQuota) X(multiplier int64) *ExpectedQuota {
+	return &ExpectedQuota{
+		Q:     q.Q,
+		Count: q.Count * multiplier,
+	}
+}
+
+type MultipleQuotas []*ExpectedQuota
+
+// X multiples quota returning new `MultipleQuotas` instance
+func (q MultipleQuotas) X(multiplier int64) MultipleQuotas {
+	newOne := make(MultipleQuotas, len(q))
+	for i, q := range q {
+		newOne[i] = q.X(multiplier)
+	}
+	return newOne
+}
+
 // AcquireMultipleQuotas tries to acquire all given quotas, reverting on failure
 func AcquireMultipleQuotas(e []*ExpectedQuota, interval time.Duration) error {
 	// validate if all Count values of ExpectQuota are correct

--- a/opentelekomcloud/acceptance/common/quotas/quotas_test.go
+++ b/opentelekomcloud/acceptance/common/quotas/quotas_test.go
@@ -138,3 +138,19 @@ func TestQuota_MultipleUnreleased(t *testing.T) {
 	err := AcquireMultipleQuotas(qts, 0)
 	th.AssertEquals(t, namelessTimeout, err.Error())
 }
+
+func TestMultipleQuotas(t *testing.T) {
+	q1, _ := NewQuotaWithTimeout(3, 2*time.Millisecond)
+	q2, _ := NewQuotaWithTimeout(3, 2*time.Millisecond)
+	qtsOrig := MultipleQuotas{{q1, 1}, {q2, 1}}
+
+	qts := qtsOrig.X(2)
+
+	th.AssertEquals(t, qts[0].Q, qtsOrig[0].Q)
+	th.AssertEquals(t, qts[0].Count, qtsOrig[0].Count*2)
+
+	th.AssertNoErr(t, AcquireMultipleQuotas(qts, 0))     // -2
+	th.AssertNoErr(t, AcquireMultipleQuotas(qtsOrig, 0)) // -1
+	err := AcquireMultipleQuotas(qtsOrig, 0)
+	th.AssertEquals(t, namelessTimeout, err.Error())
+}


### PR DESCRIPTION
## Summary of the Pull Request
Allow `ExpectedQuota` to be multiplied

Introduce `MultipleQuotas` type supporting multiplication
