### PR TITLE
Acceptance: refactor `S3` tests

### DIFF
--- a/opentelekomcloud/acceptance/s3/data_source_opentelekomcloud_s3_bucket_object_test.go
+++ b/opentelekomcloud/acceptance/s3/data_source_opentelekomcloud_s3_bucket_object_test.go
@@ -23,7 +23,7 @@ func TestAccDataSourceS3BucketObject_basic(t *testing.T) {
 	var rObj s3.GetObjectOutput
 	var dsObj s3.GetObjectOutput
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                  func() { common.TestAccPreCheck(t) },
 		ProviderFactories:         common.TestAccProviderFactories,
 		PreventPostDestroyRefresh: true,
@@ -57,7 +57,7 @@ func TestAccDataSourceS3BucketObject_readableBody(t *testing.T) {
 	var rObj s3.GetObjectOutput
 	var dsObj s3.GetObjectOutput
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                  func() { common.TestAccPreCheck(t) },
 		ProviderFactories:         common.TestAccProviderFactories,
 		PreventPostDestroyRefresh: true,
@@ -91,7 +91,7 @@ func TestAccDataSourceAWSS3BucketObject_allParams(t *testing.T) {
 	var rObj s3.GetObjectOutput
 	var dsObj s3.GetObjectOutput
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                  func() { common.TestAccPreCheck(t) },
 		ProviderFactories:         common.TestAccProviderFactories,
 		PreventPostDestroyRefresh: true,

--- a/opentelekomcloud/acceptance/s3/resource_opentelekomcloud_s3_bucket_object_test.go
+++ b/opentelekomcloud/acceptance/s3/resource_opentelekomcloud_s3_bucket_object_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -23,20 +24,18 @@ import (
 
 func TestAccS3BucketObject_source(t *testing.T) {
 	tmpFile, err := ioutil.TempFile("", "tf-acc-s3-obj-source")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = os.Remove(tmpFile.Name()) }()
+	th.AssertNoErr(t, err)
+	t.Cleanup(func() {
+		th.AssertNoErr(t, os.Remove(tmpFile.Name()))
+	})
 
 	rInt := acctest.RandInt()
 	// first write some data to the tempfile just so it's not 0 bytes.
 	err = ioutil.WriteFile(tmpFile.Name(), []byte("{anything will do }"), 0644)
-	if err != nil {
-		t.Fatal(err)
-	}
+	th.AssertNoErr(t, err)
 	var obj s3.GetObjectOutput
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheckS3(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckS3BucketObjectDestroy,
@@ -53,7 +52,7 @@ func TestAccS3BucketObject_content(t *testing.T) {
 	rInt := acctest.RandInt()
 	var obj s3.GetObjectOutput
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheckS3(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckS3BucketObjectDestroy,
@@ -69,21 +68,19 @@ func TestAccS3BucketObject_content(t *testing.T) {
 
 func TestAccS3BucketObject_withContentCharacteristics(t *testing.T) {
 	tmpFile, err := ioutil.TempFile("", "tf-acc-s3-obj-content-characteristics")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = os.Remove(tmpFile.Name()) }()
+	th.AssertNoErr(t, err)
+	t.Cleanup(func() {
+		th.AssertNoErr(t, os.Remove(tmpFile.Name()))
+	})
 
 	rInt := acctest.RandInt()
 	// first write some data to the tempfile just so it's not 0 bytes.
 	err = ioutil.WriteFile(tmpFile.Name(), []byte("{anything will do }"), 0644)
-	if err != nil {
-		t.Fatal(err)
-	}
+	th.AssertNoErr(t, err)
 
 	var obj s3.GetObjectOutput
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheckS3(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckS3BucketObjectDestroy,
@@ -104,19 +101,17 @@ func TestAccS3BucketObject_withContentCharacteristics(t *testing.T) {
 
 func TestAccS3BucketObject_updates(t *testing.T) {
 	tmpFile, err := ioutil.TempFile("", "tf-acc-s3-obj-updates")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = os.Remove(tmpFile.Name()) }()
+	th.AssertNoErr(t, err)
+	t.Cleanup(func() {
+		th.AssertNoErr(t, os.Remove(tmpFile.Name()))
+	})
 
 	rInt := acctest.RandInt()
 	err = ioutil.WriteFile(tmpFile.Name(), []byte("initial object state"), 0644)
-	if err != nil {
-		t.Fatal(err)
-	}
+	th.AssertNoErr(t, err)
 	var obj s3.GetObjectOutput
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheckS3(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckS3BucketObjectDestroy,
@@ -147,20 +142,18 @@ func TestAccS3BucketObject_updates(t *testing.T) {
 
 func TestAccS3BucketObject_updatesWithVersioning(t *testing.T) {
 	tmpFile, err := ioutil.TempFile("", "tf-acc-s3-obj-updates-w-versions")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = os.Remove(tmpFile.Name()) }()
+	th.AssertNoErr(t, err)
+	t.Cleanup(func() {
+		th.AssertNoErr(t, os.Remove(tmpFile.Name()))
+	})
 
 	rInt := acctest.RandInt()
 	err = ioutil.WriteFile(tmpFile.Name(), []byte("initial versioned object state"), 0644)
-	if err != nil {
-		t.Fatal(err)
-	}
+	th.AssertNoErr(t, err)
 
 	var originalObj, modifiedObj s3.GetObjectOutput
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheckS3(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckS3BucketObjectDestroy,
@@ -266,21 +259,19 @@ func testAccCheckS3BucketObjectExists(n string, obj *s3.GetObjectOutput) resourc
 
 func TestAccS3BucketObject_sse(t *testing.T) {
 	tmpFile, err := ioutil.TempFile("", "tf-acc-s3-obj-source-sse")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = os.Remove(tmpFile.Name()) }()
+	th.AssertNoErr(t, err)
+	t.Cleanup(func() {
+		th.AssertNoErr(t, os.Remove(tmpFile.Name()))
+	})
 
 	// first write some data to the tempfile just so it's not 0 bytes.
 	err = ioutil.WriteFile(tmpFile.Name(), []byte("{anything will do}"), 0644)
-	if err != nil {
-		t.Fatal(err)
-	}
+	th.AssertNoErr(t, err)
 
 	rInt := acctest.RandInt()
 	var obj s3.GetObjectOutput
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheckS3(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckS3BucketObjectDestroy,
@@ -305,7 +296,7 @@ func TestAccS3BucketObject_acl(t *testing.T) {
 	rInt := acctest.RandInt()
 	var obj s3.GetObjectOutput
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheckS3(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckS3BucketObjectDestroy,
@@ -376,15 +367,16 @@ func testAccCheckS3BucketObjectAcl(n string, expectedPerms []string) resource.Te
 }
 
 func TestResourceS3BucketObjectAcl_validation(t *testing.T) {
-	_, errors := s3s.ValidateS3BucketObjectAclType("incorrect", "acl")
-	if len(errors) == 0 {
-		t.Fatalf("Expected to trigger a validation error")
-	}
+	t.Parallel()
 
 	var testCases = []struct {
 		Value    string
 		ErrCount int
 	}{
+		{
+			Value:    "incorrect",
+			ErrCount: 1,
+		},
 		{
 			Value:    "public-read",
 			ErrCount: 0,
@@ -396,23 +388,27 @@ func TestResourceS3BucketObjectAcl_validation(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		_, errors := s3s.ValidateS3BucketObjectAclType(tc.Value, "acl")
-		if len(errors) != tc.ErrCount {
-			t.Fatalf("Expected not to trigger a validation error")
-		}
+		t.Run(tc.Value, func(t *testing.T) {
+			t.Parallel()
+			_, errors := s3s.ValidateS3BucketObjectAclType(tc.Value, "acl")
+			if len(errors) != tc.ErrCount {
+				t.Fatalf("Expected to trigger %d validation errors, but got %d", tc.ErrCount, len(errors))
+			}
+		})
 	}
 }
 
 func TestResourceS3BucketObjectStorageClass_validation(t *testing.T) {
-	_, errors := validateS3BucketObjectStorageClassType("incorrect", "storage_class")
-	if len(errors) == 0 {
-		t.Fatalf("Expected to trigger a validation error")
-	}
+	t.Parallel()
 
 	var testCases = []struct {
 		Value    string
 		ErrCount int
 	}{
+		{
+			Value:    "incorrect",
+			ErrCount: 1,
+		},
 		{
 			Value:    "STANDARD",
 			ErrCount: 0,
@@ -424,10 +420,13 @@ func TestResourceS3BucketObjectStorageClass_validation(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		_, errors := validateS3BucketObjectStorageClassType(tc.Value, "storage_class")
-		if len(errors) != tc.ErrCount {
-			t.Fatalf("Expected not to trigger a validation error")
-		}
+		t.Run(tc.Value, func(t *testing.T) {
+			t.Parallel()
+			_, errors := validateS3BucketObjectStorageClassType(tc.Value, "storage_class")
+			if len(errors) != tc.ErrCount {
+				t.Fatalf("Expected not to trigger a validation error")
+			}
+		})
 	}
 }
 

--- a/opentelekomcloud/acceptance/s3/resource_opentelekomcloud_s3_bucket_policy_test.go
+++ b/opentelekomcloud/acceptance/s3/resource_opentelekomcloud_s3_bucket_policy_test.go
@@ -23,7 +23,7 @@ func TestAccS3BucketPolicy_basic(t *testing.T) {
 		`{"Version":"2008-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":["*"]},"Action":["s3:*"],"Resource":["arn:aws:s3:::%s/*","arn:aws:s3:::%s"]}]}`,
 		name, name)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheckS3(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckS3BucketDestroy,
@@ -50,7 +50,7 @@ func TestAccS3BucketPolicy_policyUpdate(t *testing.T) {
 		`{"Version":"2008-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":["*"]},"Action":["s3:DeleteBucket", "s3:ListBucket", "s3:ListBucketVersions"], "Resource":["arn:aws:s3:::%s/*","arn:aws:s3:::%s"]}]}`,
 		name, name)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheckS3(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckS3BucketDestroy,

--- a/opentelekomcloud/acceptance/s3/resource_opentelekomcloud_s3_bucket_test.go
+++ b/opentelekomcloud/acceptance/s3/resource_opentelekomcloud_s3_bucket_test.go
@@ -48,9 +48,9 @@ func TestAccS3Bucket_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSS3MultiBucket_withTags(t *testing.T) {
+func TestAccS3MultiBucket_withTags(t *testing.T) {
 	rInt := acctest.RandInt()
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheckS3(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckS3BucketDestroy,
@@ -65,7 +65,7 @@ func TestAccAWSS3MultiBucket_withTags(t *testing.T) {
 func TestAccS3Bucket_namePrefix(t *testing.T) {
 	resourceName := "opentelekomcloud_s3_bucket.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheckS3(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckS3BucketDestroy,
@@ -84,7 +84,7 @@ func TestAccS3Bucket_namePrefix(t *testing.T) {
 func TestAccS3Bucket_generatedName(t *testing.T) {
 	resourceName := "opentelekomcloud_s3_bucket.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheckS3(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckS3BucketDestroy,
@@ -103,7 +103,7 @@ func TestAccS3Bucket_region(t *testing.T) {
 	rInt := acctest.RandInt()
 	resourceName := "opentelekomcloud_s3_bucket.bucket"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheckS3(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckS3BucketDestroy,
@@ -123,7 +123,7 @@ func TestAccS3Bucket_Policy(t *testing.T) {
 	rInt := acctest.RandInt()
 	resourceName := "opentelekomcloud_s3_bucket.bucket"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheckS3(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckS3BucketDestroy,
@@ -159,7 +159,7 @@ func TestAccS3Bucket_UpdateAcl(t *testing.T) {
 	postConfig := fmt.Sprintf(testAccS3BucketConfigWithAclUpdate, ri)
 	resourceName := "opentelekomcloud_s3_bucket.bucket"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheckS3(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckS3BucketDestroy,
@@ -186,7 +186,7 @@ func TestAccS3Bucket_Website_Simple(t *testing.T) {
 	rInt := acctest.RandInt()
 	resourceName := "opentelekomcloud_s3_bucket.bucket"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheckS3(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckS3BucketDestroy,
@@ -223,7 +223,7 @@ func TestAccS3Bucket_WebsiteRedirect(t *testing.T) {
 	rInt := acctest.RandInt()
 	resourceName := "opentelekomcloud_s3_bucket.bucket"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheckS3(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckS3BucketDestroy,
@@ -260,7 +260,7 @@ func TestAccS3Bucket_WebsiteRoutingRules(t *testing.T) {
 	rInt := acctest.RandInt()
 	resourceName := "opentelekomcloud_s3_bucket.bucket"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheckS3(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckS3BucketDestroy,
@@ -305,7 +305,7 @@ func TestAccS3Bucket_shouldFailNotFound(t *testing.T) {
 	rInt := acctest.RandInt()
 	resourceName := "opentelekomcloud_s3_bucket.bucket"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheckS3(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckS3BucketDestroy,
@@ -326,7 +326,7 @@ func TestAccS3Bucket_Versioning(t *testing.T) {
 	rInt := acctest.RandInt()
 	resourceName := "opentelekomcloud_s3_bucket.bucket"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheckS3(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckS3BucketDestroy,
@@ -360,7 +360,7 @@ func TestAccS3Bucket_VersioningSecond(t *testing.T) {
 	rInt := acctest.RandInt()
 	resourceName := "opentelekomcloud_s3_bucket.bucket"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheckS3(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckS3BucketDestroy,
@@ -420,7 +420,7 @@ func TestAccS3Bucket_Cors(t *testing.T) {
 		}
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheckS3(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckS3BucketDestroy,
@@ -469,7 +469,7 @@ func TestAccS3Bucket_Logging(t *testing.T) {
 	rInt := acctest.RandInt()
 	resourceName := "opentelekomcloud_s3_bucket.bucket"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheckS3(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckS3BucketDestroy,
@@ -489,7 +489,7 @@ func TestAccS3Bucket_Lifecycle(t *testing.T) {
 	rInt := acctest.RandInt()
 	resourceName := "opentelekomcloud_s3_bucket.bucket"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheckS3(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckS3BucketDestroy,
@@ -500,14 +500,10 @@ func TestAccS3Bucket_Lifecycle(t *testing.T) {
 					testAccCheckS3BucketExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "lifecycle_rule.0.id", "id1"),
 					resource.TestCheckResourceAttr(resourceName, "lifecycle_rule.0.prefix", "path1/"),
-					resource.TestCheckResourceAttr(resourceName, "lifecycle_rule.0.expiration.2613713285.days", "365"),
-					resource.TestCheckResourceAttr(resourceName, "lifecycle_rule.0.expiration.2613713285.date", ""),
-					resource.TestCheckResourceAttr(resourceName, "lifecycle_rule.0.expiration.2613713285.expired_object_delete_marker", "false"),
+					resource.TestCheckResourceAttr(resourceName, "lifecycle_rule.0.expiration.0.days", "365"),
 					resource.TestCheckResourceAttr(resourceName, "lifecycle_rule.1.id", "id2"),
 					resource.TestCheckResourceAttr(resourceName, "lifecycle_rule.1.prefix", "path2/"),
-					resource.TestCheckResourceAttr(resourceName, "lifecycle_rule.1.expiration.2855832418.date", "2016-01-12"),
-					resource.TestCheckResourceAttr(resourceName, "lifecycle_rule.1.expiration.2855832418.days", "0"),
-					resource.TestCheckResourceAttr(resourceName, "lifecycle_rule.1.expiration.2855832418.expired_object_delete_marker", "false"),
+					resource.TestCheckResourceAttr(resourceName, "lifecycle_rule.1.expiration.0.date", "2016-01-12"),
 					resource.TestCheckResourceAttr(resourceName, "lifecycle_rule.2.id", "id3"),
 					resource.TestCheckResourceAttr(resourceName, "lifecycle_rule.2.prefix", "path3/"),
 					resource.TestCheckResourceAttr(resourceName, "lifecycle_rule.3.id", "id4"),
@@ -521,11 +517,11 @@ func TestAccS3Bucket_Lifecycle(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "lifecycle_rule.0.id", "id1"),
 					resource.TestCheckResourceAttr(resourceName, "lifecycle_rule.0.prefix", "path1/"),
 					resource.TestCheckResourceAttr(resourceName, "lifecycle_rule.0.enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "lifecycle_rule.0.noncurrent_version_expiration.80908210.days", "365"),
+					resource.TestCheckResourceAttr(resourceName, "lifecycle_rule.0.noncurrent_version_expiration.0.days", "365"),
 					resource.TestCheckResourceAttr(resourceName, "lifecycle_rule.1.id", "id2"),
 					resource.TestCheckResourceAttr(resourceName, "lifecycle_rule.1.prefix", "path2/"),
 					resource.TestCheckResourceAttr(resourceName, "lifecycle_rule.1.enabled", "false"),
-					resource.TestCheckResourceAttr(resourceName, "lifecycle_rule.1.noncurrent_version_expiration.80908210.days", "365"),
+					resource.TestCheckResourceAttr(resourceName, "lifecycle_rule.1.noncurrent_version_expiration.0.days", "365"),
 					resource.TestCheckResourceAttr(resourceName, "lifecycle_rule.2.id", "id3"),
 					resource.TestCheckResourceAttr(resourceName, "lifecycle_rule.2.prefix", "path3/"),
 				),


### PR DESCRIPTION
## Summary of the Pull Request
Make S3 tests parallel

Use `t.Cleanup` instead of `defer` in tests

Remove checks impossible with the current terraform plugin SDK


## PR Checklist

* [x] Refers to: #1538
* [x] Tests added/passed.

## Acceptance Steps Performed

```
=== RUN   TestAccDataSourceS3BucketObject_basic
=== PAUSE TestAccDataSourceS3BucketObject_basic
=== CONT  TestAccDataSourceS3BucketObject_basic
--- PASS: TestAccDataSourceS3BucketObject_basic (245.15s)
=== RUN   TestAccDataSourceS3BucketObject_readableBody
=== PAUSE TestAccDataSourceS3BucketObject_readableBody
=== CONT  TestAccDataSourceS3BucketObject_readableBody
--- PASS: TestAccDataSourceS3BucketObject_readableBody (245.60s)
=== RUN   TestAccDataSourceAWSS3BucketObject_allParams
=== PAUSE TestAccDataSourceAWSS3BucketObject_allParams
=== CONT  TestAccDataSourceAWSS3BucketObject_allParams
--- PASS: TestAccDataSourceAWSS3BucketObject_allParams (244.83s)
=== RUN   TestAccS3BucketObject_source
=== PAUSE TestAccS3BucketObject_source
=== CONT  TestAccS3BucketObject_source
--- PASS: TestAccS3BucketObject_source (136.20s)
=== RUN   TestAccS3BucketObject_content
=== PAUSE TestAccS3BucketObject_content
=== CONT  TestAccS3BucketObject_content
--- PASS: TestAccS3BucketObject_content (136.55s)
=== RUN   TestAccS3BucketObject_withContentCharacteristics
=== PAUSE TestAccS3BucketObject_withContentCharacteristics
=== CONT  TestAccS3BucketObject_withContentCharacteristics
--- PASS: TestAccS3BucketObject_withContentCharacteristics (134.08s)
=== RUN   TestAccS3BucketObject_updates
=== PAUSE TestAccS3BucketObject_updates
=== CONT  TestAccS3BucketObject_updates
--- PASS: TestAccS3BucketObject_updates (246.80s)
=== RUN   TestAccS3BucketObject_updatesWithVersioning
=== PAUSE TestAccS3BucketObject_updatesWithVersioning
=== CONT  TestAccS3BucketObject_updatesWithVersioning
--- PASS: TestAccS3BucketObject_updatesWithVersioning (247.52s)
=== RUN   TestAccS3BucketObject_sse
=== PAUSE TestAccS3BucketObject_sse
=== CONT  TestAccS3BucketObject_sse
--- PASS: TestAccS3BucketObject_sse (134.98s)
=== RUN   TestAccS3BucketObject_acl
=== PAUSE TestAccS3BucketObject_acl
=== CONT  TestAccS3BucketObject_acl
--- PASS: TestAccS3BucketObject_acl (243.80s)
=== RUN   TestResourceS3BucketObjectAcl_validation
=== PAUSE TestResourceS3BucketObjectAcl_validation
=== CONT  TestResourceS3BucketObjectAcl_validation
--- PASS: TestResourceS3BucketObjectAcl_validation (0.00s)
=== RUN   TestResourceS3BucketObjectAcl_validation/incorrect
=== PAUSE TestResourceS3BucketObjectAcl_validation/incorrect
=== CONT  TestResourceS3BucketObjectAcl_validation/incorrect
    --- PASS: TestResourceS3BucketObjectAcl_validation/incorrect (0.00s)
=== RUN   TestResourceS3BucketObjectAcl_validation/public-read
=== PAUSE TestResourceS3BucketObjectAcl_validation/public-read
=== CONT  TestResourceS3BucketObjectAcl_validation/public-read
    --- PASS: TestResourceS3BucketObjectAcl_validation/public-read (0.00s)
=== RUN   TestResourceS3BucketObjectAcl_validation/public-read-write
=== PAUSE TestResourceS3BucketObjectAcl_validation/public-read-write
=== CONT  TestResourceS3BucketObjectAcl_validation/public-read-write
    --- PASS: TestResourceS3BucketObjectAcl_validation/public-read-write (0.00s)
=== RUN   TestResourceS3BucketObjectStorageClass_validation
=== PAUSE TestResourceS3BucketObjectStorageClass_validation
=== CONT  TestResourceS3BucketObjectStorageClass_validation
--- PASS: TestResourceS3BucketObjectStorageClass_validation (0.00s)
=== RUN   TestResourceS3BucketObjectStorageClass_validation/incorrect
=== PAUSE TestResourceS3BucketObjectStorageClass_validation/incorrect
=== CONT  TestResourceS3BucketObjectStorageClass_validation/incorrect
    --- PASS: TestResourceS3BucketObjectStorageClass_validation/incorrect (0.00s)
=== RUN   TestResourceS3BucketObjectStorageClass_validation/STANDARD
=== PAUSE TestResourceS3BucketObjectStorageClass_validation/STANDARD
=== CONT  TestResourceS3BucketObjectStorageClass_validation/STANDARD
    --- PASS: TestResourceS3BucketObjectStorageClass_validation/STANDARD (0.00s)
=== RUN   TestResourceS3BucketObjectStorageClass_validation/REDUCED_REDUNDANCY
=== PAUSE TestResourceS3BucketObjectStorageClass_validation/REDUCED_REDUNDANCY
=== CONT  TestResourceS3BucketObjectStorageClass_validation/REDUCED_REDUNDANCY
    --- PASS: TestResourceS3BucketObjectStorageClass_validation/REDUCED_REDUNDANCY (0.00s)
=== RUN   TestAccS3BucketPolicy_basic
=== PAUSE TestAccS3BucketPolicy_basic
=== CONT  TestAccS3BucketPolicy_basic
--- PASS: TestAccS3BucketPolicy_basic (133.98s)
=== RUN   TestAccS3BucketPolicy_policyUpdate
=== PAUSE TestAccS3BucketPolicy_policyUpdate
=== CONT  TestAccS3BucketPolicy_policyUpdate
--- PASS: TestAccS3BucketPolicy_policyUpdate (243.60s)
=== RUN   TestAccS3Bucket_basic
--- PASS: TestAccS3Bucket_basic (141.24s)
=== RUN   TestAccS3MultiBucket_withTags
=== PAUSE TestAccS3MultiBucket_withTags
=== CONT  TestAccS3MultiBucket_withTags
--- PASS: TestAccS3MultiBucket_withTags (135.87s)
=== RUN   TestAccS3Bucket_namePrefix
=== PAUSE TestAccS3Bucket_namePrefix
=== CONT  TestAccS3Bucket_namePrefix
--- PASS: TestAccS3Bucket_namePrefix (133.57s)
=== RUN   TestAccS3Bucket_generatedName
=== PAUSE TestAccS3Bucket_generatedName
=== CONT  TestAccS3Bucket_generatedName
--- PASS: TestAccS3Bucket_generatedName (134.77s)
=== RUN   TestAccS3Bucket_region
=== PAUSE TestAccS3Bucket_region
=== CONT  TestAccS3Bucket_region
--- PASS: TestAccS3Bucket_region (133.25s)
=== RUN   TestAccS3Bucket_Policy
=== PAUSE TestAccS3Bucket_Policy
=== CONT  TestAccS3Bucket_Policy
--- PASS: TestAccS3Bucket_Policy (352.71s)
=== RUN   TestAccS3Bucket_UpdateAcl
=== PAUSE TestAccS3Bucket_UpdateAcl
=== CONT  TestAccS3Bucket_UpdateAcl
--- PASS: TestAccS3Bucket_UpdateAcl (243.75s)
=== RUN   TestAccS3Bucket_Website_Simple
=== PAUSE TestAccS3Bucket_Website_Simple
=== CONT  TestAccS3Bucket_Website_Simple
--- PASS: TestAccS3Bucket_Website_Simple (355.63s)
=== RUN   TestAccS3Bucket_WebsiteRedirect
=== PAUSE TestAccS3Bucket_WebsiteRedirect
=== CONT  TestAccS3Bucket_WebsiteRedirect
--- PASS: TestAccS3Bucket_WebsiteRedirect (359.55s)
=== RUN   TestAccS3Bucket_WebsiteRoutingRules
=== PAUSE TestAccS3Bucket_WebsiteRoutingRules
=== CONT  TestAccS3Bucket_WebsiteRoutingRules
--- PASS: TestAccS3Bucket_WebsiteRoutingRules (247.86s)
=== RUN   TestAccS3Bucket_shouldFailNotFound
=== PAUSE TestAccS3Bucket_shouldFailNotFound
=== CONT  TestAccS3Bucket_shouldFailNotFound
--- PASS: TestAccS3Bucket_shouldFailNotFound (124.31s)
=== RUN   TestAccS3Bucket_Versioning
=== PAUSE TestAccS3Bucket_Versioning
=== CONT  TestAccS3Bucket_Versioning
--- PASS: TestAccS3Bucket_Versioning (356.77s)
=== RUN   TestAccS3Bucket_VersioningSecond
=== PAUSE TestAccS3Bucket_VersioningSecond
=== CONT  TestAccS3Bucket_VersioningSecond
--- PASS: TestAccS3Bucket_VersioningSecond (247.74s)
=== RUN   TestAccS3Bucket_Cors
=== PAUSE TestAccS3Bucket_Cors
=== CONT  TestAccS3Bucket_Cors
--- PASS: TestAccS3Bucket_Cors (245.65s)
=== RUN   TestAccS3Bucket_Logging
=== PAUSE TestAccS3Bucket_Logging
=== CONT  TestAccS3Bucket_Logging
--- PASS: TestAccS3Bucket_Logging (141.28s)
=== RUN   TestAccS3Bucket_Lifecycle
=== PAUSE TestAccS3Bucket_Lifecycle
=== CONT  TestAccS3Bucket_Lifecycle
--- PASS: TestAccS3Bucket_Lifecycle (355.99s)
PASS
ok  	github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/s3	636.151s

Process finished with the exit code 0

```
