### PR TITLE
[CCE] Fail early if node creation job has no ID

### DIFF
--- a/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_v3.go
+++ b/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_v3.go
@@ -442,6 +442,13 @@ func resourceCCEEipIDs(d *schema.ResourceData) []string {
 	return id
 }
 
+func explainNodesJob(job *nodes.Job) string {
+	return fmt.Sprintf(`Job %s in status "%s":
+Reason: %s
+Message: %s
+`, job.Metadata.ID, job.Status.Phase, job.Status.Reason, job.Status.Message)
+}
+
 func resourceCCENodeV3Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
 	client, err := config.CceV3Client(config.GetRegion(d))
@@ -566,6 +573,9 @@ func resourceCCENodeV3Create(ctx context.Context, d *schema.ResourceData, meta i
 			nodeID = s.Spec.ResourceID
 			break
 		}
+	}
+	if nodeID == "" {
+		return fmterr.Errorf("can't find node ID in job response\n%s", explainNodesJob(subJob))
 	}
 
 	log.Printf("[DEBUG] Waiting for CCE Node (%s) to become available", node.Metadata.Name)

--- a/releasenotes/notes/cce-node-fail-fdb63f012117f652.yaml
+++ b/releasenotes/notes/cce-node-fail-fdb63f012117f652.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    **[CCE]** Make ``resource/opentelekomcloud_cce_node_v3`` creation fail early if node ID can't be determined
+    (`#1706 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1706>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Fail CCE node creation with distinct error if job contains no node ID

Related to #1705

## PR Checklist

* [x] Refers to: #1705
* [x] Tests added/passed.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccCCENodesV3Basic
=== PAUSE TestAccCCENodesV3Basic
=== CONT  TestAccCCENodesV3Basic
=== CONT  TestAccCCENodesV3Basic
    resource_opentelekomcloud_cce_node_v3_test.go:28: Cluster is required by the test. 1 test(s) are using cluster.
=== CONT  TestAccCCENodesV3Basic
    cluster.go:137: Cluster is released by the test. 10 test(s) are still using cluster.
--- PASS: TestAccCCENodesV3Basic (676.35s)
=== RUN   TestAccCCENodesV3Timeout
=== PAUSE TestAccCCENodesV3Timeout
=== CONT  TestAccCCENodesV3Timeout
=== CONT  TestAccCCENodesV3Timeout
    resource_opentelekomcloud_cce_node_v3_test.go:63: Cluster is required by the test. 7 test(s) are using cluster.
=== CONT  TestAccCCENodesV3Timeout
    cluster.go:137: Cluster is released by the test. 11 test(s) are still using cluster.
--- PASS: TestAccCCENodesV3Timeout (676.30s)
=== RUN   TestAccCCENodesV3OS
=== PAUSE TestAccCCENodesV3OS
=== CONT  TestAccCCENodesV3OS
    resource_opentelekomcloud_cce_node_v3_test.go:85: Cluster is required by the test. 6 test(s) are using cluster.
=== CONT  TestAccCCENodesV3OS
    cluster.go:137: Cluster is released by the test. 6 test(s) are still using cluster.
--- PASS: TestAccCCENodesV3OS (997.93s)
=== RUN   TestAccCCENodesV3_eipIds
=== PAUSE TestAccCCENodesV3_eipIds
=== CONT  TestAccCCENodesV3_eipIds
    resource_opentelekomcloud_cce_node_v3_test.go:145: Cluster is required by the test. 4 test(s) are using cluster.
=== CONT  TestAccCCENodesV3_eipIds
    cluster.go:137: Cluster usage is 0 now, ready to delete the cluster
    cluster.go:100: starting deleting shared cluster
--- PASS: TestAccCCENodesV3_eipIds (1543.34s)
=== RUN   TestAccCCENodesV3IpSetNull
=== PAUSE TestAccCCENodesV3IpSetNull
=== CONT  TestAccCCENodesV3IpSetNull
    resource_opentelekomcloud_cce_node_v3_test.go:175: Cluster is required by the test. 3 test(s) are using cluster.
=== CONT  TestAccCCENodesV3IpSetNull
    cluster.go:137: Cluster is released by the test. 9 test(s) are still using cluster.
--- PASS: TestAccCCENodesV3IpSetNull (678.91s)
=== RUN   TestAccCCENodesV3IpCreate
=== PAUSE TestAccCCENodesV3IpCreate
=== CONT  TestAccCCENodesV3IpCreate
    resource_opentelekomcloud_cce_node_v3_test.go:208: Cluster is required by the test. 2 test(s) are using cluster.
=== CONT  TestAccCCENodesV3IpCreate
    cluster.go:137: Cluster is released by the test. 8 test(s) are still using cluster.
--- PASS: TestAccCCENodesV3IpCreate (772.43s)
=== RUN   TestAccCCENodesV3IpWithExtendedParameters
=== PAUSE TestAccCCENodesV3IpWithExtendedParameters
=== CONT  TestAccCCENodesV3IpWithExtendedParameters
=== CONT  TestAccCCENodesV3IpWithExtendedParameters
    resource_opentelekomcloud_cce_node_v3_test.go:238: Cluster is required by the test. 11 test(s) are using cluster.
=== CONT  TestAccCCENodesV3IpWithExtendedParameters
    cluster.go:137: Cluster is released by the test. 7 test(s) are still using cluster.
--- PASS: TestAccCCENodesV3IpWithExtendedParameters (996.63s)
=== RUN   TestAccCCENodesV3IpNulls
=== PAUSE TestAccCCENodesV3IpNulls
=== CONT  TestAccCCENodesV3IpNulls
=== CONT  TestAccCCENodesV3IpNulls
    resource_opentelekomcloud_cce_node_v3_test.go:265: Cluster is required by the test. 9 test(s) are using cluster.
=== CONT  TestAccCCENodesV3IpNulls
    cluster.go:137: Cluster is released by the test. 5 test(s) are still using cluster.
--- PASS: TestAccCCENodesV3IpNulls (1008.60s)
=== RUN   TestAccCCENodesV3EncryptedVolume
=== PAUSE TestAccCCENodesV3EncryptedVolume
=== CONT  TestAccCCENodesV3EncryptedVolume
=== CONT  TestAccCCENodesV3EncryptedVolume
    resource_opentelekomcloud_cce_node_v3_test.go:287: Cluster is required by the test. 8 test(s) are using cluster.
=== CONT  TestAccCCENodesV3EncryptedVolume
    cluster.go:137: Cluster is released by the test. 3 test(s) are still using cluster.
--- PASS: TestAccCCENodesV3EncryptedVolume (1094.95s)
=== RUN   TestAccCCENodesV3_extendParams
=== PAUSE TestAccCCENodesV3_extendParams
=== CONT  TestAccCCENodesV3_extendParams
=== CONT  TestAccCCENodesV3_extendParams
    resource_opentelekomcloud_cce_node_v3_test.go:338: Cluster is required by the test. 10 test(s) are using cluster.
=== CONT  TestAccCCENodesV3_extendParams
    cluster.go:137: Cluster is released by the test. 1 test(s) are still using cluster.
--- PASS: TestAccCCENodesV3_extendParams (1389.37s)
FAIL

Process finished with the exit code 0
```
