### PR TITLE
[CCE] Use `client` from `ctx` in `cce_v3` resources

### DIFF
--- a/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_addon_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_addon_v3_test.go
@@ -181,6 +181,7 @@ resource opentelekomcloud_cce_cluster_v3 cluster_1 {
   flavor_id               = "cce.s1.small"
   vpc_id                  = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
   subnet_id               = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  cluster_version         = "v1.19"
   container_network_type  = "overlay_l2"
   kubernetes_svc_ip_range = "10.247.0.0/16"
 }
@@ -238,6 +239,7 @@ resource opentelekomcloud_cce_cluster_v3 cluster_1 {
   flavor_id               = "cce.s1.small"
   vpc_id                  = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
   subnet_id               = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  cluster_version         = "v1.19"
   container_network_type  = "overlay_l2"
   kubernetes_svc_ip_range = "10.247.0.0/16"
 }
@@ -295,6 +297,7 @@ resource opentelekomcloud_cce_cluster_v3 cluster_1 {
   flavor_id               = "cce.s1.medium"
   vpc_id                  = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
   subnet_id               = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  cluster_version         = "v1.19"
   container_network_type  = "overlay_l2"
   kubernetes_svc_ip_range = "10.247.0.0/16"
 }

--- a/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_cluster_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_cluster_v3_test.go
@@ -312,7 +312,7 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   kubernetes_svc_ip_range = "10.247.0.0/16"
   ignore_addons           = true
   eni_subnet_id           = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
-  eni_subnet_cidr         = "192.168.0.0/16"
+  eni_subnet_cidr         = "192.168.0.0/24"
 }
 `, common.DataSourceSubnet, clusterName)
 }

--- a/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_cluster_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_cluster_v3_test.go
@@ -312,7 +312,7 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   kubernetes_svc_ip_range = "10.247.0.0/16"
   ignore_addons           = true
   eni_subnet_id           = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
-  eni_subnet_cidr         = "192.168.0.0/24"
+  eni_subnet_cidr         = "192.168.0.0/16"
 }
 `, common.DataSourceSubnet, clusterName)
 }

--- a/opentelekomcloud/services/cce/common.go
+++ b/opentelekomcloud/services/cce/common.go
@@ -1,5 +1,7 @@
 package cce
 
 const (
-	cceClientError = "error creating Open Telekom Cloud CCEv3 client: %w"
+	cceClientError   = "error creating Open Telekom Cloud CCEv3 client: %w"
+	keyClientV3      = "cce-v3-client"
+	keyClientAddonV3 = "cce-addon-v3-client"
 )

--- a/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_pool_v3.go
+++ b/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_pool_v3.go
@@ -272,7 +272,9 @@ func resourceCCENodePoolUserTags(d *schema.ResourceData) []tags.ResourceTag {
 
 func resourceCCENodePoolV3Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	client, err := config.CceV3Client(config.GetRegion(d))
+	client, err := common.ClientFromCtx(ctx, keyClientV3, func() (*golangsdk.ServiceClient, error) {
+		return config.CceV3Client(config.GetRegion(d))
+	})
 	if err != nil {
 		return fmterr.Errorf(cceClientError, err)
 	}
@@ -386,12 +388,15 @@ func resourceCCENodePoolV3Create(ctx context.Context, d *schema.ResourceData, me
 		return fmterr.Errorf(createError, err)
 	}
 
-	return resourceCCENodePoolV3Read(ctx, d, meta)
+	clientCtx := common.CtxWithClient(ctx, client, keyClientV3)
+	return resourceCCENodePoolV3Read(clientCtx, d, meta)
 }
 
-func resourceCCENodePoolV3Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCCENodePoolV3Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	client, err := config.CceV3Client(config.GetRegion(d))
+	client, err := common.ClientFromCtx(ctx, keyClientV3, func() (*golangsdk.ServiceClient, error) {
+		return config.CceV3Client(config.GetRegion(d))
+	})
 	if err != nil {
 		return fmterr.Errorf(cceClientError, err)
 	}
@@ -466,10 +471,13 @@ func resourceCCENodePoolV3Read(_ context.Context, d *schema.ResourceData, meta i
 
 func resourceCCENodePoolV3Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	client, err := config.CceV3Client(config.GetRegion(d))
+	client, err := common.ClientFromCtx(ctx, keyClientV3, func() (*golangsdk.ServiceClient, error) {
+		return config.CceV3Client(config.GetRegion(d))
+	})
 	if err != nil {
 		return fmterr.Errorf(cceClientError, err)
 	}
+
 	updateOpts := nodepools.UpdateOpts{
 		Kind:       "NodePool",
 		ApiVersion: "v3",
@@ -511,12 +519,15 @@ func resourceCCENodePoolV3Update(ctx context.Context, d *schema.ResourceData, me
 		return fmterr.Errorf("error waiting for Open Telekom Cloud CCE Node Pool to update: %w", err)
 	}
 
-	return resourceCCENodePoolV3Read(ctx, d, meta)
+	clientCtx := common.CtxWithClient(ctx, client, keyClientV3)
+	return resourceCCENodePoolV3Read(clientCtx, d, meta)
 }
 
 func resourceCCENodePoolV3Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	client, err := config.CceV3Client(config.GetRegion(d))
+	client, err := common.ClientFromCtx(ctx, keyClientV3, func() (*golangsdk.ServiceClient, error) {
+		return config.CceV3Client(config.GetRegion(d))
+	})
 	if err != nil {
 		return fmterr.Errorf(cceClientError, err)
 	}

--- a/releasenotes/notes/cce-throttle-e70fbbc43adaf7f1.yaml
+++ b/releasenotes/notes/cce-throttle-e70fbbc43adaf7f1.yaml
@@ -1,0 +1,10 @@
+---
+enhancements:
+  - |
+    **[CCE]** Reduce amount of init client requests in ``resource/opentelekomcloud_cce_cluster_v3`` (`#1756 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1756>`_)
+  - |
+    **[CCE]** Reduce amount of init client requests in ``resource/opentelekomcloud_cce_node_v3`` (`#1756 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1756>`_)
+  - |
+    **[CCE]** Reduce amount of init client requests in ``resource/opentelekomcloud_cce_node_pool_v3`` (`#1756 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1756>`_)
+  - |
+    **[CCE]** Reduce amount of init client requests in ``resource/opentelekomcloud_cce_addon_v3`` (`#1756 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1756>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Use `client` from `ctx` in `resource/opentelekomcloud_cce_cluster_v3`, `resource/opentelekomcloud_cce_node_v3`, `resource/opentelekomcloud_cce_node_pool_v3` and `resource/opentelekomcloud_cce_addon_v3`
Resolves: #1755

## PR Checklist

* [x] Refers to: #1755
* [x] Tests added/passed.
* [x] Release notes added.

## Acceptance Steps Performed

CCE NodePool
```
=== RUN   TestAccCCENodePoolsV3_basic
=== PAUSE TestAccCCENodePoolsV3_basic
=== CONT  TestAccCCENodePoolsV3_basic
=== CONT  TestAccCCENodePoolsV3_basic
    resource_opentelekomcloud_cce_node_pool_v3_test.go:32: Cluster is required by the test. 1 test(s) are using cluster.
=== CONT  TestAccCCENodePoolsV3_basic
    cluster.go:49: starting creating shared cluster
2022/06/07 10:59:40 [DEBUG] Waiting for state to become: [Available]
=== CONT  TestAccCCENodePoolsV3_basic
    cluster.go:137: Cluster usage is 0 now, ready to delete the cluster
    cluster.go:100: starting deleting shared cluster
=== RUN   TestAccCCENodePoolV3ImportBasic
=== PAUSE TestAccCCENodePoolV3ImportBasic
=== CONT  TestAccCCENodePoolV3ImportBasic
=== CONT  TestAccCCENodePoolV3ImportBasic
    resource_opentelekomcloud_cce_node_pool_v3_test.go:62: Cluster is required by the test. 4 test(s) are using cluster.
=== CONT  TestAccCCENodePoolV3ImportBasic
    cluster.go:137: Cluster is released by the test. 1 test(s) are still using cluster.
--- PASS: TestAccCCENodePoolV3ImportBasic (645.00s)
=== RUN   TestAccCCENodePoolsV3_randomAZ
=== PAUSE TestAccCCENodePoolsV3_randomAZ
=== CONT  TestAccCCENodePoolsV3_randomAZ
=== CONT  TestAccCCENodePoolsV3_randomAZ
    resource_opentelekomcloud_cce_node_pool_v3_test.go:107: Cluster is required by the test. 3 test(s) are using cluster.
=== CONT  TestAccCCENodePoolsV3_randomAZ
    cluster.go:137: Cluster is released by the test. 2 test(s) are still using cluster.
--- PASS: TestAccCCENodePoolsV3_randomAZ (611.71s)
=== RUN   TestAccCCENodePoolsV3EncryptedVolume
=== PAUSE TestAccCCENodePoolsV3EncryptedVolume
=== CONT  TestAccCCENodePoolsV3EncryptedVolume
=== CONT  TestAccCCENodePoolsV3EncryptedVolume
    resource_opentelekomcloud_cce_node_pool_v3_test.go:129: Cluster is required by the test. 2 test(s) are using cluster.
=== CONT  TestAccCCENodePoolsV3EncryptedVolume
    cluster.go:137: Cluster is released by the test. 3 test(s) are still using cluster.
--- PASS: TestAccCCENodePoolsV3EncryptedVolume (611.50s)
=== RUN   TestAccCCENodePoolsV3ExtendParams
=== PAUSE TestAccCCENodePoolsV3ExtendParams
=== CONT  TestAccCCENodePoolsV3ExtendParams
=== CONT  TestAccCCENodePoolsV3ExtendParams
    resource_opentelekomcloud_cce_node_pool_v3_test.go:151: Cluster is required by the test. 5 test(s) are using cluster.
=== CONT  TestAccCCENodePoolsV3ExtendParams
    cluster.go:137: Cluster is released by the test. 4 test(s) are still using cluster.
--- PASS: TestAccCCENodePoolsV3ExtendParams (611.29s)
--- PASS: TestAccCCENodePoolsV3_basic (1095.35s)
PASS

Process finished with the exit code 0
```
CCE Cluster
```
=== RUN   TestAccCCEClusterV3_basic
=== PAUSE TestAccCCEClusterV3_basic
=== CONT  TestAccCCEClusterV3_basic
--- PASS: TestAccCCEClusterV3_basic (583.01s)
=== RUN   TestAccCCEClusterV3_importBasic
=== PAUSE TestAccCCEClusterV3_importBasic
=== CONT  TestAccCCEClusterV3_importBasic
--- PASS: TestAccCCEClusterV3_importBasic (478.41s)
=== RUN   TestAccCCEClusterV3_invalidNetwork
=== PAUSE TestAccCCEClusterV3_invalidNetwork
=== CONT  TestAccCCEClusterV3_invalidNetwork
--- PASS: TestAccCCEClusterV3_invalidNetwork (563.10s)
=== RUN   TestAccCCEClusterV3_proxyAuth
=== PAUSE TestAccCCEClusterV3_proxyAuth
=== CONT  TestAccCCEClusterV3_proxyAuth
--- PASS: TestAccCCEClusterV3_proxyAuth (577.92s)
=== RUN   TestAccCCEClusterV3_timeout
=== PAUSE TestAccCCEClusterV3_timeout
=== CONT  TestAccCCEClusterV3_timeout
--- PASS: TestAccCCEClusterV3_timeout (631.01s)
=== RUN   TestAccCCEClusterV3NoAddons
=== PAUSE TestAccCCEClusterV3NoAddons
=== CONT  TestAccCCEClusterV3NoAddons
--- PASS: TestAccCCEClusterV3NoAddons (524.24s)
=== RUN   TestAccCCEClusterV3_withVersionDiff
=== PAUSE TestAccCCEClusterV3_withVersionDiff
=== CONT  TestAccCCEClusterV3_withVersionDiff
--- PASS: TestAccCCEClusterV3_withVersionDiff (975.28s)
PASS

Process finished with the exit code 0
```
CCE Node
```
=== RUN   TestAccCCENodesV3Basic
=== PAUSE TestAccCCENodesV3Basic
=== CONT  TestAccCCENodesV3Basic
=== CONT  TestAccCCENodesV3Basic
    resource_opentelekomcloud_cce_node_v3_test.go:28: Cluster is required by the test. 1 test(s) are using cluster.
=== CONT  TestAccCCENodesV3Basic
    cluster.go:137: Cluster is released by the test. 2 test(s) are still using cluster.
--- PASS: TestAccCCENodesV3Basic (1457.80s)
=== RUN   TestAccCCENodesV3Multiple
=== PAUSE TestAccCCENodesV3Multiple
=== CONT  TestAccCCENodesV3Multiple
    resource_opentelekomcloud_cce_node_v3_test.go:61: Cluster is required by the test. 8 test(s) are using cluster.
=== RUN   TestAccCCENodesV3Timeout
=== PAUSE TestAccCCENodesV3Timeout
=== CONT  TestAccCCENodesV3Timeout
    resource_opentelekomcloud_cce_node_v3_test.go:80: Cluster is required by the test. 8 test(s) are using cluster.
=== CONT  TestAccCCENodesV3Timeout
    cluster.go:137: Cluster is released by the test. 7 test(s) are still using cluster.
--- PASS: TestAccCCENodesV3Timeout (316.79s)
=== RUN   TestAccCCENodesV3OS
=== PAUSE TestAccCCENodesV3OS
=== CONT  TestAccCCENodesV3OS
    resource_opentelekomcloud_cce_node_v3_test.go:102: Cluster is required by the test. 8 test(s) are using cluster.
=== CONT  TestAccCCENodesV3OS
    cluster.go:137: Cluster is released by the test. 6 test(s) are still using cluster.
--- PASS: TestAccCCENodesV3OS (346.53s)
=== RUN   TestAccCCENodesV3BandWidthResize
=== PAUSE TestAccCCENodesV3BandWidthResize
=== CONT  TestAccCCENodesV3BandWidthResize
    resource_opentelekomcloud_cce_node_v3_test.go:127: Cluster is required by the test. 8 test(s) are using cluster.
=== CONT  TestAccCCENodesV3BandWidthResize
    cluster.go:137: Cluster is released by the test. 5 test(s) are still using cluster.
--- PASS: TestAccCCENodesV3BandWidthResize (395.18s)
=== RUN   TestAccCCENodesV3_eipIds
=== PAUSE TestAccCCENodesV3_eipIds
=== CONT  TestAccCCENodesV3_eipIds
=== CONT  TestAccCCENodesV3_eipIds
    resource_opentelekomcloud_cce_node_v3_test.go:162: Cluster is required by the test. 4 test(s) are using cluster.
=== CONT  TestAccCCENodesV3_eipIds
    cluster.go:49: starting creating shared cluster
2022/06/07 12:34:06 [DEBUG] Waiting for state to become: [Available]
=== CONT  TestAccCCENodesV3_eipIds
    cluster.go:137: Cluster is released by the test. 7 test(s) are still using cluster.
--- PASS: TestAccCCENodesV3_eipIds (719.31s)
=== RUN   TestAccCCENodesV3IpSetNull
=== PAUSE TestAccCCENodesV3IpSetNull
=== CONT  TestAccCCENodesV3IpSetNull
=== CONT  TestAccCCENodesV3IpSetNull
    resource_opentelekomcloud_cce_node_v3_test.go:192: Cluster is required by the test. 8 test(s) are using cluster.
=== CONT  TestAccCCENodesV3IpSetNull
    cluster.go:137: Cluster is released by the test. 1 test(s) are still using cluster.
--- PASS: TestAccCCENodesV3IpSetNull (1492.29s)
=== RUN   TestAccCCENodesV3IpWithExtendedParameters
=== PAUSE TestAccCCENodesV3IpWithExtendedParameters
=== CONT  TestAccCCENodesV3IpWithExtendedParameters
    resource_opentelekomcloud_cce_node_v3_test.go:255: Cluster is required by the test. 8 test(s) are using cluster.
=== CONT  TestAccCCENodesV3IpWithExtendedParameters
    cluster.go:137: Cluster is released by the test. 4 test(s) are still using cluster.
--- PASS: TestAccCCENodesV3IpWithExtendedParameters (405.56s)
=== RUN   TestAccCCENodesV3IpNulls
=== PAUSE TestAccCCENodesV3IpNulls
=== CONT  TestAccCCENodesV3IpNulls
=== CONT  TestAccCCENodesV3IpNulls
    resource_opentelekomcloud_cce_node_v3_test.go:282: Cluster is required by the test. 7 test(s) are using cluster.
=== CONT  TestAccCCENodesV3IpNulls
    cluster.go:137: Cluster is released by the test. 7 test(s) are still using cluster.
--- PASS: TestAccCCENodesV3IpNulls (713.57s)
=== RUN   TestAccCCENodesV3EncryptedVolume
=== PAUSE TestAccCCENodesV3EncryptedVolume
=== CONT  TestAccCCENodesV3EncryptedVolume
=== CONT  TestAccCCENodesV3EncryptedVolume
    resource_opentelekomcloud_cce_node_v3_test.go:304: Cluster is required by the test. 3 test(s) are using cluster.
=== CONT  TestAccCCENodesV3EncryptedVolume
    cluster.go:137: Cluster is released by the test. 7 test(s) are still using cluster.
--- PASS: TestAccCCENodesV3EncryptedVolume (691.73s)
=== RUN   TestAccCCENodesV3TaintsK8sTags
=== PAUSE TestAccCCENodesV3TaintsK8sTags
=== CONT  TestAccCCENodesV3TaintsK8sTags
=== CONT  TestAccCCENodesV3TaintsK8sTags
    resource_opentelekomcloud_cce_node_v3_test.go:327: Cluster is required by the test. 6 test(s) are using cluster.
=== CONT  TestAccCCENodesV3TaintsK8sTags
    cluster.go:137: Cluster is released by the test. 7 test(s) are still using cluster.
--- PASS: TestAccCCENodesV3TaintsK8sTags (689.53s)
=== RUN   TestAccCCENodesV3_extendParams
=== PAUSE TestAccCCENodesV3_extendParams
=== CONT  TestAccCCENodesV3_extendParams
=== CONT  TestAccCCENodesV3_extendParams
    resource_opentelekomcloud_cce_node_v3_test.go:355: Cluster is required by the test. 5 test(s) are using cluster.
=== CONT  TestAccCCENodesV3_extendParams
    cluster.go:137: Cluster is released by the test. 3 test(s) are still using cluster.
--- PASS: TestAccCCENodesV3_extendParams (1453.25s)
=== CONT  TestAccCCENodesV3Multiple
    cluster.go:137: Cluster usage is 0 now, ready to delete the cluster
    cluster.go:100: starting deleting shared cluster
--- PASS: TestAccCCENodesV3Multiple (1183.98s)
PASS

Process finished with the exit code 0
```
CCE Addons
```
=== RUN   TestAccCCEAddonV3Basic
=== PAUSE TestAccCCEAddonV3Basic
=== CONT  TestAccCCEAddonV3Basic
--- PASS: TestAccCCEAddonV3Basic (566.15s)
=== RUN   TestAccCCEAddonV3ImportBasic
=== PAUSE TestAccCCEAddonV3ImportBasic
=== CONT  TestAccCCEAddonV3ImportBasic
=== RUN   TestAccCCEAddonV3ForceNewCCE
=== PAUSE TestAccCCEAddonV3ForceNewCCE
=== CONT  TestAccCCEAddonV3ForceNewCCE
--- PASS: TestAccCCEAddonV3ImportBasic (669.98s)
--- PASS: TestAccCCEAddonV3ForceNewCCE (1069.51s)
PASS

Process finished with the exit code 0
```