### PR TITLE
[ELB] Allow zero weight in `lb_member_v2`

### DIFF
--- a/docs/resources/lb_member_v2.md
+++ b/docs/resources/lb_member_v2.md
@@ -44,7 +44,7 @@ The following arguments are supported:
 * `weight` - (Optional)  A positive integer value that indicates the relative
   portion of traffic that this member should receive from the pool. For
   example, a member with a `weight` of `10` receives five times as much traffic
-  as a member with a `weight` of `2`.
+  as a member with a `weight` of `2`. If the value is `0`, the backend server will not accept new requests
 
 * `admin_state_up` - (Optional) The administrative state of the member.
   A valid value is `true` (UP) or `false` (DOWN).

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/jinzhu/copier v0.2.3
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.5.9-0.20220331171453-78af5f0bf9ee
+	github.com/opentelekomcloud/gophertelekomcloud v0.5.9-0.20220401102507-1f027860f666
 	github.com/unknwon/com v1.0.1
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -297,8 +297,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.5.9-0.20220331171453-78af5f0bf9ee h1:aoTsLiXj0L89srv6eDemsaKko8MChPmNbOesc66HPkQ=
-github.com/opentelekomcloud/gophertelekomcloud v0.5.9-0.20220331171453-78af5f0bf9ee/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
+github.com/opentelekomcloud/gophertelekomcloud v0.5.9-0.20220401102507-1f027860f666 h1:2vbqkGtLZV0j2b5k9zi0nuyOV39sC3kdAj3TgE+cECk=
+github.com/opentelekomcloud/gophertelekomcloud v0.5.9-0.20220401102507-1f027860f666/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/opentelekomcloud/acceptance/elb/v2/resource_opentelekomcloud_lb_member_v2_test.go
+++ b/opentelekomcloud/acceptance/elb/v2/resource_opentelekomcloud_lb_member_v2_test.go
@@ -43,6 +43,8 @@ func TestAccLBV2Member_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLBV2MemberExists(resourceMemberName1, &member1),
 					testAccCheckLBV2MemberExists(resourceMemberName2, &member2),
+					resource.TestCheckResourceAttr(resourceMemberName1, "weight", "0"),
+					resource.TestCheckResourceAttr(resourceMemberName2, "weight", "10"),
 				),
 			},
 			{
@@ -50,7 +52,7 @@ func TestAccLBV2Member_basic(t *testing.T) {
 				ExpectNonEmptyPlan: true, // Because admin_state_up remains false, unfinished elb?
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceMemberName1, "weight", "10"),
-					resource.TestCheckResourceAttr(resourceMemberName2, "weight", "15"),
+					resource.TestCheckResourceAttr(resourceMemberName2, "weight", "0"),
 				),
 			},
 		},
@@ -175,6 +177,7 @@ resource "opentelekomcloud_lb_member_v2" "member_1" {
   protocol_port = 8080
   pool_id       = opentelekomcloud_lb_pool_v2.pool_1.id
   subnet_id     = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.subnet_id
+  weight        = 0
 }
 
 resource "opentelekomcloud_lb_member_v2" "member_2" {
@@ -182,6 +185,7 @@ resource "opentelekomcloud_lb_member_v2" "member_2" {
   protocol_port = 8080
   pool_id       = opentelekomcloud_lb_pool_v2.pool_1.id
   subnet_id     = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.subnet_id
+  weight        = 10
 }
 `, common.DataSourceSubnet)
 
@@ -219,7 +223,7 @@ resource "opentelekomcloud_lb_member_v2" "member_1" {
 resource "opentelekomcloud_lb_member_v2" "member_2" {
   address        = "192.168.0.11"
   protocol_port  = 8080
-  weight         = 15
+  weight         = 0
   admin_state_up = true
   pool_id        = opentelekomcloud_lb_pool_v2.pool_1.id
   subnet_id      = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.subnet_id

--- a/opentelekomcloud/services/elb/v2/resource_opentelekomcloud_lb_member_v2.go
+++ b/opentelekomcloud/services/elb/v2/resource_opentelekomcloud_lb_member_v2.go
@@ -66,8 +66,8 @@ func ResourceMemberV2() *schema.Resource {
 			"weight": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.IntBetween(1, 100),
+				ValidateFunc: validation.IntBetween(0, 100),
+				Default:      1,
 			},
 			"subnet_id": {
 				Type:     schema.TypeString,
@@ -101,7 +101,7 @@ func resourceMemberV2Create(ctx context.Context, d *schema.ResourceData, meta in
 		ProtocolPort: d.Get("protocol_port").(int),
 		Name:         d.Get("name").(string),
 		TenantID:     d.Get("tenant_id").(string),
-		Weight:       d.Get("weight").(int),
+		Weight:       golangsdk.IntToPointer(d.Get("weight").(int)),
 		SubnetID:     d.Get("subnet_id").(string),
 		AdminStateUp: &adminStateUp,
 	}
@@ -188,7 +188,7 @@ func resourceMemberV2Update(ctx context.Context, d *schema.ResourceData, meta in
 		updateOpts.Name = d.Get("name").(string)
 	}
 	if d.HasChange("weight") {
-		updateOpts.Weight = d.Get("weight").(int)
+		updateOpts.Weight = golangsdk.IntToPointer(d.Get("weight").(int))
 	}
 	if d.HasChange("admin_state_up") {
 		asu := d.Get("admin_state_up").(bool)

--- a/releasenotes/notes/elbv2-member-weight-9f0abeee0e580c49.yaml
+++ b/releasenotes/notes/elbv2-member-weight-9f0abeee0e580c49.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    **[ELB]** Allow passing zero to ``weight`` of ``resource/opentelekomcloud_lb_member_v2``
+    (`#1693 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1693>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Update SDK to the version supporting zero weight of ELBv2 member

Set default weight to `1` (per documentation)

Fix #1691

## PR Checklist

* [x] Refers to: #1691 
* [x] Tests added/passed.
* [x] Documentation updated
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccLBV2Member_basic
=== PAUSE TestAccLBV2Member_basic
=== CONT  TestAccLBV2Member_basic
--- PASS: TestAccLBV2Member_basic (189.86s)
PASS

Process finished with the exit code 0

```
