### PR TITLE
[VPN] Enable `site_connection` by default

### DIFF
--- a/docs/resources/vpnaas_site_connection_v2.md
+++ b/docs/resources/vpnaas_site_connection_v2.md
@@ -4,7 +4,7 @@ subcategory: "Virtual Private Network (VPN)"
 
 # opentelekomcloud_vpnaas_site_connection_v2
 
-Manages a V2 IPSec site connection resource within OpenTelekomCloud.
+Manages a V2 site connection resource within OpenTelekomCloud.
 
 ## Example Usage
 
@@ -39,47 +39,48 @@ The following arguments are supported:
 * `description` - (Optional) The human-readable description for the connection.
   Changing this updates the description of the existing connection.
 
-* `admin_state_up` - (Optional) The administrative state of the resource. Can either be up(true) or down(false).
-  Changing this updates the administrative state of the existing connection.
+* `admin_state_up` - (Optional) The administrative state of the resource. Can either be up(`true`) or
+  down(`false`). Changing this updates the administrative state of the existing connection.
 
 * `ikepolicy_id` - (Required) The ID of the IKE policy. Changing this creates a new connection.
 
 * `vpnservice_id` - (Required) The ID of the VPN service. Changing this creates a new connection.
 
-* `local_ep_group_id` - (Optional) The ID for the endpoint group that contains private subnets for the local side of the connection.
-  You must specify this parameter with the peer_ep_group_id parameter unless
-  in backward- compatible mode where peer_cidrs is provided with a subnet_id for the VPN service.
+* `local_ep_group_id` - (Optional) The ID for the endpoint group that contains private subnets for the
+  local side of the connection. You must specify this parameter with the `peer_ep_group_id` parameter unless
+  in backward-compatible mode where `peer_cidrs` is provided with a `subnet_id` for the VPN service.
   Changing this updates the existing connection.
 
 * `ipsecpolicy_id` - (Required) The ID of the IPsec policy. Changing this creates a new connection.
 
-* `peer_id` - (Required) The peer router identity for authentication. A valid value is an IPv4 address, IPv6 address, e-mail address, key ID, or FQDN.
-  Typically, this value matches the peer_address value.
+* `peer_id` - (Required) The peer router identity for authentication. A valid value is an IPv4 address,
+  IPv6 address, e-mail address, key ID, or FQDN. Typically, this value matches the peer_address value.
   Changing this updates the existing policy.
 
-* `peer_ep_group_id` - (Optional) The ID for the endpoint group that contains private CIDRs in the form < net_address > / < prefix > for the peer side of the connection.
-  You must specify this parameter with the local_ep_group_id parameter unless in backward-compatible mode
-  where peer_cidrs is provided with a subnet_id for the VPN service.
+* `peer_ep_group_id` - (Optional) The ID for the endpoint group that contains private CIDRs in the form
+  <net_address>/<prefix> for the peer side of the connection. You must specify this parameter with the
+  `local_ep_group_id` parameter unless in backward-compatible mode where `peer_cidrs` is provided
+  with a `subnet_id` for the VPN service.
 
-* `local_id` - (Optional) An ID to be used instead of the external IP address for a virtual router used in traffic between instances on different networks in east-west traffic.
-  Most often, local ID would be domain name, email address, etc.
-  If this is not configured then the external IP address will be used as the ID.
+* `local_id` - (Optional) An ID to be used instead of the external IP address for a virtual router used in
+  traffic between instances on different networks in east-west traffic. Most often, local ID would be domain name,
+  email address, etc. If this is not configured then the external IP address will be used as the ID.
 
 * `peer_address` - (Required) The peer gateway public IPv4 or IPv6 address or FQDN.
 
 * `psk` - (Required) The pre-shared key. A valid value is any string.
 
-* `initiator` - (Optional) A valid value is response-only or bi-directional. Default is bi-directional.
+* `initiator` - (Optional) A valid value is `response-only` or `bi-directional`.
 
-* `peer_cidrs` - (Optional) Unique list of valid peer private CIDRs in the form < net_address > / < prefix > .
+* `peer_cidrs` - (Optional) Unique list of valid peer private CIDRs in the form <net_address>/<prefix>.
 
 * `dpd` - (Optional) A dictionary with dead peer detection (DPD) protocol controls.
   * `action` - (Optional) The dead peer detection (DPD) action.
   A valid value is `clear`, `hold`, `restart`, `disabled` or `restart-by-peer`. Default value is `hold`.
   * `timeout` - (Optional) The dead peer detection (DPD) timeout in seconds.
-  A valid value is a positive integer that is greater than the DPD interval value. Default is 120.
+  A valid value is a positive integer that is greater than the DPD interval value. Default is `120`.
   * `interval` - (Optional) The dead peer detection (DPD) interval, in seconds.
-  A valid value is a positive integer. Default is 30.
+  A valid value is a positive integer. Default is `30`.
 
 * `mtu` - (Optional) The maximum transmission unit (MTU) value to address fragmentation.
   Minimum value is 68 for IPv4, and 1280 for IPv6.

--- a/opentelekomcloud/acceptance/vpn/resource_opentelekomcloud_vpnaas_site_connection_v2_test.go
+++ b/opentelekomcloud/acceptance/vpn/resource_opentelekomcloud_vpnaas_site_connection_v2_test.go
@@ -41,6 +41,27 @@ func TestAccVpnSiteConnectionV2_basic(t *testing.T) {
 	})
 }
 
+func TestAccVpnSiteConnectionV2_import(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckSiteConnectionV2Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSiteConnectionV2Basic,
+			},
+			{
+				ResourceName:      resourceSiteConnectionName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"psk",
+				},
+			},
+		},
+	})
+}
+
 func testAccCheckSiteConnectionV2Destroy(s *terraform.State) error {
 	config := common.TestAccProvider.Meta().(*cfg.Config)
 	client, err := config.NetworkingV2Client(env.OS_REGION_NAME)

--- a/opentelekomcloud/acceptance/vpn/resource_opentelekomcloud_vpnaas_site_connection_v2_test.go
+++ b/opentelekomcloud/acceptance/vpn/resource_opentelekomcloud_vpnaas_site_connection_v2_test.go
@@ -7,12 +7,13 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/vpnaas/siteconnections"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 )
+
+const resourceSiteConnectionName = "opentelekomcloud_vpnaas_site_connection_v2.conn_1"
 
 func TestAccVpnSiteConnectionV2_basic(t *testing.T) {
 	var conn siteconnections.Connection
@@ -24,18 +25,17 @@ func TestAccVpnSiteConnectionV2_basic(t *testing.T) {
 			{
 				Config: testAccSiteConnectionV2Basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSiteConnectionV2Exists(
-						"opentelekomcloud_vpnaas_site_connection_v2.conn_1", &conn),
-					resource.TestCheckResourceAttrPtr("opentelekomcloud_vpnaas_site_connection_v2.conn_1", "ikepolicy_id", &conn.IKEPolicyID),
-					resource.TestCheckResourceAttr("opentelekomcloud_vpnaas_site_connection_v2.conn_1", "admin_state_up", strconv.FormatBool(conn.AdminStateUp)),
-					resource.TestCheckResourceAttr("opentelekomcloud_vpnaas_site_connection_v2.conn_1", "tags.foo", "bar"),
-					resource.TestCheckResourceAttr("opentelekomcloud_vpnaas_site_connection_v2.conn_1", "tags.key", "value"),
-					resource.TestCheckResourceAttrPtr("opentelekomcloud_vpnaas_site_connection_v2.conn_1", "ipsecpolicy_id", &conn.IPSecPolicyID),
-					resource.TestCheckResourceAttrPtr("opentelekomcloud_vpnaas_site_connection_v2.conn_1", "vpnservice_id", &conn.VPNServiceID),
-					resource.TestCheckResourceAttrPtr("opentelekomcloud_vpnaas_site_connection_v2.conn_1", "local_ep_group_id", &conn.LocalEPGroupID),
-					resource.TestCheckResourceAttrPtr("opentelekomcloud_vpnaas_site_connection_v2.conn_1", "local_id", &conn.LocalID),
-					resource.TestCheckResourceAttrPtr("opentelekomcloud_vpnaas_site_connection_v2.conn_1", "peer_ep_group_id", &conn.PeerEPGroupID),
-					resource.TestCheckResourceAttrPtr("opentelekomcloud_vpnaas_site_connection_v2.conn_1", "name", &conn.Name),
+					testAccCheckSiteConnectionV2Exists(resourceSiteConnectionName, &conn),
+					resource.TestCheckResourceAttrPtr(resourceSiteConnectionName, "ikepolicy_id", &conn.IKEPolicyID),
+					resource.TestCheckResourceAttr(resourceSiteConnectionName, "admin_state_up", strconv.FormatBool(conn.AdminStateUp)),
+					resource.TestCheckResourceAttr(resourceSiteConnectionName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceSiteConnectionName, "tags.key", "value"),
+					resource.TestCheckResourceAttrPtr(resourceSiteConnectionName, "ipsecpolicy_id", &conn.IPSecPolicyID),
+					resource.TestCheckResourceAttrPtr(resourceSiteConnectionName, "vpnservice_id", &conn.VPNServiceID),
+					resource.TestCheckResourceAttrPtr(resourceSiteConnectionName, "local_ep_group_id", &conn.LocalEPGroupID),
+					resource.TestCheckResourceAttrPtr(resourceSiteConnectionName, "local_id", &conn.LocalID),
+					resource.TestCheckResourceAttrPtr(resourceSiteConnectionName, "peer_ep_group_id", &conn.PeerEPGroupID),
+					resource.TestCheckResourceAttrPtr(resourceSiteConnectionName, "name", &conn.Name),
 				),
 			},
 		},
@@ -44,20 +44,18 @@ func TestAccVpnSiteConnectionV2_basic(t *testing.T) {
 
 func testAccCheckSiteConnectionV2Destroy(s *terraform.State) error {
 	config := common.TestAccProvider.Meta().(*cfg.Config)
-	networkingClient, err := config.NetworkingV2Client(env.OS_REGION_NAME)
+	client, err := config.NetworkingV2Client(env.OS_REGION_NAME)
 	if err != nil {
-		return fmt.Errorf("error creating OpenTelekomCloud networking client: %s", err)
+		return fmt.Errorf("error creating OpenTelekomCloud NetworkingV2 client: %s", err)
 	}
+
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "opentelekomcloud_vpnaas_site_connection" {
+		if rs.Type != "opentelekomcloud_vpnaas_site_connection_v2" {
 			continue
 		}
-		_, err = siteconnections.Get(networkingClient, rs.Primary.ID).Extract()
+		_, err = siteconnections.Get(client, rs.Primary.ID).Extract()
 		if err == nil {
-			return fmt.Errorf("site connection (%s) still exists.", rs.Primary.ID)
-		}
-		if _, ok := err.(golangsdk.ErrDefault404); !ok {
-			return err
+			return fmt.Errorf("site connection (%s) still exists", rs.Primary.ID)
 		}
 	}
 	return nil
@@ -75,17 +73,18 @@ func testAccCheckSiteConnectionV2Exists(n string, conn *siteconnections.Connecti
 		}
 
 		config := common.TestAccProvider.Meta().(*cfg.Config)
-		networkingClient, err := config.NetworkingV2Client(env.OS_REGION_NAME)
+		client, err := config.NetworkingV2Client(env.OS_REGION_NAME)
 		if err != nil {
-			return fmt.Errorf("error creating OpenTelekomCloud networking client: %s", err)
+			return fmt.Errorf("error creating OpenTelekomCloud NetworkingV2 client: %s", err)
 		}
 
 		var found *siteconnections.Connection
 
-		found, err = siteconnections.Get(networkingClient, rs.Primary.ID).Extract()
+		found, err = siteconnections.Get(client, rs.Primary.ID).Extract()
 		if err != nil {
 			return err
 		}
+
 		*conn = *found
 
 		return nil
@@ -97,7 +96,7 @@ var testAccSiteConnectionV2Basic = fmt.Sprintf(`
 
 resource "opentelekomcloud_networking_network_v2" "network_1" {
   name           = "tf_test_network"
-  admin_state_up = "true"
+  admin_state_up = true
 }
 
 resource "opentelekomcloud_networking_subnet_v2" "subnet_1" {
@@ -118,14 +117,12 @@ resource "opentelekomcloud_networking_router_interface_v2" "router_interface_1" 
 
 resource "opentelekomcloud_vpnaas_service_v2" "service_1" {
   router_id      = opentelekomcloud_networking_router_v2.router_1.id
-  admin_state_up = "false"
+  admin_state_up = false
 }
 
-resource "opentelekomcloud_vpnaas_ipsec_policy_v2" "policy_1" {
-}
+resource "opentelekomcloud_vpnaas_ipsec_policy_v2" "policy_1" { }
 
-resource "opentelekomcloud_vpnaas_ike_policy_v2" "policy_2" {
-}
+resource "opentelekomcloud_vpnaas_ike_policy_v2" "policy_2" { }
 
 resource "opentelekomcloud_vpnaas_endpoint_group_v2" "group_1" {
   type      = "cidr"

--- a/opentelekomcloud/acceptance/vpn/resource_opentelekomcloud_vpnaas_site_connection_v2_test.go
+++ b/opentelekomcloud/acceptance/vpn/resource_opentelekomcloud_vpnaas_site_connection_v2_test.go
@@ -119,9 +119,9 @@ resource "opentelekomcloud_vpnaas_service_v2" "service_1" {
   admin_state_up = true
 }
 
-resource "opentelekomcloud_vpnaas_ipsec_policy_v2" "policy_1" { }
+resource "opentelekomcloud_vpnaas_ipsec_policy_v2" "policy_1" {}
 
-resource "opentelekomcloud_vpnaas_ike_policy_v2" "policy_2" { }
+resource "opentelekomcloud_vpnaas_ike_policy_v2" "policy_2" {}
 
 resource "opentelekomcloud_vpnaas_endpoint_group_v2" "group_1" {
   type      = "cidr"

--- a/opentelekomcloud/services/vpn/common.go
+++ b/opentelekomcloud/services/vpn/common.go
@@ -1,0 +1,6 @@
+package vpn
+
+const (
+	errCreationV2Client = "error creating OpenTelekomCloud NetworkingV2 client: %w"
+	keyClientV2         = "vpc-v2-client"
+)

--- a/releasenotes/notes/vpn-site-enable-d2f8a04618fb0d88.yaml
+++ b/releasenotes/notes/vpn-site-enable-d2f8a04618fb0d88.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[VPN]** Make ``resource/opentelekomcloud_vpnaas_site_connection_v2`` enabled by default (`#1743 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1743>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Set field `admin_state_up` by default `true` so `resource/opentelekomcloud_vpnaas_site_connection_v2` will be enabled
Resolves: #1730

## PR Checklist

* [x] Refers to: #1730
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccVpnSiteConnectionV2_basic

--- PASS: TestAccVpnSiteConnectionV2_basic (96.25s)
=== RUN   TestAccVpnSiteConnectionV2_import
--- PASS: TestAccVpnSiteConnectionV2_import (107.69s)
PASS


Process finished with the exit code 0
```
