### PR TITLE
[ELB] Make `default_pool_id` field `Computed` in `lb_listener_v3`

### DIFF
--- a/opentelekomcloud/acceptance/elb/v3/resource_opentelekomcloud_lb_listener_v3_test.go
+++ b/opentelekomcloud/acceptance/elb/v3/resource_opentelekomcloud_lb_listener_v3_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/elb/v3/listeners"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/elb/v3/pools"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
@@ -45,6 +47,43 @@ func TestAccLBV3Listener_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceListenerName, "name", "listener_1_updated"),
 					resource.TestCheckResourceAttr(resourceListenerName, "description", ""),
+				),
+			},
+		},
+	})
+}
+
+func TestAccLBV3Listener_withPool(t *testing.T) {
+	var listener listeners.Listener
+
+	t.Parallel()
+	qts := []*quotas.ExpectedQuota{
+		{Q: quotas.LbCertificate, Count: 1},
+		{Q: quotas.LoadBalancer, Count: 1},
+		{Q: quotas.LbListener, Count: 1},
+	}
+	quotas.BookMany(t, qts)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckLBV3ListenerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLBV3ListenerConfigBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLBV3ListenerExists(resourceListenerName, &listener),
+					resource.TestCheckResourceAttr(resourceListenerName, "name", "listener_1"),
+					resource.TestCheckResourceAttr(resourceListenerName, "description", "some interesting description"),
+				),
+			},
+			{
+				PreConfig: func() {
+					addElbV3Pool(t, &listener.ID)
+				},
+				Config: testAccLBV3ListenerConfigBasic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceListenerName, "name", "listener_1"),
 				),
 			},
 		},
@@ -201,6 +240,21 @@ func testAccCheckLBV3ListenerExists(n string, listener *listeners.Listener) reso
 
 		return nil
 	}
+}
+
+func addElbV3Pool(t *testing.T, instanceID *string) {
+	config := common.TestAccProvider.Meta().(*cfg.Config)
+	client, err := config.ElbV3Client(env.OS_REGION_NAME)
+	th.AssertNoErr(t, err)
+
+	createOpts := pools.CreateOpts{
+		LBMethod:   "ROUND_ROBIN",
+		Protocol:   "HTTP",
+		ListenerID: *instanceID,
+	}
+
+	pool, err := pools.Create(client, createOpts).Extract()
+	th.AssertNoErr(t, err)
 }
 
 var testAccLBV3ListenerConfigBasic = fmt.Sprintf(`

--- a/opentelekomcloud/services/elb/v3/resource_opentelekomcloud_lb_listener_v3.go
+++ b/opentelekomcloud/services/elb/v3/resource_opentelekomcloud_lb_listener_v3.go
@@ -50,6 +50,7 @@ func ResourceListenerV3() *schema.Resource {
 			"default_pool_id": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"default_tls_container_ref": {
 				Type:     schema.TypeString,

--- a/releasenotes/notes/fix-listener-pool-8d7c3c7a8e69d9ea.yaml
+++ b/releasenotes/notes/fix-listener-pool-8d7c3c7a8e69d9ea.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[ELB]** Fix issue with ``null`` value of ``default_pool_id`` in ``resource/opentelekomcloud_lb_listener_v3`` (`#1746 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1746>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Make `default_pool_id` field `Computed` in `resource/opentelekomcloud_lb_listener_v3`
Resolves: #1692

## PR Checklist

* [x] Refers to: #1692
* [x] Tests added/passed.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccLBV3Listener_basic
=== PAUSE TestAccLBV3Listener_basic
=== CONT  TestAccLBV3Listener_basic
--- PASS: TestAccLBV3Listener_basic (79.59s)
=== RUN   TestAccLBV3Listener_TCP
=== PAUSE TestAccLBV3Listener_TCP
=== CONT  TestAccLBV3Listener_TCP
--- PASS: TestAccLBV3Listener_TCP (77.52s)
=== RUN   TestAccLBV3Listener_HTTP_to_TCP
=== PAUSE TestAccLBV3Listener_HTTP_to_TCP
=== CONT  TestAccLBV3Listener_HTTP_to_TCP
--- PASS: TestAccLBV3Listener_HTTP_to_TCP (79.43s)
=== RUN   TestAccLBV3Listener_import
=== PAUSE TestAccLBV3Listener_import
=== CONT  TestAccLBV3Listener_import
--- PASS: TestAccLBV3Listener_import (52.82s)
PASS


Process finished with the exit code 0
```
