### PR TITLE
[SFS-Turbo] doc-fix import resource

### DIFF
--- a/docs/resources/sfs_turbo_share_v1.md
+++ b/docs/resources/sfs_turbo_share_v1.md
@@ -85,5 +85,5 @@ This resource provides the following timeouts configuration options:
 SFS Turbo can be imported using the `id`, e.g.
 
 ```shell
-terraform import opentelekomcloud_sfs_turbo_v1 9e3dd316-64g9-0245-8456-71e9387d71ab
+terraform import opentelekomcloud_sfs_turbo_share_v1 9e3dd316-64g9-0245-8456-71e9387d71ab
 ```

--- a/docs/resources/sfs_turbo_share_v1.md
+++ b/docs/resources/sfs_turbo_share_v1.md
@@ -84,6 +84,6 @@ This resource provides the following timeouts configuration options:
 
 SFS Turbo can be imported using the `id`, e.g.
 
-```
-$ terraform import opentelekomcloud_sfs_turbo_v1 9e3dd316-64g9-0245-8456-71e9387d71ab
+```shell
+terraform import opentelekomcloud_sfs_turbo_v1 9e3dd316-64g9-0245-8456-71e9387d71ab
 ```


### PR DESCRIPTION
## Summary of the Pull Request

- fixed wrong resource name reference in import example for resource `opentelekomcloud_sfs_turbo_share_v1`
- updated linting and format

## PR Checklist

* [ ] Refers to: #xxx
* [ ] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.
* [ ] Release notes added.