### PR TITLE
[ECS] fix recreating with `opentelekomcloud_compute_volume_attach_v2` in `opentelekomcloud_ecs_instance_v1`

### DIFF
--- a/docs/resources/ecs_instance_v1.md
+++ b/docs/resources/ecs_instance_v1.md
@@ -295,7 +295,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `nics/port_id` - The port ID of the NIC on that network.
 
-* `data_disks/id` - The ID of the data disk.
+* `volumes_attached/id` - The ID of the data disk.
 
 ## Import
 

--- a/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_ecs_instance_v1_test.go
+++ b/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_ecs_instance_v1_test.go
@@ -613,6 +613,7 @@ resource "opentelekomcloud_ecs_instance_v1" "instance_1" {
   image_id = data.opentelekomcloud_images_image_v2.latest_image.id
   flavor   = "s2.medium.1"
   vpc_id   = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+
   availability_zone = "%s"
 
   nics {
@@ -644,6 +645,7 @@ resource "opentelekomcloud_ecs_instance_v1" "instance_1" {
   image_id = data.opentelekomcloud_images_image_v2.latest_image.id
   flavor   = "s2.medium.1"
   vpc_id   = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+
   availability_zone = "%s"
 
   nics {

--- a/opentelekomcloud/services/ecs/resource_opentelekomcloud_ecs_instance_v1.go
+++ b/opentelekomcloud/services/ecs/resource_opentelekomcloud_ecs_instance_v1.go
@@ -179,6 +179,35 @@ func ResourceEcsInstanceV1() *schema.Resource {
 					},
 				},
 			},
+			"volumes_attached": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"size": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+						"kms_id": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							DefaultFunc: schema.EnvDefaultFunc("OS_KMS_ID", nil),
+						},
+						"snapshot_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
 			"security_groups": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -328,7 +357,7 @@ func resourceEcsInstanceV1Read(ctx context.Context, d *schema.ResourceData, meta
 		volumeList = append(volumeList, dataVolume)
 	}
 	mErr = multierror.Append(mErr,
-		d.Set("data_disks", volumeList),
+		d.Set("volumes_attached", volumeList),
 	)
 
 	// Get the instance network and address information

--- a/releasenotes/notes/fix-ecs-v1-recreate-volumes-5df58d08e08aca92.yaml
+++ b/releasenotes/notes/fix-ecs-v1-recreate-volumes-5df58d08e08aca92.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[ECS]** Fix recreating with ``opentelekomcloud_compute_volume_attach_v2`` in ``opentelekomcloud_ecs_instance_v1`` (`#1843 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1843>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Attaching volumes leads to recreate on second apply, get rid of data_disks from state, set volumes_attached instead

## PR Checklist

* [x] Refers to: #1820
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccEcsV1InstanceBasic
=== PAUSE TestAccEcsV1InstanceBasic
=== CONT  TestAccEcsV1InstanceBasic
--- PASS: TestAccEcsV1InstanceBasic (236.56s)
=== RUN   TestAccEcsV1InstanceIp
=== PAUSE TestAccEcsV1InstanceIp
=== CONT  TestAccEcsV1InstanceIp
--- PASS: TestAccEcsV1InstanceIp (184.17s)
=== RUN   TestAccEcsV1InstanceDeleted
=== PAUSE TestAccEcsV1InstanceDeleted
=== CONT  TestAccEcsV1InstanceDeleted
--- PASS: TestAccEcsV1InstanceDeleted (353.74s)
=== RUN   TestAccEcsV1Instance_import
=== PAUSE TestAccEcsV1Instance_import
=== CONT  TestAccEcsV1Instance_import
--- PASS: TestAccEcsV1Instance_import (191.50s)
=== RUN   TestAccEcsV1InstanceDiskTypeValidation
=== PAUSE TestAccEcsV1InstanceDiskTypeValidation
=== CONT  TestAccEcsV1InstanceDiskTypeValidation
--- PASS: TestAccEcsV1InstanceDiskTypeValidation (30.15s)
=== RUN   TestAccEcsV1InstanceVPCValidation
=== PAUSE TestAccEcsV1InstanceVPCValidation
=== CONT  TestAccEcsV1InstanceVPCValidation
--- PASS: TestAccEcsV1InstanceVPCValidation (205.99s)
=== RUN   TestAccEcsV1InstanceVolumeAttach
=== PAUSE TestAccEcsV1InstanceVolumeAttach
=== CONT  TestAccEcsV1InstanceVolumeAttach
--- PASS: TestAccEcsV1InstanceVolumeAttach (271.97s)
PASS


Process finished with the exit code 0
```
