### PR TITLE
[CCE] Implement new data-source `cce_kubeconfig_v3`

### DIFF
--- a/docs/data-sources/cce_cluster_kubeconfig_v3.md
+++ b/docs/data-sources/cce_cluster_kubeconfig_v3.md
@@ -12,7 +12,7 @@ Use this data source to get details about a cluster kubeconfig file from OpenTel
 variable "cluster_id" {}
 
 data "opentelekomcloud_cce_cluster_kubeconfig_v3" "this" {
-  name   = var.cluster_id
+  name = var.cluster_id
 }
 ```
 

--- a/docs/data-sources/cce_cluster_kubeconfig_v3.md
+++ b/docs/data-sources/cce_cluster_kubeconfig_v3.md
@@ -4,7 +4,7 @@ subcategory: "Cloud Container Engine (CCE)"
 
 # opentelekomcloud_cce_cluster_kubeconfig_v3
 
-Use this data source to get details about a cluster kubeconfig file from OpenTelekomCloud.
+Use this data source to get a cluster's kubeconfig file from OpenTelekomCloud.
 
 ## Example Usage
 
@@ -32,4 +32,4 @@ All above argument parameters can be exported as attribute parameters along with
 
 * `id` - The ID of the cluster.
 
-* `kubeconfig` - The kubeconfig file of the cluster.
+* `kubeconfig` - The cluster's kubeconfig file contents.

--- a/docs/data-sources/cce_cluster_kubeconfig_v3.md
+++ b/docs/data-sources/cce_cluster_kubeconfig_v3.md
@@ -1,0 +1,35 @@
+---
+subcategory: "Cloud Container Engine (CCE)"
+---
+
+# opentelekomcloud_cce_cluster_kubeconfig_v3
+
+Use this data source to get details about a cluster kubeconfig file from OpenTelekomCloud.
+
+## Example Usage
+
+```hcl
+variable "cluster_id" {}
+
+data "opentelekomcloud_cce_cluster_kubeconfig_v3" "this" {
+  name   = var.cluster_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `cluster_id` -  (Optional) The Name of the cluster resource.
+
+* `duration` - (Optional) Period during which a cluster certificate is valid, in days. A cluster certificate can
+  be valid for `1` to `1825` days. If this parameter is set to `-1`, the validity period is `1825` days (about 5 years).
+  Default vault `-1`.
+
+## Attributes Reference
+
+All above argument parameters can be exported as attribute parameters along with attribute reference:
+
+* `id` - The ID of the cluster.
+
+* `kubeconfig` - The kubeconfig file of the cluster.

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/jinzhu/copier v0.2.3
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.5.8-0.20220221160844-ec42c008a99c
+	github.com/opentelekomcloud/gophertelekomcloud v0.5.8-0.20220310072709-39155931e269
 	github.com/unknwon/com v1.0.1
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -297,8 +297,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.5.8-0.20220221160844-ec42c008a99c h1:5A3OmRW4bNYAsdOOMoOrdsUO+9RRqwvX6d9gMe65Gm8=
-github.com/opentelekomcloud/gophertelekomcloud v0.5.8-0.20220221160844-ec42c008a99c/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
+github.com/opentelekomcloud/gophertelekomcloud v0.5.8-0.20220310072709-39155931e269 h1:hhhJ7jGz39lEYisE1T+FySuNqKh5yKalE+gDrQwIkeA=
+github.com/opentelekomcloud/gophertelekomcloud v0.5.8-0.20220310072709-39155931e269/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/opentelekomcloud/acceptance/cce/data_source_opentelekomcloud_cce_cluster_kubeconfig_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/data_source_opentelekomcloud_cce_cluster_kubeconfig_v3_test.go
@@ -1,0 +1,87 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
+)
+
+const dataSourceName = "data.opentelekomcloud_cce_cluster_kubeconfig_v3.this"
+
+func TestAccCCEKubeConfigV3DataSource_basic(t *testing.T) {
+	var cceName = fmt.Sprintf("cce-test-%s", acctest.RandString(5))
+
+	t.Parallel()
+	quotas.BookOne(t, quotas.CCEClusterQuota)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCCEClusterKubeconfigV3DataSourceInit(cceName),
+			},
+			{
+				Config: testAccCCEClusterKubeconfigV3DataSourceBasic(cceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCCEClusterKubeconfigV3DataSourceID(dataSourceName),
+					resource.TestCheckResourceAttrSet(dataSourceName, "kubeconfig"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCCEClusterKubeconfigV3DataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("can't find kubeconfig data source: %s ", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("kubeconfig data source ID not set ")
+		}
+
+		return nil
+	}
+}
+
+func testAccCCEClusterKubeconfigV3DataSourceInit(cceName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
+  name                   = "%s"
+  cluster_type           = "VirtualMachine"
+  flavor_id              = "cce.s1.small"
+  vpc_id                 = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  subnet_id              = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  container_network_type = "overlay_l2"
+}
+`, common.DataSourceSubnet, cceName)
+}
+
+func testAccCCEClusterKubeconfigV3DataSourceBasic(cceName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
+  name                   = "%s"
+  cluster_type           = "VirtualMachine"
+  flavor_id              = "cce.s1.small"
+  vpc_id                 = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  subnet_id              = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  container_network_type = "overlay_l2"
+}
+
+data "opentelekomcloud_cce_cluster_kubeconfig_v3" "this" {
+  cluster_id = opentelekomcloud_cce_cluster_v3.cluster_1.id
+}
+`, common.DataSourceSubnet, cceName)
+}

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -231,6 +231,7 @@ func Provider() *schema.Provider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"opentelekomcloud_antiddos_v1":                     antiddos.DataSourceAntiDdosV1(),
 			"opentelekomcloud_cce_cluster_v3":                  cce.DataSourceCCEClusterV3(),
+			"opentelekomcloud_cce_cluster_kubeconfig_v3":       cce.DataSourceCCEClusterKubeConfigV3(),
 			"opentelekomcloud_cce_node_ids_v3":                 cce.DataSourceCceNodeIdsV3(),
 			"opentelekomcloud_cce_node_v3":                     cce.DataSourceCceNodesV3(),
 			"opentelekomcloud_compute_availability_zones_v2":   ecs.DataSourceComputeAvailabilityZonesV2(),

--- a/opentelekomcloud/services/cce/data_source_opentelekomcloud_cce_cluster_kubeconfig_v3.go
+++ b/opentelekomcloud/services/cce/data_source_opentelekomcloud_cce_cluster_kubeconfig_v3.go
@@ -1,0 +1,80 @@
+package cce
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/cce/v3/clusters"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
+)
+
+func DataSourceCCEClusterKubeConfigV3() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceCCEClusterKubeConfigV3Read,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"cluster_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.IsUUID,
+			},
+			"expiration": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  -1,
+			},
+			"kubeconfig": {
+				Type:     schema.TypeString,
+				Computed: true,
+				StateFunc: func(v interface{}) string {
+					jsonString, _ := common.NormalizeJsonString(v)
+					return jsonString
+				},
+			},
+		},
+	}
+}
+
+func dataSourceCCEClusterKubeConfigV3Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := config.CceV3Client(config.GetRegion(d))
+	if err != nil {
+		return fmterr.Errorf(cceClientError, err)
+	}
+
+	clusterID := d.Get("cluster_id").(string)
+	expiration := d.Get("expiration").(int)
+	expiryOpts := clusters.ExpirationOpts{
+		Duration: expiration,
+	}
+
+	kubeconfig, err := clusters.GetCertWithExpiration(client, clusterID, expiryOpts).ExtractMap()
+	if err != nil {
+		return fmterr.Errorf("unable to retrieve cluster kubeconfig: %w", err)
+	}
+
+	d.SetId(clusterID)
+
+	mErr := multierror.Append(nil,
+		d.Set("cluster_id", clusterID),
+		d.Set("expiration", expiration),
+		d.Set("kubeconfig", kubeconfig),
+		d.Set("region", config.GetRegion(d)),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}

--- a/opentelekomcloud/services/cce/data_source_opentelekomcloud_cce_cluster_kubeconfig_v3.go
+++ b/opentelekomcloud/services/cce/data_source_opentelekomcloud_cce_cluster_kubeconfig_v3.go
@@ -18,12 +18,6 @@ func DataSourceCCEClusterKubeConfigV3() *schema.Resource {
 		ReadContext: dataSourceCCEClusterKubeConfigV3Read,
 
 		Schema: map[string]*schema.Schema{
-			"region": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
 			"cluster_id": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -70,7 +64,6 @@ func dataSourceCCEClusterKubeConfigV3Read(_ context.Context, d *schema.ResourceD
 		d.Set("cluster_id", clusterID),
 		d.Set("expiration", expiration),
 		d.Set("kubeconfig", kubeconfig),
-		d.Set("region", config.GetRegion(d)),
 	)
 	if err := mErr.ErrorOrNil(); err != nil {
 		return diag.FromErr(err)

--- a/opentelekomcloud/services/cce/data_source_opentelekomcloud_cce_cluster_kubeconfig_v3.go
+++ b/opentelekomcloud/services/cce/data_source_opentelekomcloud_cce_cluster_kubeconfig_v3.go
@@ -2,13 +2,13 @@ package cce
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/cce/v3/clusters"
-	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
 )
@@ -23,7 +23,7 @@ func DataSourceCCEClusterKubeConfigV3() *schema.Resource {
 				Required:     true,
 				ValidateFunc: validation.IsUUID,
 			},
-			"expiration": {
+			"duration": {
 				Type:     schema.TypeInt,
 				Optional: true,
 				Default:  -1,
@@ -31,10 +31,6 @@ func DataSourceCCEClusterKubeConfigV3() *schema.Resource {
 			"kubeconfig": {
 				Type:     schema.TypeString,
 				Computed: true,
-				StateFunc: func(v interface{}) string {
-					jsonString, _ := common.NormalizeJsonString(v)
-					return jsonString
-				},
 			},
 		},
 	}
@@ -48,9 +44,9 @@ func dataSourceCCEClusterKubeConfigV3Read(_ context.Context, d *schema.ResourceD
 	}
 
 	clusterID := d.Get("cluster_id").(string)
-	expiration := d.Get("expiration").(int)
+	duration := d.Get("duration").(int)
 	expiryOpts := clusters.ExpirationOpts{
-		Duration: expiration,
+		Duration: duration,
 	}
 
 	kubeconfig, err := clusters.GetCertWithExpiration(client, clusterID, expiryOpts).ExtractMap()
@@ -60,10 +56,15 @@ func dataSourceCCEClusterKubeConfigV3Read(_ context.Context, d *schema.ResourceD
 
 	d.SetId(clusterID)
 
+	jsonStr, err := json.Marshal(kubeconfig)
+	if err != nil {
+		return fmterr.Errorf("unable to marshal kubeconfig: %w", err)
+	}
+
 	mErr := multierror.Append(nil,
 		d.Set("cluster_id", clusterID),
-		d.Set("expiration", expiration),
-		d.Set("kubeconfig", kubeconfig),
+		d.Set("duration", duration),
+		d.Set("kubeconfig", string(jsonStr)),
 	)
 	if err := mErr.ErrorOrNil(); err != nil {
 		return diag.FromErr(err)

--- a/releasenotes/notes/d-cce-kubeconfig-c1b09a7c51ea2b96.yaml
+++ b/releasenotes/notes/d-cce-kubeconfig-c1b09a7c51ea2b96.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    **New Data Source:** ``opentelekomcloud_cce_cluster_kubeconfig_v3`` (`#1649 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1649>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Implement data-source `opentelekomcloud_cce_cluster_kubeconfig_v3`

## PR Checklist

* [x] Refers to: #1644
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccCCEKubeConfigV3DataSource_basic
=== PAUSE TestAccCCEKubeConfigV3DataSource_basic
=== CONT  TestAccCCEKubeConfigV3DataSource_basic
--- PASS: TestAccCCEKubeConfigV3DataSource_basic (539.35s)
PASS

Process finished with the exit code 0

```
