### PR TITLE
[CCE] Add missing KMS config of system volume

### DIFF
--- a/docs/resources/cce_node_pool_v3.md
+++ b/docs/resources/cce_node_pool_v3.md
@@ -114,6 +114,7 @@ the AZ based on the AZ sequence. For more details see
   * `size` - (Required) Disk size in GB.
   * `volumetype` - (Required) Disk type.
   * `extend_param` - (Optional) Disk expansion parameters.
+  * `kms_id` - (Optional) The Encryption KMS ID of the system volume. By default, it tries to get from env by `OS_KMS_ID`.
 
 * `data_volumes` - (Required) Represents the data disk to be created. Changing this parameter will create a new resource.
   * `size` - (Required) Disk size in GB.

--- a/docs/resources/cce_node_v3.md
+++ b/docs/resources/cce_node_v3.md
@@ -134,6 +134,7 @@ The following arguments are supported:
   * `size` - (Required) Disk size in GB.
   * `volumetype` - (Required) Disk type.
   * `extend_param` - (Optional) Disk expansion parameters.
+  * `kms_id` - (Optional) The Encryption KMS ID of the system volume. By default, it tries to get from env by `OS_KMS_ID`.
 
 * `data_volumes` - (Required) Represents the data disk to be created. Changing this parameter will create a new resource.
   * `size` - (Required) Disk size in GB.

--- a/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_node_pool_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_node_pool_v3_test.go
@@ -138,6 +138,7 @@ func TestAccCCENodePoolsV3EncryptedVolume(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCCENodePoolV3Exists(nodePoolResourceName, shared.DataSourceClusterName, &nodePool),
 					resource.TestCheckResourceAttr(nodePoolResourceName, "data_volumes.0.kms_id", env.OS_KMS_ID),
+					resource.TestCheckResourceAttr(nodePoolResourceName, "root_volume.0.kms_id", env.OS_KMS_ID),
 				),
 			},
 		},
@@ -344,13 +345,14 @@ resource "opentelekomcloud_cce_node_pool_v3" "node_pool" {
   root_volume {
     size       = 40
     volumetype = "SSD"
+    kms_id     = "%s"
   }
   data_volumes {
     size       = 100
     volumetype = "SSD"
     kms_id     = "%s"
   }
-}`, shared.DataSourceCluster, env.OS_KEYPAIR_NAME, env.OS_KMS_ID)
+}`, shared.DataSourceCluster, env.OS_KEYPAIR_NAME, env.OS_KMS_ID, env.OS_KMS_ID)
 
 var testAccCCENodePoolV3ExtendParams = fmt.Sprintf(`
 %s

--- a/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_node_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_node_v3_test.go
@@ -314,7 +314,7 @@ func TestAccCCENodesV3EncryptedVolume(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCCENodeV3Exists(resourceNameNode, shared.DataSourceClusterName, &node),
 					resource.TestCheckResourceAttr(resourceNameNode, "data_volumes.0.kms_id", env.OS_KMS_ID),
-					resource.TestCheckResourceAttr(resourceNameNode, "root_volume.kms_id", env.OS_KMS_ID),
+					resource.TestCheckResourceAttr(resourceNameNode, "root_volume.0.kms_id", env.OS_KMS_ID),
 				),
 			},
 		},

--- a/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_node_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_node_v3_test.go
@@ -314,6 +314,7 @@ func TestAccCCENodesV3EncryptedVolume(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCCENodeV3Exists(resourceNameNode, shared.DataSourceClusterName, &node),
 					resource.TestCheckResourceAttr(resourceNameNode, "data_volumes.0.kms_id", env.OS_KMS_ID),
+					resource.TestCheckResourceAttr(resourceNameNode, "root_volume.kms_id", env.OS_KMS_ID),
 				),
 			},
 		},
@@ -761,6 +762,7 @@ resource "opentelekomcloud_cce_node_v3" "node_1" {
   root_volume {
     size       = 40
     volumetype = "SATA"
+    kms_id     = "%s"
   }
 
   data_volumes {
@@ -769,7 +771,7 @@ resource "opentelekomcloud_cce_node_v3" "node_1" {
     kms_id     = "%s"
   }
 }
-`, shared.DataSourceCluster, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME, env.OS_KMS_ID)
+`, shared.DataSourceCluster, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME, env.OS_KMS_ID, env.OS_KMS_ID)
 
 func testAccCCENodeV3TaintsK8sTags(privateIP string) string {
 	return fmt.Sprintf(`

--- a/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_pool_v3.go
+++ b/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_pool_v3.go
@@ -104,6 +104,12 @@ func ResourceCCENodePoolV3() *schema.Resource {
 							Required: true,
 							ForceNew: true,
 						},
+						"kms_id": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							ForceNew:    true,
+							DefaultFunc: schema.EnvDefaultFunc("OS_KMS_ID", nil),
+						},
 						"extend_param": {
 							Type:     schema.TypeString,
 							Optional: true,
@@ -413,6 +419,9 @@ func resourceCCENodePoolV3Read(ctx context.Context, d *schema.ResourceData, meta
 			"volumetype":   s.Spec.NodeTemplate.RootVolume.VolumeType,
 			"extend_param": s.Spec.NodeTemplate.RootVolume.ExtendParam,
 		},
+	}
+	if s.Spec.NodeTemplate.RootVolume.Metadata != nil {
+		rootVolume[0]["kms_id"] = s.Spec.NodeTemplate.RootVolume.Metadata["__system__cmkid"]
 	}
 
 	mErr := multierror.Append(

--- a/releasenotes/notes/cce-node-f6f2602e8d342142.yaml
+++ b/releasenotes/notes/cce-node-f6f2602e8d342142.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[CCE]** Add kms key id for system volume via ``kms_id`` in ``resource/opentelekomcloud_cce_node_pool_v3`` and ``resource/opentelekomcloud_cce_node_v3`` (`#1813 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/1813>`_)


### PR DESCRIPTION
## Encryption on system volume
@anton-sidelnikov: Re-created #1819 pr because of failing labeler job

@r-ising: I added the kms id on system volume / root volume.

## PR Checklist

* [X] Refers to: #1813
* [X] Tests added.
* [X] Documentation updated.
* [X] Schema updated.
* [X] Release notes added.

## Tests
```
2022/07/19 10:59:02 [INFO] Building Swift S3 auth structure
2022/07/19 10:59:02 [INFO] Setting AWS metadata API timeout to 100ms
2022/07/19 10:59:03 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2022/07/19 10:59:03 [INFO] Swift S3 Auth provider used: "StaticProvider"
=== RUN   TestAccCCENodesV3EncryptedVolume
=== PAUSE TestAccCCENodesV3EncryptedVolume
=== CONT  TestAccCCENodesV3EncryptedVolume
    resource_opentelekomcloud_cce_node_v3_test.go:304: Cluster is required by the test. 1 test(s) are using cluster.
    cluster.go:49: starting creating shared cluster
2022/07/19 10:59:09 [DEBUG] Waiting for state to become: [Available]
    cluster.go:137: Cluster usage is 0 now, ready to delete the cluster
    cluster.go:100: starting deleting shared cluster
--- PASS: TestAccCCENodesV3EncryptedVolume (809.12s)
PASS

2022/07/19 11:29:25 [INFO] Building Swift S3 auth structure
2022/07/19 11:29:25 [INFO] Setting AWS metadata API timeout to 100ms
2022/07/19 11:29:27 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2022/07/19 11:29:27 [INFO] Swift S3 Auth provider used: "StaticProvider"
=== RUN   TestAccCCENodePoolsV3EncryptedVolume
=== PAUSE TestAccCCENodePoolsV3EncryptedVolume
=== CONT  TestAccCCENodePoolsV3EncryptedVolume
    resource_opentelekomcloud_cce_node_pool_v3_test.go:129: Cluster is required by the test. 1 test(s) are using cluster.
    cluster.go:49: starting creating shared cluster
    cluster.go:137: Cluster usage is 0 now, ready to delete the cluster
    cluster.go:100: starting deleting shared cluster
--- PASS: TestAccCCENodePoolsV3EncryptedVolume (908.83s)
PASS
```
