### PR TITLE
[ECS] Fix refresh of deleted instance v1

### DIFF
--- a/opentelekomcloud/services/ecs/resource_opentelekomcloud_ecs_instance_v1.go
+++ b/opentelekomcloud/services/ecs/resource_opentelekomcloud_ecs_instance_v1.go
@@ -262,6 +262,10 @@ func resourceEcsInstanceV1Read(ctx context.Context, d *schema.ResourceData, meta
 	if err != nil {
 		return diag.FromErr(common.CheckDeleted(d, err, "CloudServer"))
 	}
+	if server.Status == "DELETED" {
+		d.SetId("")
+		return nil
+	}
 
 	mErr := multierror.Append(
 		d.Set("name", server.Name),

--- a/releasenotes/notes/ecs-deleted-d324eb94cc537edb.yaml
+++ b/releasenotes/notes/ecs-deleted-d324eb94cc537edb.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    **[ECS]** Fix refreshing state of ``resource/opentelekomcloud_ecs_instance_v1`` when ECS is deleted
+    (`#1586 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1586>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Fix error when refreshing state of `opentelekomcloud_ecs_instance_v1` for deleted ECS instance

Fix #1585

## PR Checklist

* [x] Refers to: #1585
* [x] Tests added/passed.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccEcsV1InstanceDeleted
=== PAUSE TestAccEcsV1InstanceDeleted
=== CONT  TestAccEcsV1InstanceDeleted
--- PASS: TestAccEcsV1InstanceDeleted (328.91s)
PASS

Process finished with the exit code 0

```
