### PR TITLE
[ECS] Add `disk_id` in schema of `ecs_instance_v1`

### DIFF
--- a/docs/resources/ecs_instance_v1.md
+++ b/docs/resources/ecs_instance_v1.md
@@ -287,11 +287,15 @@ The `data_disks` block supports:
 
 In addition to all arguments above, the following attributes are exported:
 
+* `system_disk_id` - The ID of the system disk.
+
 * `nics/mac_address` - The MAC address of the NIC on that network.
 
 * `nics/type` - The type of the address of the NIC on that network.
 
 * `nics/port_id` - The port ID of the NIC on that network.
+
+* `data_disks/id` - The ID of the data disk.
 
 ## Import
 

--- a/opentelekomcloud/services/ecs/resource_opentelekomcloud_ecs_instance_v1.go
+++ b/opentelekomcloud/services/ecs/resource_opentelekomcloud_ecs_instance_v1.go
@@ -122,6 +122,10 @@ func ResourceEcsInstanceV1() *schema.Resource {
 					},
 				},
 			},
+			"system_disk_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"system_disk_type": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -147,6 +151,10 @@ func ResourceEcsInstanceV1() *schema.Resource {
 				MaxItems: 23,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"type": {
 							Type:     schema.TypeString,
 							Required: true,
@@ -303,6 +311,7 @@ func resourceEcsInstanceV1Read(ctx context.Context, d *schema.ResourceData, meta
 		}
 		if disk.Bootable == "true" {
 			mErr = multierror.Append(mErr,
+				d.Set("system_disk_id", disk.ID),
 				d.Set("system_disk_size", disk.Size),
 				d.Set("system_disk_type", disk.VolumeType),
 				d.Set("system_disk_kms_id", disk.Metadata["__system__cmkid"]),
@@ -310,6 +319,7 @@ func resourceEcsInstanceV1Read(ctx context.Context, d *schema.ResourceData, meta
 			continue
 		}
 		dataVolume := map[string]interface{}{
+			"id":          disk.ID,
 			"type":        disk.VolumeType,
 			"size":        disk.Size,
 			"kms_id":      disk.Metadata["__system__cmkid"],

--- a/releasenotes/notes/ecs-disk-id-51f6d66ab608f029.yaml
+++ b/releasenotes/notes/ecs-disk-id-51f6d66ab608f029.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[ECS]** Return ``IDs`` of ``data_disks`` and ``system_disk`` in ``resource/opentelekomcloud_ecs_instance_v1`` (`#1801 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1801>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Return `IDs` of `data_disks` and `system_disk` in `resource/opentelekomcloud_ecs_instance_v1`

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccEcsV1InstanceBasic
=== PAUSE TestAccEcsV1InstanceBasic
=== CONT  TestAccEcsV1InstanceBasic
--- PASS: TestAccEcsV1InstanceBasic (254.68s)
PASS


Process finished with the exit code 0
```
