### PR TITLE
[CSS] Fix cluster creation without `type`

### DIFF
--- a/opentelekomcloud/services/css/resource_opentelekomcloud_css_cluster_v1.go
+++ b/opentelekomcloud/services/css/resource_opentelekomcloud_css_cluster_v1.go
@@ -155,8 +155,8 @@ func ResourceCssClusterV1() *schema.Resource {
 						"type": {
 							Type:     schema.TypeString,
 							Optional: true,
-							Computed: true,
 							ForceNew: true,
+							Default:  "elasticsearch",
 						},
 						"version": {
 							Type:     schema.TypeString,

--- a/releasenotes/notes/css-cluster-datastore-type-df86d990a094b4e8.yaml
+++ b/releasenotes/notes/css-cluster-datastore-type-df86d990a094b4e8.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    **[CSS]** Make ``elasicsearch`` a default value for ``datastore.type`` in ``resource/opentelekomcloud_css_cluster_v1``
+    (`#1638 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1638>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Add a default value to cluster datastore type

Fix #1637 

## PR Checklist

* [x] Refers to: #1637
* [x] Tests added/passed.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
--- PASS: TestAccCssClusterV1_basic (1919.29s)
PASS

Process finished with the exit code 0
```
