### PR TITLE
Acceptance: Get rid of `defer` in `VPC` tests

### DIFF
--- a/opentelekomcloud/acceptance/vpc/data_source_opentelekomcloud_networking_network_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/data_source_opentelekomcloud_networking_network_v2_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
@@ -19,8 +18,7 @@ func TestAccNetworkingNetworkV2DataSource_basic(t *testing.T) {
 	cidr := fmt.Sprintf("192.168.%d.0/24", rand.Intn(200))
 
 	t.Parallel()
-	th.AssertNoErr(t, quotas.Network.Acquire())
-	defer quotas.Network.Release()
+	quotas.BookOne(t, quotas.Network)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },

--- a/opentelekomcloud/acceptance/vpc/data_source_opentelekomcloud_networking_port_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/data_source_opentelekomcloud_networking_port_v2_test.go
@@ -2,10 +2,8 @@ package acceptance
 
 import (
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
@@ -15,8 +13,7 @@ func TestAccNetworkingV2PortDataSource_basic(t *testing.T) {
 	t.Parallel()
 	qts := subnetQuotas()
 	qts = append(qts, &quotas.ExpectedQuota{Q: quotas.SecurityGroup, Count: 1})
-	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
-	defer quotas.ReleaseMultipleQuotas(qts)
+	quotas.BookMany(t, qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },

--- a/opentelekomcloud/acceptance/vpc/data_source_opentelekomcloud_networking_secgroup_rule_ids_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/data_source_opentelekomcloud_networking_secgroup_rule_ids_v2_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 )
@@ -13,8 +12,7 @@ import (
 func TestAccNetworkingSecGroupRuleIdsV2DataSource_basic(t *testing.T) {
 	dataSourceName := "data.opentelekomcloud_networking_secgroup_rule_ids_v2.secgroup_ids"
 	t.Parallel()
-	th.AssertNoErr(t, quotas.SecurityGroup.Acquire())
-	defer quotas.SecurityGroup.Release()
+	quotas.BookOne(t, quotas.SecurityGroup)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },

--- a/opentelekomcloud/acceptance/vpc/data_source_opentelekomcloud_networking_secgroup_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/data_source_opentelekomcloud_networking_secgroup_v2_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
@@ -14,8 +13,7 @@ import (
 
 func TestAccOpenTelekomCloudNetworkingSecGroupV2DataSource_basic(t *testing.T) {
 	t.Parallel()
-	th.AssertNoErr(t, quotas.SecurityGroup.Acquire())
-	defer quotas.SecurityGroup.Release()
+	quotas.BookOne(t, quotas.SecurityGroup)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },

--- a/opentelekomcloud/acceptance/vpc/data_source_opentelekomcloud_vpc_bandwidth_test.go
+++ b/opentelekomcloud/acceptance/vpc/data_source_opentelekomcloud_vpc_bandwidth_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestAccBandWidthDataSource_basic(t *testing.T) {
-	t.Skip("VPC bandwidth creation is not supported")
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
 	dataName := "data.opentelekomcloud_vpc_bandwidth.test"
 
@@ -24,7 +23,7 @@ func TestAccBandWidthDataSource_basic(t *testing.T) {
 		ProviderFactories: common.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBandWidthDataSource_basic(rName),
+				Config: testAccBandWidthDataSourceBasic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBandWidthDataSourceExists(dataName),
 					resource.TestCheckResourceAttr(dataName, "name", rName),
@@ -42,9 +41,9 @@ func testAccCheckBandWidthDataSourceExists(n string) resource.TestCheckFunc { //
 			return fmt.Errorf("root module has no resource called %s", n)
 		}
 
-		bandwidthRs, ok := s.RootModule().Resources["opentelekomcloud_vpc_bandwidth.test"]
+		bandwidthRs, ok := s.RootModule().Resources["opentelekomcloud_vpc_bandwidth_v2.test"]
 		if !ok {
-			return fmt.Errorf("can't find opentelekomcloud_vpc_bandwidth.test in state")
+			return fmt.Errorf("can't find opentelekomcloud_vpc_bandwidth_v2.test in state")
 		}
 
 		attr := rs.Primary.Attributes
@@ -57,15 +56,15 @@ func testAccCheckBandWidthDataSourceExists(n string) resource.TestCheckFunc { //
 	}
 }
 
-func testAccBandWidthDataSource_basic(rName string) string { // nolint:unused
+func testAccBandWidthDataSourceBasic(rName string) string {
 	return fmt.Sprintf(`
-resource "opentelekomcloud_vpc_bandwidth" "test" {
+resource "opentelekomcloud_vpc_bandwidth_v2" "test" {
   name = "%s"
   size = 10
 }
 
 data "opentelekomcloud_vpc_bandwidth" "test" {
-  name = opentelekomcloud_vpc_bandwidth.test.name
+  name = opentelekomcloud_vpc_bandwidth_v2.test.name
 }
 `, rName)
 }

--- a/opentelekomcloud/acceptance/vpc/data_source_opentelekomcloud_vpc_eip_v1_test.go
+++ b/opentelekomcloud/acceptance/vpc/data_source_opentelekomcloud_vpc_eip_v1_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 )
@@ -13,8 +12,7 @@ func TestAccVpcEipV1DataSource_basic(t *testing.T) {
 	dataSourceNameByID := "data.opentelekomcloud_vpc_eip_v1.by_id"
 	dataSourceNameByTags := "data.opentelekomcloud_vpc_eip_v1.by_tags"
 	t.Parallel()
-	th.AssertNoErr(t, quotas.FloatingIP.Acquire())
-	defer quotas.FloatingIP.Release()
+	quotas.BookOne(t, quotas.FloatingIP)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },

--- a/opentelekomcloud/acceptance/vpc/data_source_opentelekomcloud_vpc_peering_connection_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/data_source_opentelekomcloud_vpc_peering_connection_v2_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
@@ -20,8 +19,10 @@ const (
 
 func TestAccVpcPeeringConnectionV2DataSource_basic(t *testing.T) {
 	t.Parallel()
-	th.AssertNoErr(t, quotas.Router.AcquireMultiple(3))
-	defer quotas.Router.ReleaseMultiple(3)
+	qts := quotas.MultipleQuotas{
+		{Q: quotas.Router, Count: 3},
+	}
+	quotas.BookMany(t, qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },

--- a/opentelekomcloud/acceptance/vpc/data_source_opentelekomcloud_vpc_route_ids_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/data_source_opentelekomcloud_vpc_route_ids_v2_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
@@ -14,8 +13,7 @@ import (
 
 func TestAccVpcRouteIdsV2DataSource_basic(t *testing.T) {
 	t.Parallel()
-	th.AssertNoErr(t, quotas.Router.AcquireMultiple(2))
-	defer quotas.Router.ReleaseMultiple(2)
+	quotas.BookMany(t, multipleRouters(2))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },

--- a/opentelekomcloud/acceptance/vpc/data_source_opentelekomcloud_vpc_route_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/data_source_opentelekomcloud_vpc_route_v2_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
@@ -14,8 +13,10 @@ import (
 
 func TestAccVpcRouteV2DataSource_basic(t *testing.T) {
 	t.Parallel()
-	th.AssertNoErr(t, quotas.Router.AcquireMultiple(3))
-	defer quotas.Router.ReleaseMultiple(3)
+	qts := quotas.MultipleQuotas{
+		{Q: quotas.Router, Count: 3},
+	}
+	quotas.BookMany(t, qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },

--- a/opentelekomcloud/acceptance/vpc/data_source_opentelekomcloud_vpc_subnet_ids_v1_test.go
+++ b/opentelekomcloud/acceptance/vpc/data_source_opentelekomcloud_vpc_subnet_ids_v1_test.go
@@ -3,11 +3,9 @@ package acceptance
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
@@ -16,8 +14,7 @@ import (
 func TestAccVpcSubnetIdsV2DataSource_basic(t *testing.T) {
 	t.Parallel()
 	qts := vpcSubnetQuotas()
-	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
-	defer quotas.ReleaseMultipleQuotas(qts)
+	quotas.BookMany(t, qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },

--- a/opentelekomcloud/acceptance/vpc/data_source_opentelekomcloud_vpc_subnet_v1_test.go
+++ b/opentelekomcloud/acceptance/vpc/data_source_opentelekomcloud_vpc_subnet_v1_test.go
@@ -3,11 +3,9 @@ package acceptance
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
@@ -20,8 +18,7 @@ func TestAccVpcSubnetV1DataSource_basic(t *testing.T) {
 	dataSourceNameByVPC := "data.opentelekomcloud_vpc_subnet_v1.by_vpc_id"
 	t.Parallel()
 	qts := vpcSubnetQuotas()
-	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
-	defer quotas.ReleaseMultipleQuotas(qts)
+	quotas.BookMany(t, qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },

--- a/opentelekomcloud/acceptance/vpc/data_source_opentelekomcloud_vpc_v1_test.go
+++ b/opentelekomcloud/acceptance/vpc/data_source_opentelekomcloud_vpc_v1_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
-	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
@@ -23,8 +22,7 @@ func TestAccVpcV1DataSource_basic(t *testing.T) {
 	name := tools.RandomString("vpc-test-", 3)
 
 	t.Parallel()
-	th.AssertNoErr(t, quotas.Router.Acquire())
-	defer quotas.Router.Release()
+	quotas.BookOne(t, quotas.Router)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_floatingip_associate_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_floatingip_associate_v2_test.go
@@ -3,12 +3,10 @@ package acceptance
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
-	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/layer3/floatingips"
@@ -25,8 +23,7 @@ func TestAccNetworkingV2FloatingIPAssociate_basic(t *testing.T) {
 	t.Parallel()
 	qts := vpcSubnetQuotas()
 	qts = append(qts, &quotas.ExpectedQuota{Q: quotas.FloatingIP, Count: 1})
-	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
-	defer quotas.ReleaseMultipleQuotas(qts)
+	quotas.BookMany(t, qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_floatingip_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_floatingip_v2_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/layer3/floatingips"
@@ -21,8 +20,7 @@ const resourceFloatingIPName = "opentelekomcloud_networking_floatingip_v2.fip_1"
 func TestAccNetworkingV2FloatingIP_basic(t *testing.T) {
 	var fip floatingips.FloatingIP
 	t.Parallel()
-	th.AssertNoErr(t, quotas.FloatingIP.Acquire())
-	defer quotas.FloatingIP.Release()
+	quotas.BookOne(t, quotas.FloatingIP)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -42,8 +40,7 @@ func TestAccNetworkingV2FloatingIP_basic(t *testing.T) {
 func TestAccNetworkingV2FloatingIP_timeout(t *testing.T) {
 	var fip floatingips.FloatingIP
 	t.Parallel()
-	th.AssertNoErr(t, quotas.FloatingIP.Acquire())
-	defer quotas.FloatingIP.Release()
+	quotas.BookOne(t, quotas.FloatingIP)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -62,8 +59,7 @@ func TestAccNetworkingV2FloatingIP_timeout(t *testing.T) {
 
 func TestAccNetworkingV2FloatingIP_importBasic(t *testing.T) {
 	t.Parallel()
-	th.AssertNoErr(t, quotas.FloatingIP.Acquire())
-	defer quotas.FloatingIP.Release()
+	quotas.BookOne(t, quotas.FloatingIP)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_network_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_network_v2_test.go
@@ -3,11 +3,9 @@ package acceptance
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/layer3/routers"
@@ -26,8 +24,7 @@ func TestAccNetworkingV2Network_basic(t *testing.T) {
 	var network networks.Network
 
 	t.Parallel()
-	th.AssertNoErr(t, quotas.Network.Acquire())
-	defer quotas.Network.Release()
+	quotas.BookOne(t, quotas.Network)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -76,8 +73,7 @@ func TestAccNetworkingV2Network_netstack(t *testing.T) {
 
 	t.Parallel()
 	qts := vpcSubnetQuotas()
-	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
-	defer quotas.ReleaseMultipleQuotas(qts)
+	quotas.BookMany(t, qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -100,8 +96,7 @@ func TestAccNetworkingV2Network_netstack(t *testing.T) {
 func TestAccNetworkingV2Network_timeout(t *testing.T) {
 	var network networks.Network
 	t.Parallel()
-	th.AssertNoErr(t, quotas.Network.Acquire())
-	defer quotas.Network.Release()
+	quotas.BookOne(t, quotas.Network)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -121,8 +116,7 @@ func TestAccNetworkingV2Network_timeout(t *testing.T) {
 func TestAccNetworkingV2Network_multipleSegmentMappings(t *testing.T) {
 	var network networks.Network
 	t.Parallel()
-	th.AssertNoErr(t, quotas.Network.Acquire())
-	defer quotas.Network.Release()
+	quotas.BookOne(t, quotas.Network)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_port_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_port_v2_test.go
@@ -3,7 +3,6 @@ package acceptance
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -11,7 +10,6 @@ import (
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/networks"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/ports"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/subnets"
-	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
@@ -33,8 +31,7 @@ func TestAccNetworkingV2Port_basic(t *testing.T) {
 
 	t.Parallel()
 	qts := subnetQuotas()
-	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
-	defer quotas.ReleaseMultipleQuotas(qts)
+	quotas.BookMany(t, qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -56,8 +53,7 @@ func TestAccNetworkingV2Port_basic(t *testing.T) {
 func TestAccNetworkingV2Port_importBasic(t *testing.T) {
 	t.Parallel()
 	qts := subnetQuotas()
-	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
-	defer quotas.ReleaseMultipleQuotas(qts)
+	quotas.BookMany(t, qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -86,8 +82,7 @@ func TestAccNetworkingV2Port_noip(t *testing.T) {
 	var subnet subnets.Subnet
 	t.Parallel()
 	qts := subnetQuotas()
-	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
-	defer quotas.ReleaseMultipleQuotas(qts)
+	quotas.BookMany(t, qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -113,8 +108,7 @@ func TestAccNetworkingV2Port_allowedAddressPairs(t *testing.T) {
 	var vrrpPort1, vrrpPort2, instancePort ports.Port
 	t.Parallel()
 	qts := subnetQuotas()
-	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
-	defer quotas.ReleaseMultipleQuotas(qts)
+	quotas.BookMany(t, qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -140,8 +134,7 @@ func TestAccNetworkingV2Port_portSecurity_enabled(t *testing.T) {
 	resourceName := "opentelekomcloud_networking_port_v2.port_1"
 	t.Parallel()
 	qts := subnetQuotas()
-	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
-	defer quotas.ReleaseMultipleQuotas(qts)
+	quotas.BookMany(t, qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -174,8 +167,7 @@ func TestAccNetworkingV2Port_timeout(t *testing.T) {
 	var subnet subnets.Subnet
 	t.Parallel()
 	qts := subnetQuotas()
-	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
-	defer quotas.ReleaseMultipleQuotas(qts)
+	quotas.BookMany(t, qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_router_interface_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_router_interface_v2_test.go
@@ -3,11 +3,9 @@ package acceptance
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/layer3/routers"
@@ -27,8 +25,7 @@ func TestAccNetworkingV2RouterInterface_basic_subnet(t *testing.T) {
 
 	t.Parallel()
 	qts := vpcSubnetQuotas()
-	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
-	defer quotas.ReleaseMultipleQuotas(qts)
+	quotas.BookMany(t, qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -56,8 +53,7 @@ func TestAccNetworkingV2RouterInterface_basic_port(t *testing.T) {
 
 	t.Parallel()
 	qts := vpcSubnetQuotas()
-	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
-	defer quotas.ReleaseMultipleQuotas(qts)
+	quotas.BookMany(t, qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -85,8 +81,7 @@ func TestAccNetworkingV2RouterInterface_timeout(t *testing.T) {
 
 	t.Parallel()
 	qts := vpcSubnetQuotas()
-	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
-	defer quotas.ReleaseMultipleQuotas(qts)
+	quotas.BookMany(t, qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_router_route_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_router_route_v2_test.go
@@ -3,11 +3,9 @@ package acceptance
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/layer3/routers"
@@ -30,8 +28,7 @@ func TestAccNetworkingV2RouterRoute_basic(t *testing.T) {
 		{Q: quotas.Network, Count: 2},
 		{Q: quotas.Subnet, Count: 2},
 	}
-	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
-	defer quotas.ReleaseMultipleQuotas(qts)
+	quotas.BookMany(t, qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_router_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_router_v2_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/layer3/routers"
@@ -21,8 +20,7 @@ const resourceRouterName = "opentelekomcloud_networking_router_v2.router_1"
 func TestAccNetworkingV2Router_basic(t *testing.T) {
 	var router routers.Router
 	t.Parallel()
-	th.AssertNoErr(t, quotas.Router.Acquire())
-	defer quotas.Router.Release()
+	quotas.BookOne(t, quotas.Router)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -48,8 +46,7 @@ func TestAccNetworkingV2Router_basic(t *testing.T) {
 func TestAccNetworkingV2Router_update_external_gw(t *testing.T) {
 	var router routers.Router
 	t.Parallel()
-	th.AssertNoErr(t, quotas.Router.Acquire())
-	defer quotas.Router.Release()
+	quotas.BookOne(t, quotas.Router)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -75,8 +72,7 @@ func TestAccNetworkingV2Router_update_external_gw(t *testing.T) {
 func TestAccNetworkingV2Router_timeout(t *testing.T) {
 	var router routers.Router
 	t.Parallel()
-	th.AssertNoErr(t, quotas.Router.Acquire())
-	defer quotas.Router.Release()
+	quotas.BookOne(t, quotas.Router)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_secgroup_rule_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_secgroup_rule_v2_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/security/groups"
@@ -25,8 +24,10 @@ func TestAccNetworkingV2SecGroupRule_basic(t *testing.T) {
 	var secgroupRule1 rules.SecGroupRule
 	var secgroupRule2 rules.SecGroupRule
 	t.Parallel()
-	th.AssertNoErr(t, quotas.SecurityGroup.AcquireMultiple(2))
-	defer quotas.SecurityGroup.ReleaseMultiple(2)
+	qts := quotas.MultipleQuotas{
+		{Q: quotas.SecurityGroup, Count: 2},
+	}
+	quotas.BookMany(t, qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -50,15 +51,17 @@ func TestAccNetworkingV2SecGroupRule_basic(t *testing.T) {
 }
 
 func TestAccNetworkingV2SecGroupRule_importBasic(t *testing.T) {
+	t.Parallel()
+	quotas.BookOne(t, quotas.SecurityGroup)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckNetworkingV2SecGroupRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkingV2SecGroupRuleBasic,
+				Config: testAccNetworkingV2SecGroupRuleNumericProtocol,
 			},
-
 			{
 				ResourceName:      resourceNwSGRuleName,
 				ImportState:       true,
@@ -72,8 +75,10 @@ func TestAccNetworkingV2SecGroupRule_timeout(t *testing.T) {
 	var secgroup_1 groups.SecGroup
 	var secgroup_2 groups.SecGroup
 	t.Parallel()
-	th.AssertNoErr(t, quotas.SecurityGroup.AcquireMultiple(2))
-	defer quotas.SecurityGroup.ReleaseMultiple(2)
+	qts := quotas.MultipleQuotas{
+		{Q: quotas.SecurityGroup, Count: 2},
+	}
+	quotas.BookMany(t, qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -96,8 +101,7 @@ func TestAccNetworkingV2SecGroupRule_numericProtocol(t *testing.T) {
 	var secgroup1 groups.SecGroup
 	var secgroupRule1 rules.SecGroupRule
 	t.Parallel()
-	th.AssertNoErr(t, quotas.SecurityGroup.AcquireMultiple(2))
-	defer quotas.SecurityGroup.ReleaseMultiple(2)
+	quotas.BookOne(t, quotas.SecurityGroup)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_secgroup_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_secgroup_v2_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/security/groups"
@@ -21,8 +20,7 @@ const resourceNwSecGroupName = "opentelekomcloud_networking_secgroup_v2.secgroup
 func TestAccNetworkingV2SecGroup_basic(t *testing.T) {
 	var securityGroup groups.SecGroup
 	t.Parallel()
-	th.AssertNoErr(t, quotas.SecurityGroup.Acquire())
-	defer quotas.SecurityGroup.Release()
+	quotas.BookOne(t, quotas.SecurityGroup)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -49,8 +47,7 @@ func TestAccNetworkingV2SecGroup_basic(t *testing.T) {
 
 func TestAccNetworkingV2SecGroup_importBasic(t *testing.T) {
 	t.Parallel()
-	th.AssertNoErr(t, quotas.SecurityGroup.Acquire())
-	defer quotas.SecurityGroup.Release()
+	quotas.BookOne(t, quotas.SecurityGroup)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -72,8 +69,7 @@ func TestAccNetworkingV2SecGroup_importBasic(t *testing.T) {
 func TestAccNetworkingV2SecGroup_noDefaultRules(t *testing.T) {
 	var securityGroup groups.SecGroup
 	t.Parallel()
-	th.AssertNoErr(t, quotas.SecurityGroup.Acquire())
-	defer quotas.SecurityGroup.Release()
+	quotas.BookOne(t, quotas.SecurityGroup)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -94,8 +90,7 @@ func TestAccNetworkingV2SecGroup_noDefaultRules(t *testing.T) {
 func TestAccNetworkingV2SecGroup_timeout(t *testing.T) {
 	var securityGroup groups.SecGroup
 	t.Parallel()
-	th.AssertNoErr(t, quotas.SecurityGroup.Acquire())
-	defer quotas.SecurityGroup.Release()
+	quotas.BookOne(t, quotas.SecurityGroup)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_subnet_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_subnet_v2_test.go
@@ -3,11 +3,9 @@ package acceptance
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/subnets"
@@ -22,9 +20,7 @@ const resourceNwSubnetName = "opentelekomcloud_networking_subnet_v2.subnet_1"
 func TestAccNetworkingV2Subnet_basic(t *testing.T) {
 	var subnet subnets.Subnet
 	t.Parallel()
-	qts := subnetQuotas()
-	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 2*time.Second))
-	defer quotas.ReleaseMultipleQuotas(qts)
+	quotas.BookMany(t, subnetQuotas())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -53,9 +49,7 @@ func TestAccNetworkingV2Subnet_basic(t *testing.T) {
 
 func TestAccNetworkingV2Subnet_import(t *testing.T) {
 	t.Parallel()
-	qts := subnetQuotas()
-	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 2*time.Second))
-	defer quotas.ReleaseMultipleQuotas(qts)
+	quotas.BookMany(t, subnetQuotas())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -78,9 +72,7 @@ func TestAccNetworkingV2Subnet_import(t *testing.T) {
 func TestAccNetworkingV2Subnet_enableDHCP(t *testing.T) {
 	var subnet subnets.Subnet
 	t.Parallel()
-	qts := subnetQuotas()
-	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 2*time.Second))
-	defer quotas.ReleaseMultipleQuotas(qts)
+	quotas.BookMany(t, subnetQuotas())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -101,9 +93,7 @@ func TestAccNetworkingV2Subnet_enableDHCP(t *testing.T) {
 func TestAccNetworkingV2Subnet_noGateway(t *testing.T) {
 	var subnet subnets.Subnet
 	t.Parallel()
-	qts := subnetQuotas()
-	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 2*time.Second))
-	defer quotas.ReleaseMultipleQuotas(qts)
+	quotas.BookMany(t, subnetQuotas())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -124,9 +114,7 @@ func TestAccNetworkingV2Subnet_noGateway(t *testing.T) {
 func TestAccNetworkingV2Subnet_impliedGateway(t *testing.T) {
 	var subnet subnets.Subnet
 	t.Parallel()
-	qts := subnetQuotas()
-	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 2*time.Second))
-	defer quotas.ReleaseMultipleQuotas(qts)
+	quotas.BookMany(t, subnetQuotas())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -147,9 +135,7 @@ func TestAccNetworkingV2Subnet_impliedGateway(t *testing.T) {
 func TestAccNetworkingV2Subnet_timeout(t *testing.T) {
 	var subnet subnets.Subnet
 	t.Parallel()
-	qts := subnetQuotas()
-	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 2*time.Second))
-	defer quotas.ReleaseMultipleQuotas(qts)
+	quotas.BookMany(t, subnetQuotas())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_vip_associate_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_vip_associate_v2_test.go
@@ -4,13 +4,11 @@ import (
 	"fmt"
 	"log"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/ports"
-	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
@@ -31,8 +29,7 @@ func TestAccNetworkingV2VIPAssociate_basic(t *testing.T) {
 		&quotas.ExpectedQuota{Q: quotas.VolumeSize, Count: 4 + 4},
 		&quotas.ExpectedQuota{Q: quotas.Server, Count: 2},
 	)
-	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
-	defer quotas.ReleaseMultipleQuotas(qts)
+	quotas.BookMany(t, qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_vip_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_vip_v2_test.go
@@ -4,12 +4,10 @@ import (
 	"fmt"
 	"log"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/ports"
-	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
@@ -24,8 +22,7 @@ func TestAccNetworkingV2VIP_basic(t *testing.T) {
 	var vip ports.Port
 	t.Parallel()
 	qts := vpcSubnetQuotas()
-	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
-	defer quotas.ReleaseMultipleQuotas(qts)
+	quotas.BookMany(t, qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_vpc_eip_v1_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_vpc_eip_v1_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v1/eips"
@@ -21,8 +20,7 @@ const resourceVPCEIPName = "opentelekomcloud_vpc_eip_v1.eip_1"
 func TestAccVpcV1EIP_basic(t *testing.T) {
 	var eip eips.PublicIp
 	t.Parallel()
-	th.AssertNoErr(t, quotas.FloatingIP.Acquire())
-	defer quotas.FloatingIP.Release()
+	quotas.BookOne(t, quotas.FloatingIP)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -51,8 +49,7 @@ func TestAccVpcV1EIP_basic(t *testing.T) {
 func TestAccVpcV1EIP_timeout(t *testing.T) {
 	var eip eips.PublicIp
 	t.Parallel()
-	th.AssertNoErr(t, quotas.FloatingIP.Acquire())
-	defer quotas.FloatingIP.Release()
+	quotas.BookOne(t, quotas.FloatingIP)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_vpc_flow_log_v1_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_vpc_flow_log_v1_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v1/flowlogs"
@@ -25,8 +24,7 @@ const (
 func TestAccVpcFlowLogV1_basic(t *testing.T) {
 	var flowLog flowlogs.FlowLog
 	t.Parallel()
-	th.AssertNoErr(t, quotas.Router.Acquire())
-	defer quotas.Router.Release()
+	quotas.BookOne(t, quotas.Router)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_vpc_peering_connection_accepter_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_vpc_peering_connection_accepter_v2_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
@@ -14,8 +13,7 @@ import (
 
 func TestAccVpcPeeringConnectionAcceptorV2_basic(t *testing.T) {
 	t.Parallel()
-	th.AssertNoErr(t, quotas.Router.AcquireMultiple(2))
-	defer quotas.Router.ReleaseMultiple(2)
+	quotas.BookMany(t, multipleRouters(2))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_vpc_peering_connection_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_vpc_peering_connection_v2_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/peerings"
-	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
@@ -20,8 +19,7 @@ const resourceVPCPeeringName = "opentelekomcloud_vpc_peering_connection_v2.peeri
 func TestAccVpcPeeringConnectionV2_basic(t *testing.T) {
 	var peering peerings.Peering
 	t.Parallel()
-	th.AssertNoErr(t, quotas.Router.AcquireMultiple(2))
-	defer quotas.Router.ReleaseMultiple(2)
+	quotas.BookMany(t, multipleRouters(2))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -48,8 +46,7 @@ func TestAccVpcPeeringConnectionV2_basic(t *testing.T) {
 
 func TestAccVpcPeeringConnectionV2_import(t *testing.T) {
 	t.Parallel()
-	th.AssertNoErr(t, quotas.Router.AcquireMultiple(2))
-	defer quotas.Router.ReleaseMultiple(2)
+	quotas.BookMany(t, multipleRouters(2))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -71,8 +68,7 @@ func TestAccVpcPeeringConnectionV2_import(t *testing.T) {
 func TestAccVpcPeeringConnectionV2_timeout(t *testing.T) {
 	var peering peerings.Peering
 	t.Parallel()
-	th.AssertNoErr(t, quotas.Router.AcquireMultiple(2))
-	defer quotas.Router.ReleaseMultiple(2)
+	quotas.BookMany(t, multipleRouters(2))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_vpc_route_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_vpc_route_v2_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/routes"
@@ -22,8 +21,7 @@ func TestAccVpcRouteV2_basic(t *testing.T) {
 	var route routes.Route
 
 	t.Parallel()
-	th.AssertNoErr(t, quotas.Router.AcquireMultiple(2))
-	defer quotas.Router.ReleaseMultiple(2)
+	quotas.BookMany(t, multipleRouters(2))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -43,8 +41,7 @@ func TestAccVpcRouteV2_basic(t *testing.T) {
 }
 func TestAccVpcRouteV2_import(t *testing.T) {
 	t.Parallel()
-	th.AssertNoErr(t, quotas.Router.AcquireMultiple(2))
-	defer quotas.Router.ReleaseMultiple(2)
+	quotas.BookMany(t, multipleRouters(2))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -67,8 +64,7 @@ func TestAccVpcRouteV2_timeout(t *testing.T) {
 	var route routes.Route
 
 	t.Parallel()
-	th.AssertNoErr(t, quotas.Router.AcquireMultiple(2))
-	defer quotas.Router.ReleaseMultiple(2)
+	quotas.BookMany(t, multipleRouters(2))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_vpc_subnet_v1_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_vpc_subnet_v1_test.go
@@ -3,11 +3,9 @@ package acceptance
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v1/subnets"
@@ -23,8 +21,7 @@ func TestAccVpcSubnetV1Basic(t *testing.T) {
 	var subnet subnets.Subnet
 	t.Parallel()
 	qts := vpcSubnetQuotas()
-	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
-	defer quotas.ReleaseMultipleQuotas(qts)
+	quotas.BookMany(t, qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -59,8 +56,7 @@ func TestAccVpcSubnetV1Basic(t *testing.T) {
 func TestAccVpcSubnetV1Import(t *testing.T) {
 	t.Parallel()
 	qts := vpcSubnetQuotas()
-	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
-	defer quotas.ReleaseMultipleQuotas(qts)
+	quotas.BookMany(t, qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -83,8 +79,7 @@ func TestAccVpcSubnetV1Timeout(t *testing.T) {
 	var subnet subnets.Subnet
 	t.Parallel()
 	qts := vpcSubnetQuotas()
-	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
-	defer quotas.ReleaseMultipleQuotas(qts)
+	quotas.BookMany(t, qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -105,8 +100,7 @@ func TestAccVpcSubnetV1DnsList(t *testing.T) {
 	var subnet subnets.Subnet
 	t.Parallel()
 	qts := vpcSubnetQuotas()
-	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
-	defer quotas.ReleaseMultipleQuotas(qts)
+	quotas.BookMany(t, qts)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_vpc_v1_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_vpc_v1_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v1/vpcs"
@@ -21,8 +20,7 @@ const resourceVPCName = "opentelekomcloud_vpc_v1.vpc_1"
 func TestAccVpcV1_basic(t *testing.T) {
 	var vpc vpcs.Vpc
 	t.Parallel()
-	th.AssertNoErr(t, quotas.Router.Acquire())
-	defer quotas.Router.Release()
+	quotas.BookOne(t, quotas.Router)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -57,8 +55,7 @@ func TestAccVpcV1_basic(t *testing.T) {
 func TestAccVpcV1_timeout(t *testing.T) {
 	var vpc vpcs.Vpc
 	t.Parallel()
-	th.AssertNoErr(t, quotas.Router.Acquire())
-	defer quotas.Router.Release()
+	quotas.BookOne(t, quotas.Router)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -77,8 +74,7 @@ func TestAccVpcV1_timeout(t *testing.T) {
 
 func TestAccVpcV1_import(t *testing.T) {
 	t.Parallel()
-	th.AssertNoErr(t, quotas.Router.Acquire())
-	defer quotas.Router.Release()
+	quotas.BookOne(t, quotas.Router)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },

--- a/opentelekomcloud/acceptance/vpc/utils.go
+++ b/opentelekomcloud/acceptance/vpc/utils.go
@@ -239,3 +239,9 @@ func subnetQuotas() []*quotas.ExpectedQuota {
 		{Q: quotas.Subnet, Count: 1},
 	}
 }
+
+func multipleRouters(n int64) quotas.MultipleQuotas {
+	return quotas.MultipleQuotas{{
+		Q: quotas.Router, Count: n,
+	}}
+}


### PR DESCRIPTION
## Summary of the Pull Request
Replace `defer` statements with `quotas.Book...`


## PR Checklist

* [x] Refers to: #1538 
* [x] Tests added/passed.


## Acceptance Steps Performed

```
=== RUN   TestAccNetworkingNetworkV2DataSource_basic
=== PAUSE TestAccNetworkingNetworkV2DataSource_basic
=== CONT  TestAccNetworkingNetworkV2DataSource_basic
--- PASS: TestAccNetworkingNetworkV2DataSource_basic (60.38s)
=== RUN   TestAccNetworkingV2PortDataSource_basic
=== PAUSE TestAccNetworkingV2PortDataSource_basic
=== CONT  TestAccNetworkingV2PortDataSource_basic
--- PASS: TestAccNetworkingV2PortDataSource_basic (81.00s)
=== RUN   TestAccNetworkingSecGroupRuleIdsV2DataSource_basic
=== PAUSE TestAccNetworkingSecGroupRuleIdsV2DataSource_basic
=== CONT  TestAccNetworkingSecGroupRuleIdsV2DataSource_basic
--- PASS: TestAccNetworkingSecGroupRuleIdsV2DataSource_basic (46.01s)
=== RUN   TestAccOpenTelekomCloudNetworkingSecGroupV2DataSource_basic
=== PAUSE TestAccOpenTelekomCloudNetworkingSecGroupV2DataSource_basic
=== CONT  TestAccOpenTelekomCloudNetworkingSecGroupV2DataSource_basic
--- PASS: TestAccOpenTelekomCloudNetworkingSecGroupV2DataSource_basic (63.59s)
=== RUN   TestAccBandWidthDataSource_basic
=== PAUSE TestAccBandWidthDataSource_basic
=== CONT  TestAccBandWidthDataSource_basic
--- PASS: TestAccBandWidthDataSource_basic (21.22s)
=== RUN   TestAccBandWidthV2DataSource_basic
=== PAUSE TestAccBandWidthV2DataSource_basic
=== CONT  TestAccBandWidthV2DataSource_basic
--- PASS: TestAccBandWidthV2DataSource_basic (20.45s)
=== RUN   TestAccVpcEipV1DataSource_basic
=== PAUSE TestAccVpcEipV1DataSource_basic
=== CONT  TestAccVpcEipV1DataSource_basic
--- PASS: TestAccVpcEipV1DataSource_basic (74.43s)
=== RUN   TestAccVpcPeeringConnectionV2DataSource_basic
=== PAUSE TestAccVpcPeeringConnectionV2DataSource_basic
=== CONT  TestAccVpcPeeringConnectionV2DataSource_basic
--- PASS: TestAccVpcPeeringConnectionV2DataSource_basic (342.40s)
=== RUN   TestAccVpcRouteIdsV2DataSource_basic
=== PAUSE TestAccVpcRouteIdsV2DataSource_basic
=== CONT  TestAccVpcRouteIdsV2DataSource_basic
--- PASS: TestAccVpcRouteIdsV2DataSource_basic (106.00s)
=== RUN   TestAccVpcRouteV2DataSource_basic
=== PAUSE TestAccVpcRouteV2DataSource_basic
=== CONT  TestAccVpcRouteV2DataSource_basic
--- PASS: TestAccVpcRouteV2DataSource_basic (335.42s)
=== RUN   TestAccVpcSubnetIdsV2DataSource_basic
=== PAUSE TestAccVpcSubnetIdsV2DataSource_basic
=== CONT  TestAccVpcSubnetIdsV2DataSource_basic
--- PASS: TestAccVpcSubnetIdsV2DataSource_basic (118.74s)
=== RUN   TestAccVpcSubnetV1DataSource_basic
=== PAUSE TestAccVpcSubnetV1DataSource_basic
=== CONT  TestAccVpcSubnetV1DataSource_basic
--- PASS: TestAccVpcSubnetV1DataSource_basic (59.48s)
=== RUN   TestAccVpcV1DataSource_basic
=== PAUSE TestAccVpcV1DataSource_basic
=== CONT  TestAccVpcV1DataSource_basic
--- PASS: TestAccVpcV1DataSource_basic (40.42s)
=== RUN   TestAccNetworkingV2FloatingIPAssociate_basic
=== PAUSE TestAccNetworkingV2FloatingIPAssociate_basic
=== CONT  TestAccNetworkingV2FloatingIPAssociate_basic
--- PASS: TestAccNetworkingV2FloatingIPAssociate_basic (206.28s)
=== RUN   TestAccNetworkingV2FloatingIP_basic
=== PAUSE TestAccNetworkingV2FloatingIP_basic
=== CONT  TestAccNetworkingV2FloatingIP_basic
--- PASS: TestAccNetworkingV2FloatingIP_basic (50.05s)
=== RUN   TestAccNetworkingV2FloatingIP_timeout
=== PAUSE TestAccNetworkingV2FloatingIP_timeout
=== CONT  TestAccNetworkingV2FloatingIP_timeout
--- PASS: TestAccNetworkingV2FloatingIP_timeout (37.41s)
=== RUN   TestAccNetworkingV2FloatingIP_importBasic
=== PAUSE TestAccNetworkingV2FloatingIP_importBasic
=== CONT  TestAccNetworkingV2FloatingIP_importBasic
--- PASS: TestAccNetworkingV2FloatingIP_importBasic (40.51s)
=== RUN   TestAccNetworkingV2Network_basic
=== PAUSE TestAccNetworkingV2Network_basic
=== CONT  TestAccNetworkingV2Network_basic
--- PASS: TestAccNetworkingV2Network_basic (50.03s)
=== RUN   TestAccNetworkingV2Network_importBasic
--- PASS: TestAccNetworkingV2Network_importBasic (38.13s)
=== RUN   TestAccNetworkingV2Network_netstack
=== PAUSE TestAccNetworkingV2Network_netstack
=== CONT  TestAccNetworkingV2Network_netstack
--- PASS: TestAccNetworkingV2Network_netstack (86.24s)
=== RUN   TestAccNetworkingV2Network_timeout
=== PAUSE TestAccNetworkingV2Network_timeout
=== CONT  TestAccNetworkingV2Network_timeout
--- PASS: TestAccNetworkingV2Network_timeout (34.34s)
=== RUN   TestAccNetworkingV2Network_multipleSegmentMappings
=== PAUSE TestAccNetworkingV2Network_multipleSegmentMappings
=== CONT  TestAccNetworkingV2Network_multipleSegmentMappings
    common.go:83: Skipping test because it requires set OS_TENANT_ADMIN
--- SKIP: TestAccNetworkingV2Network_multipleSegmentMappings (0.00s)

Test ignored.
=== RUN   TestAccNetworkingV2Port_basic
=== PAUSE TestAccNetworkingV2Port_basic
=== CONT  TestAccNetworkingV2Port_basic
--- PASS: TestAccNetworkingV2Port_basic (71.87s)
=== RUN   TestAccNetworkingV2Port_importBasic
=== PAUSE TestAccNetworkingV2Port_importBasic
=== CONT  TestAccNetworkingV2Port_importBasic
--- PASS: TestAccNetworkingV2Port_importBasic (74.20s)
=== RUN   TestAccNetworkingV2Port_noip
=== PAUSE TestAccNetworkingV2Port_noip
=== CONT  TestAccNetworkingV2Port_noip
--- PASS: TestAccNetworkingV2Port_noip (69.00s)
=== RUN   TestAccNetworkingV2Port_allowedAddressPairs
=== PAUSE TestAccNetworkingV2Port_allowedAddressPairs
=== CONT  TestAccNetworkingV2Port_allowedAddressPairs
--- PASS: TestAccNetworkingV2Port_allowedAddressPairs (88.67s)
=== RUN   TestAccNetworkingV2Port_portSecurity_enabled
=== PAUSE TestAccNetworkingV2Port_portSecurity_enabled
=== CONT  TestAccNetworkingV2Port_portSecurity_enabled
--- PASS: TestAccNetworkingV2Port_portSecurity_enabled (88.23s)
=== RUN   TestAccNetworkingV2Port_timeout
=== PAUSE TestAccNetworkingV2Port_timeout
=== CONT  TestAccNetworkingV2Port_timeout
--- PASS: TestAccNetworkingV2Port_timeout (69.58s)
=== RUN   TestAccNetworkingV2RouterInterface_basic_subnet
=== PAUSE TestAccNetworkingV2RouterInterface_basic_subnet
=== CONT  TestAccNetworkingV2RouterInterface_basic_subnet
--- PASS: TestAccNetworkingV2RouterInterface_basic_subnet (83.04s)
=== RUN   TestAccNetworkingV2RouterInterface_basic_port
=== PAUSE TestAccNetworkingV2RouterInterface_basic_port
=== CONT  TestAccNetworkingV2RouterInterface_basic_port
--- PASS: TestAccNetworkingV2RouterInterface_basic_port (84.97s)
=== RUN   TestAccNetworkingV2RouterInterface_timeout
=== PAUSE TestAccNetworkingV2RouterInterface_timeout
=== CONT  TestAccNetworkingV2RouterInterface_timeout
--- PASS: TestAccNetworkingV2RouterInterface_timeout (87.69s)
=== RUN   TestAccNetworkingV2RouterRoute_basic
=== PAUSE TestAccNetworkingV2RouterRoute_basic
=== CONT  TestAccNetworkingV2RouterRoute_basic
--- PASS: TestAccNetworkingV2RouterRoute_basic (132.92s)
=== RUN   TestAccNetworkingV2Router_basic
=== PAUSE TestAccNetworkingV2Router_basic
=== CONT  TestAccNetworkingV2Router_basic
--- PASS: TestAccNetworkingV2Router_basic (50.36s)
=== RUN   TestAccNetworkingV2Router_update_external_gw
=== PAUSE TestAccNetworkingV2Router_update_external_gw
=== CONT  TestAccNetworkingV2Router_update_external_gw
--- PASS: TestAccNetworkingV2Router_update_external_gw (53.23s)
=== RUN   TestAccNetworkingV2Router_timeout
=== PAUSE TestAccNetworkingV2Router_timeout
=== CONT  TestAccNetworkingV2Router_timeout
--- PASS: TestAccNetworkingV2Router_timeout (33.74s)
=== RUN   TestAccNetworkingV2SecGroupRule_basic
=== PAUSE TestAccNetworkingV2SecGroupRule_basic
=== CONT  TestAccNetworkingV2SecGroupRule_basic
--- PASS: TestAccNetworkingV2SecGroupRule_basic (39.35s)
=== RUN   TestAccNetworkingV2SecGroupRule_importBasic
=== PAUSE TestAccNetworkingV2SecGroupRule_importBasic
=== CONT  TestAccNetworkingV2SecGroupRule_importBasic
--- PASS: TestAccNetworkingV2SecGroupRule_importBasic (42.04s)
=== RUN   TestAccNetworkingV2SecGroupRule_timeout
=== PAUSE TestAccNetworkingV2SecGroupRule_timeout
=== CONT  TestAccNetworkingV2SecGroupRule_timeout
--- PASS: TestAccNetworkingV2SecGroupRule_timeout (41.56s)
=== RUN   TestAccNetworkingV2SecGroupRule_numericProtocol
=== PAUSE TestAccNetworkingV2SecGroupRule_numericProtocol
=== CONT  TestAccNetworkingV2SecGroupRule_numericProtocol
--- PASS: TestAccNetworkingV2SecGroupRule_numericProtocol (39.36s)
=== RUN   TestAccNetworkingV2SecGroup_basic
=== PAUSE TestAccNetworkingV2SecGroup_basic
=== CONT  TestAccNetworkingV2SecGroup_basic
--- PASS: TestAccNetworkingV2SecGroup_basic (44.11s)
=== RUN   TestAccNetworkingV2SecGroup_importBasic
=== PAUSE TestAccNetworkingV2SecGroup_importBasic
=== CONT  TestAccNetworkingV2SecGroup_importBasic
--- PASS: TestAccNetworkingV2SecGroup_importBasic (33.82s)
=== RUN   TestAccNetworkingV2SecGroup_noDefaultRules
=== PAUSE TestAccNetworkingV2SecGroup_noDefaultRules
=== CONT  TestAccNetworkingV2SecGroup_noDefaultRules
--- PASS: TestAccNetworkingV2SecGroup_noDefaultRules (29.86s)
=== RUN   TestAccNetworkingV2SecGroup_timeout
=== PAUSE TestAccNetworkingV2SecGroup_timeout
=== CONT  TestAccNetworkingV2SecGroup_timeout
--- PASS: TestAccNetworkingV2SecGroup_timeout (26.80s)
=== RUN   TestAccNetworkingV2Subnet_basic
=== PAUSE TestAccNetworkingV2Subnet_basic
=== CONT  TestAccNetworkingV2Subnet_basic
--- PASS: TestAccNetworkingV2Subnet_basic (70.47s)
=== RUN   TestAccNetworkingV2Subnet_import
=== PAUSE TestAccNetworkingV2Subnet_import
=== CONT  TestAccNetworkingV2Subnet_import
--- PASS: TestAccNetworkingV2Subnet_import (56.55s)
=== RUN   TestAccNetworkingV2Subnet_enableDHCP
=== PAUSE TestAccNetworkingV2Subnet_enableDHCP
=== CONT  TestAccNetworkingV2Subnet_enableDHCP
--- PASS: TestAccNetworkingV2Subnet_enableDHCP (51.56s)
=== RUN   TestAccNetworkingV2Subnet_noGateway
=== PAUSE TestAccNetworkingV2Subnet_noGateway
=== CONT  TestAccNetworkingV2Subnet_noGateway
--- PASS: TestAccNetworkingV2Subnet_noGateway (50.84s)
=== RUN   TestAccNetworkingV2Subnet_impliedGateway
=== PAUSE TestAccNetworkingV2Subnet_impliedGateway
=== CONT  TestAccNetworkingV2Subnet_impliedGateway
--- PASS: TestAccNetworkingV2Subnet_impliedGateway (51.21s)
=== RUN   TestAccNetworkingV2Subnet_timeout
=== PAUSE TestAccNetworkingV2Subnet_timeout
=== CONT  TestAccNetworkingV2Subnet_timeout
--- PASS: TestAccNetworkingV2Subnet_timeout (52.21s)
=== RUN   TestAccNetworkingV2VIPAssociate_basic
    resource_opentelekomcloud_networking_vip_associate_v2_test.go:21: this test produces dangling resources
--- SKIP: TestAccNetworkingV2VIPAssociate_basic (0.00s)

Test ignored.
=== RUN   TestAccNetworkingV2VIP_basic
=== PAUSE TestAccNetworkingV2VIP_basic
=== CONT  TestAccNetworkingV2VIP_basic
--- PASS: TestAccNetworkingV2VIP_basic (74.23s)
=== RUN   TestBandwidthAssociateV2_basic
=== PAUSE TestBandwidthAssociateV2_basic
=== CONT  TestBandwidthAssociateV2_basic
--- PASS: TestBandwidthAssociateV2_basic (70.30s)
=== RUN   TestBandwidthAssociateV2_EIPv1
=== PAUSE TestBandwidthAssociateV2_EIPv1
=== CONT  TestBandwidthAssociateV2_EIPv1
--- PASS: TestBandwidthAssociateV2_EIPv1 (74.07s)
=== RUN   TestBandwidthAssociateV2_import
=== PAUSE TestBandwidthAssociateV2_import
=== CONT  TestBandwidthAssociateV2_import
--- PASS: TestBandwidthAssociateV2_import (44.61s)
=== RUN   TestBandwidthV2_basic
=== PAUSE TestBandwidthV2_basic
=== CONT  TestBandwidthV2_basic
--- PASS: TestBandwidthV2_basic (33.83s)
=== RUN   TestBandwidthV2_import
=== PAUSE TestBandwidthV2_import
=== CONT  TestBandwidthV2_import
--- PASS: TestBandwidthV2_import (22.59s)
=== RUN   TestAccVpcV1EIP_basic
=== PAUSE TestAccVpcV1EIP_basic
=== CONT  TestAccVpcV1EIP_basic
--- PASS: TestAccVpcV1EIP_basic (54.26s)
=== RUN   TestAccVpcV1EIP_timeout
=== PAUSE TestAccVpcV1EIP_timeout
=== CONT  TestAccVpcV1EIP_timeout
--- PASS: TestAccVpcV1EIP_timeout (33.15s)
=== RUN   TestAccVpcFlowLogV1_basic
=== PAUSE TestAccVpcFlowLogV1_basic
=== CONT  TestAccVpcFlowLogV1_basic
--- PASS: TestAccVpcFlowLogV1_basic (57.09s)
=== RUN   TestAccVpcPeeringConnectionAcceptorV2_basic
=== PAUSE TestAccVpcPeeringConnectionAcceptorV2_basic
=== CONT  TestAccVpcPeeringConnectionAcceptorV2_basic
--- PASS: TestAccVpcPeeringConnectionAcceptorV2_basic (111.01s)
=== RUN   TestAccVpcPeeringConnectionV2_basic
=== PAUSE TestAccVpcPeeringConnectionV2_basic
=== CONT  TestAccVpcPeeringConnectionV2_basic
--- PASS: TestAccVpcPeeringConnectionV2_basic (129.81s)
=== RUN   TestAccVpcPeeringConnectionV2_import
=== PAUSE TestAccVpcPeeringConnectionV2_import
=== CONT  TestAccVpcPeeringConnectionV2_import
--- PASS: TestAccVpcPeeringConnectionV2_import (188.58s)
=== RUN   TestAccVpcPeeringConnectionV2_timeout
=== PAUSE TestAccVpcPeeringConnectionV2_timeout
=== CONT  TestAccVpcPeeringConnectionV2_timeout
--- PASS: TestAccVpcPeeringConnectionV2_timeout (56.97s)
=== RUN   TestAccVpcRouteV2_basic
=== PAUSE TestAccVpcRouteV2_basic
=== CONT  TestAccVpcRouteV2_basic
--- PASS: TestAccVpcRouteV2_basic (66.78s)
=== RUN   TestAccVpcRouteV2_import
=== PAUSE TestAccVpcRouteV2_import
=== CONT  TestAccVpcRouteV2_import
--- PASS: TestAccVpcRouteV2_import (64.69s)
=== RUN   TestAccVpcRouteV2_timeout
=== PAUSE TestAccVpcRouteV2_timeout
=== CONT  TestAccVpcRouteV2_timeout
--- PASS: TestAccVpcRouteV2_timeout (103.12s)
=== RUN   TestAccVpcSubnetV1Basic
=== PAUSE TestAccVpcSubnetV1Basic
=== CONT  TestAccVpcSubnetV1Basic
--- PASS: TestAccVpcSubnetV1Basic (99.56s)
=== RUN   TestAccVpcSubnetV1Import
=== PAUSE TestAccVpcSubnetV1Import
=== CONT  TestAccVpcSubnetV1Import
--- PASS: TestAccVpcSubnetV1Import (63.02s)
=== RUN   TestAccVpcSubnetV1Timeout
=== PAUSE TestAccVpcSubnetV1Timeout
=== CONT  TestAccVpcSubnetV1Timeout
--- PASS: TestAccVpcSubnetV1Timeout (59.91s)
=== RUN   TestAccVpcSubnetV1DnsList
=== PAUSE TestAccVpcSubnetV1DnsList
=== CONT  TestAccVpcSubnetV1DnsList
--- PASS: TestAccVpcSubnetV1DnsList (123.25s)
=== RUN   TestAccVpcV1_basic
=== PAUSE TestAccVpcV1_basic
=== CONT  TestAccVpcV1_basic
--- PASS: TestAccVpcV1_basic (71.13s)
=== RUN   TestAccVpcV1_timeout
=== PAUSE TestAccVpcV1_timeout
=== CONT  TestAccVpcV1_timeout
--- PASS: TestAccVpcV1_timeout (66.31s)
=== RUN   TestAccVpcV1_import
=== PAUSE TestAccVpcV1_import
=== CONT  TestAccVpcV1_import
--- PASS: TestAccVpcV1_import (75.52s)
PASS
ok  	github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/vpc	476.253s

Process finished with the exit code 0

```
