### PR TITLE
[ELB] Add SSL passthrough for lbv2 listener

### DIFF
--- a/docs/resources/lb_listener_v2.md
+++ b/docs/resources/lb_listener_v2.md
@@ -69,6 +69,10 @@ The following arguments are supported:
   [here](https://docs.otc.t-systems.com/api/elb/elb_zq_jt_0001.html) for details about the supported cipher
   suites. The option is effective only in conjunction with `TERMINATED_HTTPS`.
 
+* `transparent_client_ip_enable` - (Optional) Specifies whether to pass source IP addresses of the clients to
+  backend servers. The value can be true or false, and the default value is false for `TCP` and `UDP` listeners.
+  The value can only be true for `HTTP` and `HTTPS` listeners.
+
 * `admin_state_up` - (Optional) The administrative state of the Listener.
   A valid value is `true` (UP) or `false` (DOWN).
 

--- a/releasenotes/notes/elb-ssl-passthrough-5efe3c1d2d993b9c.yaml
+++ b/releasenotes/notes/elb-ssl-passthrough-5efe3c1d2d993b9c.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    **[ELB]** Add ``transparent_client_ip_enable`` argument to ``resource/opentelekomcloud_lb_listener_v2``
+    (`#1648 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1648>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Add `transparent_client_ip_enable` to `r/lb_listener_v2`

Resolve #1647

## PR Checklist

* [x] Refers to: #1647
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccLBV2Listener_basic
=== PAUSE TestAccLBV2Listener_basic
=== CONT  TestAccLBV2Listener_basic
--- PASS: TestAccLBV2Listener_basic (137.12s)
PASS

Process finished with the exit code 0

=== RUN   TestAccLBV2Listener_SSLPassthrough
=== PAUSE TestAccLBV2Listener_SSLPassthrough
=== CONT  TestAccLBV2Listener_SSLPassthrough
--- PASS: TestAccLBV2Listener_SSLPassthrough (130.49s)
PASS

Process finished with the exit code 0

```
