### PR TITLE
[CCE] Clarify node pool random AZ usage

### DIFF
--- a/docs/resources/cce_node_pool_v3.md
+++ b/docs/resources/cce_node_pool_v3.md
@@ -50,6 +50,13 @@ The following arguments are supported:
   specified than `node_pool` will be in randomly selected AZ. The default value is `random`. Changing
   this parameter will create a new resource.
 
+->
+If AZ is set to `random`, when you create a node pool or update the number of nodes in a node pool, a scaling task is
+triggered. The system selects an AZ from all AZs where scaling is allowed to add nodes based on priorities. AZs with a
+smaller the number of existing nodes have a higher priority. If AZs have the same number of nodes, the system selects
+the AZ based on the AZ sequence. For more details see
+[API documentation](https://docs.otc.t-systems.com/en-us/api2/cce/cce_02_0354.html#cce_02_0354__table620623542313)
+
 * `key_pair` - (Optional) Key pair name when logging in to select the key pair mode.
   This parameter and password are alternative. Changing this parameter will create a new resource.
 

--- a/releasenotes/notes/cce-pool-doc-849084148374cd96.yaml
+++ b/releasenotes/notes/cce-pool-doc-849084148374cd96.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    **[CCE]** Improve documentation of ``random`` value of ``availability_zone`` for
+    ``resource/opentelekomcloud_cce_node_pool_v3``
+    (`#1573 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1573>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Clarify usage of `random` `availability_zone` value in `cce_node_pool_v3`

Resolve #1010

## PR Checklist

* [x] Refers to: #1010
* [x] Documentation updated.
