### PR TITLE
Acceptance: refactor `OBS` tests

### DIFF
--- a/opentelekomcloud/acceptance/obs/data_source_opentelekomcloud_obs_bucket_object_test.go
+++ b/opentelekomcloud/acceptance/obs/data_source_opentelekomcloud_obs_bucket_object_test.go
@@ -21,7 +21,7 @@ func TestAccDataSourceObsBucketObject_basic(t *testing.T) {
 
 	var dsObj obs.GetObjectOutput
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                  func() { common.TestAccPreCheck(t) },
 		ProviderFactories:         common.TestAccProviderFactories,
 		PreventPostDestroyRefresh: true,
@@ -54,7 +54,7 @@ func TestAccDataSourceObsBucketObject_readableBody(t *testing.T) {
 
 	var dsObj obs.GetObjectOutput
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                  func() { common.TestAccPreCheck(t) },
 		ProviderFactories:         common.TestAccProviderFactories,
 		PreventPostDestroyRefresh: true,
@@ -82,14 +82,12 @@ func TestAccDataSourceObsBucketObject_readableBody(t *testing.T) {
 }
 
 func TestAccDataSourceObsBucketObject_allParams(t *testing.T) {
-	t.Skip("Removing versioned bucket is broken, see GH-779")
-
 	rInt := acctest.RandInt()
 	resourceOnlyConf, conf := testAccDataSourceObsObjectConfigAllParams(rInt)
 
 	var dsObj obs.GetObjectOutput
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                  func() { common.TestAccPreCheck(t) },
 		ProviderFactories:         common.TestAccProviderFactories,
 		PreventPostDestroyRefresh: true,

--- a/opentelekomcloud/acceptance/obs/data_source_opentelekomcloud_obs_bucket_test.go
+++ b/opentelekomcloud/acceptance/obs/data_source_opentelekomcloud_obs_bucket_test.go
@@ -19,7 +19,7 @@ func TestAccDataSourceObsBucket_basic(t *testing.T) {
 
 	var bucket *obs.BaseModel
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                  func() { common.TestAccPreCheck(t) },
 		ProviderFactories:         common.TestAccProviderFactories,
 		PreventPostDestroyRefresh: true,

--- a/opentelekomcloud/acceptance/obs/resource_opentelekomcloud_obs_bucket_object_test.go
+++ b/opentelekomcloud/acceptance/obs/resource_opentelekomcloud_obs_bucket_object_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/obs"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
@@ -23,7 +24,9 @@ func TestAccObsBucketObject_source(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(tmpFile.Name())
+	t.Cleanup(func() {
+		th.AssertNoErr(t, os.Remove(tmpFile.Name()))
+	})
 
 	rInt := acctest.RandInt()
 	// write some data to the tempfile
@@ -32,7 +35,7 @@ func TestAccObsBucketObject_source(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckObsBucketObjectDestroy,
@@ -64,7 +67,7 @@ func TestAccObsBucketObject_source(t *testing.T) {
 func TestAccObsBucketObject_content(t *testing.T) {
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckObsBucketObjectDestroy,
@@ -87,7 +90,7 @@ func TestAccObsBucketObject_content(t *testing.T) {
 func TestAccObsBucketObject_withVersionedContent(t *testing.T) {
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckObsBucketObjectDestroy,
@@ -106,7 +109,7 @@ func TestAccObsBucketObject_withVersionedContent(t *testing.T) {
 func TestAccObsBucketObject_nothing(t *testing.T) {
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckObsBucketObjectDestroy,

--- a/opentelekomcloud/acceptance/obs/resource_opentelekomcloud_obs_bucket_policy_test.go
+++ b/opentelekomcloud/acceptance/obs/resource_opentelekomcloud_obs_bucket_policy_test.go
@@ -24,7 +24,7 @@ func TestAccObsBucketPolicyBasic(t *testing.T) {
 		`{"Version":"2008-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":["*"]},"Action":["s3:*"],"Resource":["arn:aws:s3:::%s/*","arn:aws:s3:::%s"]}]}`,
 		name, name)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckObsBucketDestroy,
@@ -51,7 +51,7 @@ func TestAccObsBucketPolicyUpdate(t *testing.T) {
 		`{"Version":"2008-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":["*"]},"Action":["s3:DeleteBucket", "s3:ListBucket", "s3:ListBucketVersions"], "Resource":["arn:aws:s3:::%s/*","arn:aws:s3:::%s"]}]}`,
 		name, name)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckObsBucketDestroy,
@@ -78,7 +78,7 @@ func TestAccObsBucketPolicyUpdate(t *testing.T) {
 func TestAccObsBucketPolicyMalformed(t *testing.T) {
 	name := fmt.Sprintf("tf-test-bucket-%d", acctest.RandInt())
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckObsBucketDestroy,

--- a/opentelekomcloud/acceptance/obs/resource_opentelekomcloud_obs_bucket_test.go
+++ b/opentelekomcloud/acceptance/obs/resource_opentelekomcloud_obs_bucket_test.go
@@ -17,7 +17,7 @@ func TestAccObsBucket_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 	resourceName := "opentelekomcloud_obs_bucket.bucket"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckObsBucketDestroy,
@@ -55,7 +55,7 @@ func TestAccObsBucket_tags(t *testing.T) {
 	rInt := acctest.RandInt()
 	resourceName := "opentelekomcloud_obs_bucket.bucket"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		Steps: []resource.TestStep{
@@ -75,7 +75,7 @@ func TestAccObsBucket_versioning(t *testing.T) {
 	rInt := acctest.RandInt()
 	resourceName := "opentelekomcloud_obs_bucket.bucket"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckObsBucketDestroy,
@@ -103,7 +103,7 @@ func TestAccObsBucket_logging(t *testing.T) {
 	targetBucket := fmt.Sprintf("tf-test-log-bucket-%d", rInt)
 	resourceName := "opentelekomcloud_obs_bucket.bucket"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckObsBucketDestroy,
@@ -123,7 +123,7 @@ func TestAccObsBucket_lifecycle(t *testing.T) {
 	rInt := acctest.RandInt()
 	resourceName := "opentelekomcloud_obs_bucket.bucket"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckObsBucketDestroy,
@@ -152,7 +152,7 @@ func TestAccObsBucket_website(t *testing.T) {
 	rInt := acctest.RandInt()
 	resourceName := "opentelekomcloud_obs_bucket.bucket"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckObsBucketDestroy,
@@ -173,7 +173,7 @@ func TestAccObsBucket_cors(t *testing.T) {
 	rInt := acctest.RandInt()
 	resourceName := "opentelekomcloud_obs_bucket.bucket"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckObsBucketDestroy,
@@ -196,7 +196,7 @@ func TestAccObsBucket_cors(t *testing.T) {
 func TestAccObsBucket_notifications(t *testing.T) {
 	rInt := acctest.RandInt()
 	resourceName := "opentelekomcloud_obs_bucket.bucket"
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckObsBucketDestroy,


### PR DESCRIPTION
## Summary of the Pull Request
Make OBS tests parallel

Use `t.Cleanup` instead of `defer` in tests

## PR Checklist

* [x] Refers to: #1538 
* [x] Tests added/passed.

## Acceptance Steps Performed

```
=== RUN   TestAccDataSourceObsBucketObject_basic
=== PAUSE TestAccDataSourceObsBucketObject_basic
=== CONT  TestAccDataSourceObsBucketObject_basic
--- PASS: TestAccDataSourceObsBucketObject_basic (41.82s)
=== RUN   TestAccDataSourceObsBucketObject_readableBody
=== PAUSE TestAccDataSourceObsBucketObject_readableBody
=== CONT  TestAccDataSourceObsBucketObject_readableBody
--- PASS: TestAccDataSourceObsBucketObject_readableBody (42.26s)
=== RUN   TestAccDataSourceObsBucketObject_allParams
=== PAUSE TestAccDataSourceObsBucketObject_allParams
=== CONT  TestAccDataSourceObsBucketObject_allParams
--- PASS: TestAccDataSourceObsBucketObject_allParams (48.09s)
=== RUN   TestAccDataSourceObsBucket_basic
=== PAUSE TestAccDataSourceObsBucket_basic
=== CONT  TestAccDataSourceObsBucket_basic
--- PASS: TestAccDataSourceObsBucket_basic (38.85s)
=== RUN   TestAccObsBucketObject_source
=== PAUSE TestAccObsBucketObject_source
=== CONT  TestAccObsBucketObject_source
--- PASS: TestAccObsBucketObject_source (41.93s)
=== RUN   TestAccObsBucketObject_content
=== PAUSE TestAccObsBucketObject_content
=== CONT  TestAccObsBucketObject_content
--- PASS: TestAccObsBucketObject_content (23.43s)
=== RUN   TestAccObsBucketObject_withVersionedContent
=== PAUSE TestAccObsBucketObject_withVersionedContent
=== CONT  TestAccObsBucketObject_withVersionedContent
--- PASS: TestAccObsBucketObject_withVersionedContent (24.92s)
=== RUN   TestAccObsBucketObject_nothing
=== PAUSE TestAccObsBucketObject_nothing
=== CONT  TestAccObsBucketObject_nothing
--- PASS: TestAccObsBucketObject_nothing (2.95s)
=== RUN   TestAccObsBucketPolicyBasic
=== PAUSE TestAccObsBucketPolicyBasic
=== CONT  TestAccObsBucketPolicyBasic
--- PASS: TestAccObsBucketPolicyBasic (23.69s)
=== RUN   TestAccObsBucketPolicyUpdate
=== PAUSE TestAccObsBucketPolicyUpdate
=== CONT  TestAccObsBucketPolicyUpdate
--- PASS: TestAccObsBucketPolicyUpdate (45.19s)
=== RUN   TestAccObsBucketPolicyMalformed
=== PAUSE TestAccObsBucketPolicyMalformed
=== CONT  TestAccObsBucketPolicyMalformed
--- PASS: TestAccObsBucketPolicyMalformed (72.77s)
=== RUN   TestAccObsBucket_basic
=== PAUSE TestAccObsBucket_basic
=== CONT  TestAccObsBucket_basic
--- PASS: TestAccObsBucket_basic (57.58s)
=== RUN   TestAccObsBucket_tags
=== PAUSE TestAccObsBucket_tags
=== CONT  TestAccObsBucket_tags
--- PASS: TestAccObsBucket_tags (20.44s)
=== RUN   TestAccObsBucket_versioning
=== PAUSE TestAccObsBucket_versioning
=== CONT  TestAccObsBucket_versioning
--- PASS: TestAccObsBucket_versioning (39.46s)
=== RUN   TestAccObsBucket_logging
=== PAUSE TestAccObsBucket_logging
=== CONT  TestAccObsBucket_logging
--- PASS: TestAccObsBucket_logging (26.56s)
=== RUN   TestAccObsBucket_lifecycle
=== PAUSE TestAccObsBucket_lifecycle
=== CONT  TestAccObsBucket_lifecycle
--- PASS: TestAccObsBucket_lifecycle (21.80s)
=== RUN   TestAccObsBucket_website
=== PAUSE TestAccObsBucket_website
=== CONT  TestAccObsBucket_website
--- PASS: TestAccObsBucket_website (21.53s)
=== RUN   TestAccObsBucket_cors
=== PAUSE TestAccObsBucket_cors
=== CONT  TestAccObsBucket_cors
--- PASS: TestAccObsBucket_cors (21.62s)
=== RUN   TestAccObsBucket_notifications
=== PAUSE TestAccObsBucket_notifications
=== CONT  TestAccObsBucket_notifications
--- PASS: TestAccObsBucket_notifications (30.56s)
PASS
ok  	github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/obs	73.609s

Process finished with the exit code 0
```
