### PR TITLE
[WAF] Fix DataMasking and WebTamperProtection rules

### DIFF
--- a/docs/resources/waf_datamasking_rule_v1.md
+++ b/docs/resources/waf_datamasking_rule_v1.md
@@ -41,8 +41,8 @@ The following attributes are exported:
 
 ## Import
 
-Data Masking Rules can be imported using the `id`, e.g.
+Data Masking Rules can be imported using the `policy_id/id`, e.g.
 
 ```sh
-terraform import opentelekomcloud_waf_datamasking_rule_v1.rule_1 7117d38e-4c8f-4624-a505-bd96b97d024c
+terraform import opentelekomcloud_waf_datamasking_rule_v1.rule_1 b39f3a5a1b4f447a8030f0b0703f47f5/7117d38e4c8f4624a505bd96b97d024c
 ```

--- a/docs/resources/waf_falsealarmmasking_rule_v1.md
+++ b/docs/resources/waf_falsealarmmasking_rule_v1.md
@@ -6,6 +6,9 @@ subcategory: "Web Application Firewall (WAF)"
 
 Manages a WAF False Alarm Masking Rule resource within OpenTelekomCloud.
 
+!>
+This resource is known to be broken due to the API changes and will be fixed in the upcoming releases
+
 ## Example Usage
 
 ```hcl
@@ -38,8 +41,8 @@ The following attributes are exported:
 
 ## Import
 
-False Alarm Masking Rules can be imported using the `id`, e.g.
+False Alarm Masking Rules can be imported using `policy_id/id`, e.g.
 
 ```sh
-terraform import opentelekomcloud_waf_falsealarmmasking_rule_v1.rule_1 7117d38e-4c8f-4624-a505-bd96b97d024c
+terraform import opentelekomcloud_waf_falsealarmmasking_rule_v1.rule_1 ff95e71c8ae74eba9887193ab22c5757/b39f3a5a1b4f447a8030f0b0703f47f5
 ```

--- a/docs/resources/waf_webtamperprotection_rule_v1.md
+++ b/docs/resources/waf_webtamperprotection_rule_v1.md
@@ -38,8 +38,8 @@ The following attributes are exported:
 
 ## Import
 
-Web Tamper Protection Rules can be imported using the `id`, e.g.
+Web Tamper Protection Rules can be imported using the `policy_id/id`, e.g.
 
 ```sh
-terraform import opentelekomcloud_waf_webtamperprotection_rule_v1.rule_1 7117d38e-4c8f-4624-a505-bd96b97d024c
+terraform import opentelekomcloud_waf_webtamperprotection_rule_v1.rule_1 ff95e71c8ae74eba9887193ab22c5757/7117d38e4c8f4624a505-bd96b97d024c
 ```

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/jinzhu/copier v0.2.3
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.5.8-0.20220316134758-786e74396d8e
+	github.com/opentelekomcloud/gophertelekomcloud v0.5.8
 	github.com/unknwon/com v1.0.1
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -297,8 +297,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.5.8-0.20220316134758-786e74396d8e h1:5oM9AuQpgN5hXb5ADTAImMcwWA+v/RvOSrwOmUnan7k=
-github.com/opentelekomcloud/gophertelekomcloud v0.5.8-0.20220316134758-786e74396d8e/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
+github.com/opentelekomcloud/gophertelekomcloud v0.5.8 h1:jz1O9grSR5SygTeRjQs0+kLKcdVaxjs4Qxw0FbN/2ZY=
+github.com/opentelekomcloud/gophertelekomcloud v0.5.8/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/opentelekomcloud/acceptance/waf/resource_opentelekomcloud_waf_datamasking_rule_v1_test.go
+++ b/opentelekomcloud/acceptance/waf/resource_opentelekomcloud_waf_datamasking_rule_v1_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 )
 
+const resourceDMRuleName = "opentelekomcloud_waf_datamasking_rule_v1.rule_1"
+
 func TestAccWafDataMaskingRuleV1_basic(t *testing.T) {
 	var rule datamasking_rules.DataMasking
 
@@ -25,27 +27,35 @@ func TestAccWafDataMaskingRuleV1_basic(t *testing.T) {
 			{
 				Config: testAccWafDataMaskingRuleV1_basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckWafDataMaskingRuleV1Exists("opentelekomcloud_waf_datamasking_rule_v1.rule_1", &rule),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_waf_datamasking_rule_v1.rule_1", "url", "/login"),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_waf_datamasking_rule_v1.rule_1", "category", "params"),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_waf_datamasking_rule_v1.rule_1", "index", "password"),
+					testAccCheckWafDataMaskingRuleV1Exists(resourceDMRuleName, &rule),
+					resource.TestCheckResourceAttr(resourceDMRuleName, "url", "/login"),
+					resource.TestCheckResourceAttr(resourceDMRuleName, "category", "params"),
+					resource.TestCheckResourceAttr(resourceDMRuleName, "index", "password"),
 				),
 			},
 			{
 				Config: testAccWafDataMaskingRuleV1_update,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckWafDataMaskingRuleV1Exists("opentelekomcloud_waf_datamasking_rule_v1.rule_1", &rule),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_waf_datamasking_rule_v1.rule_1", "url", "/login_new"),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_waf_datamasking_rule_v1.rule_1", "category", "params"),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_waf_datamasking_rule_v1.rule_1", "index", "password"),
+					testAccCheckWafDataMaskingRuleV1Exists(resourceDMRuleName, &rule),
+					resource.TestCheckResourceAttr(resourceDMRuleName, "url", "/login_new"),
+					resource.TestCheckResourceAttr(resourceDMRuleName, "category", "params"),
+					resource.TestCheckResourceAttr(resourceDMRuleName, "index", "password"),
 				),
 			},
+		},
+	})
+}
+
+func TestAccWafDataMaskingRuleV1_import(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckWafDataMaskingRuleV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafDataMaskingRuleV1_basic,
+			},
+			stepWAFRuleImport(resourceDMRuleName),
 		},
 	})
 }

--- a/opentelekomcloud/acceptance/waf/resource_opentelekomcloud_waf_falsealarmmasking_rule_v1_test.go
+++ b/opentelekomcloud/acceptance/waf/resource_opentelekomcloud_waf_falsealarmmasking_rule_v1_test.go
@@ -14,7 +14,15 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 )
 
+const resourceFAMRuleName = "opentelekomcloud_waf_falsealarmmasking_rule_v1.rule_1"
+
+func skipFalseAlarmMasking(t *testing.T) {
+	t.Skip("This test requires existing alarms")
+}
+
 func TestAccWafFalseAlarmMaskingRuleV1_basic(t *testing.T) {
+	skipFalseAlarmMasking(t)
+
 	var rule falsealarmmasking_rules.AlarmMasking
 
 	resource.Test(t, resource.TestCase{
@@ -25,13 +33,27 @@ func TestAccWafFalseAlarmMaskingRuleV1_basic(t *testing.T) {
 			{
 				Config: testAccWafFalseAlarmMaskingRuleV1_basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckWafFalseAlarmMaskingRuleV1Exists("opentelekomcloud_waf_falsealarmmasking_rule_v1.rule_1", &rule),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_waf_falsealarmmasking_rule_v1.rule_1", "url", "/a"),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_waf_falsealarmmasking_rule_v1.rule_1", "rule", "100001"),
+					testAccCheckWafFalseAlarmMaskingRuleV1Exists(resourceFAMRuleName, &rule),
+					resource.TestCheckResourceAttr(resourceFAMRuleName, "url", "/a"),
+					resource.TestCheckResourceAttr(resourceFAMRuleName, "rule", "100001"),
 				),
 			},
+		},
+	})
+}
+
+func TestAccWafFalseAlarmMaskingRuleV1_import(t *testing.T) {
+	skipFalseAlarmMasking(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckWafFalseAlarmMaskingRuleV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafFalseAlarmMaskingRuleV1_basic,
+			},
+			stepWAFRuleImport(resourceFAMRuleName),
 		},
 	})
 }

--- a/opentelekomcloud/acceptance/waf/resource_opentelekomcloud_waf_falsealarmmasking_rule_v1_test.go
+++ b/opentelekomcloud/acceptance/waf/resource_opentelekomcloud_waf_falsealarmmasking_rule_v1_test.go
@@ -21,12 +21,13 @@ func skipFalseAlarmMasking(t *testing.T) {
 }
 
 func TestAccWafFalseAlarmMaskingRuleV1_basic(t *testing.T) {
-	skipFalseAlarmMasking(t)
-
 	var rule falsealarmmasking_rules.AlarmMasking
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { common.TestAccPreCheck(t) },
+		PreCheck: func() {
+			skipFalseAlarmMasking(t)
+			common.TestAccPreCheck(t)
+		},
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckWafFalseAlarmMaskingRuleV1Destroy,
 		Steps: []resource.TestStep{
@@ -46,7 +47,10 @@ func TestAccWafFalseAlarmMaskingRuleV1_import(t *testing.T) {
 	skipFalseAlarmMasking(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { common.TestAccPreCheck(t) },
+		PreCheck: func() {
+			skipFalseAlarmMasking(t)
+			common.TestAccPreCheck(t)
+		},
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckWafFalseAlarmMaskingRuleV1Destroy,
 		Steps: []resource.TestStep{

--- a/opentelekomcloud/acceptance/waf/resource_opentelekomcloud_waf_webtamperprotection_rule_v1_test.go
+++ b/opentelekomcloud/acceptance/waf/resource_opentelekomcloud_waf_webtamperprotection_rule_v1_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 )
 
+const resourceWTRuleName = "opentelekomcloud_waf_webtamperprotection_rule_v1.rule_1"
+
 func TestAccWebTamperProtectionRuleV1_basic(t *testing.T) {
 	var rule webtamperprotection_rules.WebTamper
 
@@ -25,13 +27,25 @@ func TestAccWebTamperProtectionRuleV1_basic(t *testing.T) {
 			{
 				Config: testAccWafWebTamperProtectionRuleV1_basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckWebTamperProtectionRuleV1Exists("opentelekomcloud_waf_webtamperprotection_rule_v1.rule_1", &rule),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_waf_webtamperprotection_rule_v1.rule_1", "hostname", "www.abc.com"),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_waf_webtamperprotection_rule_v1.rule_1", "url", "/a"),
+					testAccCheckWebTamperProtectionRuleV1Exists(resourceWTRuleName, &rule),
+					resource.TestCheckResourceAttr(resourceWTRuleName, "hostname", "www.abc.com"),
+					resource.TestCheckResourceAttr(resourceWTRuleName, "url", "/a"),
 				),
 			},
+		},
+	})
+}
+
+func TestAccWebTamperProtectionRuleV1_import(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckWafWebTamperProtectionRuleV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafWebTamperProtectionRuleV1_basic,
+			},
+			stepWAFRuleImport(resourceWTRuleName),
 		},
 	})
 }

--- a/opentelekomcloud/services/waf/resource_opentelekomcloud_waf_datamasking_rule_v1.go
+++ b/opentelekomcloud/services/waf/resource_opentelekomcloud_waf_datamasking_rule_v1.go
@@ -21,9 +21,7 @@ func ResourceWafDataMaskingRuleV1() *schema.Resource {
 		ReadContext:   resourceWafDataMaskingRuleV1Read,
 		UpdateContext: resourceWafDataMaskingRuleV1Update,
 		DeleteContext: resourceWafDataMaskingRuleV1Delete,
-		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
-		},
+		Importer:      wafRuleImporter(),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),
@@ -65,13 +63,13 @@ func resourceWafDataMaskingRuleV1Create(ctx context.Context, d *schema.ResourceD
 	}
 
 	createOpts := datamasking_rules.CreateOpts{
-		Url:      d.Get("url").(string),
+		Path:     d.Get("url").(string),
 		Category: d.Get("category").(string),
 		Index:    d.Get("index").(string),
 	}
 
-	policy_id := d.Get("policy_id").(string)
-	rule, err := datamasking_rules.Create(wafClient, policy_id, createOpts).Extract()
+	policyID := d.Get("policy_id").(string)
+	rule, err := datamasking_rules.Create(wafClient, policyID, createOpts).Extract()
 	if err != nil {
 		return fmterr.Errorf("error creating OpenTelekomcomCloud WAF DataMasking Rule: %s", err)
 	}
@@ -88,8 +86,8 @@ func resourceWafDataMaskingRuleV1Read(_ context.Context, d *schema.ResourceData,
 	if err != nil {
 		return fmterr.Errorf("error creating OpenTelekomCloud WAF client: %s", err)
 	}
-	policy_id := d.Get("policy_id").(string)
-	n, err := datamasking_rules.Get(wafClient, policy_id, d.Id()).Extract()
+	policyID := d.Get("policy_id").(string)
+	n, err := datamasking_rules.Get(wafClient, policyID, d.Id()).Extract()
 
 	if err != nil {
 		if _, ok := err.(golangsdk.ErrDefault404); ok {
@@ -102,7 +100,7 @@ func resourceWafDataMaskingRuleV1Read(_ context.Context, d *schema.ResourceData,
 
 	d.SetId(n.Id)
 	mErr := multierror.Append(
-		d.Set("url", n.Url),
+		d.Set("url", n.Path),
 		d.Set("category", n.Category),
 		d.Set("index", n.Index),
 		d.Set("policy_id", n.PolicyID),
@@ -123,15 +121,15 @@ func resourceWafDataMaskingRuleV1Update(ctx context.Context, d *schema.ResourceD
 	var updateOpts datamasking_rules.UpdateOpts
 
 	if d.HasChange("url") || d.HasChange("category") || d.HasChange("index") {
-		updateOpts.Url = d.Get("url").(string)
+		updateOpts.Path = d.Get("url").(string)
 		updateOpts.Category = d.Get("category").(string)
 		updateOpts.Index = d.Get("index").(string)
 	}
 	log.Printf("[DEBUG] updateOpts: %#v", updateOpts)
 
 	if updateOpts != (datamasking_rules.UpdateOpts{}) {
-		policy_id := d.Get("policy_id").(string)
-		_, err = datamasking_rules.Update(wafClient, policy_id, d.Id(), updateOpts).Extract()
+		policyID := d.Get("policy_id").(string)
+		_, err = datamasking_rules.Update(wafClient, policyID, d.Id(), updateOpts).Extract()
 		if err != nil {
 			return fmterr.Errorf("error updating OpenTelekomCloud WAF DataMasking Rule: %s", err)
 		}
@@ -147,8 +145,8 @@ func resourceWafDataMaskingRuleV1Delete(_ context.Context, d *schema.ResourceDat
 		return fmterr.Errorf("error creating OpenTelekomCloud WAF client: %s", err)
 	}
 
-	policy_id := d.Get("policy_id").(string)
-	err = datamasking_rules.Delete(wafClient, policy_id, d.Id()).ExtractErr()
+	policyID := d.Get("policy_id").(string)
+	err = datamasking_rules.Delete(wafClient, policyID, d.Id()).ExtractErr()
 	if err != nil {
 		return fmterr.Errorf("error deleting OpenTelekomCloud WAF DataMasking Rule: %s", err)
 	}

--- a/opentelekomcloud/services/waf/resource_opentelekomcloud_waf_falsealarmmasking_rule_v1.go
+++ b/opentelekomcloud/services/waf/resource_opentelekomcloud_waf_falsealarmmasking_rule_v1.go
@@ -19,14 +19,14 @@ func ResourceWafFalseAlarmMaskingRuleV1() *schema.Resource {
 		CreateContext: resourceWafFalseAlarmMaskingRuleV1Create,
 		ReadContext:   resourceWafFalseAlarmMaskingRuleV1Read,
 		DeleteContext: resourceWafFalseAlarmMaskingRuleV1Delete,
-		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
-		},
+		Importer:      wafRuleImporter(),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
+
+		DeprecationMessage: "This resource is known to be broken due to the API changes and will be fixed in the upcoming releases",
 
 		Schema: map[string]*schema.Schema{
 			"policy_id": {
@@ -58,8 +58,8 @@ func resourceWafFalseAlarmMaskingRuleV1Create(ctx context.Context, d *schema.Res
 	}
 
 	createOpts := falsealarmmasking_rules.CreateOpts{
-		Url:  d.Get("url").(string),
-		Rule: d.Get("rule").(string),
+		Path: d.Get("url").(string),
+		// Rule: d.Get("rule").(string),
 	}
 
 	policyID := d.Get("policy_id").(string)
@@ -90,7 +90,7 @@ func resourceWafFalseAlarmMaskingRuleV1Read(_ context.Context, d *schema.Resourc
 		if r.Id == d.Id() {
 			d.SetId(r.Id)
 			mErr := multierror.Append(
-				d.Set("url", r.Url),
+				d.Set("url", r.Path),
 				d.Set("rule", r.Rule),
 				d.Set("policy_id", r.PolicyID),
 			)

--- a/opentelekomcloud/services/waf/resource_opentelekomcloud_waf_webtamperprotection_rule_v1.go
+++ b/opentelekomcloud/services/waf/resource_opentelekomcloud_waf_webtamperprotection_rule_v1.go
@@ -20,9 +20,7 @@ func ResourceWafWebTamperProtectionRuleV1() *schema.Resource {
 		CreateContext: resourceWafWebTamperProtectionRuleV1Create,
 		ReadContext:   resourceWafWebTamperProtectionRuleV1Read,
 		DeleteContext: resourceWafWebTamperProtectionRuleV1Delete,
-		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
-		},
+		Importer:      wafRuleImporter(),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),
@@ -60,7 +58,7 @@ func resourceWafWebTamperProtectionRuleV1Create(ctx context.Context, d *schema.R
 
 	createOpts := webtamperprotection_rules.CreateOpts{
 		Hostname: d.Get("hostname").(string),
-		Url:      d.Get("url").(string),
+		Path:     d.Get("url").(string),
 	}
 
 	policyID := d.Get("policy_id").(string)
@@ -96,7 +94,7 @@ func resourceWafWebTamperProtectionRuleV1Read(_ context.Context, d *schema.Resou
 	d.SetId(n.Id)
 	mErr := multierror.Append(
 		d.Set("hostname", n.Hostname),
-		d.Set("url", n.Url),
+		d.Set("url", n.Path),
 		d.Set("policy_id", n.PolicyID),
 	)
 	if err := mErr.ErrorOrNil(); err != nil {

--- a/releasenotes/notes/waf-fix-rules-280937c869bb32e4.yaml
+++ b/releasenotes/notes/waf-fix-rules-280937c869bb32e4.yaml
@@ -1,0 +1,12 @@
+---
+issues:
+  - |
+    **[WAF]** ``resource/opentelekomcloud_waf_falsealarmmasking_rule_v1`` marked as deprecated due to API changes
+    (`#1664 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1664>`_)
+fixes:
+  - |
+    **[WAF]** Fix broken ``resource/opentelekomcloud_waf_webtamperprotection_rule_v1``
+    (`#1664 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1664>`_)
+  - |
+    **[WAF]** Fix broken ``resource/opentelekomcloud_waf_datamasking_rule_v1``
+    (`#1664 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1664>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Update SDK to version with fixed rules structures

Fix `waf_webtamperprotection_rule_v1` and `waf_datamasking_rule_v1` resources

Mark `waf_falsealarmmasking_rule_v1` resource temporary deprecated due to API changes

Fix #1662 
Resolve #1655

## PR Checklist

* [x] Refers to: #1662, #1655
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccWafCertificateV1_import
--- PASS: TestAccWafCertificateV1_import (50.30s)
=== RUN   TestAccWafAlarmNotificationV1_basic
--- PASS: TestAccWafAlarmNotificationV1_basic (65.64s)
=== RUN   TestAccWafCcAttackProtectionRuleV1_basic
--- PASS: TestAccWafCcAttackProtectionRuleV1_basic (35.12s)
=== RUN   TestAccWafCcAttackProtectionRuleV1_import
--- PASS: TestAccWafCcAttackProtectionRuleV1_import (41.68s)
=== RUN   TestAccWafCertificateV1_basic
--- PASS: TestAccWafCertificateV1_basic (58.47s)
=== RUN   TestAccWafCertificateV1_validation
--- PASS: TestAccWafCertificateV1_validation (7.37s)
=== RUN   TestAccWafDataMaskingRuleV1_basic
--- PASS: TestAccWafDataMaskingRuleV1_basic (60.80s)
=== RUN   TestAccWafDataMaskingRuleV1_import
--- PASS: TestAccWafDataMaskingRuleV1_import (38.01s)
=== RUN   TestAccWafDomainV1Basic
--- PASS: TestAccWafDomainV1Basic (109.98s)
=== RUN   TestAccWafFalseAlarmMaskingRuleV1_basic
    resource_opentelekomcloud_waf_falsealarmmasking_rule_v1_test.go:20: This test requires existing alarms
--- SKIP: TestAccWafFalseAlarmMaskingRuleV1_basic (0.00s)

Test ignored.
=== RUN   TestAccWafFalseAlarmMaskingRuleV1_import
    resource_opentelekomcloud_waf_falsealarmmasking_rule_v1_test.go:20: This test requires existing alarms
--- SKIP: TestAccWafFalseAlarmMaskingRuleV1_import (0.00s)

Test ignored.
=== RUN   TestAccWafPolicyV1_basic
--- PASS: TestAccWafPolicyV1_basic (57.15s)
=== RUN   TestAccWafPolicyV1_import
--- PASS: TestAccWafPolicyV1_import (41.19s)
=== RUN   TestAccWafPreciseProtectionRuleV1_basic
--- PASS: TestAccWafPreciseProtectionRuleV1_basic (32.71s)
=== RUN   TestAccWafPreciseProtectionRuleV1_import
--- PASS: TestAccWafPreciseProtectionRuleV1_import (38.49s)
=== RUN   TestAccWebTamperProtectionRuleV1_basic
--- PASS: TestAccWebTamperProtectionRuleV1_basic (32.66s)
=== RUN   TestAccWebTamperProtectionRuleV1_import
--- PASS: TestAccWebTamperProtectionRuleV1_import (42.02s)
=== RUN   TestAccWafWhiteBlackIpRuleV1_basic
--- PASS: TestAccWafWhiteBlackIpRuleV1_basic (61.62s)
=== RUN   TestAccWafWhiteBlackIpRuleV1_import
--- PASS: TestAccWafWhiteBlackIpRuleV1_import (41.16s)
PASS
ok  	github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/waf	815.292s

Process finished with the exit code 0
```
