### PR TITLE
[RDS] Fix issue with `Restart` in `rds_instance_v3`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/jinzhu/copier v0.3.5
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.5.10
+	github.com/opentelekomcloud/gophertelekomcloud v0.5.12-0.20220525083446-4b902a6acbe5
 	github.com/unknwon/com v1.0.1
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -201,8 +201,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.5.10 h1:ELZs2iKRONG4mCqwuLv1lTMEj8gDYEgcNao9ShAvrDI=
-github.com/opentelekomcloud/gophertelekomcloud v0.5.10/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
+github.com/opentelekomcloud/gophertelekomcloud v0.5.12-0.20220525083446-4b902a6acbe5 h1:x+f3DaCqSxA7a7+mN9H+/fM7jxvdckYV2ej0leoOKKw=
+github.com/opentelekomcloud/gophertelekomcloud v0.5.12-0.20220525083446-4b902a6acbe5/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_instance_v3.go
+++ b/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_instance_v3.go
@@ -555,7 +555,7 @@ func assureTemplateApplied(d *schema.ResourceData, client *golangsdk.ServiceClie
 }
 
 func restartInstance(d *schema.ResourceData, client *golangsdk.ServiceClient) error {
-	job, err := instances.Restart(client, instances.RestartRdsInstanceOpts{Restart: "{}"}, d.Id()).Extract()
+	job, err := instances.Restart(client, instances.RestartRdsInstanceOpts{}, d.Id()).Extract()
 	if err != nil {
 		return fmt.Errorf("error restarting RDS instance: %w", err)
 	}

--- a/releasenotes/notes/rds-restart-fix-ade47adb253baced.yaml
+++ b/releasenotes/notes/rds-restart-fix-ade47adb253baced.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[RDS]** Fix issue with ``Restart`` call in ``resource/opentelekomcloud_rds_instance_v3`` (`#1747 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1747>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Fix issue with `resource/opentelekomcloud_rds_instance_v3` `Restart` call

## PR Checklist

* [x] Refers to: https://github.com/opentelekomcloud/gophertelekomcloud/issues/342
* [x] Tests added/passed.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccRdsInstanceV3RestoreBackup
--- PASS: TestAccRdsInstanceV3RestoreBackup (1144.71s)
=== RUN   TestAccRdsInstanceV3ElasticIP
--- PASS: TestAccRdsInstanceV3ElasticIP (427.03s)
=== RUN   TestAccRdsInstanceV3HA
    resource_opentelekomcloud_rds_instance_v3_test.go:126: OS_AVAILABILITY_ZONE_2 is empty
--- SKIP: TestAccRdsInstanceV3HA (0.00s)

Test ignored.
=== RUN   TestAccRdsInstanceV3OptionalParams
--- PASS: TestAccRdsInstanceV3OptionalParams (360.52s)
=== RUN   TestAccRdsInstanceV3Backup
--- PASS: TestAccRdsInstanceV3Backup (349.75s)
=== RUN   TestAccRdsInstanceV3TemplateConfig
--- PASS: TestAccRdsInstanceV3TemplateConfig (466.86s)
=== RUN   TestAccRdsInstanceV3InvalidDBVersion
--- PASS: TestAccRdsInstanceV3InvalidDBVersion (11.34s)
=== RUN   TestAccRdsInstanceV3InvalidFlavor
--- PASS: TestAccRdsInstanceV3InvalidFlavor (13.78s)
=== RUN   TestAccRdsInstanceV3_configurationParameters
--- PASS: TestAccRdsInstanceV3_configurationParameters (438.17s)
FAIL


Process finished with the exit code 0
```
