### PR TITLE
[NAT] Fix `nat_snat_rule_v2` reading of `source_type` field

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/jinzhu/copier v0.2.3
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.5.8-0.20220208083513-62ba2ae51c2f
+	github.com/opentelekomcloud/gophertelekomcloud v0.5.8-0.20220209145831-994d7dbc48e8
 	github.com/unknwon/com v1.0.1
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -297,8 +297,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.5.8-0.20220208083513-62ba2ae51c2f h1://HhQdBZvYgWiwi4cfvB3+AgifsLdx2Q9iJYRyP+jPc=
-github.com/opentelekomcloud/gophertelekomcloud v0.5.8-0.20220208083513-62ba2ae51c2f/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
+github.com/opentelekomcloud/gophertelekomcloud v0.5.8-0.20220209145831-994d7dbc48e8 h1:DQMPv08I/S9jkii6Uhr9qyq4aUC+hwhCuJNXr56jW1I=
+github.com/opentelekomcloud/gophertelekomcloud v0.5.8-0.20220209145831-994d7dbc48e8/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/opentelekomcloud/services/nat/resource_opentelekomcloud_nat_snat_rule_v2.go
+++ b/opentelekomcloud/services/nat/resource_opentelekomcloud_nat_snat_rule_v2.go
@@ -3,7 +3,6 @@ package nat
 import (
 	"context"
 	"log"
-	"strconv"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -137,13 +136,11 @@ func resourceNatSnatRuleV2Read(_ context.Context, d *schema.ResourceData, meta i
 		d.Set("cidr", snatRule.Cidr),
 		d.Set("region", config.GetRegion(d)),
 	)
-	sourceType, err := strconv.Atoi(snatRule.SourceType)
-	if err != nil {
-		return fmterr.Errorf("error converting `source_type`: %w", err)
+	if sourceType, ok := snatRule.SourceType.(int); ok {
+		mErr = multierror.Append(mErr,
+			d.Set("source_type", sourceType),
+		)
 	}
-	mErr = multierror.Append(mErr,
-		d.Set("source_type", sourceType),
-	)
 
 	if err := mErr.ErrorOrNil(); err != nil {
 		return diag.FromErr(err)

--- a/releasenotes/notes/fix-snat-842f34b73939e693.yaml
+++ b/releasenotes/notes/fix-snat-842f34b73939e693.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[NAT]** Fix reading ``source_type`` field in ``resource/opentelekomcloud_nat_snat_rule_v2`` (`#1629 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1629>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Fix reading of `source_type` field in `resource/opentelekomcloud_nat_snat_rule_v2`
Fixes: #1628

## PR Checklist

* [x] Refers to: #1628
* [x] Tests added/passed.
* [x] Release notes added.

## Acceptance Steps Performed

`EU-DE`
```
=== RUN   TestAccNatSnatRule_basic
--- PASS: TestAccNatSnatRule_basic (98.99s)
PASS


Process finished with the exit code 0
```
`EU-NL`
```
=== RUN   TestAccNatSnatRule_basic
--- PASS: TestAccNatSnatRule_basic (101.74s)
PASS


Process finished with the exit code 0
```