### PR TITLE
[ELB] Add import support for `lb_balancer_v2`

### DIFF
--- a/docs/resources/lb_loadbalancer_v2.md
+++ b/docs/resources/lb_loadbalancer_v2.md
@@ -112,3 +112,11 @@ The following attributes are exported:
 * `vip_port_id` - The Port ID of the Load Balancer IP.
 
 * `tags` - See Argument Reference above.
+
+## Import
+
+Load balancers can be imported using the `id`, e.g.
+
+```sh
+terraform import opentelekomcloud_lb_loadbalancer_v2.lb_1 ec2e6489-8415-4ec0-9934-540f98b0d594
+```

--- a/opentelekomcloud/services/elb/v2/resource_opentelekomcloud_lb_loadbalancer_v2.go
+++ b/opentelekomcloud/services/elb/v2/resource_opentelekomcloud_lb_loadbalancer_v2.go
@@ -30,6 +30,10 @@ func ResourceLoadBalancerV2() *schema.Resource {
 			Delete: schema.DefaultTimeout(5 * time.Minute),
 		},
 
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:     schema.TypeString,

--- a/releasenotes/notes/elbv2-lb-import-3312b78c89a25746.yaml
+++ b/releasenotes/notes/elbv2-lb-import-3312b78c89a25746.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[ELB]** Add import support for ``opentelekomcloud_lb_loadbalancer_v2`` resource (`#1516 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1516>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Add import support in `resource/opentelekomcloud_lb_loadbalancer_v2`

Resolve #1515 

## PR Checklist

* [x] Refers to: #1515
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccLBV2LoadBalancer_basic
=== PAUSE TestAccLBV2LoadBalancer_basic
=== CONT  TestAccLBV2LoadBalancer_basic
--- PASS: TestAccLBV2LoadBalancer_basic (76.80s)
=== RUN   TestAccLBV2LoadBalancer_import
=== PAUSE TestAccLBV2LoadBalancer_import
=== CONT  TestAccLBV2LoadBalancer_import
--- PASS: TestAccLBV2LoadBalancer_import (46.19s)
PASS

Process finished with the exit code 0
```
