### PR TITLE
[DNS] Add `data_source/opentelekomcloud_dns_nameserver_v2`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/jinzhu/copier v0.3.5
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.5.9
+	github.com/opentelekomcloud/gophertelekomcloud v0.5.10
 	github.com/unknwon/com v1.0.1
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -199,8 +199,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.5.9 h1:cuSfJNGwYl99LNgHdMcRCoDaeuiSMHKgBviNfx4JcJ0=
-github.com/opentelekomcloud/gophertelekomcloud v0.5.9/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
+github.com/opentelekomcloud/gophertelekomcloud v0.5.10 h1:ELZs2iKRONG4mCqwuLv1lTMEj8gDYEgcNao9ShAvrDI=
+github.com/opentelekomcloud/gophertelekomcloud v0.5.10/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/opentelekomcloud/acceptance/dns/data_source_opentelekomcloud_dns_nameservers_v2_test.go
+++ b/opentelekomcloud/acceptance/dns/data_source_opentelekomcloud_dns_nameservers_v2_test.go
@@ -1,0 +1,43 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+)
+
+const dataDNSNameserverName = "data.opentelekomcloud_dns_nameservers_v2.nameservers"
+
+func TestAccDNSV2NameserverDataSource_basic(t *testing.T) {
+	zoneName := randomZoneName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheckRequiredEnvVars(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDNSV2ZoneDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDNSV2NameserverDataSource_nameserver(zoneName),
+				Check:  resource.TestCheckResourceAttr(dataDNSNameserverName, "nameservers.0.hostname", "ns1.open-telekom-cloud.com."),
+			},
+		},
+	})
+}
+
+func testAccDNSV2NameserverDataSource_nameserver(zoneName string) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_dns_zone_v2" "zone_1" {
+  name        = "%s"
+  email       = "email1@example.com"
+  description = "test public zone"
+  ttl         = 3000
+  type        = "public"
+}
+
+data "opentelekomcloud_dns_nameservers_v2" "nameservers" {
+  zone_id = opentelekomcloud_dns_zone_v2.zone_1.id
+}
+`, zoneName)
+}

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -254,6 +254,7 @@ func Provider() *schema.Provider {
 			"opentelekomcloud_dms_az_v1":                       dms.DataSourceDmsAZV1(),
 			"opentelekomcloud_dms_product_v1":                  dms.DataSourceDmsProductV1(),
 			"opentelekomcloud_dms_maintainwindow_v1":           dms.DataSourceDmsMaintainWindowV1(),
+			"opentelekomcloud_dns_nameservers_v2":              dns.DataSourceDNSNameserversV2(),
 			"opentelekomcloud_dns_zone_v2":                     dns.DataSourceDNSZoneV2(),
 			"opentelekomcloud_identity_agency_v3":              iam.DataSourceIdentityAgencyV3(),
 			"opentelekomcloud_identity_auth_scope_v3":          iam.DataSourceIdentityAuthScopeV3(),

--- a/opentelekomcloud/services/dns/data_source_opentelekomcloud_dns_nameservers_v2.go
+++ b/opentelekomcloud/services/dns/data_source_opentelekomcloud_dns_nameservers_v2.go
@@ -1,0 +1,89 @@
+package dns
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/dns/v2/nameservers"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
+)
+
+func DataSourceDNSNameserversV2() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDNSNameserverRead,
+
+		Schema: map[string]*schema.Schema{
+			"zone_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"nameservers": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"hostname": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"priority": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceDNSNameserverRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := config.DnsV2Client(config.GetRegion(d))
+	if err != nil {
+		return fmterr.Errorf(errCreationClient, err)
+	}
+
+	var allNameservers []nameservers.Nameserver
+
+	if v, ok := d.GetOk("zone_id"); ok {
+		allNameservers, err = nameservers.List(client, v.(string)).Extract()
+		if err != nil {
+			return fmterr.Errorf("Failed to extract nameservers: %s", err)
+		}
+	}
+
+	if len(allNameservers) < 1 {
+		return common.DataSourceTooFewDiag
+	}
+
+	var nameserverList []map[string]interface{}
+	for _, n := range allNameservers {
+		nameserverEntry := map[string]interface{}{
+			"hostname": n.Hostname,
+			"priority": n.Priority,
+		}
+		nameserverList = append(nameserverList, nameserverEntry)
+	}
+
+	if err := d.Set("nameservers", nameserverList); err != nil {
+		return diag.FromErr(err)
+	}
+
+	listID := nameserverList[0]["hostname"].(string)
+	d.SetId(listID)
+
+	mErr := multierror.Append(
+		d.Set("nameservers", nameserverList),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}

--- a/releasenotes/notes/dns-nameserver-01dd4b5a9f600106.yaml
+++ b/releasenotes/notes/dns-nameserver-01dd4b5a9f600106.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    **New Data Source:**  ``opentelekomcloud_dns_nameservers_v2``
+    (`#1715 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1715>`_)


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [x] Refers to: #1703, #1704
* [x] Tests added/passed.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccDNSV2NameserverDataSource_basic
--- PASS: TestAccDNSV2NameserverDataSource_basic (43.78s)
PASS

Process finished with exit code 0
```
