### PR TITLE
[EIP] Add `5_gray` option to the documentation

### DIFF
--- a/docs/resources/vpc_eip_v1.md
+++ b/docs/resources/vpc_eip_v1.md
@@ -37,7 +37,7 @@ The following arguments are supported:
 The `publicip` block supports:
 
 * `type` - (Required) The value must be a type supported by [the system](https://docs.otc.t-systems.com/api/eip/eip_api_0001.html#eip_api_0001__en-us_topic_0201534274_table4491214).
-  The value can be `5_bgp` and `5_mailbgp`. Changing this creates a new eip.
+  The value can be `5_bgp`, `5_mailbgp` and `5_gray`. Changing this creates a new eip.
 
 * `ip_address` - (Optional) The value must be a valid IP address in the available
   IP address segment. Changing this creates a new eip.

--- a/examples/basic-examples/modules/eip/main.tf
+++ b/examples/basic-examples/modules/eip/main.tf
@@ -26,7 +26,7 @@ resource "opentelekomcloud_vpc_eip_v1" "eip_1" {
 
 resource "opentelekomcloud_vpc_eip_v1" "eip_lb" {
   publicip {
-    type = "5_bgp"
+    type = "5_gray"
   }
   bandwidth {
     name        = "${var.bw_name}_lb"

--- a/releasenotes/notes/eip-type-gray-cc887d48726d8ac3.yaml
+++ b/releasenotes/notes/eip-type-gray-cc887d48726d8ac3.yaml
@@ -1,0 +1,5 @@
+---
+other:
+  - |
+    **[VPC]** Add ``5_gray`` type to ``resource/opentelekomcloud_vpc_eip_v1`` documentation and examples
+    (`#1646 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1646>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Add `5_gray` EIP type to `vpc_eip_v1` documentation and examples

Resolve #1642

## PR Checklist

* [x] Refers to: #1642
* [x] Documentation updated.
* [x] Release notes added.
