### PR TITLE
[WAF] Fix errors in `r/ccattackprotection_rule_v1`

### DIFF
--- a/docs/resources/waf_ccattackprotection_rule_v1.md
+++ b/docs/resources/waf_ccattackprotection_rule_v1.md
@@ -72,8 +72,8 @@ The following attributes are exported:
 
 ## Import
 
-CC Attack Protection Rules can be imported using the `id`, e.g.
+CC Attack Protection Rules can be imported using `policy_id/id`, e.g.
 
 ```sh
-terraform import opentelekomcloud_waf_ccattackprotection_rule_v1.rule_1 7117d38e-4c8f-4624-a505-bd96b97d024c
+terraform import opentelekomcloud_waf_ccattackprotection_rule_v1.rule_1 ff95e71c8ae74eba9887193ab22c5757/b39f3a5a1b4f447a8030f0b0703f47f5
 ```

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/jinzhu/copier v0.2.3
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.5.8-0.20220315132123-50250e134807
+	github.com/opentelekomcloud/gophertelekomcloud v0.5.8-0.20220316134758-786e74396d8e
 	github.com/unknwon/com v1.0.1
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -297,8 +297,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.5.8-0.20220315132123-50250e134807 h1:Ln2iqXrA/mF2qdBQUSW+yRsq+fh/PCv52oaxVHLgEKQ=
-github.com/opentelekomcloud/gophertelekomcloud v0.5.8-0.20220315132123-50250e134807/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
+github.com/opentelekomcloud/gophertelekomcloud v0.5.8-0.20220316134758-786e74396d8e h1:5oM9AuQpgN5hXb5ADTAImMcwWA+v/RvOSrwOmUnan7k=
+github.com/opentelekomcloud/gophertelekomcloud v0.5.8-0.20220316134758-786e74396d8e/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/opentelekomcloud/acceptance/waf/resource_opentelekomcloud_waf_ccattackprotection_rule_v1_test.go
+++ b/opentelekomcloud/acceptance/waf/resource_opentelekomcloud_waf_ccattackprotection_rule_v1_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 )
 
+const resourceCCRuleName = "opentelekomcloud_waf_ccattackprotection_rule_v1.rule_1"
+
 func TestAccWafCcAttackProtectionRuleV1_basic(t *testing.T) {
 	var rule ccattackprotection_rules.CcAttack
 
@@ -23,12 +25,34 @@ func TestAccWafCcAttackProtectionRuleV1_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckWafCcAttackProtectionRuleV1Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWafCcAttackProtectionRuleV1_basic,
+				Config: testAccWafCcAttackProtectionRuleV1Basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckWafCcAttackProtectionRuleV1Exists("opentelekomcloud_waf_ccattackprotection_rule_v1.rule_1", &rule),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_waf_ccattackprotection_rule_v1.rule_1", "url", "/abc1"),
+					testAccCheckWafCcAttackProtectionRuleV1Exists(resourceCCRuleName, &rule),
+					resource.TestCheckResourceAttr(resourceCCRuleName, "url", "/abc1"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccWafCcAttackProtectionRuleV1_import(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckWafCcAttackProtectionRuleV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafCcAttackProtectionRuleV1Basic,
+			},
+			{
+				ResourceName: resourceCCRuleName,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					policyID := s.RootModule().Resources["opentelekomcloud_waf_policy_v1.policy_1"].Primary.ID
+					ccRuleID := s.RootModule().Resources[resourceCCRuleName].Primary.ID
+					return fmt.Sprintf("%s/%s", policyID, ccRuleID), nil
+				},
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -87,21 +111,21 @@ func testAccCheckWafCcAttackProtectionRuleV1Exists(n string, rule *ccattackprote
 	}
 }
 
-const testAccWafCcAttackProtectionRuleV1_basic = `
+const testAccWafCcAttackProtectionRuleV1Basic = `
 resource "opentelekomcloud_waf_policy_v1" "policy_1" {
-	name = "policy_1"
+  name = "policy_1"
 }
 
 resource "opentelekomcloud_waf_ccattackprotection_rule_v1" "rule_1" {
-	policy_id = opentelekomcloud_waf_policy_v1.policy_1.id
-	url = "/abc1"
-	limit_num = 10
-	limit_period = 60
-	lock_time = 10
-	tag_type = "cookie"
-	tag_index = "sessionid"
-	action_category = "block"
-	block_content_type = "application/json"
-	block_content = "{\"error\":\"forbidden\"}"
+  policy_id          = opentelekomcloud_waf_policy_v1.policy_1.id
+  url                = "/abc1"
+  limit_num          = 10
+  limit_period       = 60
+  lock_time          = 10
+  tag_type           = "cookie"
+  tag_index          = "sessionid"
+  action_category    = "block"
+  block_content_type = "application/json"
+  block_content      = "{\"error\":\"forbidden\"}"
 }
 `

--- a/opentelekomcloud/common/importers.go
+++ b/opentelekomcloud/common/importers.go
@@ -46,7 +46,12 @@ func SetIDComponents(d *schema.ResourceData, attributes ...string) error {
 
 	mErr := &multierror.Error{}
 	for i, attr := range attributes {
-		mErr = multierror.Append(mErr, d.Set(attr, parts[i]))
+		v := parts[i]
+		if attr == "id" {
+			d.SetId(v)
+			continue
+		}
+		mErr = multierror.Append(mErr, d.Set(attr, v))
 	}
 	return mErr.ErrorOrNil()
 }

--- a/releasenotes/notes/waf-fix-ccrule-71325f297d253011.yaml
+++ b/releasenotes/notes/waf-fix-ccrule-71325f297d253011.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    **[WAF]** Fix creation of ``resource/opentelekomcloud_waf_ccattackprotection_rule_v1``
+    (`#1656 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1656>`_)
+  - |
+    **[WAF]** Fix import of ``resource/opentelekomcloud_waf_ccattackprotection_rule_v1``
+    (`#1656 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1656>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Update SDK to version with fixed rule create and get structure

Minor refactoring of the `opentelekomcloud_waf_ccattackprotection_rule_v1`

Fix broken import of `opentelekomcloud_waf_ccattackprotection_rule_v1`

Add support of `id` in `ImportByPath`

Fix #1652 

## PR Checklist

* [x] Refers to: #1652
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccWafCcAttackProtectionRuleV1_basic
--- PASS: TestAccWafCcAttackProtectionRuleV1_basic (34.18s)
=== RUN   TestAccWafCcAttackProtectionRuleV1_import
--- PASS: TestAccWafCcAttackProtectionRuleV1_import (37.92s)
PASS

Process finished with the exit code 0

```
