### PR TITLE
docs(data.cce_kubeconfig_v3): fix argument name

### DIFF
--- a/docs/data-sources/cce_cluster_kubeconfig_v3.md
+++ b/docs/data-sources/cce_cluster_kubeconfig_v3.md
@@ -12,7 +12,7 @@ Use this data source to get a cluster's kubeconfig file from OpenTelekomCloud.
 variable "cluster_id" {}
 
 data "opentelekomcloud_cce_cluster_kubeconfig_v3" "this" {
-  name = var.cluster_id
+  cluster_id = var.cluster_id
 }
 ```
 


### PR DESCRIPTION
## Summary of the Pull Request

The usage example in the documentation for the new (and awesome) data source `cce_kubeconfig_v3` has the wrong argument name, which leads to an error when copied verbatim.

This PR fixes it.

## PR Checklist

* [ ] Refers to: #xxx
* [ ] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.
* [ ] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (101.71s)
=== RUN   TestAccSomethingV0_timeout
--- PASS: TestAccSomethingV0_timeout (128.67s)
PASS

Process finished with exit code 0
```
