### PR TITLE
[CCE] Fix issue with missing `ForceNew` in `cce_node_pool_v3`

### DIFF
--- a/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_node_pool_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_node_pool_v3_test.go
@@ -102,7 +102,6 @@ func testAccCCENodePoolV3ImportStateIdFunc() resource.ImportStateIdFunc {
 
 func TestAccCCENodePoolsV3_randomAZ(t *testing.T) {
 	var nodePool nodepools.NodePool
-	nodePoolName := "opentelekomcloud_cce_node_pool_v3.node_pool"
 
 	t.Parallel()
 	shared.BookCluster(t)
@@ -115,8 +114,8 @@ func TestAccCCENodePoolsV3_randomAZ(t *testing.T) {
 			{
 				Config: testAccCCENodePoolV3RandomAZ,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCCENodePoolV3Exists(nodePoolName, shared.DataSourceClusterName, &nodePool),
-					resource.TestCheckResourceAttr(nodePoolName, "availability_zone", "random"),
+					testAccCheckCCENodePoolV3Exists(nodePoolResourceName, shared.DataSourceClusterName, &nodePool),
+					resource.TestCheckResourceAttr(nodePoolResourceName, "availability_zone", "random"),
 				),
 			},
 		},
@@ -125,7 +124,6 @@ func TestAccCCENodePoolsV3_randomAZ(t *testing.T) {
 
 func TestAccCCENodePoolsV3EncryptedVolume(t *testing.T) {
 	var nodePool nodepools.NodePool
-	nodePoolName := "opentelekomcloud_cce_node_pool_v3.node_pool"
 
 	t.Parallel()
 	shared.BookCluster(t)
@@ -138,8 +136,8 @@ func TestAccCCENodePoolsV3EncryptedVolume(t *testing.T) {
 			{
 				Config: testAccCCENodePoolV3Encrypted,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCCENodePoolV3Exists(nodePoolName, shared.DataSourceClusterName, &nodePool),
-					resource.TestCheckResourceAttr(nodePoolName, "data_volumes.0.kms_id", env.OS_KMS_ID),
+					testAccCheckCCENodePoolV3Exists(nodePoolResourceName, shared.DataSourceClusterName, &nodePool),
+					resource.TestCheckResourceAttr(nodePoolResourceName, "data_volumes.0.kms_id", env.OS_KMS_ID),
 				),
 			},
 		},
@@ -148,7 +146,6 @@ func TestAccCCENodePoolsV3EncryptedVolume(t *testing.T) {
 
 func TestAccCCENodePoolsV3ExtendParams(t *testing.T) {
 	var nodePool nodepools.NodePool
-	nodePoolName := "opentelekomcloud_cce_node_pool_v3.node_pool"
 
 	t.Parallel()
 	shared.BookCluster(t)
@@ -161,7 +158,7 @@ func TestAccCCENodePoolsV3ExtendParams(t *testing.T) {
 			{
 				Config: testAccCCENodePoolV3ExtendParams,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCCENodePoolV3Exists(nodePoolName, shared.DataSourceClusterName, &nodePool),
+					testAccCheckCCENodePoolV3Exists(nodePoolResourceName, shared.DataSourceClusterName, &nodePool),
 				),
 			},
 		},
@@ -210,7 +207,7 @@ func testAccCheckCCENodePoolV3Exists(n string, cluster string, nodePool *nodepoo
 			return fmt.Errorf("no ID is set")
 		}
 		if c.Primary.ID == "" {
-			return fmt.Errorf("cluster id is not set")
+			return fmt.Errorf("cluster ID is not set")
 		}
 
 		config := common.TestAccProvider.Meta().(*cfg.Config)

--- a/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_pool_v3.go
+++ b/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_pool_v3.go
@@ -555,21 +555,21 @@ func waitForCceNodePoolActive(cceClient *golangsdk.ServiceClient, clusterId, nod
 	}
 }
 
-func waitForCceNodePoolDelete(cceClient *golangsdk.ServiceClient, clusterId, nodePoolId string) resource.StateRefreshFunc {
+func waitForCceNodePoolDelete(cceClient *golangsdk.ServiceClient, clusterID, nodePoolID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		log.Printf("[DEBUG] Attempting to delete Open Telekom Cloud CCE Node Pool %s.\n", nodePoolId)
+		log.Printf("[DEBUG] Attempting to delete Open Telekom Cloud CCE Node Pool %s.\n", nodePoolID)
 
-		r, err := nodepools.Get(cceClient, clusterId, nodePoolId).Extract()
+		r, err := nodepools.Get(cceClient, clusterID, nodePoolID).Extract()
 
 		if err != nil {
 			if _, ok := err.(golangsdk.ErrDefault404); ok {
-				log.Printf("[DEBUG] Successfully deleted Open Telekom Cloud CCE Node Pool %s", nodePoolId)
+				log.Printf("[DEBUG] Successfully deleted Open Telekom Cloud CCE Node Pool %s", nodePoolID)
 				return r, "Deleted", nil
 			}
 			return r, "Deleting", err
 		}
 
-		log.Printf("[DEBUG] Open Telekom Cloud Node Pool %s still available.\n", nodePoolId)
+		log.Printf("[DEBUG] Open Telekom Cloud Node Pool %s still available.\n", nodePoolID)
 		return r, r.Status.Phase, nil
 	}
 }

--- a/releasenotes/notes/fix-cce-nodepool-9759307d6911f983.yaml
+++ b/releasenotes/notes/fix-cce-nodepool-9759307d6911f983.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[CCE]** Fix issue with missing ``ForceNew`` in ``resource/opentelekomcloud_cce_node_pool_v3`` (`#1725 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1725>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Fix issue with missing `ForceNew` in `resource/opentelekomcloud_cce_node_pool_v3`
Simplify import

Closes: #1723

## PR Checklist

* [x] Refers to: #1723
* [x] Tests added/passed.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccCCENodePoolsV3_basic
=== PAUSE TestAccCCENodePoolsV3_basic
=== CONT  TestAccCCENodePoolsV3_basic
=== CONT  TestAccCCENodePoolsV3_basic
    resource_opentelekomcloud_cce_node_pool_v3_test.go:32: Cluster is required by the test. 1 test(s) are using cluster.
=== CONT  TestAccCCENodePoolsV3_basic
    cluster.go:49: starting creating shared cluster
=== CONT  TestAccCCENodePoolsV3_basic
    cluster.go:137: Cluster usage is 0 now, ready to delete the cluster
    cluster.go:100: starting deleting shared cluster
=== RUN   TestAccCCENodePoolV3ImportBasic
=== PAUSE TestAccCCENodePoolV3ImportBasic
=== CONT  TestAccCCENodePoolV3ImportBasic
=== CONT  TestAccCCENodePoolV3ImportBasic
    resource_opentelekomcloud_cce_node_pool_v3_test.go:62: Cluster is required by the test. 5 test(s) are using cluster.
=== CONT  TestAccCCENodePoolV3ImportBasic
    cluster.go:137: Cluster is released by the test. 2 test(s) are still using cluster.
--- PASS: TestAccCCENodePoolV3ImportBasic (728.56s)
=== RUN   TestAccCCENodePoolsV3_randomAZ
=== PAUSE TestAccCCENodePoolsV3_randomAZ
=== CONT  TestAccCCENodePoolsV3_randomAZ
=== CONT  TestAccCCENodePoolsV3_randomAZ
    resource_opentelekomcloud_cce_node_pool_v3_test.go:107: Cluster is required by the test. 3 test(s) are using cluster.
=== CONT  TestAccCCENodePoolsV3_randomAZ
    cluster.go:137: Cluster is released by the test. 3 test(s) are still using cluster.
--- PASS: TestAccCCENodePoolsV3_randomAZ (662.18s)
=== RUN   TestAccCCENodePoolsV3EncryptedVolume
=== PAUSE TestAccCCENodePoolsV3EncryptedVolume
=== CONT  TestAccCCENodePoolsV3EncryptedVolume
=== CONT  TestAccCCENodePoolsV3EncryptedVolume
    resource_opentelekomcloud_cce_node_pool_v3_test.go:129: Cluster is required by the test. 2 test(s) are using cluster.
=== CONT  TestAccCCENodePoolsV3EncryptedVolume
    cluster.go:137: Cluster is released by the test. 1 test(s) are still using cluster.
--- PASS: TestAccCCENodePoolsV3EncryptedVolume (744.80s)
=== RUN   TestAccCCENodePoolsV3ExtendParams
=== PAUSE TestAccCCENodePoolsV3ExtendParams
=== CONT  TestAccCCENodePoolsV3ExtendParams
=== CONT  TestAccCCENodePoolsV3ExtendParams
    resource_opentelekomcloud_cce_node_pool_v3_test.go:151: Cluster is required by the test. 4 test(s) are using cluster.
=== CONT  TestAccCCENodePoolsV3ExtendParams
    cluster.go:137: Cluster is released by the test. 4 test(s) are still using cluster.
--- PASS: TestAccCCENodePoolsV3ExtendParams (657.90s)
--- PASS: TestAccCCENodePoolsV3_basic (1191.87s)
PASS

Process finished with the exit code 0
```
