### PR TITLE
[ECS] Deprecate `resource/opentelekomcloud_compute_secgroup_v2`

### DIFF
--- a/docs/resources/compute_secgroup_v2.md
+++ b/docs/resources/compute_secgroup_v2.md
@@ -6,6 +6,11 @@ subcategory: "Elastic Cloud Server (ECS)"
 
 Manages a V2 security group resource within OpenTelekomCloud.
 
+~>
+Security group compute APIs are marked as discarded in [documentation](https://docs.otc.t-systems.com/en-us/api/ecs/en-us_topic_0267427144.html).
+Please use `resource/opentelekomcloud_networking_secgroup_v2`
+
+
 ## Example Usage
 
 ```hcl

--- a/opentelekomcloud/services/ecs/resource_opentelekomcloud_compute_secgroup_v2.go
+++ b/opentelekomcloud/services/ecs/resource_opentelekomcloud_compute_secgroup_v2.go
@@ -28,6 +28,8 @@ func ResourceComputeSecGroupV2() *schema.Resource {
 		UpdateContext: resourceComputeSecGroupV2Update,
 		DeleteContext: resourceComputeSecGroupV2Delete,
 
+		DeprecationMessage: "please use `opentelekomcloud_networking_secgroup_v2` resource instead",
+
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},

--- a/releasenotes/notes/compute-sg-deprecate-aacb4573b187b463.yaml
+++ b/releasenotes/notes/compute-sg-deprecate-aacb4573b187b463.yaml
@@ -1,0 +1,4 @@
+---
+deprecations:
+  - |
+    **[ECS]** ``resource/opentelekomcloud_compute_secgroup_v2`` APIs are marked as discarded in (`documentation <https://docs.otc.t-systems.com/en-us/api/ecs/en-us_topic_0267427144.html>`_) (`#1594 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1594>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Deprecate `resource/opentelekomcloud_compute_secgroup_v2`

## PR Checklist

* [x] Refers to: #1588
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

