### PR TITLE
Update gophertelekomcloud module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/jinzhu/copier v0.2.3
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.5.7-0.20220128113013-321ed561d3e8
+	github.com/opentelekomcloud/gophertelekomcloud v0.5.7-0.20220202150544-c45e4b72fd15
 	github.com/unknwon/com v1.0.1
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -297,8 +297,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.5.7-0.20220128113013-321ed561d3e8 h1:GsrOfwuV+7RDdV3dyIN0gYJKH6ZNdFrHONrtnOwp0d0=
-github.com/opentelekomcloud/gophertelekomcloud v0.5.7-0.20220128113013-321ed561d3e8/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
+github.com/opentelekomcloud/gophertelekomcloud v0.5.7-0.20220202150544-c45e4b72fd15 h1:Eio3b+s1NGQ8Qv66fpUtN2PLEI30cT06+D36vvhaHDs=
+github.com/opentelekomcloud/gophertelekomcloud v0.5.7-0.20220202150544-c45e4b72fd15/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/releasenotes/notes/elb-v3-nl-ad01f9849d28c4c9.yaml
+++ b/releasenotes/notes/elb-v3-nl-ad01f9849d28c4c9.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[ELB]** Fix wrong endpoint in ``EU-NL`` region (`#1617 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1617>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Update `gophertelekomcloud` module to fix issue with wrong endpoint for EU-NL region

## PR Checklist

* [x] Refers to: #1614
* [x] Tests added/passed.
* [x] Release notes added.

## Acceptance Steps Performed

`eu-de`
```
=== RUN   TestAccLBV2LoadBalancer_basic
=== PAUSE TestAccLBV2LoadBalancer_basic
=== CONT  TestAccLBV2LoadBalancer_basic
--- PASS: TestAccLBV2LoadBalancer_basic (139.58s)
=== RUN   TestAccLBV2LoadBalancer_import
=== PAUSE TestAccLBV2LoadBalancer_import
=== CONT  TestAccLBV2LoadBalancer_import
--- PASS: TestAccLBV2LoadBalancer_import (89.58s)
PASS


Process finished with the exit code 0
```
