### PR TITLE
[CCE] Add PollInterval to resourceCCEAddonV3Delete

### DIFF
--- a/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_addon_v3.go
+++ b/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_addon_v3.go
@@ -196,6 +196,8 @@ func resourceCCEAddonV3Delete(ctx context.Context, d *schema.ResourceData, meta 
 		Target:  []string{"deleted"},
 		Refresh: waitForCCEAddonDelete(client, d.Id(), clusterID),
 		Timeout: d.Timeout(schema.TimeoutDelete),
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
 	}
 
 	_, err = stateConf.WaitForStateContext(ctx)

--- a/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_addon_v3.go
+++ b/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_addon_v3.go
@@ -192,10 +192,10 @@ func resourceCCEAddonV3Delete(ctx context.Context, d *schema.ResourceData, meta 
 	clusterID := d.Get("cluster_id").(string)
 
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{"available"},
-		Target:  []string{"deleted"},
-		Refresh: waitForCCEAddonDelete(client, d.Id(), clusterID),
-		Timeout: d.Timeout(schema.TimeoutDelete),
+		Pending:      []string{"available"},
+		Target:       []string{"deleted"},
+		Refresh:      waitForCCEAddonDelete(client, d.Id(), clusterID),
+		Timeout:      d.Timeout(schema.TimeoutDelete),
 		Delay:        10 * time.Second,
 		PollInterval: 10 * time.Second,
 	}

--- a/releasenotes/notes/cce-poll-interval-41899411a85a9039.yaml
+++ b/releasenotes/notes/cce-poll-interval-41899411a85a9039.yaml
@@ -1,0 +1,5 @@
+---
+
+enhancements:
+  - |
+    **[CCE]** Add ``PollInterval`` in ``resourceCCEAddonV3Delete`` in ``resource/opentelekomcloud_cce_addon_v3`` (`#1810 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1810>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Small fix to add a polling interval to addon deletion, otherwise hitting the rate-limit would often be an issue. 

## PR Checklist

* [x] Tests added/passed.
* [x] Release notes added.

## Acceptance Steps Performed
Ran ```make test``` without errors

## Tests
=== RUN   TestAccCCEAddonV3Basic
=== PAUSE TestAccCCEAddonV3Basic
=== CONT  TestAccCCEAddonV3Basic
--- PASS: TestAccCCEAddonV3Basic (625.51s)
PASS

Process finished with the exit code 0