### PR TITLE
[VPC] Use client from ctx in `vpc_2`

### DIFF
--- a/releasenotes/notes/vpc-client-ctx-6003195f31e238fc.yaml
+++ b/releasenotes/notes/vpc-client-ctx-6003195f31e238fc.yaml
@@ -1,0 +1,12 @@
+---
+enhancements:
+  - |
+    **[VPC]** Reduce amount of init client requests in ``resource/opentelekomcloud_networking_floatingip_associate_v2`` (`#1853 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1853>`_)
+  - |
+    **[VPC]** Reduce amount of init client requests in ``resource/opentelekomcloud_networking_floatingip_v2`` (`#1853 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1853>`_)
+  - |
+    **[VPC]** Reduce amount of init client requests in ``resource/opentelekomcloud_networking_port_v2`` (`#1853 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1853>`_)
+  - |
+    **[VPC]** Reduce amount of init client requests in ``resource/opentelekomcloud_vpc_peering_connection_v2`` (`#1853 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1853>`_)
+  - |
+    **[VPC]** Reduce amount of init client requests in ``resource/opentelekomcloud_vpc_route_v2`` (`#1853 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1853>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Use client from ctx in `floatingip_v2`, `foatingip_associate_v2`, `vpc_peering_connection_v2`, `port_v2`, `vpc_route_v2`

## PR Checklist

* [x] Refers to: #1848
* [x] Tests added/passed.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
Read comments
```
