### PR TITLE
[CBR] Add missing `ForceNew` in `tags` block

### DIFF
--- a/opentelekomcloud/services/cbr/resource_opentelekomcloud_cbr_vault_v3.go
+++ b/opentelekomcloud/services/cbr/resource_opentelekomcloud_cbr_vault_v3.go
@@ -210,7 +210,12 @@ func ResourceCBRVaultV3() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"tags": common.TagsSchema(),
+			"tags": {
+				Type:         schema.TypeMap,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: common.ValidateTags,
+			},
 			"enterprise_project_id": {
 				Type:     schema.TypeString,
 				Optional: true,

--- a/releasenotes/notes/r-vault-tags-ba139f0e8f77b4e4.yaml
+++ b/releasenotes/notes/r-vault-tags-ba139f0e8f77b4e4.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[CBR]** Add missing ``ForceNew`` in ``tags`` block in ``resource/opentelekomcloub_cbr_vault_v3`` (`#1600 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1600>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Add missing `ForceNew` in `tags` block in `resource/opentelekomcloud_cbr_vault_v3`
Resolves: #1599

## PR Checklist

* [x] Refers to: #1599
* [x] Tests added/passed.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccCBRVaultV3_basic
=== PAUSE TestAccCBRVaultV3_basic
=== CONT  TestAccCBRVaultV3_basic
--- PASS: TestAccCBRVaultV3_basic (187.89s)
=== RUN   TestAccCBRVaultV3_unAssign
=== PAUSE TestAccCBRVaultV3_unAssign
=== CONT  TestAccCBRVaultV3_unAssign
--- PASS: TestAccCBRVaultV3_unAssign (201.99s)
=== RUN   TestAccCBRVaultV3_instance
=== PAUSE TestAccCBRVaultV3_instance
=== CONT  TestAccCBRVaultV3_instance
--- PASS: TestAccCBRVaultV3_instance (158.22s)
PASS


Process finished with the exit code 0
```
