### PR TITLE
[EVS] Improve handling `volume_v2` metadata diff

### DIFF
--- a/opentelekomcloud/services/evs/resource_opentelekomcloud_blockstorage_volume_v2.go
+++ b/opentelekomcloud/services/evs/resource_opentelekomcloud_blockstorage_volume_v2.go
@@ -75,7 +75,7 @@ func ResourceBlockStorageVolumeV2() *schema.Resource {
 				Optional:         true,
 				ForceNew:         false,
 				Computed:         true,
-				DiffSuppressFunc: suppressMetadataPolicy,
+				DiffSuppressFunc: suppressMetadataComputed,
 			},
 			"snapshot_id": {
 				Type:     schema.TypeString,
@@ -502,8 +502,13 @@ func resourceVolumeV2AttachmentHash(v interface{}) int {
 	return hashcode.String(buf.String())
 }
 
-func suppressMetadataPolicy(k, old, new string, _ *schema.ResourceData) bool {
-	if k == "metadata.policy" { // metadata.policy is set by service
+var suppressedVolumeFields = []string{
+	"metadata.policy",
+	"metadata.backupId",
+}
+
+func suppressMetadataComputed(k, old, new string, _ *schema.ResourceData) bool {
+	if common.StringInSlice(k, suppressedVolumeFields) {
 		return true
 	}
 	return old == new

--- a/releasenotes/notes/evs-volume-metadata-8f2260219a0f1eb6.yaml
+++ b/releasenotes/notes/evs-volume-metadata-8f2260219a0f1eb6.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    **[EVS]** Ignore changes of ``metadata.backupId`` in ``resource/opentelekomcloud_blockstorage_volume_v2``
+    (`#1533 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1533>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Ignore diffs in `metadata.backupId` field of `opentelekomcloud_blockstorage_volume_v2` resource


## PR Checklist

* [x] Refers to: #1514 
* [x] Tests added/passed.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccBlockStorageV2Volume_basic
=== PAUSE TestAccBlockStorageV2Volume_basic
=== CONT  TestAccBlockStorageV2Volume_basic
--- PASS: TestAccBlockStorageV2Volume_basic (63.91s)
=== RUN   TestAccBlockStorageV2Volume_upscaleDownScale
=== PAUSE TestAccBlockStorageV2Volume_upscaleDownScale
=== CONT  TestAccBlockStorageV2Volume_upscaleDownScale
--- PASS: TestAccBlockStorageV2Volume_upscaleDownScale (117.56s)
=== RUN   TestAccBlockStorageV2Volume_upscaleDownScaleAssigned
=== PAUSE TestAccBlockStorageV2Volume_upscaleDownScaleAssigned
=== CONT  TestAccBlockStorageV2Volume_upscaleDownScaleAssigned
--- PASS: TestAccBlockStorageV2Volume_upscaleDownScaleAssigned (208.15s)
=== RUN   TestAccBlockStorageV2Volume_policy
=== PAUSE TestAccBlockStorageV2Volume_policy
=== CONT  TestAccBlockStorageV2Volume_policy
--- PASS: TestAccBlockStorageV2Volume_policy (71.37s)
=== RUN   TestAccBlockStorageV2Volume_tags
=== PAUSE TestAccBlockStorageV2Volume_tags
=== CONT  TestAccBlockStorageV2Volume_tags
--- PASS: TestAccBlockStorageV2Volume_tags (67.88s)
=== RUN   TestAccBlockStorageV2Volume_image
=== PAUSE TestAccBlockStorageV2Volume_image
=== CONT  TestAccBlockStorageV2Volume_image
--- PASS: TestAccBlockStorageV2Volume_image (50.63s)
=== RUN   TestAccBlockStorageV2Volume_timeout
=== PAUSE TestAccBlockStorageV2Volume_timeout
=== CONT  TestAccBlockStorageV2Volume_timeout
--- PASS: TestAccBlockStorageV2Volume_timeout (45.58s)
PASS

Process finished with the exit code 0
```
