### PR TITLE
[OBS] Move to OBS-specific API

### DIFF
--- a/docs/resources/obs_bucket.md
+++ b/docs/resources/obs_bucket.md
@@ -102,7 +102,7 @@ resource "opentelekomcloud_obs_bucket" "bucket" {
   acl           = "public-read"
 
   server_side_encryption {
-    algorithm  = "aws:kms"
+    algorithm  = "kms"
     kms_key_id = var.kms_master_key_id
   }
 }
@@ -357,7 +357,7 @@ The `noncurrent_version_transition` object supports the following
 
 The `server_side_encryption` object supports the following
 
-* `algorithm` - (Required) The algorithm used for SSE. Only `aws:kms` is supported.
+* `algorithm` - (Required) The algorithm used for SSE. Only `kms` is supported.
 
 * `kms_key_id` - (Required) The ID of KMS key used for the encryption.
 

--- a/docs/resources/obs_bucket_policy.md
+++ b/docs/resources/obs_bucket_policy.md
@@ -13,26 +13,31 @@ resource "opentelekomcloud_obs_bucket" "bucket" {
   bucket = "my-tf-test-bucket"
 }
 
-resource "opentelekomcloud_obs_bucket_policy" "policy" {
+resource "opentelekomcloud_obs_bucket_policy" "bucket" {
   bucket = opentelekomcloud_obs_bucket.bucket.id
   policy = <<POLICY
-  {
-  "Id": "MYBUCKETPOLICY",
-  "Statement": [
-    {
-      "Sid": "IPAllow",
-      "Effect": "Deny",
-      "Principal": "*",
-      "Action": "s3:*",
-      "Resource": "arn:aws:s3:::${opentelekomcloud_obs_bucket.bucket.id}/*",
-      "Condition": {
-         "IpAddress": {"aws:SourceIp": "8.8.8.8/32"}
-      }
-    }
-  ]}
+{
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {
+      "ID": ["*"]
+    },
+    "Action": [
+      "ListBucket",
+      "ListBucketVersions"
+    ],
+    "Resource": [
+      "${opentelekomcloud_obs_bucket.bucket.bucket}/*"
+    ]
+  }]
+}
 POLICY
 }
 ```
+
+~>
+  Please note that used policy syntax is OBS-specific. For s3-compatible policies check
+  `opentelekomcloud_s3_bucket_policy` resource.
 
 ## Argument Reference
 

--- a/docs/resources/obs_bucket_policy.md
+++ b/docs/resources/obs_bucket_policy.md
@@ -13,7 +13,7 @@ resource "opentelekomcloud_obs_bucket" "bucket" {
   bucket = "my-tf-test-bucket"
 }
 
-resource "opentelekomcloud_obs_bucket_policy" "bucket" {
+resource "opentelekomcloud_obs_bucket_policy" "policy" {
   bucket = opentelekomcloud_obs_bucket.bucket.id
   policy = <<POLICY
 {

--- a/opentelekomcloud/acceptance/obs/resource_opentelekomcloud_obs_bucket_object_test.go
+++ b/opentelekomcloud/acceptance/obs/resource_opentelekomcloud_obs_bucket_object_test.go
@@ -259,8 +259,9 @@ resource "opentelekomcloud_obs_bucket_object" "object" {
   source       = "%s"
   content_type = "binary/octet-stream"
   encryption   = true
+  kms_key_id   = "%s"
 }
-`, randInt, source)
+`, randInt, source, os.Getenv("OS_KMS_ID"))
 }
 
 func testAccObsBucketObject_configWithContent(randInt int) string {

--- a/opentelekomcloud/acceptance/obs/resource_opentelekomcloud_obs_bucket_policy_test.go
+++ b/opentelekomcloud/acceptance/obs/resource_opentelekomcloud_obs_bucket_policy_test.go
@@ -21,8 +21,25 @@ func TestAccObsBucketPolicyBasic(t *testing.T) {
 	name := fmt.Sprintf("tf-test-bucket-%d", acctest.RandInt())
 
 	expectedPolicyText := fmt.Sprintf(
-		`{"Version":"2008-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":["*"]},"Action":["s3:*"],"Resource":["arn:aws:s3:::%s/*","arn:aws:s3:::%s"]}]}`,
-		name, name)
+		`{
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "ID": [
+          "*"
+        ]
+      },
+      "Action": [
+        "*"
+      ],
+      "Resource": [
+        "%[1]s/*",
+        "%[1]s"
+      ]
+    }
+  ]
+}`, name)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -44,12 +61,12 @@ func TestAccObsBucketPolicyUpdate(t *testing.T) {
 	name := fmt.Sprintf("tf-test-bucket-%d", acctest.RandInt())
 
 	expectedPolicyText1 := fmt.Sprintf(
-		`{"Version":"2008-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":["*"]},"Action":["s3:*"],"Resource":["arn:aws:s3:::%s/*","arn:aws:s3:::%s"]}]}`,
-		name, name)
+		`{"Statement":[{"Effect":"Allow","Principal":{"ID":["*"]},"Action":["*"],"Resource":["%s/*","%[1]s"]}]}`,
+		name)
 
 	expectedPolicyText2 := fmt.Sprintf(
-		`{"Version":"2008-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":["*"]},"Action":["s3:DeleteBucket", "s3:ListBucket", "s3:ListBucketVersions"], "Resource":["arn:aws:s3:::%s/*","arn:aws:s3:::%s"]}]}`,
-		name, name)
+		`{"Statement":[{"Effect":"Allow","Principal":{"ID":["*"]},"Action":["DeleteBucket", "ListBucket", "ListBucketVersions"], "Resource":["%s/*","%[1]s"]}]}`,
+		name)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -136,24 +153,27 @@ resource "opentelekomcloud_obs_bucket_policy" "bucket" {
   bucket = opentelekomcloud_obs_bucket.bucket.bucket
   policy = <<POLICY
 {
-	"Version": "2008-10-17",
-	"Statement": [{
-		"Effect": "Allow",
-		"Principal": {
-			"AWS": ["*"]
-		},
-		"Action": [
-			"s3:*"
-		],
-		"Resource": [
-			"arn:aws:s3:::%s",
-			"arn:aws:s3:::%s/*"
-		]
-	}]
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "ID": [
+          "*"
+        ]
+      },
+      "Action": [
+        "*"
+      ],
+      "Resource": [
+        "%[1]s/*",
+        "%[1]s"
+      ]
+    }
+  ]
 }
 POLICY
 }
-`, bucketName, bucketName, bucketName)
+`, bucketName)
 }
 
 func testAccObsBucketPolicyConfigUpdated(bucketName string) string {
@@ -166,22 +186,21 @@ resource "opentelekomcloud_obs_bucket_policy" "bucket" {
   bucket = opentelekomcloud_obs_bucket.bucket.bucket
   policy = <<POLICY
 {
-	"Version": "2008-10-17",
-	"Statement": [{
-		"Effect": "Allow",
-		"Principal": {
-			"AWS": ["*"]
-		},
-		"Action": [
-			"s3:DeleteBucket",
-			"s3:ListBucket",
-			"s3:ListBucketVersions"
-		],
-		"Resource": [
-			"arn:aws:s3:::%s",
-			"arn:aws:s3:::%s/*"
-		]
-	}]
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {
+      "ID": ["*"]
+    },
+    "Action": [
+      "DeleteBucket",
+      "ListBucket",
+      "ListBucketVersions"
+    ],
+    "Resource": [
+      "%s",
+      "%s/*"
+    ]
+  }]
 }
 POLICY
 }
@@ -198,7 +217,7 @@ resource "opentelekomcloud_obs_bucket_policy" "bucket" {
   bucket = opentelekomcloud_obs_bucket.bucket.bucket
   policy = <<POLICY
 {
-    "Id": "BUCKET_POLICY",
+    "Sid": "BUCKET_POLICY",
     "Statement": [
         {
             "Effect": "Allow",
@@ -208,17 +227,17 @@ resource "opentelekomcloud_obs_bucket_policy" "bucket" {
                 ]
             },
             "Action": [
-                "s3:GetObject",
-                "s3:PutObject",
-                "s3:ListBucket",
-                "s3:ListBucketVersions",
-                "s3:ListBucketMultipartUploads",
-                "s3:GetBucketLocation",
-                "s3:GetBucketStorage"
+                "GetObject",
+                "PutObject",
+                "ListBucket",
+                "ListBucketVersions",
+                "ListBucketMultipartUploads",
+                "GetBucketLocation",
+                "GetBucketStorage"
             ],
             "Resource": [
-                "arn:aws:s3:::bucket/*",
-                "arn:aws:s3:::bucket"
+                "bucket/*",
+                "bucket"
             ]
         }
     ]

--- a/opentelekomcloud/acceptance/obs/resource_opentelekomcloud_obs_bucket_test.go
+++ b/opentelekomcloud/acceptance/obs/resource_opentelekomcloud_obs_bucket_test.go
@@ -44,7 +44,7 @@ func TestAccObsBucket_basic(t *testing.T) {
 				Config: testAccObsBucketSSE(rInt),
 				Check: resource.ComposeTestCheckFunc(testAccCheckObsBucketExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.0.kms_key_id", env.OS_KMS_ID),
-					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.0.algorithm", "aws:kms"),
+					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.0.algorithm", "kms"),
 				),
 			},
 		},

--- a/opentelekomcloud/acceptance/obs/resource_opentelekomcloud_obs_bucket_test.go
+++ b/opentelekomcloud/acceptance/obs/resource_opentelekomcloud_obs_bucket_test.go
@@ -327,7 +327,7 @@ resource "opentelekomcloud_obs_bucket" "bucket" {
   acl           = "public-read"
 
   server_side_encryption {
-    algorithm  = "aws:kms"
+    algorithm  = "kms"
     kms_key_id = "%s"
   }
 }

--- a/opentelekomcloud/common/cfg/config.go
+++ b/opentelekomcloud/common/cfg/config.go
@@ -634,7 +634,10 @@ func (c *Config) NewObjectStorageClient(region string) (*obs.ObsClient, error) {
 
 	setUpOBSLogging()
 
-	return obs.New(cred.AccessKey, cred.SecretKey, client.Endpoint, obs.WithSecurityToken(cred.SecurityToken))
+	return obs.New(
+		cred.AccessKey, cred.SecretKey, client.Endpoint,
+		obs.WithSecurityToken(cred.SecurityToken), obs.WithSignature(obs.SignatureObs),
+	)
 }
 
 func (c *Config) BlockStorageV2Client(region string) (*golangsdk.ServiceClient, error) {

--- a/opentelekomcloud/services/obs/resource_opentelekomcloud_obs_bucket.go
+++ b/opentelekomcloud/services/obs/resource_opentelekomcloud_obs_bucket.go
@@ -260,7 +260,7 @@ func ResourceObsBucket() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 							ValidateDiagFunc: validation.ToDiagFunc(
-								validation.StringInSlice([]string{"aws:kms"}, false),
+								validation.StringInSlice([]string{"kms"}, false),
 							),
 						},
 					},

--- a/opentelekomcloud/services/obs/resource_opentelekomcloud_obs_bucket_object.go
+++ b/opentelekomcloud/services/obs/resource_opentelekomcloud_obs_bucket_object.go
@@ -103,8 +103,7 @@ func resourceObsBucketObjectPut(ctx context.Context, d *schema.ResourceData, met
 
 	if source, ok := d.GetOk("source"); ok {
 		// check source file whether exist
-		_, err := os.Stat(source.(string))
-		if err != nil {
+		if _, err := os.Stat(source.(string)); err != nil {
 			if os.IsNotExist(err) {
 				return fmterr.Errorf("source file %s does not exist", source)
 			}
@@ -164,11 +163,11 @@ func basicInput(d *schema.ResourceData) obs.PutObjectBasicInput {
 	if v, ok := d.GetOk("content_type"); ok {
 		common.ContentType = v.(string)
 	}
-	var sseKmsHeader = obs.SseKmsHeader{}
 	if d.Get("encryption").(bool) {
-		sseKmsHeader.Encryption = obs.DEFAULT_SSE_KMS_ENCRYPTION
-		sseKmsHeader.Key = d.Get("kms_key_id").(string)
-		common.SseHeader = sseKmsHeader
+		common.SseHeader = obs.SseKmsHeader{
+			Encryption: obs.DEFAULT_SSE_KMS_ENCRYPTION_OBS,
+			Key:        d.Get("kms_key_id").(string),
+		}
 	}
 	return common
 }

--- a/releasenotes/notes/obs-kms-366e2b27c7486f8f.yaml
+++ b/releasenotes/notes/obs-kms-366e2b27c7486f8f.yaml
@@ -1,7 +1,50 @@
 ---
 issues:
   - |
-    Fix not encyrpting OBS bucket with `kms` algorythm
+    Fix not encrypting OBS bucket with `kms` algorythm (`#1180 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1180>`_)
 upgrade:
   - |
-    `aws:kms` algorythm stop working for OBS bucket encryption
+    S3-compatibility is broken for OBS resources. SSE stop supporting `aws:kms` algorythm. Rules passed to `opentelekomcloud_obs_bucket_policy`
+    should be OBS-specififc, e.g.
+    .. code-block:: JSON
+        {
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "ID": [
+                  "*"
+                ]
+              },
+              "Action": [
+                "*"
+              ],
+              "Resource": [
+                "tf-test-bucket-2185738448437901391",
+                "tf-test-bucket-2185738448437901391/*"
+              ]
+            }
+          ]
+        }
+    instead of S3-compatible
+    .. code-block:: JSON
+        {
+          "Version": "2008-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": [
+                  "*"
+                ]
+              },
+              "Action": [
+                "s3:*"
+              ],
+              "Resource": [
+                "arn:aws:s3:::tf-test-bucket-2185738448437901391/*",
+                "arn:aws:s3:::tf-test-bucket-2185738448437901391"
+              ]
+            }
+          ]
+        }

--- a/releasenotes/notes/obs-kms-366e2b27c7486f8f.yaml
+++ b/releasenotes/notes/obs-kms-366e2b27c7486f8f.yaml
@@ -1,0 +1,7 @@
+---
+issues:
+  - |
+    Fix not encyrpting OBS bucket with `kms` algorythm
+upgrade:
+  - |
+    `aws:kms` algorythm stop working for OBS bucket encryption

--- a/releasenotes/notes/obs-kms-366e2b27c7486f8f.yaml
+++ b/releasenotes/notes/obs-kms-366e2b27c7486f8f.yaml
@@ -1,12 +1,18 @@
 ---
+prelude:
+  OBS resources now do not support S3-compatibility mode (see below for the details)."
 issues:
   - |
-    Fix not encrypting OBS bucket with `kms` algorythm (`#1180 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1180>`_)
+    **[OBS]** Fix not encrypting OBS bucket with ``kms`` algorythm
+    (`#1685 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1685>`_)
 upgrade:
   - |
-    S3-compatibility is broken for OBS resources. SSE stop supporting `aws:kms` algorythm. Rules passed to `opentelekomcloud_obs_bucket_policy`
-    should be OBS-specififc, e.g.
+    **[OBS]** SSE algorithm ``aws:kms`` is now not supported for ``resource/opentelekomcloud_obs_bucket``, please use ``kms`` instead.
+  - |
+    **[OBS]** Rules passed to ``resource/opentelekomcloud_obs_bucket_policy`` should be OBS-specififc, e.g.
+
     .. code-block:: JSON
+
         {
           "Statement": [
             {
@@ -26,8 +32,11 @@ upgrade:
             }
           ]
         }
+
     instead of S3-compatible
+
     .. code-block:: JSON
+
         {
           "Version": "2008-10-17",
           "Statement": [
@@ -48,3 +57,5 @@ upgrade:
             }
           ]
         }
+
+    For S3-compatible rules use ``resource/opentelekomcloud_s3_bucket_policy``.


### PR DESCRIPTION
## Summary of the Pull Request
Resolve #1160 

## PR Checklist

* [x] Refers to: #1160 
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccDataSourceObsBucketObject_basic
=== PAUSE TestAccDataSourceObsBucketObject_basic
=== CONT  TestAccDataSourceObsBucketObject_basic
--- PASS: TestAccDataSourceObsBucketObject_basic (63.08s)
=== RUN   TestAccDataSourceObsBucketObject_readableBody
=== PAUSE TestAccDataSourceObsBucketObject_readableBody
=== CONT  TestAccDataSourceObsBucketObject_readableBody
--- PASS: TestAccDataSourceObsBucketObject_readableBody (63.84s)
=== RUN   TestAccDataSourceObsBucketObject_allParams
=== PAUSE TestAccDataSourceObsBucketObject_allParams
=== CONT  TestAccDataSourceObsBucketObject_allParams
--- PASS: TestAccDataSourceObsBucketObject_allParams (62.69s)
=== RUN   TestAccDataSourceObsBucket_basic
=== PAUSE TestAccDataSourceObsBucket_basic
=== CONT  TestAccDataSourceObsBucket_basic
--- PASS: TestAccDataSourceObsBucket_basic (61.23s)
=== RUN   TestAccObsBucketObject_source
=== PAUSE TestAccObsBucketObject_source
=== CONT  TestAccObsBucketObject_source
--- PASS: TestAccObsBucketObject_source (63.68s)
=== RUN   TestAccObsBucketObject_content
=== PAUSE TestAccObsBucketObject_content
=== CONT  TestAccObsBucketObject_content
--- PASS: TestAccObsBucketObject_content (35.29s)
=== RUN   TestAccObsBucketObject_withVersionedContent
=== PAUSE TestAccObsBucketObject_withVersionedContent
=== CONT  TestAccObsBucketObject_withVersionedContent
--- PASS: TestAccObsBucketObject_withVersionedContent (37.09s)
=== RUN   TestAccObsBucketObject_nothing
=== PAUSE TestAccObsBucketObject_nothing
=== CONT  TestAccObsBucketObject_nothing
--- PASS: TestAccObsBucketObject_nothing (5.93s)
=== RUN   TestAccObsBucketPolicyBasic
=== PAUSE TestAccObsBucketPolicyBasic
=== CONT  TestAccObsBucketPolicyBasic
--- PASS: TestAccObsBucketPolicyBasic (35.48s)
=== RUN   TestAccObsBucketPolicyUpdate
=== PAUSE TestAccObsBucketPolicyUpdate
=== CONT  TestAccObsBucketPolicyUpdate
--- PASS: TestAccObsBucketPolicyUpdate (63.84s)
=== RUN   TestAccObsBucketPolicyMalformed
=== PAUSE TestAccObsBucketPolicyMalformed
=== CONT  TestAccObsBucketPolicyMalformed
--- PASS: TestAccObsBucketPolicyMalformed (81.35s)
=== RUN   TestAccObsBucket_basic
=== PAUSE TestAccObsBucket_basic
=== CONT  TestAccObsBucket_basic
--- PASS: TestAccObsBucket_basic (91.44s)
=== RUN   TestAccObsBucket_tags
=== PAUSE TestAccObsBucket_tags
=== CONT  TestAccObsBucket_tags
--- PASS: TestAccObsBucket_tags (32.07s)
=== RUN   TestAccObsBucket_versioning
=== PAUSE TestAccObsBucket_versioning
=== CONT  TestAccObsBucket_versioning
--- PASS: TestAccObsBucket_versioning (60.71s)
=== RUN   TestAccObsBucket_logging
=== PAUSE TestAccObsBucket_logging
=== CONT  TestAccObsBucket_logging
--- PASS: TestAccObsBucket_logging (40.06s)
=== RUN   TestAccObsBucket_lifecycle
=== PAUSE TestAccObsBucket_lifecycle
=== CONT  TestAccObsBucket_lifecycle
--- PASS: TestAccObsBucket_lifecycle (33.39s)
=== RUN   TestAccObsBucket_website
=== PAUSE TestAccObsBucket_website
=== CONT  TestAccObsBucket_website
--- PASS: TestAccObsBucket_website (33.48s)
=== RUN   TestAccObsBucket_cors
=== PAUSE TestAccObsBucket_cors
=== CONT  TestAccObsBucket_cors
--- PASS: TestAccObsBucket_cors (33.62s)
=== RUN   TestAccObsBucket_notifications
=== PAUSE TestAccObsBucket_notifications
=== CONT  TestAccObsBucket_notifications
--- PASS: TestAccObsBucket_notifications (42.41s)
PASS
ok  	github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/obs	92.196s

Process finished with the exit code 0
```
