### PR TITLE
[ELB] Fix wrong field name in `r/lb_listener_v3`

### DIFF
--- a/opentelekomcloud/services/elb/v3/resource_opentelekomcloud_lb_listener_v3.go
+++ b/opentelekomcloud/services/elb/v3/resource_opentelekomcloud_lb_listener_v3.go
@@ -91,7 +91,7 @@ func ResourceListenerV3() *schema.Resource {
 					"tls-1-0", "tls-1-1", "tls-1-2", "tls-1-2-strict",
 				}, false),
 			},
-			"memory_retry_enable": {
+			"member_retry_enable": {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
@@ -189,7 +189,7 @@ func resourceListenerV3Create(ctx context.Context, d *schema.ResourceData, meta 
 
 	adminStateUp := d.Get("admin_state_up").(bool)
 	http2Enable := d.Get("http2_enable").(bool)
-	memoryRetryEnable := d.Get("memory_retry_enable").(bool)
+	memberRetryEnable := d.Get("member_retry_enable").(bool)
 	createOpts := listeners.CreateOpts{
 		AdminStateUp:           &adminStateUp,
 		CAContainerRef:         d.Get("client_ca_tls_container_ref").(string),
@@ -204,7 +204,7 @@ func resourceListenerV3Create(ctx context.Context, d *schema.ResourceData, meta 
 		SniContainerRefs:       common.ExpandToStringSlice(d.Get("sni_container_refs").(*schema.Set).List()),
 		Tags:                   common.ExpandResourceTags(d.Get("tags").(map[string]interface{})),
 		TlsCiphersPolicy:       d.Get("tls_ciphers_policy").(string),
-		EnableMemberRetry:      &memoryRetryEnable,
+		EnableMemberRetry:      &memberRetryEnable,
 		KeepAliveTimeout:       d.Get("keep_alive_timeout").(int),
 		ClientTimeout:          d.Get("client_timeout").(int),
 		MemberTimeout:          d.Get("member_timeout").(int),
@@ -264,7 +264,7 @@ func setLBListenerFields(d *schema.ResourceData, listener *listeners.Listener) d
 		d.Set("protocol_port", listener.ProtocolPort),
 		d.Set("sni_container_refs", listener.SniContainerRefs),
 		d.Set("tls_ciphers_policy", listener.TlsCiphersPolicy),
-		d.Set("memory_retry_enable", listener.EnableMemberRetry),
+		d.Set("member_retry_enable", listener.EnableMemberRetry),
 		d.Set("keep_alive_timeout", listener.KeepAliveTimeout),
 		d.Set("client_timeout", listener.ClientTimeout),
 		d.Set("member_timeout", listener.MemberTimeout),

--- a/releasenotes/notes/elbv3-listener-schema-7c727a3a388c12fb.yaml
+++ b/releasenotes/notes/elbv3-listener-schema-7c727a3a388c12fb.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[ELB]** Fix wrong name of field ``member_retry_enable`` in ``resource/opentelekomcloud_lb_listener_v3`` (`#1532 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1532>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Fix wrong field name `member_retry_enable` in `resource/opentelekomcloud_lb_listener_v3`
Fixes: #1528

## PR Checklist

* [x] Refers to: #1528
* [x] Tests added/passed.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccLBV3Listener_basic
=== PAUSE TestAccLBV3Listener_basic
=== CONT  TestAccLBV3Listener_basic
--- PASS: TestAccLBV3Listener_basic (132.20s)
=== RUN   TestAccLBV3Listener_import
=== PAUSE TestAccLBV3Listener_import
=== CONT  TestAccLBV3Listener_import
--- PASS: TestAccLBV3Listener_import (93.06s)
PASS

Process finished with the exit code 0
```
