### PR TITLE
[VPC] Fix `router interface` deletion

### DIFF
--- a/opentelekomcloud/services/vpc/resource_opentelekomcloud_networking_router_interface_v2.go
+++ b/opentelekomcloud/services/vpc/resource_opentelekomcloud_networking_router_interface_v2.go
@@ -182,6 +182,12 @@ func waitForRouterInterfaceDelete(networkingClient *golangsdk.ServiceClient, d *
 				log.Printf("[DEBUG] Successfully deleted OpenTelekomCloud Router Interface %s.", routerInterfaceId)
 				return r, "DELETED", nil
 			}
+			if errCode, ok := err.(golangsdk.ErrDefault409); ok {
+				if errCode.Actual == 409 {
+					log.Printf("[DEBUG] Router Interface %s is still in use.", routerInterfaceId)
+					return r, "ACTIVE", nil
+				}
+			}
 			if errCode, ok := err.(golangsdk.ErrUnexpectedResponseCode); ok {
 				if errCode.Actual == 409 {
 					log.Printf("[DEBUG] Router Interface %s is still in use.", routerInterfaceId)

--- a/releasenotes/notes/fix-vpc-router-interface-delete-7e975ee7506c7aeb.yaml
+++ b/releasenotes/notes/fix-vpc-router-interface-delete-7e975ee7506c7aeb.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[VPC]** Fix ``deleting OpenTelekomCloud Neutron Router Interface`` in ``resource/opentelekomcloud_networking_router_interface_v2`` (`#1836 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1836>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Port exists some time after attached ECS deletion, that leads to error deleting OpenTelekomCloud Neutron Router Interface: Internal Server Error

## PR Checklist

* [x] Refers to: #1824
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccNetworkingV2RouterInterface_basic_subnet
=== PAUSE TestAccNetworkingV2RouterInterface_basic_subnet
=== CONT  TestAccNetworkingV2RouterInterface_basic_subnet
--- PASS: TestAccNetworkingV2RouterInterface_basic_subnet (96.20s)
=== RUN   TestAccNetworkingV2RouterInterface_basic_port
=== PAUSE TestAccNetworkingV2RouterInterface_basic_port
=== CONT  TestAccNetworkingV2RouterInterface_basic_port
--- PASS: TestAccNetworkingV2RouterInterface_basic_port (108.84s)
=== RUN   TestAccNetworkingV2RouterInterface_timeout
=== PAUSE TestAccNetworkingV2RouterInterface_timeout
=== CONT  TestAccNetworkingV2RouterInterface_timeout
--- PASS: TestAccNetworkingV2RouterInterface_timeout (95.78s)
=== RUN   TestAccNetworkingV2RouterInterface_port
=== PAUSE TestAccNetworkingV2RouterInterface_port
=== CONT  TestAccNetworkingV2RouterInterface_port
--- PASS: TestAccNetworkingV2RouterInterface_port (133.31s)
PASS

Process finished with the exit code 0
```
