### PR TITLE
[WAF] Fix import for `r/waf_whiteblackip_rule_v1`

### DIFF
--- a/docs/resources/waf_whiteblackip_rule_v1.md
+++ b/docs/resources/waf_whiteblackip_rule_v1.md
@@ -39,8 +39,8 @@ The following attributes are exported:
 
 ## Import
 
-WhiteBlackIP Rules can be imported using the `id`, e.g.
+WhiteBlackIP Rules can be imported using `policy_id/id`, e.g.
 
 ```sh
-terraform import opentelekomcloud_waf_whiteblackip_rule_v1.rule_1 7117d38e-4c8f-4624-a505-bd96b97d024c
+terraform import opentelekomcloud_waf_whiteblackip_rule_v1.rule_1 ff95e71c8ae74eba9887193ab22c5757/b39f3a5a1b4f447a8030f0b0703f47f5
 ```

--- a/opentelekomcloud/acceptance/waf/resource_opentelekomcloud_waf_whiteblackip_rule_v1_test.go
+++ b/opentelekomcloud/acceptance/waf/resource_opentelekomcloud_waf_whiteblackip_rule_v1_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 )
 
-const resourceRuleName = "opentelekomcloud_waf_whiteblackip_rule_v1.rule_1"
+const resourceBWRuleName = "opentelekomcloud_waf_whiteblackip_rule_v1.rule_1"
 
 func TestAccWafWhiteBlackIpRuleV1_basic(t *testing.T) {
 	var rule whiteblackip_rules.WhiteBlackIP
@@ -27,19 +27,33 @@ func TestAccWafWhiteBlackIpRuleV1_basic(t *testing.T) {
 			{
 				Config: testAccWafWhiteBlackIpRuleV1Basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckWafWhiteBlackIpRuleV1Exists(resourceRuleName, &rule),
-					resource.TestCheckResourceAttr(resourceRuleName, "addr", "192.168.0.0/24"),
-					resource.TestCheckResourceAttr(resourceRuleName, "white", "0"),
+					testAccCheckWafWhiteBlackIpRuleV1Exists(resourceBWRuleName, &rule),
+					resource.TestCheckResourceAttr(resourceBWRuleName, "addr", "192.168.0.0/24"),
+					resource.TestCheckResourceAttr(resourceBWRuleName, "white", "0"),
 				),
 			},
 			{
 				Config: testAccWafWhiteBlackIpRuleV1Update,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckWafWhiteBlackIpRuleV1Exists(resourceRuleName, &rule),
-					resource.TestCheckResourceAttr(resourceRuleName, "addr", "192.168.0.125"),
-					resource.TestCheckResourceAttr(resourceRuleName, "white", "1"),
+					testAccCheckWafWhiteBlackIpRuleV1Exists(resourceBWRuleName, &rule),
+					resource.TestCheckResourceAttr(resourceBWRuleName, "addr", "192.168.0.125"),
+					resource.TestCheckResourceAttr(resourceBWRuleName, "white", "1"),
 				),
 			},
+		},
+	})
+}
+
+func TestAccWafWhiteBlackIpRuleV1_import(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckWafWhiteBlackIpRuleV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafWhiteBlackIpRuleV1Basic,
+			},
+			stepWAFRuleImport(resourceBWRuleName),
 		},
 	})
 }

--- a/opentelekomcloud/services/waf/resource_opentelekomcloud_waf_whiteblackip_rule_v1.go
+++ b/opentelekomcloud/services/waf/resource_opentelekomcloud_waf_whiteblackip_rule_v1.go
@@ -22,9 +22,7 @@ func ResourceWafWhiteBlackIpRuleV1() *schema.Resource {
 		ReadContext:   resourceWafWhiteBlackIpRuleV1Read,
 		UpdateContext: resourceWafWhiteBlackIpRuleV1Update,
 		DeleteContext: resourceWafWhiteBlackIpRuleV1Delete,
-		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
-		},
+		Importer:      wafRuleImporter(),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),

--- a/releasenotes/notes/waf-fix-wbrule-16df73047dcc5df3.yaml
+++ b/releasenotes/notes/waf-fix-wbrule-16df73047dcc5df3.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    **[WAF]** Fix import of ``resource/opentelekomcloud_waf_whiteblackip_rule_v1``
+    (`#1661 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1661>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Fix importer used in `opentelekomcloud_whiteblackip_rule_v1`

## PR Checklist

* [x] Refers to: #1655
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccWafWhiteBlackIpRuleV1_basic
--- PASS: TestAccWafWhiteBlackIpRuleV1_basic (95.34s)
=== RUN   TestAccWafWhiteBlackIpRuleV1_import
--- PASS: TestAccWafWhiteBlackIpRuleV1_import (56.44s)
PASS

Process finished with the exit code 0
```
