### PR TITLE
Acceptance: make `DCS` tests parallel

### DIFF
--- a/opentelekomcloud/acceptance/dcs/data_source_opentelekomcloud_dcs_az_v1_test.go
+++ b/opentelekomcloud/acceptance/dcs/data_source_opentelekomcloud_dcs_az_v1_test.go
@@ -14,7 +14,7 @@ import (
 const dataAzName = "data.opentelekomcloud_dcs_az_v1.az1"
 
 func TestAccDcsAZV1DataSource_basic(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		Steps: []resource.TestStep{

--- a/opentelekomcloud/acceptance/dcs/data_source_opentelekomcloud_dcs_maintainwindow_v1_test.go
+++ b/opentelekomcloud/acceptance/dcs/data_source_opentelekomcloud_dcs_maintainwindow_v1_test.go
@@ -13,7 +13,7 @@ import (
 const dataMaintainWindowName = "data.opentelekomcloud_dcs_maintainwindow_v1.maintainwindow1"
 
 func TestAccDcsMaintainWindowV1DataSource_basic(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		Steps: []resource.TestStep{

--- a/opentelekomcloud/acceptance/dcs/data_source_opentelekomcloud_dcs_product_v1_test.go
+++ b/opentelekomcloud/acceptance/dcs/data_source_opentelekomcloud_dcs_product_v1_test.go
@@ -13,7 +13,7 @@ import (
 const dataProductName = "data.opentelekomcloud_dcs_product_v1.product1"
 
 func TestAccDcsProductV1DataSource_basic(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		Steps: []resource.TestStep{

--- a/opentelekomcloud/acceptance/dcs/resource_opentelekomcloud_dcs_instance_v1_test.go
+++ b/opentelekomcloud/acceptance/dcs/resource_opentelekomcloud_dcs_instance_v1_test.go
@@ -21,7 +21,7 @@ func TestAccDcsInstancesV1_basic(t *testing.T) {
 	var instance instances.Instance
 	var instanceName = fmt.Sprintf("dcs_instance_%s", acctest.RandString(5))
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckDcsV1InstanceDestroy,
@@ -50,7 +50,7 @@ func TestAccDcsInstancesV1_basicSingleInstance(t *testing.T) {
 	var instance instances.Instance
 	var instanceName = fmt.Sprintf("dcs_instance_%s", acctest.RandString(5))
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckDcsV1InstanceDestroy,


### PR DESCRIPTION
## Summary of the Pull Request

Parallelize DCS tests execution

## PR Checklist

* [x] Refers to: #1363 
* [x] Tests added/passed.

## Acceptance Steps Performed

```
=== RUN   TestAccDcsAZV1DataSource_basic
=== PAUSE TestAccDcsAZV1DataSource_basic
=== CONT  TestAccDcsAZV1DataSource_basic
--- PASS: TestAccDcsAZV1DataSource_basic (27.09s)
=== RUN   TestAccDcsMaintainWindowV1DataSource_basic
=== PAUSE TestAccDcsMaintainWindowV1DataSource_basic
=== CONT  TestAccDcsMaintainWindowV1DataSource_basic
--- PASS: TestAccDcsMaintainWindowV1DataSource_basic (26.97s)
=== RUN   TestAccDcsProductV1DataSource_basic
=== PAUSE TestAccDcsProductV1DataSource_basic
=== CONT  TestAccDcsProductV1DataSource_basic
--- PASS: TestAccDcsProductV1DataSource_basic (27.08s)
=== RUN   TestAccDcsInstancesV1_basic
=== PAUSE TestAccDcsInstancesV1_basic
=== CONT  TestAccDcsInstancesV1_basic
--- PASS: TestAccDcsInstancesV1_basic (408.67s)
=== RUN   TestAccDcsInstancesV1_basicSingleInstance
=== PAUSE TestAccDcsInstancesV1_basicSingleInstance
=== CONT  TestAccDcsInstancesV1_basicSingleInstance
--- PASS: TestAccDcsInstancesV1_basicSingleInstance (328.41s)
PASS
ok  	github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/dcs	409.913s

Process finished with the exit code 0
```
