### PR TITLE
[ELB] Client from ctx in `resources/lb_v2`

### DIFF
--- a/opentelekomcloud/acceptance/elb/v2/resource_opentelekomcloud_lb_member_v2_test.go
+++ b/opentelekomcloud/acceptance/elb/v2/resource_opentelekomcloud_lb_member_v2_test.go
@@ -173,7 +173,7 @@ resource "opentelekomcloud_lb_pool_v2" "pool_1" {
 }
 
 resource "opentelekomcloud_lb_member_v2" "member_1" {
-  address       = "192.168.0.10"
+  address       = "10.0.0.10"
   protocol_port = 8080
   pool_id       = opentelekomcloud_lb_pool_v2.pool_1.id
   subnet_id     = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.subnet_id
@@ -181,7 +181,7 @@ resource "opentelekomcloud_lb_member_v2" "member_1" {
 }
 
 resource "opentelekomcloud_lb_member_v2" "member_2" {
-  address       = "192.168.0.11"
+  address       = "10.0.0.11"
   protocol_port = 8080
   pool_id       = opentelekomcloud_lb_pool_v2.pool_1.id
   subnet_id     = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.subnet_id
@@ -212,7 +212,7 @@ resource "opentelekomcloud_lb_pool_v2" "pool_1" {
 }
 
 resource "opentelekomcloud_lb_member_v2" "member_1" {
-  address        = "192.168.0.10"
+  address        = "10.0.0.10"
   protocol_port  = 8080
   weight         = 10
   admin_state_up = true
@@ -221,7 +221,7 @@ resource "opentelekomcloud_lb_member_v2" "member_1" {
 }
 
 resource "opentelekomcloud_lb_member_v2" "member_2" {
-  address        = "192.168.0.11"
+  address        = "10.0.0.11"
   protocol_port  = 8080
   weight         = 0
   admin_state_up = true

--- a/opentelekomcloud/acceptance/elb/v2/resource_opentelekomcloud_lb_whitelist_v2_test.go
+++ b/opentelekomcloud/acceptance/elb/v2/resource_opentelekomcloud_lb_whitelist_v2_test.go
@@ -50,7 +50,7 @@ func TestAccLBV2Whitelist_basic(t *testing.T) {
 
 func testAccCheckLBV2WhitelistDestroy(s *terraform.State) error {
 	config := common.TestAccProvider.Meta().(*cfg.Config)
-	networkingClient, err := config.ElbV2Client(env.OS_REGION_NAME)
+	client, err := config.ElbV2Client(env.OS_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf(elb.ErrCreationV2Client, err)
 	}
@@ -60,7 +60,7 @@ func testAccCheckLBV2WhitelistDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := whitelists.Get(networkingClient, rs.Primary.ID).Extract()
+		_, err := whitelists.Get(client, rs.Primary.ID).Extract()
 		if err == nil {
 			return fmt.Errorf("whitelist still exists: %s", rs.Primary.ID)
 		}
@@ -81,12 +81,12 @@ func testAccCheckLBV2WhitelistExists(n string, whitelist *whitelists.Whitelist) 
 		}
 
 		config := common.TestAccProvider.Meta().(*cfg.Config)
-		networkingClient, err := config.ElbV2Client(env.OS_REGION_NAME)
+		client, err := config.ElbV2Client(env.OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf(elb.ErrCreationV2Client, err)
 		}
 
-		found, err := whitelists.Get(networkingClient, rs.Primary.ID).Extract()
+		found, err := whitelists.Get(client, rs.Primary.ID).Extract()
 		if err != nil {
 			return err
 		}

--- a/opentelekomcloud/services/elb/v2/common.go
+++ b/opentelekomcloud/services/elb/v2/common.go
@@ -2,4 +2,5 @@ package v2
 
 const (
 	ErrCreationV2Client = "error creating OpenTelekomCloud ELB V2 client: %w"
+	keyClient           = "lbv2-client"
 )

--- a/opentelekomcloud/services/elb/v2/lb_v2_shared.go
+++ b/opentelekomcloud/services/elb/v2/lb_v2_shared.go
@@ -31,12 +31,13 @@ func waitForLBV2Listener(ctx context.Context, client *golangsdk.ServiceClient, i
 	log.Printf("[DEBUG] Waiting for listener %s to become %s.", id, target)
 
 	stateConf := &resource.StateChangeConf{
-		Target:     []string{target},
-		Pending:    pending,
-		Refresh:    resourceLBV2ListenerRefreshFunc(client, id),
-		Timeout:    timeout,
-		Delay:      5 * time.Second,
-		MinTimeout: 1 * time.Second,
+		Target:       []string{target},
+		Pending:      pending,
+		Refresh:      resourceLBV2ListenerRefreshFunc(client, id),
+		Timeout:      timeout,
+		Delay:        5 * time.Second,
+		MinTimeout:   1 * time.Second,
+		PollInterval: 2 * time.Second,
 	}
 
 	_, err := stateConf.WaitForStateContext(ctx)
@@ -111,12 +112,13 @@ func waitForLBV2Pool(ctx context.Context, client *golangsdk.ServiceClient, id st
 	log.Printf("[DEBUG] Waiting for pool %s to become %s.", id, target)
 
 	stateConf := &resource.StateChangeConf{
-		Target:     []string{target},
-		Pending:    pending,
-		Refresh:    resourceLBV2PoolRefreshFunc(client, id),
-		Timeout:    timeout,
-		Delay:      5 * time.Second,
-		MinTimeout: 1 * time.Second,
+		Target:       []string{target},
+		Pending:      pending,
+		Refresh:      resourceLBV2PoolRefreshFunc(client, id),
+		Timeout:      timeout,
+		Delay:        5 * time.Second,
+		MinTimeout:   1 * time.Second,
+		PollInterval: 2 * time.Second,
 	}
 
 	_, err := stateConf.WaitForStateContext(ctx)
@@ -298,12 +300,13 @@ func waitForLBV2L7Policy(ctx context.Context, client *golangsdk.ServiceClient, p
 	lbID := parentListener.Loadbalancers[0].ID
 
 	stateConf := &resource.StateChangeConf{
-		Target:     []string{target},
-		Pending:    pending,
-		Refresh:    resourceLBV2L7PolicyRefreshFunc(client, lbID, l7policy),
-		Timeout:    timeout,
-		Delay:      1 * time.Second,
-		MinTimeout: 1 * time.Second,
+		Target:       []string{target},
+		Pending:      pending,
+		Refresh:      resourceLBV2L7PolicyRefreshFunc(client, lbID, l7policy),
+		Timeout:      timeout,
+		Delay:        1 * time.Second,
+		MinTimeout:   1 * time.Second,
+		PollInterval: 2 * time.Second,
 	}
 
 	_, err := stateConf.WaitForStateContext(ctx)
@@ -382,12 +385,13 @@ func waitForLBV2L7Rule(ctx context.Context, client *golangsdk.ServiceClient, par
 	lbID := parentListener.Loadbalancers[0].ID
 
 	stateConf := &resource.StateChangeConf{
-		Target:     []string{target},
-		Pending:    pending,
-		Refresh:    resourceLBV2L7RuleRefreshFunc(client, lbID, parentL7policy.ID, l7rule),
-		Timeout:    timeout,
-		Delay:      1 * time.Second,
-		MinTimeout: 1 * time.Second,
+		Target:       []string{target},
+		Pending:      pending,
+		Refresh:      resourceLBV2L7RuleRefreshFunc(client, lbID, parentL7policy.ID, l7rule),
+		Timeout:      timeout,
+		Delay:        1 * time.Second,
+		MinTimeout:   1 * time.Second,
+		PollInterval: 2 * time.Second,
 	}
 
 	_, err := stateConf.WaitForStateContext(ctx)

--- a/opentelekomcloud/services/elb/v2/resource_opentelekomcloud_lb_l7rule_v2.go
+++ b/opentelekomcloud/services/elb/v2/resource_opentelekomcloud_lb_l7rule_v2.go
@@ -373,7 +373,6 @@ func resourceL7RuleV2Delete(ctx context.Context, d *schema.ResourceData, meta in
 	return nil
 }
 
-// TODO: DROP IT
 func resourceL7RuleV2Import(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	parts := strings.SplitN(d.Id(), "/", 2)
 	if len(parts) != 2 {

--- a/opentelekomcloud/services/elb/v2/resource_opentelekomcloud_lb_listener_v2.go
+++ b/opentelekomcloud/services/elb/v2/resource_opentelekomcloud_lb_listener_v2.go
@@ -125,7 +125,9 @@ func ResourceListenerV2() *schema.Resource {
 
 func resourceListenerV2Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	client, err := config.ElbV2Client(config.GetRegion(d))
+	client, err := common.ClientFromCtx(ctx, keyClient, func() (*golangsdk.ServiceClient, error) {
+		return config.ElbV2Client(config.GetRegion(d))
+	})
 	if err != nil {
 		return fmterr.Errorf(ErrCreationV2Client, err)
 	}
@@ -138,6 +140,7 @@ func resourceListenerV2Create(ctx context.Context, d *schema.ResourceData, meta 
 			sniContainerRefs = append(sniContainerRefs, v.(string))
 		}
 	}
+
 	createOpts := listeners.CreateOpts{
 		Protocol:               listeners.Protocol(d.Get("protocol").(string)),
 		ProtocolPort:           d.Get("protocol_port").(int),
@@ -197,12 +200,15 @@ func resourceListenerV2Create(ctx context.Context, d *schema.ResourceData, meta 
 		return fmterr.Errorf("error updating ELB v2 Listener `transparent_client_ip_enable`: %w", err)
 	}
 
-	return resourceListenerV2Read(ctx, d, meta)
+	clientCtx := common.CtxWithClient(ctx, client, keyClient)
+	return resourceListenerV2Read(clientCtx, d, meta)
 }
 
-func resourceListenerV2Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceListenerV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	client, err := config.ElbV2Client(config.GetRegion(d))
+	client, err := common.ClientFromCtx(ctx, keyClient, func() (*golangsdk.ServiceClient, error) {
+		return config.ElbV2Client(config.GetRegion(d))
+	})
 	if err != nil {
 		return fmterr.Errorf(ErrCreationV2Client, err)
 	}
@@ -252,7 +258,9 @@ func resourceListenerV2Read(_ context.Context, d *schema.ResourceData, meta inte
 
 func resourceListenerV2Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	client, err := config.ElbV2Client(config.GetRegion(d))
+	client, err := common.ClientFromCtx(ctx, keyClient, func() (*golangsdk.ServiceClient, error) {
+		return config.ElbV2Client(config.GetRegion(d))
+	})
 	if err != nil {
 		return fmterr.Errorf(ErrCreationV2Client, err)
 	}
@@ -312,7 +320,6 @@ func resourceListenerV2Update(ctx context.Context, d *schema.ResourceData, meta 
 		}
 		return nil
 	})
-
 	if err != nil {
 		return fmterr.Errorf("error updating listener %s: %s", d.Id(), err)
 	}
@@ -329,12 +336,15 @@ func resourceListenerV2Update(ctx context.Context, d *schema.ResourceData, meta 
 		}
 	}
 
-	return resourceListenerV2Read(ctx, d, meta)
+	clientCtx := common.CtxWithClient(ctx, client, keyClient)
+	return resourceListenerV2Read(clientCtx, d, meta)
 }
 
 func resourceListenerV2Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	client, err := config.ElbV2Client(config.GetRegion(d))
+	client, err := common.ClientFromCtx(ctx, keyClient, func() (*golangsdk.ServiceClient, error) {
+		return config.ElbV2Client(config.GetRegion(d))
+	})
 	if err != nil {
 		return fmterr.Errorf(ErrCreationV2Client, err)
 	}
@@ -371,6 +381,7 @@ func resourceListenerV2Delete(ctx context.Context, d *schema.ResourceData, meta 
 	return nil
 }
 
+// TODO: DROP IT
 // elbV3Client user as temporary stub for missing in service catalog for eu-de, but working endpoint
 func elbV3Client(config *cfg.Config, region string) (*golangsdk.ServiceClient, error) {
 	v3Client, err := config.ElbV3Client(region)

--- a/opentelekomcloud/services/elb/v2/resource_opentelekomcloud_lb_listener_v2.go
+++ b/opentelekomcloud/services/elb/v2/resource_opentelekomcloud_lb_listener_v2.go
@@ -381,7 +381,6 @@ func resourceListenerV2Delete(ctx context.Context, d *schema.ResourceData, meta 
 	return nil
 }
 
-// TODO: DROP IT
 // elbV3Client user as temporary stub for missing in service catalog for eu-de, but working endpoint
 func elbV3Client(config *cfg.Config, region string) (*golangsdk.ServiceClient, error) {
 	v3Client, err := config.ElbV3Client(region)

--- a/opentelekomcloud/services/elb/v2/resource_opentelekomcloud_lb_member_v2.go
+++ b/opentelekomcloud/services/elb/v2/resource_opentelekomcloud_lb_member_v2.go
@@ -90,7 +90,9 @@ func ResourceMemberV2() *schema.Resource {
 
 func resourceMemberV2Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	client, err := config.ElbV2Client(config.GetRegion(d))
+	client, err := common.ClientFromCtx(ctx, keyClient, func() (*golangsdk.ServiceClient, error) {
+		return config.ElbV2Client(config.GetRegion(d))
+	})
 	if err != nil {
 		return fmterr.Errorf(ErrCreationV2Client, err)
 	}
@@ -140,12 +142,15 @@ func resourceMemberV2Create(ctx context.Context, d *schema.ResourceData, meta in
 
 	d.SetId(member.ID)
 
-	return resourceMemberV2Read(ctx, d, meta)
+	clientCtx := common.CtxWithClient(ctx, client, keyClient)
+	return resourceMemberV2Read(clientCtx, d, meta)
 }
 
-func resourceMemberV2Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceMemberV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	client, err := config.ElbV2Client(config.GetRegion(d))
+	client, err := common.ClientFromCtx(ctx, keyClient, func() (*golangsdk.ServiceClient, error) {
+		return config.ElbV2Client(config.GetRegion(d))
+	})
 	if err != nil {
 		return fmterr.Errorf(ErrCreationV2Client, err)
 	}
@@ -178,7 +183,9 @@ func resourceMemberV2Read(_ context.Context, d *schema.ResourceData, meta interf
 
 func resourceMemberV2Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	client, err := config.ElbV2Client(config.GetRegion(d))
+	client, err := common.ClientFromCtx(ctx, keyClient, func() (*golangsdk.ServiceClient, error) {
+		return config.ElbV2Client(config.GetRegion(d))
+	})
 	if err != nil {
 		return fmterr.Errorf(ErrCreationV2Client, err)
 	}
@@ -215,7 +222,6 @@ func resourceMemberV2Update(ctx context.Context, d *schema.ResourceData, meta in
 		time.Sleep(5 * time.Second)
 		return nil
 	})
-
 	if err != nil {
 		return fmterr.Errorf("unable to update member %s: %w", d.Id(), err)
 	}
@@ -224,12 +230,15 @@ func resourceMemberV2Update(ctx context.Context, d *schema.ResourceData, meta in
 		return diag.FromErr(err)
 	}
 
-	return resourceMemberV2Read(ctx, d, meta)
+	clientCtx := common.CtxWithClient(ctx, client, keyClient)
+	return resourceMemberV2Read(clientCtx, d, meta)
 }
 
 func resourceMemberV2Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	client, err := config.ElbV2Client(config.GetRegion(d))
+	client, err := common.ClientFromCtx(ctx, keyClient, func() (*golangsdk.ServiceClient, error) {
+		return config.ElbV2Client(config.GetRegion(d))
+	})
 	if err != nil {
 		return fmterr.Errorf(ErrCreationV2Client, err)
 	}

--- a/opentelekomcloud/services/elb/v2/resource_opentelekomcloud_lb_pool_v2.go
+++ b/opentelekomcloud/services/elb/v2/resource_opentelekomcloud_lb_pool_v2.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/lbaas_v2/pools"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
@@ -139,7 +140,9 @@ func resourcePoolV2Persistence(d *schema.ResourceData) (*pools.SessionPersistenc
 
 func resourceLBPoolV2Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	client, err := config.ElbV2Client(config.GetRegion(d))
+	client, err := common.ClientFromCtx(ctx, keyClient, func() (*golangsdk.ServiceClient, error) {
+		return config.ElbV2Client(config.GetRegion(d))
+	})
 	if err != nil {
 		return fmterr.Errorf(ErrCreationV2Client, err)
 	}
@@ -210,12 +213,15 @@ func resourceLBPoolV2Create(ctx context.Context, d *schema.ResourceData, meta in
 
 	d.SetId(pool.ID)
 
-	return resourceLBPoolV2Read(ctx, d, meta)
+	clientCtx := common.CtxWithClient(ctx, client, keyClient)
+	return resourceLBPoolV2Read(clientCtx, d, meta)
 }
 
-func resourceLBPoolV2Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLBPoolV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	client, err := config.ElbV2Client(config.GetRegion(d))
+	client, err := common.ClientFromCtx(ctx, keyClient, func() (*golangsdk.ServiceClient, error) {
+		return config.ElbV2Client(config.GetRegion(d))
+	})
 	if err != nil {
 		return fmterr.Errorf(ErrCreationV2Client, err)
 	}
@@ -250,7 +256,9 @@ func resourceLBPoolV2Read(_ context.Context, d *schema.ResourceData, meta interf
 
 func resourceLBPoolV2Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	client, err := config.ElbV2Client(config.GetRegion(d))
+	client, err := common.ClientFromCtx(ctx, keyClient, func() (*golangsdk.ServiceClient, error) {
+		return config.ElbV2Client(config.GetRegion(d))
+	})
 	if err != nil {
 		return fmterr.Errorf(ErrCreationV2Client, err)
 	}
@@ -290,7 +298,6 @@ func resourceLBPoolV2Update(ctx context.Context, d *schema.ResourceData, meta in
 		}
 		return nil
 	})
-
 	if err != nil {
 		return fmterr.Errorf("unable to update pool %s: %w", d.Id(), err)
 	}
@@ -305,12 +312,15 @@ func resourceLBPoolV2Update(ctx context.Context, d *schema.ResourceData, meta in
 		return diag.FromErr(err)
 	}
 
-	return resourceLBPoolV2Read(ctx, d, meta)
+	clientCtx := common.CtxWithClient(ctx, client, keyClient)
+	return resourceLBPoolV2Read(clientCtx, d, meta)
 }
 
 func resourceLBPoolV2Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	client, err := config.ElbV2Client(config.GetRegion(d))
+	client, err := common.ClientFromCtx(ctx, keyClient, func() (*golangsdk.ServiceClient, error) {
+		return config.ElbV2Client(config.GetRegion(d))
+	})
 	if err != nil {
 		return fmterr.Errorf(ErrCreationV2Client, err)
 	}

--- a/releasenotes/notes/elb-v2-client-ctx-a858bcaa6cc92662.yaml
+++ b/releasenotes/notes/elb-v2-client-ctx-a858bcaa6cc92662.yaml
@@ -1,0 +1,20 @@
+---
+enhancements:
+  - |
+    **[ELB]** Reduce amount of init client requests in ``resource/opentelekomcloud_lb_member_v2`` (`#1852 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1852>`_)
+  - |
+    **[ELB]** Reduce amount of init client requests in ``resource/opentelekomcloud_lb_monitor_v2`` (`#1852 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1852>`_)
+  - |
+    **[ELB]** Reduce amount of init client requests in ``resource/opentelekomcloud_lb_pool_v2`` (`#1852 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1852>`_)
+  - |
+    **[ELB]** Reduce amount of init client requests in ``resource/opentelekomcloud_lb_whitelist_v2`` (`#1852 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1852>`_)
+  - |
+    **[ELB]** Reduce amount of init client requests in ``resource/opentelekomcloud_lb_loadbalancer_v2`` (`#1852 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1852>`_)
+  - |
+    **[ELB]** Reduce amount of init client requests in ``resource/opentelekomcloud_lb_listener_v2`` (`#1852 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1852>`_)
+  - |
+    **[ELB]** Reduce amount of init client requests in ``resource/opentelekomcloud_lb_l7rule_v2`` (`#1852 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1852>`_)
+  - |
+    **[ELB]** Reduce amount of init client requests in ``resource/opentelekomcloud_lb_l7policy_v2`` (`#1852 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1852>`_)
+  - |
+    **[ELB]** Reduce amount of init client requests in ``resource/opentelekomcloud_lb_certificate_v2`` (`#1852 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1852>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Use client from context in

- `resource/opentelekomcloud_lb_member_v2`
- `resource/opentelekomcloud_lb_monitor_v2`
- `resource/opentelekomcloud_lb_pool_v2`
- `resource/opentelekomcloud_lb_whitelist_v2`
- `resource/opentelekomcloud_lb_loadbalancer_v2`
- `resource/opentelekomcloud_lb_listener_v2`
- `resource/opentelekomcloud_lb_l7rule_v2`
- `resource/opentelekomcloud_lb_l7policy_v2`
- `resource/opentelekomcloud_lb_certificate_v2`

## PR Checklist

* [x] Refers to: #1848
* [x] Tests added/passed.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccLBV2Whitelist_basic
=== PAUSE TestAccLBV2Whitelist_basic
=== CONT  TestAccLBV2Whitelist_basic
--- PASS: TestAccLBV2Whitelist_basic (137.18s)
PASS


Process finished with the exit code 0
```

```
=== RUN   TestAccLBV2Pool_basic
=== PAUSE TestAccLBV2Pool_basic
=== CONT  TestAccLBV2Pool_basic
--- PASS: TestAccLBV2Pool_basic (168.53s)
=== RUN   TestAccLBV2Pool_persistenceNull
=== PAUSE TestAccLBV2Pool_persistenceNull
=== CONT  TestAccLBV2Pool_persistenceNull
--- PASS: TestAccLBV2Pool_persistenceNull (113.58s)
PASS


Process finished with the exit code 0
```

```
=== RUN   TestAccLBV2Monitor_basic
=== PAUSE TestAccLBV2Monitor_basic
=== CONT  TestAccLBV2Monitor_basic
--- PASS: TestAccLBV2Monitor_basic (190.35s)
=== RUN   TestAccLBV2Monitor_minConfig
=== PAUSE TestAccLBV2Monitor_minConfig
=== CONT  TestAccLBV2Monitor_minConfig
--- PASS: TestAccLBV2Monitor_minConfig (190.90s)
PASS

Process finished with the exit code 0
```

```
=== RUN   TestAccLBV2Member_basic
=== PAUSE TestAccLBV2Member_basic
=== CONT  TestAccLBV2Member_basic
--- PASS: TestAccLBV2Member_basic (231.74s)
=== RUN   TestAccLBV2Member_import
=== PAUSE TestAccLBV2Member_import
=== CONT  TestAccLBV2Member_import
--- PASS: TestAccLBV2Member_import (154.02s)
PASS


Process finished with the exit code 0
```

```
=== RUN   TestAccLBV2LoadBalancer_basic
=== PAUSE TestAccLBV2LoadBalancer_basic
=== CONT  TestAccLBV2LoadBalancer_basic
--- PASS: TestAccLBV2LoadBalancer_basic (112.45s)
=== RUN   TestAccLBV2LoadBalancer_import
=== PAUSE TestAccLBV2LoadBalancer_import
=== CONT  TestAccLBV2LoadBalancer_import
--- PASS: TestAccLBV2LoadBalancer_import (72.07s)
PASS


Process finished with the exit code 0
```

```
=== RUN   TestAccLBV2L7Rule_basic
=== PAUSE TestAccLBV2L7Rule_basic
=== CONT  TestAccLBV2L7Rule_basic
--- PASS: TestAccLBV2L7Rule_basic (179.52s)
PASS


Process finished with the exit code 0
```

```
=== RUN   TestAccLBV2L7Policy_basic
=== PAUSE TestAccLBV2L7Policy_basic
=== CONT  TestAccLBV2L7Policy_basic
--- PASS: TestAccLBV2L7Policy_basic (118.36s)
PASS


Process finished with the exit code 0
```

```
=== RUN   TestAccLBV2Certificate_basic
=== PAUSE TestAccLBV2Certificate_basic
=== CONT  TestAccLBV2Certificate_basic
--- PASS: TestAccLBV2Certificate_basic (135.80s)
=== RUN   TestAccLBV2Certificate_import
=== PAUSE TestAccLBV2Certificate_import
=== CONT  TestAccLBV2Certificate_import
--- PASS: TestAccLBV2Certificate_import (51.91s)
PASS


Process finished with the exit code 0
```

```
=== RUN   TestAccLBV2Listener_tls
=== PAUSE TestAccLBV2Listener_tls
=== CONT  TestAccLBV2Listener_tls
--- PASS: TestAccLBV2Listener_tls (144.58s)
PASS


Process finished with the exit code 0
```