### PR TITLE
[VPC] Use client from ctx in `vpc_eip_v1`

### DIFF
--- a/releasenotes/notes/eip-throttle-4f63a9b571f23121.yaml
+++ b/releasenotes/notes/eip-throttle-4f63a9b571f23121.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[VPC]** Reduce amount of init client requests in ``resource/opentelekomcloud_vpc_eip_v1`` (`#1849 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1849>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Use client from ctx in `resource/opentelekomcloud_vcp_eip_v1`

## PR Checklist

* [x] Refers to: #1848
* [x] Tests added/passed.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccVpcV1EIP_basic
=== PAUSE TestAccVpcV1EIP_basic
=== CONT  TestAccVpcV1EIP_basic
--- PASS: TestAccVpcV1EIP_basic (95.95s)
=== RUN   TestAccVpcV1EIP_timeout
=== PAUSE TestAccVpcV1EIP_timeout
=== CONT  TestAccVpcV1EIP_timeout
--- PASS: TestAccVpcV1EIP_timeout (57.82s)
PASS


Process finished with the exit code 0
```
