### PR TITLE
[DNS] TXT recordset quotes handling

### DIFF
--- a/opentelekomcloud/acceptance/dns/resource_opentelekomcloud_dns_recordset_v2_test.go
+++ b/opentelekomcloud/acceptance/dns/resource_opentelekomcloud_dns_recordset_v2_test.go
@@ -175,7 +175,7 @@ func TestAccDNSV2RecordSet_txt(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceRecordSetName, "description", "a record set"),
 					resource.TestCheckResourceAttr(resourceRecordSetName, "type", "TXT"),
 					resource.TestCheckResourceAttr(resourceRecordSetName, "ttl", "300"),
-					resource.TestCheckResourceAttr(resourceRecordSetName, "records.0", "v=spf1 include:spf.protection.outlook.com -all"),
+					resource.TestCheckResourceAttr(resourceRecordSetName, "records.0", "v=spf1 include:my.example.try.com -all"),
 				),
 			},
 			{
@@ -183,7 +183,7 @@ func TestAccDNSV2RecordSet_txt(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceRecordSetName, "ttl", "3000"),
 					resource.TestCheckResourceAttr(resourceRecordSetName, "description", "an updated record set"),
-					resource.TestCheckResourceAttr(resourceRecordSetName, "records.0", "v=spf1 include:spf.protection.outlook.com -none"),
+					resource.TestCheckResourceAttr(resourceRecordSetName, "records.0", "v=spf1 include:my.example.try.com -none"),
 				),
 			},
 		},
@@ -453,7 +453,7 @@ resource "opentelekomcloud_dns_recordset_v2" "recordset_1" {
   type        = "TXT"
   description = "a record set"
   ttl         = 300
-  records     = ["v=spf1 include:spf.protection.outlook.com -all"]
+  records     = ["v=spf1 include:my.example.try.com -all"]
 
 }
 `, zoneName)
@@ -474,7 +474,7 @@ resource "opentelekomcloud_dns_recordset_v2" "recordset_1" {
   type        = "TXT"
   description = "an updated record set"
   ttl         = 3000
-  records     = ["v=spf1 include:spf.protection.outlook.com -none"]
+  records     = ["v=spf1 include:my.example.try.com -none"]
 
 }
 `, zoneName)

--- a/opentelekomcloud/acceptance/dns/resource_opentelekomcloud_dns_recordset_v2_test.go
+++ b/opentelekomcloud/acceptance/dns/resource_opentelekomcloud_dns_recordset_v2_test.go
@@ -158,6 +158,38 @@ func TestAccDNSV2RecordSet_shared(t *testing.T) {
 	})
 }
 
+func TestAccDNSV2RecordSet_txt(t *testing.T) {
+	var recordset recordsets.RecordSet
+	zoneName := randomZoneName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDNSV2RecordSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDNSV2RecordSetTxt(zoneName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDNSV2RecordSetExists(resourceRecordSetName, &recordset),
+					resource.TestCheckResourceAttr(resourceRecordSetName, "name", zoneName),
+					resource.TestCheckResourceAttr(resourceRecordSetName, "description", "a record set"),
+					resource.TestCheckResourceAttr(resourceRecordSetName, "type", "TXT"),
+					resource.TestCheckResourceAttr(resourceRecordSetName, "ttl", "300"),
+					resource.TestCheckResourceAttr(resourceRecordSetName, "records.0", "v=spf1 include:spf.protection.outlook.com -all"),
+				),
+			},
+			{
+				Config: testAccDNSV2RecordSetTxtUpdate(zoneName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceRecordSetName, "ttl", "3000"),
+					resource.TestCheckResourceAttr(resourceRecordSetName, "description", "an updated record set"),
+					resource.TestCheckResourceAttr(resourceRecordSetName, "records.0", "v=spf1 include:spf.protection.outlook.com -none"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckDNSV2RecordSetDestroy(s *terraform.State) error {
 	config := common.TestAccProvider.Meta().(*cfg.Config)
 	client, err := config.DnsV2Client(env.OS_REGION_NAME)
@@ -402,6 +434,48 @@ resource "opentelekomcloud_dns_recordset_v2" "recordset_sup" {
   description = "a parent record set"
   ttl         = 3000
   records     = ["10.1.0.0"]
+}
+`, zoneName)
+}
+
+func testAccDNSV2RecordSetTxt(zoneName string) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_dns_zone_v2" "zone_1" {
+  name        = "%[1]s"
+  email       = "email2@example.com"
+  description = "a zone"
+  ttl         = 6000
+}
+
+resource "opentelekomcloud_dns_recordset_v2" "recordset_1" {
+  zone_id     = opentelekomcloud_dns_zone_v2.zone_1.id
+  name        = "%[1]s"
+  type        = "TXT"
+  description = "a record set"
+  ttl         = 300
+  records     = ["v=spf1 include:spf.protection.outlook.com -all"]
+
+}
+`, zoneName)
+}
+
+func testAccDNSV2RecordSetTxtUpdate(zoneName string) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_dns_zone_v2" "zone_1" {
+  name        = "%[1]s"
+  email       = "email2@example.com"
+  description = "a zone"
+  ttl         = 6000
+}
+
+resource "opentelekomcloud_dns_recordset_v2" "recordset_1" {
+  zone_id     = opentelekomcloud_dns_zone_v2.zone_1.id
+  name        = "%[1]s"
+  type        = "TXT"
+  description = "an updated record set"
+  ttl         = 3000
+  records     = ["v=spf1 include:spf.protection.outlook.com -none"]
+
 }
 `, zoneName)
 }

--- a/releasenotes/notes/fix-txt-recordsets-6383b965e457ad71.yaml
+++ b/releasenotes/notes/fix-txt-recordsets-6383b965e457ad71.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[DNS]** Fix ``TXT recordsed`` quoting in ``resource/opentelekomcloud_dns_recordset_v2`` (`#1829 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1829>`_)


### PR DESCRIPTION
## Summary of the Pull Request
API wants TXT recordset to be extra quoted

## PR Checklist

* [x] Refers to: #1818 
* [x] Tests added/passed.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccDNSV2RecordSet_basic
--- PASS: TestAccDNSV2RecordSet_basic (96.48s)
=== RUN   TestAccDNSV2RecordSet_unDotted
--- PASS: TestAccDNSV2RecordSet_unDotted (56.72s)
=== RUN   TestAccDNSV2RecordSet_childFirst
--- PASS: TestAccDNSV2RecordSet_childFirst (90.70s)
=== RUN   TestAccDNSV2RecordSet_readTTL
--- PASS: TestAccDNSV2RecordSet_readTTL (55.84s)
=== RUN   TestAccDNSV2RecordSet_timeout
--- PASS: TestAccDNSV2RecordSet_timeout (57.07s)
=== RUN   TestAccDNSV2RecordSet_shared
--- PASS: TestAccDNSV2RecordSet_shared (114.09s)
=== RUN   TestAccDNSV2RecordSet_txt
--- PASS: TestAccDNSV2RecordSet_txt (90.05s)
PASS

Process finished with the exit code 0
```
