### PR TITLE
[ELB] Make SSL passtrough documentation more verbose

### DIFF
--- a/docs/resources/lb_listener_v2.md
+++ b/docs/resources/lb_listener_v2.md
@@ -70,8 +70,11 @@ The following arguments are supported:
   suites. The option is effective only in conjunction with `TERMINATED_HTTPS`.
 
 * `transparent_client_ip_enable` - (Optional) Specifies whether to pass source IP addresses of the clients to
-  backend servers. The value can be true or false, and the default value is false for `TCP` and `UDP` listeners.
-  The value can only be true for `HTTP` and `HTTPS` listeners.
+  backend servers. The value is always `true` for `HTTP` and `HTTPS` listeners. For `TCP` and `UDP` listeners the
+  value can be `true` or `false` with `false` by default.
+
+->
+  If the load balancer is a Dedicated Load Balancer, `transparent_client_ip_enable` is always `true`
 
 * `admin_state_up` - (Optional) The administrative state of the Listener.
   A valid value is `true` (UP) or `false` (DOWN).

--- a/releasenotes/notes/elbv2-listener-doc-a8383f1c4666f6ac.yaml
+++ b/releasenotes/notes/elbv2-listener-doc-a8383f1c4666f6ac.yaml
@@ -1,0 +1,5 @@
+---
+other:
+  - |
+    **[ELB]** Clarify ``transparent_client_ip_enable`` argument description in documentation of
+    ``resource/opentelekomcloud_lb_listener_v2`` (`#1666 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1666>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Clarify `transparent_client_ip_enable` argument documentation

Resolve #1663

## PR Checklist

* [x] Refers to: #1663
* [x] Documentation updated.
* [x] Release notes added.
