### PR TITLE
[S3] Fix bucket website removal

### DIFF
--- a/opentelekomcloud/acceptance/s3/resource_opentelekomcloud_s3_bucket_test.go
+++ b/opentelekomcloud/acceptance/s3/resource_opentelekomcloud_s3_bucket_test.go
@@ -948,17 +948,14 @@ resource "opentelekomcloud_s3_bucket" "bucket6" {
 
 func testAccS3BucketConfigWithRegion(randInt int) string {
 	return fmt.Sprintf(`
-provider "opentelekomcloud" {
-  alias  = "reg1"
-  region = "%s"
-}
+%s
 
 resource "opentelekomcloud_s3_bucket" "bucket" {
-  provider = "reg1"
+  provider = "%s"
   bucket   = "tf-test-bucket-%d"
   region   = "%s"
 }
-`, env.OS_REGION_NAME, randInt, env.OS_REGION_NAME)
+`, common.AlternativeProviderWithRegionConfig, common.AlternativeProviderWithRegionAlias, randInt, env.OS_REGION_NAME)
 }
 
 func testAccS3BucketWebsiteConfig(randInt int) string {

--- a/opentelekomcloud/services/s3/resource_opentelekomcloud_s3_bucket.go
+++ b/opentelekomcloud/services/s3/resource_opentelekomcloud_s3_bucket.go
@@ -958,6 +958,8 @@ func resourceS3BucketCorsUpdate(ctx context.Context, s3conn *s3.S3, d *schema.Re
 func resourceS3BucketWebsiteUpdate(ctx context.Context, s3conn *s3.S3, d *schema.ResourceData) error {
 	ws := d.Get("website").([]interface{})
 	switch len(ws) {
+	case 0:
+		return resourceS3BucketWebsiteDelete(ctx, s3conn, d)
 	case 1:
 		var w map[string]interface{}
 		if ws[0] != nil {
@@ -966,8 +968,6 @@ func resourceS3BucketWebsiteUpdate(ctx context.Context, s3conn *s3.S3, d *schema
 			w = make(map[string]interface{})
 		}
 		return resourceS3BucketWebsitePut(ctx, s3conn, d, w)
-	case 2:
-		return resourceS3BucketWebsiteDelete(ctx, s3conn, d)
 	default:
 		return fmt.Errorf("cannot specify more than one website")
 	}

--- a/releasenotes/notes/s3-website-a064467b8b17b337.yaml
+++ b/releasenotes/notes/s3-website-a064467b8b17b337.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[S3]** Fix error on removing website from ``resource/opentelekomcloud_s3_bucket``


### PR DESCRIPTION
## Summary of the Pull Request
Fix incorrect handling of the empty website on update

Fix #1565 

## PR Checklist

* [x] Refers to: #1565 
* [x] Tests added/passed.
* [x] Release notes added.

## Acceptance Steps Performed

```
2021/11/30 19:38:00 [INFO] Building Swift S3 auth structure
2021/11/30 19:38:00 [INFO] Setting AWS metadata API timeout to 100ms
2021/11/30 19:38:01 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2021/11/30 19:38:01 [INFO] Swift S3 Auth provider used: "StaticProvider"
=== RUN   TestAccS3Bucket_Website_Simple
--- PASS: TestAccS3Bucket_Website_Simple (368.89s)
PASS

Process finished with the exit code 0
```
