### PR TITLE
[CCE] Fix import crash in `cce_node_pool_v3`

### DIFF
--- a/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_pool_v3.go
+++ b/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_pool_v3.go
@@ -562,19 +562,9 @@ func resourceCCENodePoolV3Import(ctx context.Context, d *schema.ResourceData, me
 	}
 	clusterID := parts[0]
 	nodePool := parts[1]
-
 	d.SetId(nodePool)
 	if err := d.Set("cluster_id", clusterID); err != nil {
 		return nil, err
 	}
-
-	results := make([]*schema.ResourceData, 1)
-
-	if diagRead := resourceCCENodePoolV3Read(ctx, d, meta); diagRead.HasError() {
-		return nil, fmt.Errorf("error reading opentelekomcloud_cce_node_pool_v3 %s: %s", d.Id(), diagRead[0].Summary)
-	}
-
-	results[0] = d
-
-	return results, nil
+	return schema.ImportStatePassthroughContext(ctx, d, meta)
 }

--- a/releasenotes/notes/cce-node-pool-import-0b6d85c1e91ea2e3.yaml
+++ b/releasenotes/notes/cce-node-pool-import-0b6d85c1e91ea2e3.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[CCE]** Fix import crash in ``resource/opentelekomcloud_cce_node_pool_v3`` (`#1478 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1478>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Simplify `Importer` of `opentelekomcloud_cce_node_pool_v3` resource

Remove redundant read in `resourceCCENodePoolV3Import`

Fix #1477

## PR Checklist

* [x] Refers to: #1477
* [x] Tests added/passed.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccCCENodePoolV3ImportBasic
--- PASS: TestAccCCENodePoolV3ImportBasic (748.75s)
PASS

Process finished with the exit code 0

```
