### PR TITLE
Deprecate `compute_floatingip` APIs

### DIFF
--- a/docs/resources/compute_floatingip_associate_v2.md
+++ b/docs/resources/compute_floatingip_associate_v2.md
@@ -7,6 +7,10 @@ subcategory: "Elastic Cloud Server (ECS)"
 Associate a floating IP to an instance. This can be used instead of the
 `floating_ip` options in `opentelekomcloud_compute_instance_v2`.
 
+~>
+Floating IP compute APIs are marked as discarded in [help center](https://docs.otc.t-systems.com/en-us/api/ecs/en-us_topic_0065817682.html).
+Please use `resource/opentelekomcloud_networking_floatingip_associate_v2`
+
 ## Example Usage
 
 ### Automatically detect the correct network

--- a/docs/resources/compute_floatingip_v2.md
+++ b/docs/resources/compute_floatingip_v2.md
@@ -13,6 +13,10 @@ Floating IPs created with this module will have a bandwidth of 1000Mbit/s,
 for manually specifying the bandwidth please use the
 [`opentelekomcloud_vpc_eip_v1`](vpc_eip_v1.md) module.
 
+~>
+Floating IP compute APIs are marked as discarded in [help center](https://docs.otc.t-systems.com/en-us/api/ecs/en-us_topic_0065817682.html).
+Please use `resource/opentelekomcloud_networking_floatingip_v2` or `resource/opentelekomcloud_vpc_eip_v1`.
+
 
 ## Example Usage
 

--- a/docs/resources/networking_floatingip_associate_v2.md
+++ b/docs/resources/networking_floatingip_associate_v2.md
@@ -10,6 +10,8 @@ where you have a pre-allocated floating IP or are unable to use the
 
 ## Example Usage
 
+### Basic FloatingIP associate
+
 ```hcl
 resource "opentelekomcloud_networking_port_v2" "port_1" {
   network_id = "a5bbd213-e1d3-49b6-aed1-9df60ea94b9a"
@@ -18,6 +20,35 @@ resource "opentelekomcloud_networking_port_v2" "port_1" {
 resource "opentelekomcloud_networking_floatingip_associate_v2" "fip_1" {
   floating_ip = "1.2.3.4"
   port_id     = opentelekomcloud_networking_port_v2.port_1.id
+}
+```
+
+### Automatically detect the correct network
+
+```hcl
+variable "keypair" {}
+variable "image_id" {}
+variable "network_name" {}
+
+resource "opentelekomcloud_networking_floatingip_v2" "this" {
+  pool = "admin_external_net"
+}
+
+resource "opentelekomcloud_compute_instance_v2" "this" {
+  name            = "example-instance"
+  image_id        = var.image_id
+  flavor_id       = "s2.large.4"
+  key_pair        = var.keypair
+  security_groups = ["default"]
+
+  network {
+    name = var.network_name
+  }
+}
+
+resource "opentelekomcloud_networking_floatingip_associate_v2" "this" {
+  floating_ip = opentelekomcloud_networking_floatingip_v2.this.address
+  port_id    = opentelekomcloud_compute_instance_v2.this.network.0.port_id
 }
 ```
 

--- a/docs/resources/networking_floatingip_associate_v2.md
+++ b/docs/resources/networking_floatingip_associate_v2.md
@@ -48,7 +48,7 @@ resource "opentelekomcloud_compute_instance_v2" "this" {
 
 resource "opentelekomcloud_networking_floatingip_associate_v2" "this" {
   floating_ip = opentelekomcloud_networking_floatingip_v2.this.address
-  port_id    = opentelekomcloud_compute_instance_v2.this.network.0.port_id
+  port_id     = opentelekomcloud_compute_instance_v2.this.network.0.port_id
 }
 ```
 

--- a/docs/resources/networking_floatingip_associate_v2.md
+++ b/docs/resources/networking_floatingip_associate_v2.md
@@ -23,7 +23,7 @@ resource "opentelekomcloud_networking_floatingip_associate_v2" "fip_1" {
 }
 ```
 
-### Automatically detect the correct network
+### Associate an instance with `port_id`
 
 ```hcl
 variable "keypair" {}

--- a/opentelekomcloud/services/ecs/resource_opentelekomcloud_compute_floatingip_associate_v2.go
+++ b/opentelekomcloud/services/ecs/resource_opentelekomcloud_compute_floatingip_associate_v2.go
@@ -24,9 +24,12 @@ func ResourceComputeFloatingIPAssociateV2() *schema.Resource {
 		CreateContext: resourceComputeFloatingIPAssociateV2Create,
 		ReadContext:   resourceComputeFloatingIPAssociateV2Read,
 		DeleteContext: resourceComputeFloatingIPAssociateV2Delete,
+
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+
+		DeprecationMessage: "Please use `opentelekomcloud_networking_floatingip_associate_v2` resource instead.",
 
 		Schema: map[string]*schema.Schema{
 			"region": {

--- a/opentelekomcloud/services/ecs/resource_opentelekomcloud_compute_floatingip_v2.go
+++ b/opentelekomcloud/services/ecs/resource_opentelekomcloud_compute_floatingip_v2.go
@@ -28,6 +28,8 @@ func ResourceComputeFloatingIPV2() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
+		DeprecationMessage: "Please use `opentelekomcloud_networking_floatingip_v2` or `opentelekomcloud_vpc_eip_v1` resources instead",
+
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:     schema.TypeString,

--- a/releasenotes/notes/compute-floatingips-59c3c84cc13731e1.yaml
+++ b/releasenotes/notes/compute-floatingips-59c3c84cc13731e1.yaml
@@ -1,0 +1,6 @@
+---
+deprecations:
+  - |
+    **[ECS]** ``resource/opentelekomcloud_compute_floatingip_v2`` APIs are marked as discarded in `documentation <https://docs.otc.t-systems.com/en-us/api/ecs/en-us_topic_0065817682.html>`_ (`#1708 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1594>`_)
+  - |
+    **[ECS]** ``resource/opentelekomcloud_compute_floatingip_associate_v2`` APIs are marked as discarded in `documentation <https://docs.otc.t-systems.com/en-us/api/ecs/en-us_topic_0065817682.html>`_ (`#1708 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1594>`_)

--- a/releasenotes/notes/compute-floatingips-59c3c84cc13731e1.yaml
+++ b/releasenotes/notes/compute-floatingips-59c3c84cc13731e1.yaml
@@ -1,6 +1,6 @@
 ---
 deprecations:
   - |
-    **[ECS]** ``resource/opentelekomcloud_compute_floatingip_v2`` APIs are marked as discarded in `documentation <https://docs.otc.t-systems.com/en-us/api/ecs/en-us_topic_0065817682.html>`_ (`#1708 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1594>`_)
+    **[ECS]** ``resource/opentelekomcloud_compute_floatingip_v2`` APIs are marked as discarded in `documentation <https://docs.otc.t-systems.com/en-us/api/ecs/en-us_topic_0065817682.html>`_ (`#1708 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1708>`_)
   - |
-    **[ECS]** ``resource/opentelekomcloud_compute_floatingip_associate_v2`` APIs are marked as discarded in `documentation <https://docs.otc.t-systems.com/en-us/api/ecs/en-us_topic_0065817682.html>`_ (`#1708 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1594>`_)
+    **[ECS]** ``resource/opentelekomcloud_compute_floatingip_associate_v2`` APIs are marked as discarded in `documentation <https://docs.otc.t-systems.com/en-us/api/ecs/en-us_topic_0065817682.html>`_ (`#1708 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1708>`_)

--- a/releasenotes/notes/compute-floatingips-59c3c84cc13731e1.yaml
+++ b/releasenotes/notes/compute-floatingips-59c3c84cc13731e1.yaml
@@ -1,4 +1,4 @@
 ---
 deprecations:
   - |
-    **[ECS]** ``resource/opentelekomcloud_compute_floatingip_v2`` and ``resource/opentelekomcloud_compute_floatingip_associate_v2`` APIs are marked as discarded in `documentation <https://docs.otc.t-systems.com/en-us/api/ecs/en-us_topic_0065817682.html>`_ (`#1708 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1708>`_)
+    **[ECS]** ``resource/opentelekomcloud_compute_floatingip_v2`` and ``resource/opentelekomcloud_compute_floatingip_associate_v2`` APIs are marked as discarded in `documentation <https://docs.otc.t-systems.com/en-us/api/ecs/en-us_topic_0065817682.html>`__ (`#1708 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1708>`__)

--- a/releasenotes/notes/compute-floatingips-59c3c84cc13731e1.yaml
+++ b/releasenotes/notes/compute-floatingips-59c3c84cc13731e1.yaml
@@ -1,6 +1,4 @@
 ---
 deprecations:
   - |
-    **[ECS]** ``resource/opentelekomcloud_compute_floatingip_v2`` APIs are marked as discarded in `documentation <https://docs.otc.t-systems.com/en-us/api/ecs/en-us_topic_0065817682.html>`_ (`#1708 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1708>`_)
-  - |
-    **[ECS]** ``resource/opentelekomcloud_compute_floatingip_associate_v2`` APIs are marked as discarded in `documentation <https://docs.otc.t-systems.com/en-us/api/ecs/en-us_topic_0065817682.html>`_ (`#1708 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1708>`_)
+    **[ECS]** ``resource/opentelekomcloud_compute_floatingip_v2`` and ``resource/opentelekomcloud_compute_floatingip_associate_v2`` APIs are marked as discarded in `documentation <https://docs.otc.t-systems.com/en-us/api/ecs/en-us_topic_0065817682.html>`_ (`#1708 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1708>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Deprecate `resource/opentelekomcloud_floatingip_v2`
Deprecate `resource/opentelekomcloud_floatingip_associate_v2`

Resolves: #1643

## PR Checklist

* [x] Refers to: #1643
* [x] Documentation updated.
* [x] Release notes added.
