### PR TITLE
[VPC] Fix status attr for ``resource/opentelekomcloud_vpc_subnet_v1``

### DIFF
--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_vpc_subnet_v1_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_vpc_subnet_v1_test.go
@@ -40,6 +40,7 @@ func TestAccVpcSubnetV1Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceVPCSubnetName, "ntp_addresses", "10.100.0.33,10.100.0.34"),
 					resource.TestCheckResourceAttr(resourceVPCSubnetName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceVPCSubnetName, "tags.key", "value"),
+					resource.TestCheckResourceAttr(resourceVPCSubnetName, "status", "ACTIVE"),
 				),
 			},
 			{

--- a/opentelekomcloud/services/vpc/resource_opentelekomcloud_vpc_subnet_v1.go
+++ b/opentelekomcloud/services/vpc/resource_opentelekomcloud_vpc_subnet_v1.go
@@ -93,6 +93,10 @@ func ResourceVpcSubnetV1() *schema.Resource {
 				Computed: true,
 				ForceNew: true,
 			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"vpc_id": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -213,6 +217,7 @@ func resourceVpcSubnetV1Read(ctx context.Context, d *schema.ResourceData, meta i
 		d.Set("vpc_id", subnet.VpcID),
 		d.Set("subnet_id", subnet.SubnetID),
 		d.Set("network_id", subnet.NetworkID),
+		d.Set("status", subnet.Status),
 		d.Set("region", config.GetRegion(d)),
 	)
 

--- a/releasenotes/notes/vpc-subnet-status-fix-f1cc6b4bd7a26dab.yaml
+++ b/releasenotes/notes/vpc-subnet-status-fix-f1cc6b4bd7a26dab.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[VPC]** Fix status attr for ``resource/opentelekomcloud_vpc_subnet_v1`` (`#1846 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1846>`_)


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [x] Refers to: #1845 
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccVpcSubnetV1Basic
=== PAUSE TestAccVpcSubnetV1Basic
=== CONT  TestAccVpcSubnetV1Basic
--- PASS: TestAccVpcSubnetV1Basic (118.56s)
PASS

Process finished with exit code 0
```
