### PR TITLE
[ECS] Add possibility to encrypt `system_disk`

### DIFF
--- a/docs/resources/ecs_instance_v1.md
+++ b/docs/resources/ecs_instance_v1.md
@@ -204,6 +204,9 @@ The following arguments are supported:
   instance. The `data_disks` object structure is documented below. Changing this
   creates a new server.
 
+* `system_disk_kms_id` - (Optional) The Encryption KMS ID of the system disk. Changing this
+  creates a new server.
+
 * `security_groups` - (Optional) An array of one or more security group IDs
   to associate with the server. If this parameter is left blank, the `default`
   security group is bound to the ECS by default.
@@ -238,7 +241,8 @@ The `data_disks` block supports:
 * `size` - (Required) The size of the data disk in GB. The value range is 10 to 32768.
   Changing this creates a new server.
 
-* `kms_id` - (Optional) The Encryption KMS ID of the data disk.
+* `kms_id` - (Optional) The Encryption KMS ID of the data disk. Changing this
+  creates a new server.
 
 * `snapshot_id` - (Optional) Specifies the snapshot ID or ID of the original data disk contained in the full-ECS image.
   Changing this creates a new server.

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/jinzhu/copier v0.2.3
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.5.6-0.20211117103649-858b4c37ae87
+	github.com/opentelekomcloud/gophertelekomcloud v0.5.7-0.20211209114407-3e66d3fa56b6
 	github.com/unknwon/com v1.0.1
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -288,8 +288,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.5.6-0.20211117103649-858b4c37ae87 h1:Tn2l7VdjvwGDyTqFkeycc7UaL9POLsOpBMOZ01i6vqQ=
-github.com/opentelekomcloud/gophertelekomcloud v0.5.6-0.20211117103649-858b4c37ae87/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
+github.com/opentelekomcloud/gophertelekomcloud v0.5.7-0.20211209114407-3e66d3fa56b6 h1:rEyZBxYzIEeFoznFgiCaFDEzIrQMzqDHZ9U88RBz73Q=
+github.com/opentelekomcloud/gophertelekomcloud v0.5.7-0.20211209114407-3e66d3fa56b6/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_ecs_instance_v1_test.go
+++ b/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_ecs_instance_v1_test.go
@@ -141,6 +141,7 @@ func TestAccEcsV1InstanceEncryption(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEcsV1InstanceExists(resourceInstanceV1Name, &instance),
 					resource.TestCheckResourceAttr(resourceInstanceV1Name, "data_disks.0.kms_id", env.OS_KMS_ID),
+					resource.TestCheckResourceAttr(resourceInstanceV1Name, "system_disk_kms_id", env.OS_KMS_ID),
 				),
 			},
 		},
@@ -437,14 +438,15 @@ resource "opentelekomcloud_ecs_instance_v1" "instance_1" {
     network_id = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
 
-  password          = "Password@123"
-  availability_zone = "%s"
-  auto_recovery     = true
+  password               = "Password@123"
+  availability_zone      = "%[3]s"
+  auto_recovery          = true
+  system_disk_encryption = ""
 
   data_disks {
     size   = 10
     type   = "SAS"
-    kms_id = "%s"
+    kms_id = "%[3]s"
   }
   delete_disks_on_termination = true
 }

--- a/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_ecs_instance_v1_test.go
+++ b/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_ecs_instance_v1_test.go
@@ -438,15 +438,15 @@ resource "opentelekomcloud_ecs_instance_v1" "instance_1" {
     network_id = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
 
-  password               = "Password@123"
-  availability_zone      = "%[3]s"
-  auto_recovery          = true
-  system_disk_encryption = ""
+  password           = "Password@123"
+  availability_zone  = "%s"
+  auto_recovery      = true
+  system_disk_kms_id = "%[4]s"
 
   data_disks {
     size   = 10
     type   = "SAS"
-    kms_id = "%[3]s"
+    kms_id = "%[4]s"
   }
   delete_disks_on_termination = true
 }

--- a/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_ecs_instance_v1_test.go
+++ b/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_ecs_instance_v1_test.go
@@ -131,6 +131,10 @@ func TestAccEcsV1InstanceEncryption(t *testing.T) {
 	t.Parallel()
 	quotas.BookMany(t, qts)
 
+	if env.OS_KMS_ID == "" {
+		t.Skip("OS_KMS_ID is not set")
+	}
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,

--- a/opentelekomcloud/services/ecs/resource_opentelekomcloud_ecs_instance_v1.go
+++ b/opentelekomcloud/services/ecs/resource_opentelekomcloud_ecs_instance_v1.go
@@ -127,10 +127,9 @@ func ResourceEcsInstanceV1() *schema.Resource {
 				Computed: true,
 			},
 			"system_disk_kms_id": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				ForceNew:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_KMS_ID", nil),
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
 			},
 			"data_disks": {
 				Type:     schema.TypeList,

--- a/opentelekomcloud/services/ecs/resource_opentelekomcloud_ecs_instance_v1.go
+++ b/opentelekomcloud/services/ecs/resource_opentelekomcloud_ecs_instance_v1.go
@@ -126,6 +126,12 @@ func ResourceEcsInstanceV1() *schema.Resource {
 				ForceNew: true,
 				Computed: true,
 			},
+			"system_disk_kms_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				DefaultFunc: schema.EnvDefaultFunc("OS_KMS_ID", nil),
+			},
 			"data_disks": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -288,6 +294,7 @@ func resourceEcsInstanceV1Read(ctx context.Context, d *schema.ResourceData, meta
 			mErr = multierror.Append(mErr,
 				d.Set("system_disk_size", disk.Size),
 				d.Set("system_disk_type", disk.VolumeType),
+				d.Set("system_disk_kms_id", disk.Metadata["__system__cmkid"]),
 			)
 			continue
 		}
@@ -511,6 +518,12 @@ func resourceInstanceRootVolumeV1(d *schema.ResourceData) cloudservers.RootVolum
 	volRequest := cloudservers.RootVolume{
 		VolumeType: diskType,
 		Size:       d.Get("system_disk_size").(int),
+	}
+	if kmsID := d.Get("system_disk_kms_id").(string); kmsID != "" {
+		volRequest.Metadata = map[string]interface{}{
+			"__system__cmkid":     kmsID,
+			"__system__encrypted": "1",
+		}
 	}
 	return volRequest
 }

--- a/releasenotes/notes/ecs-sys-encryption-abed87dd6c2001e8.yaml
+++ b/releasenotes/notes/ecs-sys-encryption-abed87dd6c2001e8.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[ECS]** Add possibility to encrypt `system_disk` in `resource/opentelekomcloud_ecs_instance_v1` (`#1582 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1582>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Add possibility to encrypt `system_disk` in `resource/opentelekomcloud_ecs_instance_v1`

Resolves: #1569

## PR Checklist

* [x] Refers to: #1569
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccEcsV1InstanceBasic
=== PAUSE TestAccEcsV1InstanceBasic
=== CONT  TestAccEcsV1InstanceBasic
=== RUN   TestAccEcsV1Instance_import
=== PAUSE TestAccEcsV1Instance_import
=== CONT  TestAccEcsV1Instance_import
--- PASS: TestAccEcsV1Instance_import (268.85s)
=== RUN   TestAccEcsV1InstanceDiskTypeValidation
=== PAUSE TestAccEcsV1InstanceDiskTypeValidation
=== CONT  TestAccEcsV1InstanceDiskTypeValidation
--- PASS: TestAccEcsV1InstanceDiskTypeValidation (57.32s)
=== RUN   TestAccEcsV1InstanceVPCValidation
=== PAUSE TestAccEcsV1InstanceVPCValidation
=== CONT  TestAccEcsV1InstanceVPCValidation
--- PASS: TestAccEcsV1InstanceVPCValidation (269.71s)
=== RUN   TestAccEcsV1InstanceEncryption
=== PAUSE TestAccEcsV1InstanceEncryption
=== CONT  TestAccEcsV1InstanceEncryption
--- PASS: TestAccEcsV1InstanceEncryption (239.39s)
--- PASS: TestAccEcsV1InstanceBasic (346.65s)
PASS

Process finished with the exit code 0
```
