### PR TITLE
[ECS] Fix creating instance with `image_name`

### DIFF
--- a/opentelekomcloud/services/ims/common.go
+++ b/opentelekomcloud/services/ims/common.go
@@ -5,13 +5,39 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/imageservice/v2/images"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/imageservice/v2/members"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 )
 
 const (
 	errCreationClient = "error creating OpenTelekomCloud IMSv2 client: %w"
 )
+
+func GetImageByName(d *schema.ResourceData, cfg *cfg.Config, name string) (string, error) {
+	client, err := cfg.ImageV2Client(cfg.GetRegion(d))
+	if err != nil {
+		return "", fmt.Errorf("error creating IMSv2 client: %w", err)
+	}
+
+	opts := images.ListOpts{
+		Name: d.Get("image_name").(string),
+	}
+	pages, err := images.List(client, opts).AllPages()
+	if err != nil {
+		return "", fmt.Errorf("error listing images: %w", err)
+	}
+	imgs, err := images.ExtractImages(pages)
+	if err != nil {
+		return "", fmt.Errorf("error extracting images: %w", err)
+	}
+	if len(imgs) < 1 {
+		return "", fmt.Errorf("no image matching name: %s", name)
+	}
+	return imgs[0].ID, nil
+}
 
 func ResourceImagesImageAccessV2ParseID(id string) (string, string, error) {
 	idParts := strings.Split(id, "/")

--- a/releasenotes/notes/compute-image-by-name-31bce02e1fcaafaa.yaml
+++ b/releasenotes/notes/compute-image-by-name-31bce02e1fcaafaa.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    **[ECS]** Find image by name using ``IMSv2`` API instead of discarded compute image API
+    (`#1609 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1609>`_)
+  - |
+    **[BMS]** Find image by name using ``IMSv2`` API instead of discarded compute image API
+    (`#1609 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1609>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Move image ID resolution to `IMSv2` from discarded API

Fix #1597

## PR Checklist

* [x] Refers to: #1597
* [x] Tests added/passed.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccComputeV2Instance_imageByName
--- PASS: TestAccComputeV2Instance_imageByName (74.64s)
PASS

Process finished with the exit code 0

```
