### PR TITLE
Acceptance: Get rid of defer in `VPCEP` tests

### DIFF
--- a/opentelekomcloud/acceptance/vpcep/data_source_opentelekomcloud_vpcep_service_v1_test.go
+++ b/opentelekomcloud/acceptance/vpcep/data_source_opentelekomcloud_vpcep_service_v1_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
-	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 )
 
 const dataSourceServiceName = "data.opentelekomcloud_vpcep_service_v1.service"
@@ -15,8 +15,7 @@ const dataSourceServiceName = "data.opentelekomcloud_vpcep_service_v1.service"
 func TestDataSourceService(t *testing.T) {
 	name := tools.RandomString("tf-test-", 4)
 	t.Parallel()
-	th.AssertNoErr(t, serviceQuota.Acquire())
-	defer serviceQuota.Release()
+	quotas.BookOne(t, serviceQuota)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },

--- a/opentelekomcloud/acceptance/vpcep/resource_opentelekomcloud_vpcep_endpoint_v1_test.go
+++ b/opentelekomcloud/acceptance/vpcep/resource_opentelekomcloud_vpcep_endpoint_v1_test.go
@@ -3,14 +3,12 @@ package vpcep
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/vpcep/v1/endpoints"
-	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
@@ -24,9 +22,7 @@ func TestEndpoint_basic(t *testing.T) {
 	var ep endpoints.Endpoint
 	name := tools.RandomString("tf-test-ep-", 4)
 	t.Parallel()
-	qts := endpointQuotas()
-	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
-	defer quotas.ReleaseMultipleQuotas(qts)
+	quotas.BookMany(t, endpointQuotas())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -51,9 +47,7 @@ func TestEndpoint_basic(t *testing.T) {
 func TestEndpoint_import(t *testing.T) {
 	name := tools.RandomString("tf-test-ep-", 4)
 	t.Parallel()
-	qts := endpointQuotas()
-	th.AssertNoErr(t, quotas.AcquireMultipleQuotas(qts, 5*time.Second))
-	defer quotas.ReleaseMultipleQuotas(qts)
+	quotas.BookMany(t, endpointQuotas())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },

--- a/opentelekomcloud/acceptance/vpcep/resource_opentelekomcloud_vpcep_service_test.go
+++ b/opentelekomcloud/acceptance/vpcep/resource_opentelekomcloud_vpcep_service_test.go
@@ -9,8 +9,8 @@ import (
 	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/vpcep/v1/services"
-	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/services/vpcep"
@@ -23,8 +23,7 @@ func TestService_basic(t *testing.T) {
 	srvName := tools.RandomString("tf-test-", 4)
 	srvName2 := tools.RandomString("tf-test-", 4)
 	t.Parallel()
-	th.AssertNoErr(t, serviceQuota.Acquire())
-	defer serviceQuota.Release()
+	quotas.BookOne(t, serviceQuota)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -56,8 +55,7 @@ func TestService_basic(t *testing.T) {
 func TestService_import(t *testing.T) {
 	srvName := tools.RandomString("tf-test-", 4)
 	t.Parallel()
-	th.AssertNoErr(t, serviceQuota.Acquire())
-	defer serviceQuota.Release()
+	quotas.BookOne(t, serviceQuota)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },


### PR DESCRIPTION
## Summary of the Pull Request
Replace `defer` statements with `quotas.Book...`

## PR Checklist

* [x] Refers to: #1538
* [x] Tests added/passed.

## Acceptance Steps Performed

```
=== RUN   TestDataSourcePublicService
=== PAUSE TestDataSourcePublicService
=== CONT  TestDataSourcePublicService
--- PASS: TestDataSourcePublicService (20.01s)
=== RUN   TestDataSourceService
=== PAUSE TestDataSourceService
=== CONT  TestDataSourceService
--- PASS: TestDataSourceService (65.53s)
=== RUN   TestEndpoint_basic
=== PAUSE TestEndpoint_basic
=== CONT  TestEndpoint_basic
--- PASS: TestEndpoint_basic (50.11s)
=== RUN   TestEndpoint_import
=== PAUSE TestEndpoint_import
=== CONT  TestEndpoint_import
--- PASS: TestEndpoint_import (54.25s)
=== RUN   TestService_basic
=== PAUSE TestService_basic
=== CONT  TestService_basic
--- PASS: TestService_basic (73.55s)
=== RUN   TestService_import
=== PAUSE TestService_import
=== CONT  TestService_import
--- PASS: TestService_import (49.17s)
PASS
ok  	github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/vpcep	74.398s

Process finished with the exit code 0

```
