### PR TITLE
[VPC] Use client from `ctx` in `secgroup_v2` and `secgroup_rule_v2`

### DIFF
--- a/releasenotes/notes/sg-throttle-4b71460e2ca2e768.yaml
+++ b/releasenotes/notes/sg-throttle-4b71460e2ca2e768.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[VPC]** Fix issue with throttling in ``resource/opentelekomcloud_networking_secgroup_rule_v2`` and ``resource/opentelekomcloud_networking_secgroup_v2`` (`#1754 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1754>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Use client from `ctx` in `secgroup_v2` and `secgroup_rule_v2`

## PR Checklist

* [x] Refers to: #1753
* [x] Tests added/passed.
* [x] Release notes added.

## Acceptance Steps Performed

SecGroup rule
```
=== RUN   TestAccNetworkingV2SecGroupRule_basic
=== PAUSE TestAccNetworkingV2SecGroupRule_basic
=== CONT  TestAccNetworkingV2SecGroupRule_basic
--- PASS: TestAccNetworkingV2SecGroupRule_basic (62.23s)
=== RUN   TestAccNetworkingV2SecGroupRule_importBasic
=== PAUSE TestAccNetworkingV2SecGroupRule_importBasic
=== CONT  TestAccNetworkingV2SecGroupRule_importBasic
--- PASS: TestAccNetworkingV2SecGroupRule_importBasic (68.60s)
=== RUN   TestAccNetworkingV2SecGroupRule_timeout
=== PAUSE TestAccNetworkingV2SecGroupRule_timeout
=== CONT  TestAccNetworkingV2SecGroupRule_timeout
--- PASS: TestAccNetworkingV2SecGroupRule_timeout (62.16s)
=== RUN   TestAccNetworkingV2SecGroupRule_numericProtocol
=== PAUSE TestAccNetworkingV2SecGroupRule_numericProtocol
=== CONT  TestAccNetworkingV2SecGroupRule_numericProtocol
--- PASS: TestAccNetworkingV2SecGroupRule_numericProtocol (60.88s)
PASS


Process finished with the exit code 0
```

SecGroup
```
=== RUN   TestAccNetworkingV2SecGroup_basic
=== PAUSE TestAccNetworkingV2SecGroup_basic
=== CONT  TestAccNetworkingV2SecGroup_basic
--- PASS: TestAccNetworkingV2SecGroup_basic (75.77s)
=== RUN   TestAccNetworkingV2SecGroup_importBasic
=== PAUSE TestAccNetworkingV2SecGroup_importBasic
=== CONT  TestAccNetworkingV2SecGroup_importBasic
--- PASS: TestAccNetworkingV2SecGroup_importBasic (55.54s)
=== RUN   TestAccNetworkingV2SecGroup_noDefaultRules
=== PAUSE TestAccNetworkingV2SecGroup_noDefaultRules
=== CONT  TestAccNetworkingV2SecGroup_noDefaultRules
--- PASS: TestAccNetworkingV2SecGroup_noDefaultRules (48.54s)
=== RUN   TestAccNetworkingV2SecGroup_timeout
=== PAUSE TestAccNetworkingV2SecGroup_timeout
=== CONT  TestAccNetworkingV2SecGroup_timeout
--- PASS: TestAccNetworkingV2SecGroup_timeout (47.02s)
PASS


Process finished with the exit code 0
```