### PR TITLE
[ECS] Export fields `port_id` and `type` in `r/ecs_instance_v1`

### DIFF
--- a/docs/resources/ecs_instance_v1.md
+++ b/docs/resources/ecs_instance_v1.md
@@ -115,9 +115,11 @@ resource "opentelekomcloud_compute_volume_attach_v2" "attached" {
 ### Instance With Multiple Networks
 
 ```hcl
-resource "opentelekomcloud_networking_floatingip_v2" "myip" {}
+resource "opentelekomcloud_networking_floatingip_v2" "this" {
+  pool = "admin_external_net"
+}
 
-resource "opentelekomcloud_ecs_instance_v1" "multi-net" {
+resource "opentelekomcloud_ecs_instance_v1" "this" {
   name     = "server_1"
   image_id = "ad091b52-742f-469e-8f3c-fd81cadf0743"
   flavor   = "s2.large.2"
@@ -135,10 +137,9 @@ resource "opentelekomcloud_ecs_instance_v1" "multi-net" {
   key_name          = "KeyPair-test"
 }
 
-resource "opentelekomcloud_compute_floatingip_associate_v2" "myip" {
-  floating_ip = opentelekomcloud_networking_floatingip_v2.myip.address
-  instance_id = opentelekomcloud_ecs_instance_v1.multi-net.id
-  fixed_ip    = opentelekomcloud_ecs_instance_v1.multi-net.nics.0.ip_address
+resource "opentelekomcloud_networking_floatingip_associate_v2" "this" {
+  floating_ip = opentelekomcloud_networking_floatingip_v2.this.address
+  port_id     = opentelekomcloud_ecs_instance_v1.this.nics.0.port_id
 }
 ```
 
@@ -286,8 +287,11 @@ The `data_disks` block supports:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The ID of the server.
 * `nics/mac_address` - The MAC address of the NIC on that network.
+
+* `nics/type` - The type of the address of the NIC on that network.
+
+* `nics/port_id` - The port ID of the NIC on that network.
 
 ## Import
 

--- a/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_ecs_instance_v1_test.go
+++ b/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_ecs_instance_v1_test.go
@@ -535,7 +535,7 @@ resource "opentelekomcloud_networking_floatingip_v2" "this" {
 }
 
 resource "opentelekomcloud_ecs_instance_v1" "instance_1" {
-  name     = "server"
+  name     = "server_1"
   image_id = data.opentelekomcloud_images_image_v2.latest_image.id
   flavor   = "s2.medium.1"
   vpc_id   = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id

--- a/opentelekomcloud/services/ecs/resource_opentelekomcloud_ecs_instance_v1.go
+++ b/opentelekomcloud/services/ecs/resource_opentelekomcloud_ecs_instance_v1.go
@@ -111,6 +111,14 @@ func ResourceEcsInstanceV1() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"port_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 					},
 				},
 			},
@@ -599,6 +607,8 @@ func flattenInstanceNicsV1(d *schema.ResourceData, meta interface{}, addresses m
 				"network_id":  network,
 				"ip_address":  addr.Addr,
 				"mac_address": addr.MacAddr,
+				"port_id":     addr.PortID,
+				"type":        addr.Type,
 			}
 			nics = append(nics, v)
 		}

--- a/releasenotes/notes/ecs-instance-port-4d7dc5a2efbe2158.yaml
+++ b/releasenotes/notes/ecs-instance-port-4d7dc5a2efbe2158.yaml
@@ -1,0 +1,7 @@
+---
+enhancements:
+  - |
+    **[ECS]** Export ``nics.*.port_id`` and ``nics.*.type`` values in ``resource/opentelekomcloud_ecs_instance_v1`` (`#1737 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1737>`_)
+other:
+  - |
+    **[ECS]** Remove use-cases with deprecated resources in documentation examples in ``resource/opentelekomcloud_ecs_instance_v1`` (`#1737 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1737>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Export fields `port_id` and `type` in `resource/opentelekomcloud_ecs_instance_v1`
Resolves: #1731

## PR Checklist

* [x] Refers to: #1731
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccEcsV1InstanceBasic
=== PAUSE TestAccEcsV1InstanceBasic
=== CONT  TestAccEcsV1InstanceBasic
--- PASS: TestAccEcsV1InstanceBasic (259.12s)
=== RUN   TestAccEcsV1InstanceIp
=== PAUSE TestAccEcsV1InstanceIp
=== CONT  TestAccEcsV1InstanceIp
--- PASS: TestAccEcsV1InstanceIp (194.56s)
=== RUN   TestAccEcsV1InstanceDeleted
=== PAUSE TestAccEcsV1InstanceDeleted
=== CONT  TestAccEcsV1InstanceDeleted
--- PASS: TestAccEcsV1InstanceDeleted (369.02s)
=== RUN   TestAccEcsV1Instance_import
=== PAUSE TestAccEcsV1Instance_import
=== CONT  TestAccEcsV1Instance_import
--- PASS: TestAccEcsV1Instance_import (204.42s)
=== RUN   TestAccEcsV1InstanceDiskTypeValidation
=== PAUSE TestAccEcsV1InstanceDiskTypeValidation
=== CONT  TestAccEcsV1InstanceDiskTypeValidation
--- PASS: TestAccEcsV1InstanceDiskTypeValidation (33.71s)
=== RUN   TestAccEcsV1InstanceVPCValidation
=== PAUSE TestAccEcsV1InstanceVPCValidation
=== CONT  TestAccEcsV1InstanceVPCValidation
--- PASS: TestAccEcsV1InstanceVPCValidation (214.58s)

Test ignored.
PASS


Process finished with the exit code 0
```
