### PR TITLE
Acceptance: Make `CBR` tests parallel

### DIFF
--- a/opentelekomcloud/acceptance/cbr/resource_opentelekomcloud_cbr_policy_v3_test.go
+++ b/opentelekomcloud/acceptance/cbr/resource_opentelekomcloud_cbr_policy_v3_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/cbr/v3/policies"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
@@ -18,8 +19,11 @@ const resourcePolicyName = "opentelekomcloud_cbr_policy_v3.policy"
 func TestAccCBRPolicyV3_basic(t *testing.T) {
 	var cbrPolicy policies.Policy
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { common.TestAccPreCheck(t) },
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+			quotas.BookOne(t, quotas.CBRPolicy)
+		},
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckCBRPolicyV3Destroy,
 		Steps: []resource.TestStep{
@@ -47,8 +51,11 @@ func TestAccCBRPolicyV3_basic(t *testing.T) {
 func TestAccCBRPolicyV3_minConfig(t *testing.T) {
 	var cbrPolicy policies.Policy
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { common.TestAccPreCheck(t) },
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+			quotas.BookOne(t, quotas.CBRPolicy)
+		},
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckCBRPolicyV3Destroy,
 		Steps: []resource.TestStep{

--- a/opentelekomcloud/acceptance/cbr/resource_opentelekomcloud_cbr_vault_v3_test.go
+++ b/opentelekomcloud/acceptance/cbr/resource_opentelekomcloud_cbr_vault_v3_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
@@ -13,8 +14,16 @@ import (
 const resourceVaultName = "opentelekomcloud_cbr_vault_v3.vault"
 
 func TestAccCBRVaultV3_basic(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { common.TestAccPreCheck(t) },
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+			qts := quotas.MultipleQuotas{
+				{Q: quotas.Volume, Count: 2},
+				{Q: quotas.VolumeSize, Count: 20},
+				{Q: quotas.CBRPolicy, Count: 1},
+			}
+			quotas.BookMany(t, qts)
+		},
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckCBRPolicyV3Destroy,
 		Steps: []resource.TestStep{
@@ -22,7 +31,6 @@ func TestAccCBRVaultV3_basic(t *testing.T) {
 				Config: testAccCBRVaultV3BasicVolumes,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceVaultName, "resource.#", "2"),
-					resource.TestCheckResourceAttr(resourceVaultName, "resource.0.name", "cbr-test-volume"),
 					resource.TestCheckResourceAttrSet(resourceVaultName, "backup_policy_id"),
 				),
 			},
@@ -44,8 +52,16 @@ func TestAccCBRVaultV3_basic(t *testing.T) {
 }
 
 func TestAccCBRVaultV3_unAssign(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { common.TestAccPreCheck(t) },
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+			qts := quotas.MultipleQuotas{
+				{Q: quotas.Volume, Count: 2},
+				{Q: quotas.VolumeSize, Count: 20},
+				{Q: quotas.CBRPolicy, Count: 1},
+			}
+			quotas.BookMany(t, qts)
+		},
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckCBRPolicyV3Destroy,
 		Steps: []resource.TestStep{
@@ -73,8 +89,16 @@ func TestAccCBRVaultV3_unAssign(t *testing.T) {
 }
 
 func TestAccCBRVaultV3_instance(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { common.TestAccPreCheck(t) },
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+			qts := quotas.MultipleQuotas{
+				{Q: quotas.Volume, Count: 2},
+				{Q: quotas.VolumeSize, Count: 20},
+				{Q: quotas.CBRPolicy, Count: 1},
+			}
+			quotas.BookMany(t, qts)
+		},
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckCBRPolicyV3Destroy,
 		Steps: []resource.TestStep{

--- a/opentelekomcloud/acceptance/common/quotas/quotas.go
+++ b/opentelekomcloud/acceptance/common/quotas/quotas.go
@@ -156,6 +156,8 @@ var (
 
 	ASGroup         = FromEnv("OS_AS_GROUP_QUOTA", 25)
 	ASConfiguration = FromEnv("OS_AS_CONFIGURATION_QUOTA", 100)
+
+	CBRPolicy = FromEnv("OS_CBR_POLICY_QUOTA", 32)
 )
 
 // ExpectedQuota is a simple container of quota + count used for `Multiple` operations


### PR DESCRIPTION
## Summary of the Pull Request
Parallelize CBR resources tests execution

Add CBR quotas

## PR Checklist

* [x] Refers to: #1363
* [x] Tests added/passed.

## Acceptance Steps Performed

```
=== RUN   TestAccCBRPolicyV3_basic
=== PAUSE TestAccCBRPolicyV3_basic
=== CONT  TestAccCBRPolicyV3_basic
--- PASS: TestAccCBRPolicyV3_basic (70.32s)
=== RUN   TestAccCBRPolicyV3_minConfig
=== PAUSE TestAccCBRPolicyV3_minConfig
=== CONT  TestAccCBRPolicyV3_minConfig
--- PASS: TestAccCBRPolicyV3_minConfig (69.41s)
=== RUN   TestAccCBRVaultV3_basic
=== PAUSE TestAccCBRVaultV3_basic
=== CONT  TestAccCBRVaultV3_basic
--- PASS: TestAccCBRVaultV3_basic (125.45s)
=== RUN   TestAccCBRVaultV3_unAssign
=== PAUSE TestAccCBRVaultV3_unAssign
=== CONT  TestAccCBRVaultV3_unAssign
--- PASS: TestAccCBRVaultV3_unAssign (145.96s)
=== RUN   TestAccCBRVaultV3_instance
=== PAUSE TestAccCBRVaultV3_instance
=== CONT  TestAccCBRVaultV3_instance
--- PASS: TestAccCBRVaultV3_instance (120.00s)
PASS
ok  	github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/cbr	147.774s

Process finished with the exit code 0

```
