### PR TITLE
[CES] use client from ctx in `opentelekomcloud_ces_alarmrule`

### DIFF
--- a/opentelekomcloud/acceptance/ces/resource_opentelekomcloud_ces_alarmrule_test.go
+++ b/opentelekomcloud/acceptance/ces/resource_opentelekomcloud_ces_alarmrule_test.go
@@ -105,7 +105,10 @@ var testCESAlarmRuleBasic = fmt.Sprintf(`
 %s
 
 resource "opentelekomcloud_compute_instance_v2" "vm_1" {
-  name = "instance_1"
+  name        = "instance_1"
+  image_name  = "Standard_Debian_11_latest"
+  flavor_name = "s3.large.2"
+
   network {
     uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
@@ -150,7 +153,9 @@ var testCESAlarmRuleUpdate = fmt.Sprintf(`
 %s
 
 resource "opentelekomcloud_compute_instance_v2" "vm_1" {
-  name = "instance_1"
+  name        = "instance_1"
+  image_name  = "Standard_Debian_11_latest"
+  flavor_name = "s3.large.2"
   network {
     uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }

--- a/opentelekomcloud/services/ces/common.go
+++ b/opentelekomcloud/services/ces/common.go
@@ -2,4 +2,5 @@ package ces
 
 const (
 	errCreationClient = "error creating CESv1 client: %w"
+	cesClientV1       = "ces-v1-client"
 )

--- a/opentelekomcloud/services/ces/resource_opentelekomcloud_ces_alarmrule.go
+++ b/opentelekomcloud/services/ces/resource_opentelekomcloud_ces_alarmrule.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/cloudeyeservice/alarmrule"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
@@ -318,7 +319,9 @@ func getAlarmAction(d *schema.ResourceData, name string) []alarmrule.ActionOpts 
 
 func resourceAlarmRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	client, err := config.CesV1Client(config.GetRegion(d))
+	client, err := common.ClientFromCtx(ctx, cesClientV1, func() (*golangsdk.ServiceClient, error) {
+		return config.CesV1Client(config.GetRegion(d))
+	})
 	if err != nil {
 		return fmterr.Errorf(errCreationClient, err)
 	}
@@ -355,12 +358,15 @@ func resourceAlarmRuleCreate(ctx context.Context, d *schema.ResourceData, meta i
 
 	d.SetId(r.AlarmID)
 
-	return resourceAlarmRuleRead(ctx, d, meta)
+	clientCtx := common.CtxWithClient(ctx, client, cesClientV1)
+	return resourceAlarmRuleRead(clientCtx, d, meta)
 }
 
-func resourceAlarmRuleRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAlarmRuleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	client, err := config.CesV1Client(config.GetRegion(d))
+	client, err := common.ClientFromCtx(ctx, cesClientV1, func() (*golangsdk.ServiceClient, error) {
+		return config.CesV1Client(config.GetRegion(d))
+	})
 	if err != nil {
 		return fmterr.Errorf(errCreationClient, err)
 	}
@@ -461,7 +467,9 @@ func resourceAlarmRuleRead(_ context.Context, d *schema.ResourceData, meta inter
 
 func resourceAlarmRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	client, err := config.CesV1Client(config.GetRegion(d))
+	client, err := common.ClientFromCtx(ctx, cesClientV1, func() (*golangsdk.ServiceClient, error) {
+		return config.CesV1Client(config.GetRegion(d))
+	})
 	if err != nil {
 		return fmterr.Errorf(errCreationClient, err)
 	}
@@ -487,12 +495,15 @@ func resourceAlarmRuleUpdate(ctx context.Context, d *schema.ResourceData, meta i
 		return fmterr.Errorf("error updating alarm rule %s: %w", alarmRuleID, err)
 	}
 
-	return resourceAlarmRuleRead(ctx, d, meta)
+	clientCtx := common.CtxWithClient(ctx, client, cesClientV1)
+	return resourceAlarmRuleRead(clientCtx, d, meta)
 }
 
 func resourceAlarmRuleDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	client, err := config.CesV1Client(config.GetRegion(d))
+	client, err := common.ClientFromCtx(ctx, cesClientV1, func() (*golangsdk.ServiceClient, error) {
+		return config.CesV1Client(config.GetRegion(d))
+	})
 	if err != nil {
 		return fmterr.Errorf(errCreationClient, err)
 	}

--- a/releasenotes/notes/ces-fix-throttling-c92557430ae94e3a.yaml
+++ b/releasenotes/notes/ces-fix-throttling-c92557430ae94e3a.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[CES]** Reduce amount of init client requests in ``resource/opentelekomcloud_ces_alarmrule`` (`#1847 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1847>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Use client from ctx in opentelekomcloud_ces_alarmrule

## PR Checklist

* [x] Refers to: #1840
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestCESAlarmRule_basic
=== PAUSE TestCESAlarmRule_basic
=== CONT  TestCESAlarmRule_basic
--- PASS: TestCESAlarmRule_basic (124.12s)
PASS


Process finished with the exit code 0
```
