### PR TITLE
[ELB] New `data_source/lb_member_ids_v2`

### DIFF
--- a/docs/data-sources/lb_member_ids_v2.md
+++ b/docs/data-sources/lb_member_ids_v2.md
@@ -1,0 +1,29 @@
+---
+subcategory: "Elastic Load Balancer (ELB)"
+---
+
+# opentelekomcloud_lb_member_ids_v2
+
+Use this data source to get a list of member IDs for a ELBv2 pool from OpenTelekomCloud.
+This data source can be useful for getting back a list of member IDs for a ELBv2 pool.
+
+## Example Usage
+
+```hcl
+data "opentelekomcloud_lb_member_ids_v2" "this" {
+  pool_id = var.cluster_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `pool_id` - (Required) Specifies the ELBv2 pool ID used as the query filter.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `ids` - A list of all the member IDs found. This data source will fail if none are found.
+

--- a/docs/data-sources/lb_member_ids_v2.md
+++ b/docs/data-sources/lb_member_ids_v2.md
@@ -25,5 +25,5 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `ids` - A list of all the member IDs found. This data source will fail if none are found.
+* `ids` - A list of all the member IDs found.
 

--- a/docs/data-sources/lb_member_ids_v2.md
+++ b/docs/data-sources/lb_member_ids_v2.md
@@ -11,7 +11,7 @@ This data source can be useful for getting back a list of member IDs for a ELBv2
 
 ```hcl
 data "opentelekomcloud_lb_member_ids_v2" "this" {
-  pool_id = var.cluster_id
+  pool_id = var.pool_id
 }
 ```
 

--- a/opentelekomcloud/acceptance/elb/v2/data_source_opentelekomcloud_lb_member_ids_v2_test.go
+++ b/opentelekomcloud/acceptance/elb/v2/data_source_opentelekomcloud_lb_member_ids_v2_test.go
@@ -30,7 +30,8 @@ func TestAccLbMemberIDsV2DataSource_basic(t *testing.T) {
 				ExpectNonEmptyPlan: true, // Because admin_state_up remains false, unfinished elb?
 			},
 			{
-				Config: testAccLbMemberIDsV2DataSourceBasic,
+				Config:             testAccLbMemberIDsV2DataSourceBasic,
+				ExpectNonEmptyPlan: true, // Because admin_state_up remains false, unfinished elb?
 				Check: resource.ComposeTestCheckFunc(
 					testAccLbMemberIDsV3DataSourceID(dataMemberIDsName),
 					resource.TestCheckResourceAttr(dataMemberIDsName, "ids.#", "1"),

--- a/opentelekomcloud/acceptance/elb/v2/data_source_opentelekomcloud_lb_member_ids_v2_test.go
+++ b/opentelekomcloud/acceptance/elb/v2/data_source_opentelekomcloud_lb_member_ids_v2_test.go
@@ -1,0 +1,121 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
+)
+
+const dataMemberIDsName = "data.opentelekomcloud_lb_member_ids_v2.this"
+
+func TestAccLbMemberIDsV2DataSource_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+			qts := quotas.MultipleQuotas{
+				{Q: quotas.LoadBalancer, Count: 1},
+				{Q: quotas.LbListener, Count: 1},
+				{Q: quotas.LbPool, Count: 1},
+			}
+			quotas.BookMany(t, qts)
+		},
+		ProviderFactories: common.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLbMemberIDsV2DataSourceInit,
+			},
+			{
+				Config: testAccLbMemberIDsV2DataSourceBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccLbMemberIDsV3DataSourceID(dataMemberIDsName),
+					resource.TestCheckResourceAttr(dataMemberIDsName, "ids.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccLbMemberIDsV3DataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("can't find CCE Node data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		return nil
+	}
+}
+
+var testAccLbMemberIDsV2DataSourceInit = fmt.Sprintf(`
+%s
+
+resource "opentelekomcloud_lb_loadbalancer_v2" "loadbalancer_1" {
+  name          = "loadbalancer_1"
+  vip_subnet_id = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.subnet_id
+}
+
+resource "opentelekomcloud_lb_listener_v2" "listener_1" {
+  name            = "listener_1"
+  protocol        = "HTTP"
+  protocol_port   = 8080
+  loadbalancer_id = opentelekomcloud_lb_loadbalancer_v2.loadbalancer_1.id
+}
+
+resource "opentelekomcloud_lb_pool_v2" "pool_1" {
+  name        = "pool_1"
+  protocol    = "HTTP"
+  lb_method   = "ROUND_ROBIN"
+  listener_id = opentelekomcloud_lb_listener_v2.listener_1.id
+}
+
+resource "opentelekomcloud_lb_member_v2" "member_2" {
+  address       = "192.168.0.11"
+  protocol_port = 8080
+  pool_id       = opentelekomcloud_lb_pool_v2.pool_1.id
+  subnet_id     = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.subnet_id
+  weight        = 10
+}
+`, common.DataSourceSubnet)
+
+var testAccLbMemberIDsV2DataSourceBasic = fmt.Sprintf(`
+%s
+
+resource "opentelekomcloud_lb_loadbalancer_v2" "loadbalancer_1" {
+  name          = "loadbalancer_1"
+  vip_subnet_id = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.subnet_id
+}
+
+resource "opentelekomcloud_lb_listener_v2" "listener_1" {
+  name            = "listener_1"
+  protocol        = "HTTP"
+  protocol_port   = 8080
+  loadbalancer_id = opentelekomcloud_lb_loadbalancer_v2.loadbalancer_1.id
+}
+
+resource "opentelekomcloud_lb_pool_v2" "pool_1" {
+  name        = "pool_1"
+  protocol    = "HTTP"
+  lb_method   = "ROUND_ROBIN"
+  listener_id = opentelekomcloud_lb_listener_v2.listener_1.id
+}
+
+resource "opentelekomcloud_lb_member_v2" "member_2" {
+  address       = "192.168.0.11"
+  protocol_port = 8080
+  pool_id       = opentelekomcloud_lb_pool_v2.pool_1.id
+  subnet_id     = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.subnet_id
+  weight        = 10
+}
+
+data "opentelekomcloud_lb_member_ids_v2" "this" {
+  pool_id = opentelekomcloud_lb_pool_v2.pool_1.id
+}
+`, common.DataSourceSubnet)

--- a/opentelekomcloud/acceptance/elb/v2/data_source_opentelekomcloud_lb_member_ids_v2_test.go
+++ b/opentelekomcloud/acceptance/elb/v2/data_source_opentelekomcloud_lb_member_ids_v2_test.go
@@ -43,7 +43,7 @@ func testAccLbMemberIDsV3DataSourceID(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("can't find CCE Node data source: %s", n)
+			return fmt.Errorf("can't find ELBv2 Member IDs data source: %s", n)
 		}
 
 		if rs.Primary.ID == "" {

--- a/opentelekomcloud/acceptance/elb/v2/data_source_opentelekomcloud_lb_member_ids_v2_test.go
+++ b/opentelekomcloud/acceptance/elb/v2/data_source_opentelekomcloud_lb_member_ids_v2_test.go
@@ -26,7 +26,8 @@ func TestAccLbMemberIDsV2DataSource_basic(t *testing.T) {
 		ProviderFactories: common.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLbMemberIDsV2DataSourceInit,
+				Config:             testAccLbMemberIDsV2DataSourceInit,
+				ExpectNonEmptyPlan: true, // Because admin_state_up remains false, unfinished elb?
 			},
 			{
 				Config: testAccLbMemberIDsV2DataSourceBasic,
@@ -107,7 +108,7 @@ resource "opentelekomcloud_lb_pool_v2" "pool_1" {
   listener_id = opentelekomcloud_lb_listener_v2.listener_1.id
 }
 
-resource "opentelekomcloud_lb_member_v2" "member_2" {
+resource "opentelekomcloud_lb_member_v2" "member_1" {
   address       = "192.168.0.11"
   protocol_port = 8080
   pool_id       = opentelekomcloud_lb_pool_v2.pool_1.id

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -270,6 +270,7 @@ func Provider() *schema.Provider {
 			"opentelekomcloud_lb_flavor_v3":                    elbv3.DataSourceLBFlavorV3(),
 			"opentelekomcloud_lb_loadbalancer_v3":              elbv3.DataSourceLoadBalancerV3(),
 			"opentelekomcloud_lb_listener_v3":                  elbv3.DataSourceListenerV3(),
+			"opentelekomcloud_lb_member_ids_v2":                elbv2.DataSourceLBMemberIDsV2(),
 			"opentelekomcloud_networking_network_v2":           vpc.DataSourceNetworkingNetworkV2(),
 			"opentelekomcloud_networking_port_v2":              vpc.DataSourceNetworkingPortV2(),
 			"opentelekomcloud_networking_secgroup_v2":          vpc.DataSourceNetworkingSecGroupV2(),

--- a/opentelekomcloud/services/elb/v2/data_source_opentelekomcloud_lb_member_ids_v2.go
+++ b/opentelekomcloud/services/elb/v2/data_source_opentelekomcloud_lb_member_ids_v2.go
@@ -2,13 +2,13 @@ package v2
 
 import (
 	"context"
+	"log"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/lbaas_v2/pools"
-	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
 )
@@ -59,7 +59,7 @@ func dataSourceLBMemberIDsV2Read(_ context.Context, d *schema.ResourceData, meta
 	}
 
 	if len(refinedMembers) < 1 {
-		return common.DataSourceTooFewDiag
+		log.Println("[WARN] Your query returned no results. Please change your search criteria and try again.")
 	}
 
 	var memberList []string

--- a/opentelekomcloud/services/elb/v2/data_source_opentelekomcloud_lb_member_ids_v2.go
+++ b/opentelekomcloud/services/elb/v2/data_source_opentelekomcloud_lb_member_ids_v2.go
@@ -1,0 +1,85 @@
+package v2
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/lbaas/members"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
+)
+
+func DataSourceLBMemberIDsV2() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceLBMemberIDsV2Read,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"pool_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.IsUUID,
+			},
+			"ids": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+		},
+	}
+}
+
+func dataSourceLBMemberIDsV2Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := config.ElbV3Client(config.GetRegion(d))
+	if err != nil {
+		return fmterr.Errorf(ErrCreationV2Client, err)
+	}
+
+	poolID := d.Get("pool_id").(string)
+	listOpts := members.ListOpts{
+		PoolID: poolID,
+	}
+
+	memberPages, err := members.List(client, listOpts).AllPages()
+	if err != nil {
+		return fmterr.Errorf("unable to retrieve member pages: %w", err)
+	}
+
+	refinedMembers, err := members.ExtractMembers(memberPages)
+	if err != nil {
+		return fmterr.Errorf("error extracting ELBv2 members: %w", err)
+	}
+
+	if len(refinedMembers) < 1 {
+		return common.DataSourceTooFewDiag
+	}
+
+	var memberList []string
+	for _, member := range refinedMembers {
+		memberList = append(memberList, member.ID)
+	}
+
+	d.SetId(poolID)
+
+	mErr := multierror.Append(
+		d.Set("ids", memberList),
+		d.Set("region", config.GetRegion(d)),
+	)
+
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}

--- a/opentelekomcloud/services/elb/v2/data_source_opentelekomcloud_lb_member_ids_v2.go
+++ b/opentelekomcloud/services/elb/v2/data_source_opentelekomcloud_lb_member_ids_v2.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/lbaas/members"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/lbaas_v2/pools"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
@@ -47,16 +47,13 @@ func dataSourceLBMemberIDsV2Read(_ context.Context, d *schema.ResourceData, meta
 	}
 
 	poolID := d.Get("pool_id").(string)
-	listOpts := members.ListOpts{
-		PoolID: poolID,
-	}
 
-	memberPages, err := members.List(client, listOpts).AllPages()
+	memberPages, err := pools.ListMembers(client, poolID, pools.ListMembersOpts{}).AllPages()
 	if err != nil {
 		return fmterr.Errorf("unable to retrieve ELBv2 member pages: %w", err)
 	}
 
-	refinedMembers, err := members.ExtractMembers(memberPages)
+	refinedMembers, err := pools.ExtractMembers(memberPages)
 	if err != nil {
 		return fmterr.Errorf("error extracting ELBv2 members: %w", err)
 	}

--- a/opentelekomcloud/services/elb/v2/data_source_opentelekomcloud_lb_member_ids_v2.go
+++ b/opentelekomcloud/services/elb/v2/data_source_opentelekomcloud_lb_member_ids_v2.go
@@ -53,7 +53,7 @@ func dataSourceLBMemberIDsV2Read(_ context.Context, d *schema.ResourceData, meta
 
 	memberPages, err := members.List(client, listOpts).AllPages()
 	if err != nil {
-		return fmterr.Errorf("unable to retrieve member pages: %w", err)
+		return fmterr.Errorf("unable to retrieve ELBv2 member pages: %w", err)
 	}
 
 	refinedMembers, err := members.ExtractMembers(memberPages)

--- a/opentelekomcloud/services/elb/v2/data_source_opentelekomcloud_lb_member_ids_v2.go
+++ b/opentelekomcloud/services/elb/v2/data_source_opentelekomcloud_lb_member_ids_v2.go
@@ -41,7 +41,7 @@ func DataSourceLBMemberIDsV2() *schema.Resource {
 
 func dataSourceLBMemberIDsV2Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	client, err := config.ElbV3Client(config.GetRegion(d))
+	client, err := config.ElbV2Client(config.GetRegion(d))
 	if err != nil {
 		return fmterr.Errorf(ErrCreationV2Client, err)
 	}

--- a/releasenotes/notes/d-elbv2-member-ids-421a29360c85532e.yaml
+++ b/releasenotes/notes/d-elbv2-member-ids-421a29360c85532e.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   - |
-    **[ELB]** New ``data_source/opentelekomcloud_lb_member_ids_v2`` (`#1766 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1766>`_)
+    **New Data Source:** ``opentelekomcloud_lb_member_ids_v2`` (`#1766 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1766>`_)

--- a/releasenotes/notes/d-elbv2-member-ids-421a29360c85532e.yaml
+++ b/releasenotes/notes/d-elbv2-member-ids-421a29360c85532e.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    **[ELB]** New ``data_source/opentelekomcloud_lb_member_ids_v2`` (`#1766 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1766>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Implement new New `data_source/opentelekomcloud_lb_member_ids_v2`
Resolves: #1757

## PR Checklist

* [x] Refers to: #1757
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccLbMemberIDsV2DataSource_basic
=== PAUSE TestAccLbMemberIDsV2DataSource_basic
=== CONT  TestAccLbMemberIDsV2DataSource_basic
--- PASS: TestAccLbMemberIDsV2DataSource_basic (248.67s)
PASS


Process finished with the exit code 0
```
