### PR TITLE
Acceptance: fix ELBv3 quota usage

### DIFF
--- a/opentelekomcloud/acceptance/elb/v3/resource_opentelekomcloud_lb_listener_v3_test.go
+++ b/opentelekomcloud/acceptance/elb/v3/resource_opentelekomcloud_lb_listener_v3_test.go
@@ -3,6 +3,7 @@ package acceptance
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -21,14 +22,13 @@ func TestAccLBV3Listener_basic(t *testing.T) {
 	var listener listeners.Listener
 
 	t.Parallel()
-	th.AssertNoErr(t, quotas.LbCertificate.Acquire())
-	th.AssertNoErr(t, quotas.LoadBalancer.Acquire())
-	th.AssertNoErr(t, quotas.LbListener.Acquire())
-	defer func() {
-		quotas.LbListener.Release()
-		quotas.LoadBalancer.Release()
-		quotas.LbCertificate.Release()
-	}()
+	qts := []*quotas.ExpectedQuota{
+		{Q: quotas.LbCertificate, Count: 1},
+		{Q: quotas.LoadBalancer, Count: 1},
+		{Q: quotas.LbListener, Count: 1},
+	}
+	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
+	defer quotas.ReleaseMultipleQuotas(qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -56,14 +56,13 @@ func TestAccLBV3Listener_basic(t *testing.T) {
 
 func TestAccLBV3Listener_import(t *testing.T) {
 	t.Parallel()
-	th.AssertNoErr(t, quotas.LbCertificate.Acquire())
-	th.AssertNoErr(t, quotas.LoadBalancer.Acquire())
-	th.AssertNoErr(t, quotas.LbListener.Acquire())
-	defer func() {
-		quotas.LbListener.Release()
-		quotas.LoadBalancer.Release()
-		quotas.LbCertificate.Release()
-	}()
+	qts := []*quotas.ExpectedQuota{
+		{Q: quotas.LbCertificate, Count: 1},
+		{Q: quotas.LoadBalancer, Count: 1},
+		{Q: quotas.LbListener, Count: 1},
+	}
+	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
+	defer quotas.ReleaseMultipleQuotas(qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },

--- a/opentelekomcloud/acceptance/elb/v3/resource_opentelekomcloud_lb_member_v3_test.go
+++ b/opentelekomcloud/acceptance/elb/v3/resource_opentelekomcloud_lb_member_v3_test.go
@@ -22,7 +22,10 @@ const resourceMemberName = "opentelekomcloud_lb_member_v3.member"
 func TestLBMemberV3_basic(t *testing.T) {
 	var member members.Member
 	t.Parallel()
-	qts := lbQuotas()
+	qts := []*quotas.ExpectedQuota{
+		{Q: quotas.LbPool, Count: 1},
+		{Q: quotas.LoadBalancer, Count: 1},
+	}
 	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
 	defer quotas.ReleaseMultipleQuotas(qts)
 
@@ -53,7 +56,10 @@ func TestLBMemberV3_basic(t *testing.T) {
 
 func TestLBMemberV3_import(t *testing.T) {
 	t.Parallel()
-	qts := lbQuotas()
+	qts := []*quotas.ExpectedQuota{
+		{Q: quotas.LbPool, Count: 1},
+		{Q: quotas.LoadBalancer, Count: 1},
+	}
 	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
 	defer quotas.ReleaseMultipleQuotas(qts)
 

--- a/opentelekomcloud/acceptance/elb/v3/resource_opentelekomcloud_lb_policy_v3_test.go
+++ b/opentelekomcloud/acceptance/elb/v3/resource_opentelekomcloud_lb_policy_v3_test.go
@@ -27,7 +27,6 @@ func TestAccLBV3Policy_basic(t *testing.T) {
 		{Q: quotas.LbPolicy, Count: 1},
 		{Q: quotas.LoadBalancer, Count: 1},
 		{Q: quotas.LbListener, Count: 1},
-		{Q: quotas.Server, Count: 1},
 	}
 	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
 	defer quotas.ReleaseMultipleQuotas(qts)
@@ -60,7 +59,6 @@ func TestAccLBPolicyV3_import(t *testing.T) {
 		{Q: quotas.LbPolicy, Count: 1},
 		{Q: quotas.LoadBalancer, Count: 1},
 		{Q: quotas.LbListener, Count: 1},
-		{Q: quotas.Server, Count: 1},
 	}
 	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
 	defer quotas.ReleaseMultipleQuotas(qts)

--- a/opentelekomcloud/acceptance/elb/v3/resource_opentelekomcloud_lb_pool_v3_test.go
+++ b/opentelekomcloud/acceptance/elb/v3/resource_opentelekomcloud_lb_pool_v3_test.go
@@ -21,7 +21,10 @@ const resourcePoolName = "opentelekomcloud_lb_pool_v3.pool"
 func TestLBPoolV3_basic(t *testing.T) {
 	var pool pools.Pool
 	t.Parallel()
-	qts := lbQuotas()
+	qts := []*quotas.ExpectedQuota{
+		{Q: quotas.LbPool, Count: 1},
+		{Q: quotas.LoadBalancer, Count: 1},
+	}
 	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
 	defer quotas.ReleaseMultipleQuotas(qts)
 
@@ -52,7 +55,10 @@ func TestLBPoolV3_basic(t *testing.T) {
 
 func TestLBPoolV3_import(t *testing.T) {
 	t.Parallel()
-	qts := lbQuotas()
+	qts := []*quotas.ExpectedQuota{
+		{Q: quotas.LbPool, Count: 1},
+		{Q: quotas.LoadBalancer, Count: 1},
+	}
 	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
 	defer quotas.ReleaseMultipleQuotas(qts)
 


### PR DESCRIPTION
## Summary of the Pull Request
Fix quotas used in ELBv3 acceptance tests

## PR Checklist

* [x] Tests added/passed.

## Acceptance Steps Performed

```
=== RUN   TestLBFlavorV3_basic
=== PAUSE TestLBFlavorV3_basic
=== CONT  TestLBFlavorV3_basic
--- PASS: TestLBFlavorV3_basic (18.06s)
=== RUN   TestLBFlavorV3_byID
=== PAUSE TestLBFlavorV3_byID
=== CONT  TestLBFlavorV3_byID
--- PASS: TestLBFlavorV3_byID (16.97s)
=== RUN   TestAccLBV3Certificate_basic
=== PAUSE TestAccLBV3Certificate_basic
=== CONT  TestAccLBV3Certificate_basic
--- PASS: TestAccLBV3Certificate_basic (66.59s)
=== RUN   TestAccLBv3Certificate_importBasic
=== PAUSE TestAccLBv3Certificate_importBasic
=== CONT  TestAccLBv3Certificate_importBasic
--- PASS: TestAccLBv3Certificate_importBasic (24.63s)
=== RUN   TestAccLBV3Listener_basic
=== PAUSE TestAccLBV3Listener_basic
=== CONT  TestAccLBV3Listener_basic
--- PASS: TestAccLBV3Listener_basic (46.86s)
=== RUN   TestAccLBV3Listener_import
=== PAUSE TestAccLBV3Listener_import
=== CONT  TestAccLBV3Listener_import
--- PASS: TestAccLBV3Listener_import (31.45s)
=== RUN   TestAccLBV3LoadBalancer_basic
=== PAUSE TestAccLBV3LoadBalancer_basic
=== CONT  TestAccLBV3LoadBalancer_basic
--- PASS: TestAccLBV3LoadBalancer_basic (47.45s)
=== RUN   TestLBMemberV3_basic
=== PAUSE TestLBMemberV3_basic
=== CONT  TestLBMemberV3_basic
--- PASS: TestLBMemberV3_basic (48.71s)
=== RUN   TestLBMemberV3_import
=== PAUSE TestLBMemberV3_import
=== CONT  TestLBMemberV3_import
--- PASS: TestLBMemberV3_import (32.64s)
=== RUN   TestAccLBV3Policy_basic
=== PAUSE TestAccLBV3Policy_basic
=== CONT  TestAccLBV3Policy_basic
--- PASS: TestAccLBV3Policy_basic (47.75s)
=== RUN   TestAccLBPolicyV3_import
=== PAUSE TestAccLBPolicyV3_import
=== CONT  TestAccLBPolicyV3_import
--- PASS: TestAccLBPolicyV3_import (32.48s)
=== RUN   TestLBPoolV3_basic
=== PAUSE TestLBPoolV3_basic
=== CONT  TestLBPoolV3_basic
--- PASS: TestLBPoolV3_basic (46.50s)
=== RUN   TestLBPoolV3_import
=== PAUSE TestLBPoolV3_import
=== CONT  TestLBPoolV3_import
--- PASS: TestLBPoolV3_import (31.87s)
PASS

Process finished with the exit code 0

```
