### PR TITLE
Acceptance: Parallelize `CSS` tests

### DIFF
--- a/opentelekomcloud/acceptance/css/data_source_opentelekomcloud_css_flavor_v1_test.go
+++ b/opentelekomcloud/acceptance/css/data_source_opentelekomcloud_css_flavor_v1_test.go
@@ -13,7 +13,7 @@ import (
 const dataFlavorName = "data.opentelekomcloud_css_flavor_v1.flavor"
 
 func TestAccCSSFlavorV1DataSource_basic(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		Steps: []resource.TestStep{
@@ -32,7 +32,7 @@ func TestAccCSSFlavorV1DataSource_basic(t *testing.T) {
 }
 
 func TestAccCSSFlavorV1DataSource_byName(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		Steps: []resource.TestStep{

--- a/opentelekomcloud/acceptance/css/resource_opentelekomcloud_css_cluster_v1_test.go
+++ b/opentelekomcloud/acceptance/css/resource_opentelekomcloud_css_cluster_v1_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/css/v1/clusters"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
@@ -21,8 +22,11 @@ func TestAccCssClusterV1_basic(t *testing.T) {
 	name := fmt.Sprintf("css-%s", acctest.RandString(10))
 	var cluster clusters.Cluster
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { common.TestAccPreCheck(t) },
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+			quotas.BookMany(t, sharedFlavorQuotas(t, 2, 40))
+		},
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckCssClusterV1Destroy,
 		Steps: []resource.TestStep{
@@ -48,7 +52,7 @@ func TestAccCssClusterV1_basic(t *testing.T) {
 func TestAccCssClusterV1_validateDiskAndFlavor(t *testing.T) {
 	name := fmt.Sprintf("css-%s", acctest.RandString(10))
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		Steps: []resource.TestStep{
@@ -80,11 +84,14 @@ func TestAccCssClusterV1_encrypted(t *testing.T) {
 	var cluster clusters.Cluster
 	name := fmt.Sprintf("css-%s", acctest.RandString(10))
 	if env.OS_KMS_ID == "" {
-		t.Skip("KMS key ID is not set")
+		t.Skip("OS_KMS_ID is not set")
 	}
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { common.TestAccPreCheck(t) },
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+			quotas.BookMany(t, sharedFlavorQuotas(t, 1, 40))
+		},
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckCssClusterV1Destroy,
 		Steps: []resource.TestStep{

--- a/opentelekomcloud/acceptance/css/resource_opentelekomcloud_css_snapshot_configuration_v1_test.go
+++ b/opentelekomcloud/acceptance/css/resource_opentelekomcloud_css_snapshot_configuration_v1_test.go
@@ -7,21 +7,21 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	acc "github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
 )
 
 func TestResourceCSSSnapshotConfigurationV1_basic(t *testing.T) {
-	if osAgency == "" {
-		t.Skip("OS_AGENCY is required for the test")
-	}
-
 	name := fmt.Sprintf("css-%s", acctest.RandString(10))
 	resourceName := "opentelekomcloud_css_snapshot_configuration_v1.config"
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { acc.TestAccPreCheck(t) },
-		ProviderFactories: acc.TestAccProviderFactories,
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+			quotas.BookMany(t, sharedFlavorQuotas(t, 1, 100))
+		},
+		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckCssClusterV1Destroy,
 		Steps: []resource.TestStep{
 			{
@@ -42,7 +42,15 @@ func TestResourceCSSSnapshotConfigurationV1_basic(t *testing.T) {
 	})
 }
 
-var osAgency = os.Getenv("OS_AGENCY")
+func getOsAgency() string {
+	agency := os.Getenv("OS_CSS_OBS_AGENCY")
+	if agency == "" {
+		agency = "css_obs_agency"
+	}
+	return agency
+}
+
+var osAgency = getOsAgency()
 
 func testResourceCSSSnapshotConfigurationV1Basic(name string) string {
 	return fmt.Sprintf(`
@@ -66,6 +74,9 @@ resource "opentelekomcloud_css_cluster_v1" "cluster" {
     }
 
     availability_zone = "%s"
+  }
+  datastore {
+    version = "7.6.2"
   }
 
   enable_https     = true
@@ -92,7 +103,7 @@ resource "opentelekomcloud_css_snapshot_configuration_v1" "config" {
     delete_auto = true
   }
 }
-`, acc.DataSourceSecGroupDefault, acc.DataSourceSubnet, name, env.OS_AVAILABILITY_ZONE, osAgency)
+`, common.DataSourceSecGroupDefault, common.DataSourceSubnet, name, env.OS_AVAILABILITY_ZONE, osAgency)
 }
 
 func testResourceCSSSnapshotConfigurationV1Updated(name string) string {
@@ -116,6 +127,9 @@ resource "opentelekomcloud_css_cluster_v1" "cluster" {
     }
 
     availability_zone = "%s"
+  }
+  datastore {
+    version = "7.6.2"
   }
 
   enable_https     = true
@@ -142,5 +156,5 @@ resource "opentelekomcloud_css_snapshot_configuration_v1" "config" {
     delete_auto = true
   }
 }
-`, acc.DataSourceSecGroupDefault, acc.DataSourceSubnet, name, env.OS_AVAILABILITY_ZONE, osAgency)
+`, common.DataSourceSecGroupDefault, common.DataSourceSubnet, name, env.OS_AVAILABILITY_ZONE, osAgency)
 }

--- a/opentelekomcloud/acceptance/css/utils.go
+++ b/opentelekomcloud/acceptance/css/utils.go
@@ -1,0 +1,62 @@
+package acceptance
+
+import (
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/css/v1/flavors"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+)
+
+const sharedFlavorName = "css.medium.8"
+
+var (
+	flavor   *flavors.Flavor
+	flavOnce sync.Once
+)
+
+func findSharedFlavor(t *testing.T) {
+	t.Helper()
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("findSharedFlavor can be used only in acceptance tests")
+	}
+	flavOnce.Do(func() {
+		t.Helper()
+		config := common.TestAccProvider.Meta().(*cfg.Config)
+		client, err := config.CssV1Client(env.OS_REGION_NAME)
+		if err != nil {
+			t.Fatalf("error creating CSSv1 client: %s", err)
+		}
+
+		pages, err := flavors.List(client).AllPages()
+		if err != nil {
+			t.Fatalf("error reading cluster value: %s", err)
+		}
+
+		versions, err := flavors.ExtractVersions(pages)
+		if err != nil {
+			t.Fatalf("error extracting versions: %s", err)
+		}
+
+		flavor = flavors.FindFlavor(versions, flavors.FilterOpts{FlavorName: sharedFlavorName})
+	})
+}
+
+func sharedFlavorQuotas(t *testing.T, nodeCount int64, volumeSize int64) quotas.MultipleQuotas {
+	t.Helper()
+	findSharedFlavor(t)
+
+	qts := quotas.MultipleQuotas{
+		{Q: quotas.Server, Count: 1},
+		{Q: quotas.Volume, Count: 1},
+		{Q: quotas.VolumeSize, Count: volumeSize},
+		{Q: quotas.RAM, Count: int64(flavor.RAM * 1024)},
+		{Q: quotas.CPU, Count: int64(flavor.CPU)},
+	}
+	qts.X(nodeCount)
+	return qts
+}


### PR DESCRIPTION
## Summary of the Pull Request
Make `CSS` tests parallel

Fix CSS test problems

## PR Checklist

* [x] Refers to: #1363
* [x] Tests added/passed.


## Acceptance Steps Performed

```
=== RUN   TestAccCSSFlavorV1DataSource_basic
=== PAUSE TestAccCSSFlavorV1DataSource_basic
=== CONT  TestAccCSSFlavorV1DataSource_basic
--- PASS: TestAccCSSFlavorV1DataSource_basic (42.35s)
=== RUN   TestAccCSSFlavorV1DataSource_byName
=== PAUSE TestAccCSSFlavorV1DataSource_byName
=== CONT  TestAccCSSFlavorV1DataSource_byName
--- PASS: TestAccCSSFlavorV1DataSource_byName (44.31s)
=== RUN   TestAccCssClusterV1_basic
=== PAUSE TestAccCssClusterV1_basic
=== CONT  TestAccCssClusterV1_basic
--- PASS: TestAccCssClusterV1_basic (1894.42s)
=== RUN   TestAccCssClusterV1_validateDiskAndFlavor
=== PAUSE TestAccCssClusterV1_validateDiskAndFlavor
=== CONT  TestAccCssClusterV1_validateDiskAndFlavor
--- PASS: TestAccCssClusterV1_validateDiskAndFlavor (53.93s)
=== RUN   TestAccCssClusterV1_encrypted
=== PAUSE TestAccCssClusterV1_encrypted
=== CONT  TestAccCssClusterV1_encrypted
--- PASS: TestAccCssClusterV1_encrypted (1155.51s)
=== RUN   TestResourceCSSSnapshotConfigurationV1_basic
=== PAUSE TestResourceCSSSnapshotConfigurationV1_basic
=== CONT  TestResourceCSSSnapshotConfigurationV1_basic
--- PASS: TestResourceCSSSnapshotConfigurationV1_basic (988.65s)
PASS
ok  	github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/css	1895.259s

Process finished with the exit code 0
```
