### PR TITLE
[CSS] Add `tags` support for cluster

### DIFF
--- a/docs/resources/css_cluster_v1.md
+++ b/docs/resources/css_cluster_v1.md
@@ -67,6 +67,8 @@ lowercase letters, numbers, and special characters (`~!@#$%^&*()-_=+\\|[{}];:,<.
 
 * `expect_node_num` - (Optional) Number of cluster instances. The value range is `1` to `32`.
 
+* `tags` - (Optional) Tags key/value pairs to associate with the cluster.
+
 The `node_config` block supports:
 
 * `availability_zone` - (Optional) Availability zone (AZ). Changing this parameter will create a new resource.

--- a/opentelekomcloud/acceptance/css/resource_opentelekomcloud_css_cluster_v1_test.go
+++ b/opentelekomcloud/acceptance/css/resource_opentelekomcloud_css_cluster_v1_test.go
@@ -49,6 +49,30 @@ func TestAccCssClusterV1_basic(t *testing.T) {
 	})
 }
 
+func TestAccCssClusterV1_tags(t *testing.T) {
+	name := fmt.Sprintf("css-%s", acctest.RandString(10))
+	var cluster clusters.Cluster
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+			quotas.BookMany(t, sharedFlavorQuotas(t, 2, 40))
+		},
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckCssClusterV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCssClusterV1Tags(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCssClusterV1Exists(resourceClusterName, &cluster),
+					resource.TestCheckResourceAttr(resourceClusterName, "nodes.#", "1"),
+					resource.TestCheckResourceAttr(resourceClusterName, "tags.say", "hi"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccCssClusterV1_validateDiskAndFlavor(t *testing.T) {
 	name := fmt.Sprintf("css-%s", acctest.RandString(10))
 
@@ -189,6 +213,43 @@ resource "opentelekomcloud_css_cluster_v1" "cluster" {
   enable_https     = true
   enable_authority = true
   admin_pass       = "QwertyUI!"
+}
+`, common.DataSourceSecGroupDefault, common.DataSourceSubnet, name, env.OS_AVAILABILITY_ZONE)
+}
+
+func testAccCssClusterV1Tags(name string) string {
+	return fmt.Sprintf(`
+%s
+
+%s
+
+resource "opentelekomcloud_css_cluster_v1" "cluster" {
+  expect_node_num = 1
+  name            = "%s"
+  node_config {
+    flavor = "css.medium.8"
+    network_info {
+      security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
+      network_id        = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+      vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+    }
+    volume {
+      volume_type = "COMMON"
+      size        = 40
+    }
+
+    availability_zone = "%s"
+  }
+  datastore {
+    version = "7.6.2"
+  }
+  enable_https     = true
+  enable_authority = true
+  admin_pass       = "QwertyUI!"
+
+  tags = {
+    say = "hi"
+  }
 }
 `, common.DataSourceSecGroupDefault, common.DataSourceSubnet, name, env.OS_AVAILABILITY_ZONE)
 }

--- a/releasenotes/notes/css-cluster-tags-de43792ca6f6bd59.yaml
+++ b/releasenotes/notes/css-cluster-tags-de43792ca6f6bd59.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    **[CSS]** Add ``tags`` argument to ``resource/opentelekomcloud_css_cluster_v1``
+    (`#1639 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1639>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Add `tags` attribute in `r/opentelekomcloud_css_cluster_v1`

Resolve #1634

## PR Checklist

* [x] Refers to: #1634
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccCssClusterV1_tags
=== PAUSE TestAccCssClusterV1_tags
=== CONT  TestAccCssClusterV1_tags
--- PASS: TestAccCssClusterV1_tags (952.70s)
PASS

Process finished with the exit code 0

```
