### PR TITLE
[CCE] Add missing node pool `extendParams`

### DIFF
--- a/docs/resources/cce_node_pool_v3.md
+++ b/docs/resources/cce_node_pool_v3.md
@@ -73,6 +73,15 @@ The following arguments are supported:
 * `postinstall` - (Optional) Script required after installation. The input value can be a Base64 encoded string or not.
   Changing this parameter will create a new resource.
 
+* `max_pods` - (Optional) The maximum number of instances a node is allowed to create.
+  Changing this parameter will create a new node pool.
+
+* `docker_base_size` - (Optional) Available disk space of a single Docker container on the node using the device mapper.
+  Changing this parameter will create a new node pool.
+
+* `docker_lvm_config_override` - (Optional) `ConfigMap` of the Docker data disk.
+  Changing this parameter will create a new node.
+
 * `scale_enable` - (Optional) Whether to enable auto scaling. If Autoscaler is enabled, install the autoscaler add-on to use the auto scaling feature.
 
 * `min_node_count` - (Optional) Minimum number of nodes allowed if auto scaling is enabled.

--- a/docs/resources/cce_node_v3.md
+++ b/docs/resources/cce_node_v3.md
@@ -99,7 +99,7 @@ The following arguments are supported:
 
 * `product_id` - (Optional) The Product ID. Changing this parameter will create a new cluster resource.
 
-* `max_pods` - (Optional) The maximum number of instances a node is allowed to create. Changing this parameter will create a new cluster resource.
+* `max_pods` - (Optional) The maximum number of instances a node is allowed to create. Changing this parameter will create a new node resource.
 
 * `public_key` - (Optional) The Public key. Changing this parameter will create a new cluster resource.
 
@@ -112,8 +112,10 @@ The following arguments are supported:
   Changing this parameter will create a new resource.
 
 * `docker_base_size` - (Optional) Available disk space of a single Docker container on the node using the device mapper.
+  Changing this parameter will create a new node.
 
 * `docker_lvm_config_override` - (Optional) `ConfigMap` of the Docker data disk.
+  Changing this parameter will create a new node.
 
   Example:
 

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/jinzhu/copier v0.2.3
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.5.6-0.20211116100039-008f098aa0c8
+	github.com/opentelekomcloud/gophertelekomcloud v0.5.6-0.20211117103649-858b4c37ae87
 	github.com/unknwon/com v1.0.1
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -287,8 +287,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.5.6-0.20211116100039-008f098aa0c8 h1:i6OzTlyGlgUhFAimIIdrl5tMjJbYffB2XYjLPI4bDdQ=
-github.com/opentelekomcloud/gophertelekomcloud v0.5.6-0.20211116100039-008f098aa0c8/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
+github.com/opentelekomcloud/gophertelekomcloud v0.5.6-0.20211117103649-858b4c37ae87 h1:Tn2l7VdjvwGDyTqFkeycc7UaL9POLsOpBMOZ01i6vqQ=
+github.com/opentelekomcloud/gophertelekomcloud v0.5.6-0.20211117103649-858b4c37ae87/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_pool_v3.go
+++ b/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_pool_v3.go
@@ -210,6 +210,21 @@ func ResourceCCENodePoolV3() *schema.Resource {
 				ForceNew:  true,
 				StateFunc: common.GetHashOrEmpty,
 			},
+			"max_pods": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+			},
+			"docker_base_size": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+			},
+			"docker_lvm_config_override": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 			"scale_enable": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -308,8 +323,11 @@ func resourceCCENodePoolV3Create(ctx context.Context, d *schema.ResourceData, me
 					},
 				},
 				ExtendParam: nodes.ExtendParam{
-					PreInstall:  base64PreInstall,
-					PostInstall: base64PostInstall,
+					MaxPods:                 d.Get("max_pods").(int),
+					PreInstall:              base64PreInstall,
+					PostInstall:             base64PostInstall,
+					DockerBaseSize:          d.Get("docker_base_size").(int),
+					DockerLVMConfigOverride: d.Get("docker_lvm_config_override").(string),
 				},
 				Taints:   resourceCCENodeTaints(d),
 				K8sTags:  resourceCCENodeK8sTags(d),

--- a/releasenotes/notes/cce-node-pool-ext-param-f5f051337bbe24e8.yaml
+++ b/releasenotes/notes/cce-node-pool-ext-param-f5f051337bbe24e8.yaml
@@ -1,0 +1,5 @@
+enhancements:
+  - |
+    **[CCE]** Add extend params to the ``resource/opentelekomcloud_cce_node_pool_v3``:
+    ``max_pods``, ``docker_base_size``, ``docker_lvm_config_override``
+    (`#1537 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1537>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Add `docker_base_size`, `docker_lvm_config_override` and `max_pods` arguments
to `resource/opentelekomcloud_cce_node_pool_v3`

Resolve #1535 

## PR Checklist

* [x] Refers to: #1535
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccCCENodePoolsV3ExtendParams
--- PASS: TestAccCCENodePoolsV3ExtendParams (1066.17s)
PASS

Process finished with the exit code 0

```

Additionally checked set values via `kubectl`
