### PR TITLE
Improve documentation for load balancers

### DIFF
--- a/docs/resources/elb_backend.md
+++ b/docs/resources/elb_backend.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Elastic Load Balance (ELB)"
+subcategory: "Classic Load Balancer (LB)"
 ---
 
 # opentelekomcloud_elb_backend
@@ -8,6 +8,7 @@ Manages a classic loadbalancer backend resource within OpenTelekomCloud.
 
 ~>
 Classic load balancers are no longer provided. Please use elastic load balancers instead.
+This resource was replaced with `opentelekomcloud_lb_member_v2`.
 
 ## Example Usage
 

--- a/docs/resources/elb_health.md
+++ b/docs/resources/elb_health.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Elastic Load Balance (ELB)"
+subcategory: "Classic Load Balancer (LB)"
 ---
 
 # opentelekomcloud_elb_health
@@ -8,6 +8,7 @@ Manages a classic loadbalancer health resource within OpenTelekomCloud.
 
 ~>
 Classic load balancers are no longer provided. Please use elastic load balancers instead.
+This resource was replaced with `opentelekomcloud_lb_monitor_v2`.
 
 ## Example Usage
 

--- a/docs/resources/elb_listener.md
+++ b/docs/resources/elb_listener.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Elastic Load Balance (ELB)"
+subcategory: "Classic Load Balancer (LB)"
 ---
 
 # opentelekomcloud_elb_listener
@@ -8,6 +8,7 @@ Manages a classic loadbalancer listener resource within OpenTelekomCloud.
 
 ~>
 Classic load balancers are no longer provided. Please use elastic load balancers instead.
+This resource was replaced with `opentelekomcloud_lb_listener_v2`.
 
 ## Example Usage
 

--- a/docs/resources/elb_loadbalancer.md
+++ b/docs/resources/elb_loadbalancer.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Elastic Load Balance (ELB)"
+subcategory: "Classic Load Balancer (LB)"
 ---
 
 # opentelekomcloud_elb_loadbalancer
@@ -8,6 +8,7 @@ Manages a classic loadbalancer resource within OpenTelekomCloud.
 
 ~>
 Classic load balancers are no longer provided. Please use elastic load balancers instead.
+This resource was replaced with `opentelekomcloud_lb_loadbalancer_v2`.
 
 ## Example Usage
 

--- a/docs/resources/lb_certificate_v2.md
+++ b/docs/resources/lb_certificate_v2.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Elastic Load Balance (ELB)"
+subcategory: "Elastic Load Balancer (ELB)"
 ---
 
 # opentelekomcloud_lb_certificate_v2

--- a/docs/resources/lb_l7policy_v2.md
+++ b/docs/resources/lb_l7policy_v2.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Elastic Load Balance (ELB)"
+subcategory: "Elastic Load Balancer (ELB)"
 ---
 
 # opentelekomcloud_lb_l7policy_v2

--- a/docs/resources/lb_l7rule_v2.md
+++ b/docs/resources/lb_l7rule_v2.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Elastic Load Balance (ELB)"
+subcategory: "Elastic Load Balancer (ELB)"
 ---
 
 # opentelekomcloud_lb_l7rule_v2

--- a/docs/resources/lb_listener_v2.md
+++ b/docs/resources/lb_listener_v2.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Elastic Load Balance (ELB)"
+subcategory: "Elastic Load Balancer (ELB)"
 ---
 
 # opentelekomcloud_lb_listener_v2

--- a/docs/resources/lb_loadbalancer_v2.md
+++ b/docs/resources/lb_loadbalancer_v2.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Elastic Load Balance (ELB)"
+subcategory: "Elastic Load Balancer (ELB)"
 ---
 
 # opentelekomcloud_lb_loadbalancer_v2

--- a/docs/resources/lb_member_v2.md
+++ b/docs/resources/lb_member_v2.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Elastic Load Balance (ELB)"
+subcategory: "Elastic Load Balancer (ELB)"
 ---
 
 # opentelekomcloud_lb_member_v2

--- a/docs/resources/lb_monitor_v2.md
+++ b/docs/resources/lb_monitor_v2.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Elastic Load Balance (ELB)"
+subcategory: "Elastic Load Balancer (ELB)"
 ---
 
 # opentelekomcloud_lb_monitor_v2

--- a/docs/resources/lb_pool_v2.md
+++ b/docs/resources/lb_pool_v2.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Elastic Load Balance (ELB)"
+subcategory: "Elastic Load Balancer (ELB)"
 ---
 
 # opentelekomcloud_lb_pool_v2

--- a/docs/resources/lb_whitelist_v2.md
+++ b/docs/resources/lb_whitelist_v2.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Elastic Load Balance (ELB)"
+subcategory: "Elastic Load Balancer (ELB)"
 ---
 
 # opentelekomcloud_lb_whitelist_v2

--- a/releasenotes/notes/elb-doc-0d490885cab18cfb.yaml
+++ b/releasenotes/notes/elb-doc-0d490885cab18cfb.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    [ELB] Improve documentation of loadbalancer resources (`#1520 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1520>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Change `LBv1` resource category to `Classic Load Balancer (LB)`

Point to the replacing resource in `LBv1` deprecation notes

Fix `ELB` category name

Resolve #1519

## PR Checklist

* [x] Refers to: #1519
* [x] Documentation updated.
* [x] Release notes added.
