### PR TITLE
[ECS] Fix missing `port` in `compute_instance_v2`

### DIFF
--- a/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_instance_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_instance_v2_test.go
@@ -43,6 +43,7 @@ func TestAccComputeV2Instance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceInstanceV2Name, "name", "instance_1"),
 					resource.TestCheckResourceAttr(resourceInstanceV2Name, "availability_zone", env.OS_AVAILABILITY_ZONE),
 					resource.TestCheckResourceAttr(resourceInstanceV2Name, "tags.muh", "value-create"),
+					resource.TestCheckResourceAttrSet(resourceInstanceV2Name, "network.0.port"),
 				),
 			},
 			{

--- a/releasenotes/notes/compute-instance-port-8531fdf0c7e6b1ae.yaml
+++ b/releasenotes/notes/compute-instance-port-8531fdf0c7e6b1ae.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    **[ECS]** Fix populating value of ``network.port`` of ``resource/opentelekomcloud_compute_instance_v2``
+    (`#1686 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1686>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Fix populating network port on read in `compute_instance_v2`

Fix #1670

## PR Checklist

* [x] Refers to: #1670
* [x] Tests added/passed.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccComputeV2Instance_basic
=== PAUSE TestAccComputeV2Instance_basic
=== CONT  TestAccComputeV2Instance_basic
--- PASS: TestAccComputeV2Instance_basic (120.17s)
PASS

Process finished with the exit code 0

```
