### PR TITLE
[DNS] handling non-informative error for ``resource/opentelekomcloud_dns_zone_v2`` router

### DIFF
--- a/opentelekomcloud/acceptance/dns/resource_opentelekomcloud_dns_zone_v2_test.go
+++ b/opentelekomcloud/acceptance/dns/resource_opentelekomcloud_dns_zone_v2_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/dns/v2/zones"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
@@ -131,6 +130,20 @@ func TestAccDNSV2Zone_timeout(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDNSV2ZoneExists(resourceZoneName, &zone),
 				),
+			},
+		},
+	})
+}
+
+func TestAccCheckDNSV2ZoneRouterValidation(t *testing.T) {
+	var zoneName = fmt.Sprintf("ACPTTEST%s.com.", acctest.RandString(5))
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDNSV2ZoneWrongRouterSetting(zoneName),
+				ExpectError: regexp.MustCompile(`region is invalid.+`),
 			},
 		},
 	})
@@ -269,4 +282,27 @@ resource "opentelekomcloud_dns_zone_v2" "zone_1" {
   }
 }
 `, zoneName)
+}
+
+func testAccDNSV2ZoneWrongRouterSetting(zoneName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "opentelekomcloud_dns_zone_v2" "zone_1" {
+  name        = "%s"
+  email       = "email1@example.com"
+  description = "a private zone"
+  ttl         = 3000
+  type        = "private"
+
+  router {
+    router_id     = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+    router_region = "BAD"
+  }
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, common.DataSourceSubnet, zoneName)
 }

--- a/opentelekomcloud/acceptance/dns/resource_opentelekomcloud_dns_zone_v2_test.go
+++ b/opentelekomcloud/acceptance/dns/resource_opentelekomcloud_dns_zone_v2_test.go
@@ -135,7 +135,7 @@ func TestAccDNSV2Zone_timeout(t *testing.T) {
 	})
 }
 
-func TestAccCheckDNSV2ZoneRouterValidation(t *testing.T) {
+func TestAccCheckDNSV2Zone_routerValidation(t *testing.T) {
 	var zoneName = fmt.Sprintf("ACPTTEST%s.com.", acctest.RandString(5))
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },

--- a/releasenotes/notes/dns-zone-router-err-f3684bf91f96af1c.yaml
+++ b/releasenotes/notes/dns-zone-router-err-f3684bf91f96af1c.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[DNS]** Add proper error logging for ``resource/opentelekomcloud_dns_zone_v2`` router (`#1783 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1783>`_)


### PR DESCRIPTION
If you create private zone with unexpected values in router field, you got:
Error: error creating OpenTelekomCloud DNS zone: Internal Server Error

Need more proper message, to avoid misunderstanding.

## PR Checklist

* [x] Refers to: #1781
* [x] Tests added/passed.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccDNSV2Zone_basic
--- PASS: TestAccDNSV2Zone_basic (88.03s)
=== RUN   TestAccDNSV2Zone_unDotted
--- PASS: TestAccDNSV2Zone_unDotted (49.64s)
=== RUN   TestAccDNSV2Zone_private
--- PASS: TestAccDNSV2Zone_private (55.25s)
=== RUN   TestAccDNSV2Zone_readTTL
--- PASS: TestAccDNSV2Zone_readTTL (50.14s)
=== RUN   TestAccDNSV2Zone_timeout
--- PASS: TestAccDNSV2Zone_timeout (49.83s)
=== RUN   TestAccCheckDNSV2Zone_routerValidation
--- PASS: TestAccCheckDNSV2Zone_routerValidation (21.52s)
PASS


Process finished with the exit code 0
```
