### PR TITLE
[VPC] Add `vpc_bandwidth_v2` resource

### DIFF
--- a/docs/resources/vpc_bandwidth_v2.md
+++ b/docs/resources/vpc_bandwidth_v2.md
@@ -8,7 +8,7 @@ Provides a resource to create a shared bandwidth within OpenTelekomCloud.
 ## Example Usage
 
 ```hcl
-resource "opentelekomcloud_vpc_bandwidth_v2" "100mb" {
+resource "opentelekomcloud_vpc_bandwidth_v2" "band_100mb" {
   name = "shared-100Mbit"
   size = 100
 }
@@ -42,5 +42,5 @@ In addition, the following attributes are exported:
 VPC bandwidth can be imported using the `id`, e.g.
 
 ```sh
-terraform import opentelekomcloud_vpc_bandwidth_v2.100mb eb187fc8-e482-43eb-a18a-9da947ef89f6
+terraform import opentelekomcloud_vpc_bandwidth_v2.band_100mb eb187fc8-e482-43eb-a18a-9da947ef89f6
 ```

--- a/docs/resources/vpc_bandwidth_v2.md
+++ b/docs/resources/vpc_bandwidth_v2.md
@@ -1,0 +1,46 @@
+---
+subcategory: "Virtual Private Cloud (VPC)"
+---
+# opentelekomcloud_vpc_bandwidth_v2
+
+Provides a resource to create a shared bandwidth within OpenTelekomCloud.
+
+## Example Usage
+
+```hcl
+resource "opentelekomcloud_vpc_bandwidth_v2" "100mb" {
+  name = "shared-100Mbit"
+  size = 100
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Specifies the bandwidth name.
+
+  The value is a string of 1 to 64 characters that can contain letters, digits, underscores (_), hyphens (-), and periods (.).
+
+* `size` - (Required) Specifies the bandwidth size.
+  The value ranges from 5 Mbit/s to 1000 Mbit/s by default.
+
+->
+  The specific range may vary depending on the configuration in each region.
+  You can see the available bandwidth range on the management console.
+
+## Attributes Reference
+
+In addition, the following attributes are exported:
+
+* `id` - Specifies the bandwidth ID, which uniquely identifies the bandwidth.
+
+* `status` - Specifies the bandwidth status.
+
+## Import
+
+VPC bandwidth can be imported using the `id`, e.g.
+
+```sh
+terraform import opentelekomcloud_vpc_bandwidth_v2.100mb eb187fc8-e482-43eb-a18a-9da947ef89f6
+```

--- a/opentelekomcloud/acceptance/common/quotas/quotas.go
+++ b/opentelekomcloud/acceptance/common/quotas/quotas.go
@@ -125,7 +125,8 @@ var (
 	// Networking
 
 	// FloatingIP - shared floating IP quota
-	FloatingIP = FromEnv("OS_FLOATING_IP_QUOTA", 3)
+	FloatingIP      = FromEnv("OS_FLOATING_IP_QUOTA", 3)
+	SharedBandwidth = FromEnv("OS_BANDWIDTH_QUOTA", 5)
 	// Router - shared router(VPC) quota
 	Router        = FromEnv("OS_ROUTER_QUOTA", 7) // safe value
 	Subnet        = FromEnv("OS_SUBNET_QUOTA", 50)

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_vpc_bandwidth_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_vpc_bandwidth_v2_test.go
@@ -1,0 +1,129 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/bandwidths"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+)
+
+const resourceBandwidthName = "opentelekomcloud_vpc_bandwidth_v2.band_test"
+
+func TestBandwidthV2_basic(t *testing.T) {
+	var b bandwidths.Bandwidth
+
+	t.Parallel()
+	quotas.BookOne(t, quotas.SharedBandwidth)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testCheckBandwidthV2Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testBandwidthV2Basic,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckBandwidthExists(resourceBandwidthName, &b),
+					resource.TestCheckResourceAttr(resourceBandwidthName, "size", "100"),
+					resource.TestCheckResourceAttr(resourceBandwidthName, "status", "NORMAL"),
+				),
+			},
+			{
+				Config: testBandwidthV2Updated,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckBandwidthExists(resourceBandwidthName, &b),
+					resource.TestCheckResourceAttr(resourceBandwidthName, "size", "50"),
+					resource.TestCheckResourceAttr(resourceBandwidthName, "status", "NORMAL"),
+				),
+			},
+		},
+	})
+}
+
+func TestBandwidthV2_import(t *testing.T) {
+	t.Parallel()
+	quotas.BookOne(t, quotas.SharedBandwidth)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testCheckBandwidthV2Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testBandwidthV2Basic,
+			},
+			{
+				ResourceName:      resourceBandwidthName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testCheckBandwidthExists(name string, bandwidth *bandwidths.Bandwidth) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("not found: %s", name)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+		config := common.TestAccProvider.Meta().(*cfg.Config)
+		client, err := config.NetworkingV2Client(env.OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("error creating networkingV2 client: %s", err)
+		}
+		found, err := bandwidths.Get(client, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+		if found.ID != rs.Primary.ID {
+			return fmt.Errorf("bandwidth not found")
+		}
+		*bandwidth = *found
+		return nil
+	}
+}
+
+func testCheckBandwidthV2Destroy(s *terraform.State) error {
+	config := common.TestAccProvider.Meta().(*cfg.Config)
+	networkingClient, err := config.NetworkingV2Client(env.OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("eror creating NetworkingV2 client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "opentelekomcloud_vpc_bandwidth_v2" {
+			continue
+		}
+
+		_, err := bandwidths.Get(networkingClient, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("bandwidth still exists")
+		}
+	}
+
+	return nil
+}
+
+const testBandwidthV2Basic = `
+resource "opentelekomcloud_vpc_bandwidth_v2" "band_test" {
+  name = "shared-test"
+  size = 100
+}
+`
+
+const testBandwidthV2Updated = `
+resource "opentelekomcloud_vpc_bandwidth_v2" "band_test" {
+  name = "shared-test"
+  size = 50
+}
+`

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -424,6 +424,7 @@ func Provider() *schema.Provider {
 			"opentelekomcloud_swr_organization_permissions_v2":    swr.ResourceSwrOrganizationPermissionsV2(),
 			"opentelekomcloud_swr_organization_v2":                swr.ResourceSwrOrganizationV2(),
 			"opentelekomcloud_swr_repository_v2":                  swr.ResourceSwrRepositoryV2(),
+			"opentelekomcloud_vpc_bandwidth_v2":                   vpc.ResourceBandwidthV2(),
 			"opentelekomcloud_vpc_eip_v1":                         vpc.ResourceVpcEIPV1(),
 			"opentelekomcloud_vpc_v1":                             vpc.ResourceVirtualPrivateCloudV1(),
 			"opentelekomcloud_vpc_peering_connection_v2":          vpc.ResourceVpcPeeringConnectionV2(),

--- a/opentelekomcloud/services/vpc/common.go
+++ b/opentelekomcloud/services/vpc/common.go
@@ -3,4 +3,5 @@ package vpc
 const (
 	errCreationV2Client = "error creating OpenTelekomCloud NetworkingV2 client: %w"
 	errCreationV1Client = "error creating OpenTelekomCloud NetworkingV1 client: %w"
+	keyClientV2         = "vpc-v2-client"
 )

--- a/opentelekomcloud/services/vpc/resource_opentelekomcloud_vpc_bandwidth_v2.go
+++ b/opentelekomcloud/services/vpc/resource_opentelekomcloud_vpc_bandwidth_v2.go
@@ -1,0 +1,141 @@
+package vpc
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/bandwidths"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
+)
+
+func ResourceBandwidthV2() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceBandwidthV2Create,
+		ReadContext:   resourceBandwidthV2Read,
+		UpdateContext: resourceBandwidthV2Update,
+		DeleteContext: resourceBandwidthV2Delete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(1, 64),
+					validation.StringMatch(
+						regexp.MustCompile(`^[\w-.]+$`),
+						"The value is a string that can contain letters, digits, underscores (_), hyphens (-), and periods (.).",
+					),
+				),
+			},
+			"size": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceBandwidthV2Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, keyClientV2, func() (*golangsdk.ServiceClient, error) {
+		return config.NetworkingV2Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV2Client, err)
+	}
+
+	opts := bandwidths.CreateOpts{
+		Name: d.Get("name").(string),
+		Size: d.Get("size").(int),
+	}
+	bandwidth, err := bandwidths.Create(client, opts).Extract()
+	if err != nil {
+		return fmterr.Errorf("error creating bandwidth: %w", err)
+	}
+	d.SetId(bandwidth.ID)
+
+	clientCtx := common.CtxWithClient(ctx, client, keyClientV2)
+	return resourceBandwidthV2Read(clientCtx, d, meta)
+}
+
+func resourceBandwidthV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, keyClientV2, func() (*golangsdk.ServiceClient, error) {
+		return config.NetworkingV2Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV2Client, err)
+	}
+
+	bandwidth, err := bandwidths.Get(client, d.Id()).Extract()
+	if err != nil {
+		return diag.FromErr(common.CheckDeleted(d, err, "error reading bandwidth"))
+	}
+
+	mErr := multierror.Append(
+		d.Set("name", bandwidth.Name),
+		d.Set("size", bandwidth.Size),
+		d.Set("status", bandwidth.Status),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return fmterr.Errorf("error setting bandwidth fields: %w", err)
+	}
+
+	return nil
+}
+
+func resourceBandwidthV2Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, keyClientV2, func() (*golangsdk.ServiceClient, error) {
+		return config.NetworkingV2Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV2Client, err)
+	}
+
+	opts := bandwidths.UpdateOpts{}
+	if d.HasChange("name") {
+		opts.Name = d.Get("name").(string)
+	}
+	if d.HasChange("size") {
+		opts.Size = d.Get("size").(int)
+	}
+	_, err = bandwidths.Update(client, d.Id(), opts).Extract()
+	if err != nil {
+		return fmterr.Errorf("error updating bandwidth")
+	}
+
+	clientCtx := common.CtxWithClient(ctx, client, keyClientV2)
+	return resourceBandwidthV2Read(clientCtx, d, meta)
+}
+
+func resourceBandwidthV2Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, keyClientV2, func() (*golangsdk.ServiceClient, error) {
+		return config.NetworkingV2Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV2Client, err)
+	}
+
+	if err := bandwidths.Delete(client, d.Id()).ExtractErr(); err != nil {
+		return fmterr.Errorf("error deleting bandwidth: %w", err)
+	}
+
+	return nil
+}

--- a/releasenotes/notes/vpc-bandwidth-v2-b34b0a3322be891a.yaml
+++ b/releasenotes/notes/vpc-bandwidth-v2-b34b0a3322be891a.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    **New Resource:** ``opentelekomcloud_vpc_bandwidth_v2``


### PR DESCRIPTION
## Summary of the Pull Request
Add `resource/opentelekomcloud_vpc_bandwidth_v2`

Part of #716 (still need a resource for associating)

## PR Checklist

* [x] Refers to: #716 
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestBandwidthV2_basic
=== PAUSE TestBandwidthV2_basic
=== CONT  TestBandwidthV2_basic
--- PASS: TestBandwidthV2_basic (34.25s)
=== RUN   TestBandwidthV2_import
=== PAUSE TestBandwidthV2_import
=== CONT  TestBandwidthV2_import
--- PASS: TestBandwidthV2_import (22.37s)
PASS

Process finished with the exit code 0
```
