### PR TITLE
Acceptance: Make `AS` tests parallel

### DIFF
--- a/opentelekomcloud/acceptance/as/resource_opentelekomcloud_as_configuration_v1_test.go
+++ b/opentelekomcloud/acceptance/as/resource_opentelekomcloud_as_configuration_v1_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/autoscaling/v1/configurations"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
@@ -18,8 +19,11 @@ func TestAccASV1Configuration_basic(t *testing.T) {
 	var asConfig configurations.Configuration
 	resourceName := "opentelekomcloud_as_configuration_v1.as_config"
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { common.TestAccPreCheck(t) },
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+			quotas.BookOne(t, quotas.ASConfiguration)
+		},
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckASV1ConfigurationDestroy,
 		Steps: []resource.TestStep{
@@ -37,8 +41,11 @@ func TestAccASV1Configuration_publicIP(t *testing.T) {
 	var asConfig configurations.Configuration
 	resourceName := "opentelekomcloud_as_configuration_v1.as_config"
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { common.TestAccPreCheck(t) },
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+			quotas.BookOne(t, quotas.ASConfiguration)
+		},
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckASV1ConfigurationDestroy,
 		Steps: []resource.TestStep{
@@ -56,8 +63,11 @@ func TestAccASV1Configuration_publicIP(t *testing.T) {
 }
 
 func TestAccASV1Configuration_invalidDiskSize(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { common.TestAccPreCheck(t) },
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+			quotas.BookOne(t, quotas.ASConfiguration)
+		},
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckASV1ConfigurationDestroy,
 		Steps: []resource.TestStep{
@@ -74,8 +84,15 @@ func TestAccASV1Configuration_multipleSecurityGroups(t *testing.T) {
 	var asConfig configurations.Configuration
 	resourceName := "opentelekomcloud_as_configuration_v1.as_config"
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { common.TestAccPreCheck(t) },
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+			qts := quotas.MultipleQuotas{
+				{Q: quotas.ASConfiguration, Count: 1},
+				{Q: quotas.SecurityGroup, Count: 3},
+			}
+			quotas.BookMany(t, qts)
+		},
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckASV1ConfigurationDestroy,
 		Steps: []resource.TestStep{

--- a/opentelekomcloud/acceptance/as/resource_opentelekomcloud_as_group_v1_test.go
+++ b/opentelekomcloud/acceptance/as/resource_opentelekomcloud_as_group_v1_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/autoscaling/v1/groups"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
@@ -17,8 +18,17 @@ func TestAccASV1Group_basic(t *testing.T) {
 	var asGroup groups.Group
 	resourceName := "opentelekomcloud_as_group_v1.as_group"
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { common.TestAccPreCheck(t) },
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+			qts := quotas.MultipleQuotas{
+				{Q: quotas.LoadBalancer, Count: 1},
+				{Q: quotas.LbListener, Count: 1},
+				{Q: quotas.LbPool, Count: 1},
+				{Q: quotas.ASGroup, Count: 1},
+			}
+			quotas.BookMany(t, qts)
+		},
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckASV1GroupDestroy,
 		Steps: []resource.TestStep{
@@ -48,8 +58,15 @@ func TestAccASV1Group_RemoveWithSetMinNumber(t *testing.T) {
 	var asGroup groups.Group
 	resourceName := "opentelekomcloud_as_group_v1.as_group"
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { common.TestAccPreCheck(t) },
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+			qts := quotas.MultipleQuotas{
+				{Q: quotas.ASGroup, Count: 1},
+				{Q: quotas.ASConfiguration, Count: 1},
+			}
+			quotas.BookMany(t, qts)
+		},
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckASV1GroupDestroy,
 		Steps: []resource.TestStep{
@@ -70,8 +87,15 @@ func TestAccASV1Group_WithoutSecurityGroups(t *testing.T) {
 
 	resourceName := "opentelekomcloud_as_group_v1.as_group"
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { common.TestAccPreCheck(t) },
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+			qts := quotas.MultipleQuotas{
+				{Q: quotas.ASGroup, Count: 1},
+				{Q: quotas.ASConfiguration, Count: 1},
+			}
+			quotas.BookMany(t, qts)
+		},
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckASV1GroupDestroy,
 		Steps: []resource.TestStep{

--- a/opentelekomcloud/acceptance/as/resource_opentelekomcloud_as_policy_v1_test.go
+++ b/opentelekomcloud/acceptance/as/resource_opentelekomcloud_as_policy_v1_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/autoscaling/v1/policies"
 
@@ -17,8 +18,15 @@ import (
 func TestAccASV1Policy_basic(t *testing.T) {
 	var asPolicy policies.Policy
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { common.TestAccPreCheck(t) },
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+			qts := quotas.MultipleQuotas{
+				{Q: quotas.ASGroup, Count: 1},
+				{Q: quotas.ASConfiguration, Count: 1},
+			}
+			quotas.BookMany(t, qts)
+		},
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckASV1PolicyDestroy,
 		Steps: []resource.TestStep{

--- a/opentelekomcloud/acceptance/as/resource_opentelekomcloud_as_policy_v2_test.go
+++ b/opentelekomcloud/acceptance/as/resource_opentelekomcloud_as_policy_v2_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/autoscaling/v2/policies"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 )
@@ -16,8 +17,15 @@ func TestAccASPolicyV2_basic(t *testing.T) {
 	var asPolicy policies.Policy
 	resourceName := "opentelekomcloud_as_policy_v2.as_policy"
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { common.TestAccPreCheck(t) },
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+			qts := quotas.MultipleQuotas{
+				{Q: quotas.ASGroup, Count: 1},
+				{Q: quotas.ASConfiguration, Count: 1},
+			}
+			quotas.BookMany(t, qts)
+		},
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckASV2PolicyDestroy,
 		Steps: []resource.TestStep{

--- a/opentelekomcloud/acceptance/common/quotas/quotas.go
+++ b/opentelekomcloud/acceptance/common/quotas/quotas.go
@@ -153,6 +153,9 @@ var (
 
 	// CCEClusterQuota is a quota for controlling number of CCE clusters existing in the parallel
 	CCEClusterQuota = FromEnv("OS_CCE_CLUSTER_QUOTA", 5)
+
+	ASGroup         = FromEnv("OS_AS_GROUP_QUOTA", 25)
+	ASConfiguration = FromEnv("OS_AS_CONFIGURATION_QUOTA", 100)
 )
 
 // ExpectedQuota is a simple container of quota + count used for `Multiple` operations


### PR DESCRIPTION
## Summary of the Pull Request
Parallelize AutoScaling resources tests execution

Add AS quotas

## PR Checklist

* [x] Refers to: #1363
* [x] Tests added/passed.


## Acceptance Steps Performed

```
=== RUN   TestAccASV1Configuration_basic
=== PAUSE TestAccASV1Configuration_basic
=== CONT  TestAccASV1Configuration_basic
--- PASS: TestAccASV1Configuration_basic (41.07s)
=== RUN   TestAccASV1Configuration_publicIP
=== PAUSE TestAccASV1Configuration_publicIP
=== CONT  TestAccASV1Configuration_publicIP
--- PASS: TestAccASV1Configuration_publicIP (41.32s)
=== RUN   TestAccASV1Configuration_invalidDiskSize
=== PAUSE TestAccASV1Configuration_invalidDiskSize
=== CONT  TestAccASV1Configuration_invalidDiskSize
--- PASS: TestAccASV1Configuration_invalidDiskSize (10.74s)
=== RUN   TestAccASV1Configuration_multipleSecurityGroups
=== PAUSE TestAccASV1Configuration_multipleSecurityGroups
=== CONT  TestAccASV1Configuration_multipleSecurityGroups
--- PASS: TestAccASV1Configuration_multipleSecurityGroups (56.64s)
=== RUN   TestAccASV1Group_basic
=== PAUSE TestAccASV1Group_basic
=== CONT  TestAccASV1Group_basic
--- PASS: TestAccASV1Group_basic (157.76s)
=== RUN   TestAccASV1Group_RemoveWithSetMinNumber
=== PAUSE TestAccASV1Group_RemoveWithSetMinNumber
=== CONT  TestAccASV1Group_RemoveWithSetMinNumber
--- PASS: TestAccASV1Group_RemoveWithSetMinNumber (152.92s)
=== RUN   TestAccASV1Group_WithoutSecurityGroups
=== PAUSE TestAccASV1Group_WithoutSecurityGroups
=== CONT  TestAccASV1Group_WithoutSecurityGroups
--- PASS: TestAccASV1Group_WithoutSecurityGroups (152.79s)
=== RUN   TestAccASV1Policy_basic
=== PAUSE TestAccASV1Policy_basic
=== CONT  TestAccASV1Policy_basic
--- PASS: TestAccASV1Policy_basic (57.97s)
=== RUN   TestAccASPolicyV2_basic
=== PAUSE TestAccASPolicyV2_basic
=== CONT  TestAccASPolicyV2_basic
--- PASS: TestAccASPolicyV2_basic (91.78s)
PASS
ok  	github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/as	158.584s

Process finished with the exit code 0

```
