### PR TITLE
Acceptance: Refactor `ELBv2` tests

### DIFF
--- a/opentelekomcloud/acceptance/elb/v2/resource_opentelekomcloud_lb_certificate_v2_test.go
+++ b/opentelekomcloud/acceptance/elb/v2/resource_opentelekomcloud_lb_certificate_v2_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 	elb "github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/services/elb/v2"
 
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/lbaas_v2/certificates"
@@ -16,11 +17,13 @@ import (
 )
 
 func TestAccLBV2Certificate_basic(t *testing.T) {
-	t.Parallel()
 	var c certificates.Certificate
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { common.TestAccPreCheck(t) },
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+			quotas.BookOne(t, quotas.LbCertificate)
+		},
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckLBV2CertificateDestroy,
 		Steps: []resource.TestStep{

--- a/opentelekomcloud/acceptance/elb/v2/resource_opentelekomcloud_lb_l7policy_v2_test.go
+++ b/opentelekomcloud/acceptance/elb/v2/resource_opentelekomcloud_lb_l7policy_v2_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 	elb "github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/services/elb/v2"
 
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/lbaas_v2/l7policies"
@@ -19,11 +20,19 @@ import (
 const resourcePolicyName = "opentelekomcloud_lb_l7policy_v2.l7policy_1"
 
 func TestAccLBV2L7Policy_basic(t *testing.T) {
-	t.Parallel()
 	var l7Policy l7policies.L7Policy
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { common.TestAccPreCheck(t) },
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+			qts := quotas.MultipleQuotas{
+				{Q: quotas.LoadBalancer, Count: 1},
+				{Q: quotas.LbListener, Count: 1},
+				{Q: quotas.LbPool, Count: 1},
+				{Q: quotas.LbPolicy, Count: 1},
+			}
+			quotas.BookMany(t, qts)
+		},
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckLBV2L7PolicyDestroy,
 		Steps: []resource.TestStep{

--- a/opentelekomcloud/acceptance/elb/v2/resource_opentelekomcloud_lb_l7rule_v2_test.go
+++ b/opentelekomcloud/acceptance/elb/v2/resource_opentelekomcloud_lb_l7rule_v2_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 	elb "github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/services/elb/v2"
 
 	l7rules "github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/lbaas_v2/l7policies"
@@ -19,11 +20,19 @@ import (
 const resourceL7RuleName = "opentelekomcloud_lb_l7rule_v2.l7rule_1"
 
 func TestAccLBV2L7Rule_basic(t *testing.T) {
-	t.Parallel()
 	var l7rule l7rules.Rule
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { common.TestAccPreCheck(t) },
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+			qts := quotas.MultipleQuotas{
+				{Q: quotas.LoadBalancer, Count: 1},
+				{Q: quotas.LbListener, Count: 1},
+				{Q: quotas.LbPool, Count: 1},
+				{Q: quotas.LbPolicy, Count: 1},
+			}
+			quotas.BookMany(t, qts)
+		},
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckLBV2L7RuleDestroy,
 		Steps: []resource.TestStep{

--- a/opentelekomcloud/acceptance/elb/v2/resource_opentelekomcloud_lb_listener_v2_test.go
+++ b/opentelekomcloud/acceptance/elb/v2/resource_opentelekomcloud_lb_listener_v2_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/lbaas_v2/listeners"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 	elb "github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/services/elb/v2"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
@@ -15,12 +16,18 @@ import (
 )
 
 func TestAccLBV2Listener_basic(t *testing.T) {
-	t.Parallel()
 	var listener listeners.Listener
 	resourceName := "opentelekomcloud_lb_listener_v2.listener_1"
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { common.TestAccPreCheck(t) },
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+			qts := quotas.MultipleQuotas{
+				{Q: quotas.LoadBalancer, Count: 1},
+				{Q: quotas.LbListener, Count: 1},
+			}
+			quotas.BookMany(t, qts)
+		},
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckLBV2ListenerDestroy,
 		Steps: []resource.TestStep{
@@ -43,12 +50,19 @@ func TestAccLBV2Listener_basic(t *testing.T) {
 }
 
 func TestAccLBV2Listener_tls(t *testing.T) {
-	t.Parallel()
 	var listener listeners.Listener
 	resourceName := "opentelekomcloud_lb_listener_v2.listener_tls"
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { common.TestAccPreCheck(t) },
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+			qts := quotas.MultipleQuotas{
+				{Q: quotas.LoadBalancer, Count: 1},
+				{Q: quotas.LbListener, Count: 1},
+				{Q: quotas.LbCertificate, Count: 2},
+			}
+			quotas.BookMany(t, qts)
+		},
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckLBV2ListenerDestroy,
 		Steps: []resource.TestStep{
@@ -77,11 +91,18 @@ func TestAccLBV2Listener_tls(t *testing.T) {
 }
 
 func TestAccLBV2ListenerSni(t *testing.T) {
-	t.Parallel()
 	resourceName := "opentelekomcloud_lb_listener_v2.elb_listener"
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { common.TestAccPreCheck(t) },
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+			qts := quotas.MultipleQuotas{
+				{Q: quotas.LoadBalancer, Count: 1},
+				{Q: quotas.LbListener, Count: 1},
+				{Q: quotas.LbCertificate, Count: 3},
+			}
+			quotas.BookMany(t, qts)
+		},
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckLBV2ListenerDestroy,
 		Steps: []resource.TestStep{

--- a/opentelekomcloud/acceptance/elb/v2/resource_opentelekomcloud_lb_loadbalancer_v2_test.go
+++ b/opentelekomcloud/acceptance/elb/v2/resource_opentelekomcloud_lb_loadbalancer_v2_test.go
@@ -21,11 +21,11 @@ const resourceLBName = "opentelekomcloud_lb_loadbalancer_v2.loadbalancer_1"
 func TestAccLBV2LoadBalancer_basic(t *testing.T) {
 	var lb loadbalancers.LoadBalancer
 
-	t.Parallel()
-	quotas.BookOne(t, quotas.FloatingIP)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { common.TestAccPreCheck(t) },
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+			quotas.BookOne(t, quotas.LoadBalancer)
+		},
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckLBV2LoadBalancerDestroy,
 		Steps: []resource.TestStep{
@@ -46,11 +46,11 @@ func TestAccLBV2LoadBalancer_basic(t *testing.T) {
 	})
 }
 func TestAccLBV2LoadBalancer_import(t *testing.T) {
-	t.Parallel()
-	quotas.BookOne(t, quotas.FloatingIP)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { common.TestAccPreCheck(t) },
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+			quotas.BookOne(t, quotas.LoadBalancer)
+		},
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckLBV2LoadBalancerDestroy,
 		Steps: []resource.TestStep{
@@ -130,12 +130,6 @@ resource "opentelekomcloud_lb_loadbalancer_v2" "loadbalancer_1" {
     muh = "value-create"
     kuh = "value-create"
   }
-
-  timeouts {
-    create = "5m"
-    update = "5m"
-    delete = "5m"
-  }
 }
 `, common.DataSourceSubnet)
 
@@ -149,12 +143,6 @@ resource "opentelekomcloud_lb_loadbalancer_v2" "loadbalancer_1" {
 
   tags = {
     muh = "value-update"
-  }
-
-  timeouts {
-    create = "5m"
-    update = "5m"
-    delete = "5m"
   }
 }
 `, common.DataSourceSubnet)

--- a/opentelekomcloud/acceptance/elb/v2/resource_opentelekomcloud_lb_monitor_v2_test.go
+++ b/opentelekomcloud/acceptance/elb/v2/resource_opentelekomcloud_lb_monitor_v2_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/lbaas_v2/monitors"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 	elb "github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/services/elb/v2"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
@@ -17,11 +18,18 @@ import (
 const resourceMonitorName = "opentelekomcloud_lb_monitor_v2.monitor_1"
 
 func TestAccLBV2Monitor_basic(t *testing.T) {
-	t.Parallel()
 	var monitor monitors.Monitor
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { common.TestAccPreCheck(t) },
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+			qts := quotas.MultipleQuotas{
+				{Q: quotas.LoadBalancer, Count: 1},
+				{Q: quotas.LbListener, Count: 1},
+				{Q: quotas.LbPool, Count: 1},
+			}
+			quotas.BookMany(t, qts)
+		},
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckLBV2MonitorDestroy,
 		Steps: []resource.TestStep{
@@ -49,28 +57,34 @@ func TestAccLBV2Monitor_basic(t *testing.T) {
 }
 
 func TestAccLBV2Monitor_minConfig(t *testing.T) {
-	t.Parallel()
 	var monitor monitors.Monitor
-	resourceName := "opentelekomcloud_lb_monitor_v2.monitor_1"
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { common.TestAccPreCheck(t) },
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+			qts := quotas.MultipleQuotas{
+				{Q: quotas.LoadBalancer, Count: 1},
+				{Q: quotas.LbListener, Count: 1},
+				{Q: quotas.LbPool, Count: 1},
+			}
+			quotas.BookMany(t, qts)
+		},
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckLBV2MonitorDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccLBV2MonitorConfigMinConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLBV2MonitorExists(resourceName, &monitor),
-					resource.TestCheckResourceAttr(resourceName, "delay", "20"),
-					resource.TestCheckResourceAttr(resourceName, "timeout", "10"),
+					testAccCheckLBV2MonitorExists(resourceMonitorName, &monitor),
+					resource.TestCheckResourceAttr(resourceMonitorName, "delay", "20"),
+					resource.TestCheckResourceAttr(resourceMonitorName, "timeout", "10"),
 				),
 			},
 			{
 				Config: testAccLBV2MonitorConfigUpdate,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", "monitor_1_updated"),
-					resource.TestCheckResourceAttr(resourceName, "monitor_port", "120"),
+					resource.TestCheckResourceAttr(resourceMonitorName, "name", "monitor_1_updated"),
+					resource.TestCheckResourceAttr(resourceMonitorName, "monitor_port", "120"),
 				),
 			},
 		},

--- a/opentelekomcloud/acceptance/elb/v2/resource_opentelekomcloud_lb_pool_v2_test.go
+++ b/opentelekomcloud/acceptance/elb/v2/resource_opentelekomcloud_lb_pool_v2_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/lbaas_v2/pools"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 	elb "github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/services/elb/v2"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
@@ -17,11 +18,18 @@ import (
 const resourcePoolName = "opentelekomcloud_lb_pool_v2.pool_1"
 
 func TestAccLBV2Pool_basic(t *testing.T) {
-	t.Parallel()
 	var pool pools.Pool
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { common.TestAccPreCheck(t) },
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+			qts := quotas.MultipleQuotas{
+				{Q: quotas.LoadBalancer, Count: 1},
+				{Q: quotas.LbListener, Count: 1},
+				{Q: quotas.LbPool, Count: 1},
+			}
+			quotas.BookMany(t, qts)
+		},
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckLBV2PoolDestroy,
 		Steps: []resource.TestStep{
@@ -46,11 +54,10 @@ func TestAccLBV2Pool_basic(t *testing.T) {
 }
 
 func TestAccLBV2Pool_persistenceNull(t *testing.T) {
-	t.Parallel()
 	var pool pools.Pool
 	resourceName := "opentelekomcloud_lb_pool_v2.pool_1"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckLBV2PoolDestroy,

--- a/opentelekomcloud/acceptance/elb/v2/resource_opentelekomcloud_lb_whitelist_v2_test.go
+++ b/opentelekomcloud/acceptance/elb/v2/resource_opentelekomcloud_lb_whitelist_v2_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/lbaas_v2/whitelists"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 	elb "github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/services/elb/v2"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
@@ -17,11 +18,17 @@ import (
 const resourceWhitelistName = "opentelekomcloud_lb_whitelist_v2.whitelist_1"
 
 func TestAccLBV2Whitelist_basic(t *testing.T) {
-	t.Parallel()
 	var whitelist whitelists.Whitelist
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { common.TestAccPreCheck(t) },
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+			qts := quotas.MultipleQuotas{
+				{Q: quotas.LoadBalancer, Count: 1},
+				{Q: quotas.LbListener, Count: 1},
+			}
+			quotas.BookMany(t, qts)
+		},
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckLBV2WhitelistDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
## Summary of the Pull Request
Add missing quotas

Replace `t.Parallel()` with `resource.ParallelTest`

Fix #1504 

## PR Checklist

* [x] Refers to: #1504
* [x] Tests added/passed.

## Acceptance Steps Performed

```
=== RUN   TestAccLBV2Certificate_basic
=== PAUSE TestAccLBV2Certificate_basic
=== CONT  TestAccLBV2Certificate_basic
--- PASS: TestAccLBV2Certificate_basic (99.34s)
=== RUN   TestAccLBV2L7Policy_basic
=== PAUSE TestAccLBV2L7Policy_basic
=== CONT  TestAccLBV2L7Policy_basic
--- PASS: TestAccLBV2L7Policy_basic (101.84s)
=== RUN   TestAccLBV2L7Rule_basic
=== PAUSE TestAccLBV2L7Rule_basic
=== CONT  TestAccLBV2L7Rule_basic
--- PASS: TestAccLBV2L7Rule_basic (153.68s)
=== RUN   TestAccLBV2Listener_basic
=== PAUSE TestAccLBV2Listener_basic
=== CONT  TestAccLBV2Listener_basic
--- PASS: TestAccLBV2Listener_basic (124.01s)
=== RUN   TestAccLBV2Listener_tls
=== PAUSE TestAccLBV2Listener_tls
=== CONT  TestAccLBV2Listener_tls
--- PASS: TestAccLBV2Listener_tls (119.52s)
=== RUN   TestAccLBV2ListenerSni
=== PAUSE TestAccLBV2ListenerSni
=== CONT  TestAccLBV2ListenerSni
--- PASS: TestAccLBV2ListenerSni (165.89s)
=== RUN   TestAccLBV2LoadBalancer_basic
=== PAUSE TestAccLBV2LoadBalancer_basic
=== CONT  TestAccLBV2LoadBalancer_basic
--- PASS: TestAccLBV2LoadBalancer_basic (88.49s)
=== RUN   TestAccLBV2LoadBalancer_import
=== PAUSE TestAccLBV2LoadBalancer_import
=== CONT  TestAccLBV2LoadBalancer_import
--- PASS: TestAccLBV2LoadBalancer_import (56.13s)
=== RUN   TestAccLBV2Member_basic
=== PAUSE TestAccLBV2Member_basic
=== CONT  TestAccLBV2Member_basic
--- PASS: TestAccLBV2Member_basic (167.24s)
=== RUN   TestAccLBV2Monitor_basic
=== PAUSE TestAccLBV2Monitor_basic
=== CONT  TestAccLBV2Monitor_basic
--- PASS: TestAccLBV2Monitor_basic (166.88s)
=== RUN   TestAccLBV2Monitor_minConfig
=== PAUSE TestAccLBV2Monitor_minConfig
=== CONT  TestAccLBV2Monitor_minConfig
--- PASS: TestAccLBV2Monitor_minConfig (167.11s)
=== RUN   TestAccLBV2Pool_basic
=== PAUSE TestAccLBV2Pool_basic
=== CONT  TestAccLBV2Pool_basic
--- PASS: TestAccLBV2Pool_basic (140.03s)
=== RUN   TestAccLBV2Pool_persistenceNull
=== PAUSE TestAccLBV2Pool_persistenceNull
=== CONT  TestAccLBV2Pool_persistenceNull
--- PASS: TestAccLBV2Pool_persistenceNull (98.64s)
=== RUN   TestAccLBV2Whitelist_basic
=== PAUSE TestAccLBV2Whitelist_basic
=== CONT  TestAccLBV2Whitelist_basic
--- PASS: TestAccLBV2Whitelist_basic (111.39s)
PASS
ok  	github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/elb/v2	168.037s
```
