### PR TITLE
[KMS] fix kms deletion with  enabled rotation

### DIFF
--- a/opentelekomcloud/acceptance/kms/resource_opentelekomcloud_kms_key_v1_test.go
+++ b/opentelekomcloud/acceptance/kms/resource_opentelekomcloud_kms_key_v1_test.go
@@ -192,6 +192,28 @@ func TestAccKmsKey_cancelDeletion(t *testing.T) {
 	})
 }
 
+func TestAccKmsKey_cancelDeletionWithRotation(t *testing.T) {
+	var key keys.Key
+	createName := "test_key_gopher_2"
+	resourceName := "opentelekomcloud_kms_key_v1.key_1"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckKmsV1KeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKmsV1Key_cancelDeletionWithRotation(createName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKmsV1KeyExists(resourceName, &key),
+					resource.TestCheckResourceAttr(resourceName, "key_alias", createName),
+					resource.TestCheckResourceAttr(resourceName, "is_enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
 func testAccKmsV1Key_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "opentelekomcloud_kms_key_v1" "key_1" {
@@ -257,6 +279,18 @@ resource "opentelekomcloud_kms_key_v1" "key_1" {
     muh = "value-create"
     kuh = "value-create"
   }
+}
+`, rName)
+}
+
+func testAccKmsV1Key_cancelDeletionWithRotation(rName string) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_kms_key_v1" "key_1" {
+  key_alias             = "%s"
+  key_description       = "A test key"
+  rotation_enabled      = true
+  rotation_interval     = 90
+  allow_cancel_deletion = true
 }
 `, rName)
 }

--- a/opentelekomcloud/services/kms/resource_opentelekomcloud_kms_key_v1.go
+++ b/opentelekomcloud/services/kms/resource_opentelekomcloud_kms_key_v1.go
@@ -207,7 +207,7 @@ func resourceKmsKeyV1Create(ctx context.Context, d *schema.ResourceData, meta in
 		if err != nil {
 			return fmterr.Errorf("failed to fetch KMS key rotation status: %s", err)
 		}
-		if keyRotation.Enabled == false {
+		if !keyRotation.Enabled {
 			err := keys.EnableKeyRotation(client, rotationOpts).ExtractErr()
 			if err != nil {
 				return fmterr.Errorf("failed to enable KMS key rotation: %s", err)
@@ -427,7 +427,7 @@ func resourceKmsKeyV1Delete(_ context.Context, d *schema.ResourceData, meta inte
 		if err != nil {
 			return fmterr.Errorf("failed to fetch KMS key rotation status: %s", err)
 		}
-		if keyRotation.Enabled == true {
+		if keyRotation.Enabled {
 			err := keys.DisableKeyRotation(client, rotationOpts).ExtractErr()
 			if err != nil {
 				return fmterr.Errorf("failed to disable KMS key rotation: %s", err)

--- a/releasenotes/notes/kms-fix-delete-rotation-a3bb49f050801dcd.yaml
+++ b/releasenotes/notes/kms-fix-delete-rotation-a3bb49f050801dcd.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[KMS]** Fix key deletion with enabled ``rotation`` in ``resource/opentelekomcloud_kms_key_v1`` (`#1823 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1823>`_)


### PR DESCRIPTION
## Summary of the Pull Request
When reenable key, which was created with rotation: {"error":{"error_msg":"The rotation state of key is not disabled.","error_code":"KMS.2901"}}.

## PR Checklist

* [x] Refers to: #1804 #1821
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccKmsKeyV1_basic
--- PASS: TestAccKmsKeyV1_basic (83.19s)
=== RUN   TestAccKmsKey_isEnabled
--- PASS: TestAccKmsKey_isEnabled (116.61s)
=== RUN   TestAccKmsKey_rotation
--- PASS: TestAccKmsKey_rotation (51.10s)
=== RUN   TestAccKmsKey_cancelDeletion
--- PASS: TestAccKmsKey_cancelDeletion (50.83s)
=== RUN   TestAccKmsKey_cancelDeletionWithRotation
--- PASS: TestAccKmsKey_cancelDeletionWithRotation (52.38s)
PASS


Process finished with the exit code 0

```
