### PR TITLE
[IAM] Make AKSK encryption optional for ``resource/opentelekomcloud_identity_credential_v3``

### DIFF
--- a/docs/resources/identity_credential_v3.md
+++ b/docs/resources/identity_credential_v3.md
@@ -52,7 +52,8 @@ The following attributes are exported:
 
 * `access` - Access key ID.
 
-* `secret` - The encrypted secret, base64 encoded. The encrypted secret may be decrypted using the command
+* `secret` - Secret key ID. If `pgp_key` is not set, secret will be in plain text.
+  The encrypted secret, base64 encoded. The encrypted secret may be decrypted using the command
   line, for example: `terraform output encrypted_secret | base64 --decode | keybase pgp decrypt`.
 
 * `create_time` - Time of the access key creation.

--- a/opentelekomcloud/acceptance/iam/resource_opentelekomcloud_identity_credential_v3_test.go
+++ b/opentelekomcloud/acceptance/iam/resource_opentelekomcloud_identity_credential_v3_test.go
@@ -35,7 +35,7 @@ func TestAccIdentityV3Credential_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccIdentityV3CredentialKeybase,
+				Config: testAccIdentityV3CredentialNoPGP,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("opentelekomcloud_identity_credential_v3.aksk", "access"),
 					resource.TestCheckResourceAttrSet("opentelekomcloud_identity_credential_v3.aksk", "secret"),
@@ -94,10 +94,9 @@ resource opentelekomcloud_identity_credential_v3 aksk {
   pgp_key = "mDMEYs6CMxYJKwYBBAHaRw8BAQdAoF5tLs+wvwvF+A5+mAfdGLrwz3bKdKsUA3iuxQcDUZe0JFZsYWRpbWlyIFZzaGl2a292IDxlbnJyb3VAZ21haWwuY29tPoiZBBMWCgBBFiEEDdv9KvPC2UDkSDiCKWyGs27oaG0FAmLOgjMCGwMFCQPCZwAFCwkIBwICIgIGFQoJCAsCBBYCAwECHgcCF4AACgkQKWyGs27oaG1VKgD8CBsP+kSZsuVXsa+OV1l3bOu1Ql1Ep7iTljk6ih+AIUUBAMIt2Xbm4UjN1RW2Z6lOOJqiMTDKZQ3y37bXdC74UKYOuDgEYs6CMxIKKwYBBAGXVQEFAQEHQE8bDiDqHGlFvwadjLXQ/FSYCWt4Hk7uOAoAdRsR+L8pAwEIB4h+BBgWCgAmFiEEDdv9KvPC2UDkSDiCKWyGs27oaG0FAmLOgjMCGwwFCQPCZwAACgkQKWyGs27oaG0FpQEApm+XVsFSaWA/cfoJadrWQwZzG3+Ifnbw/+yWk9FTxZIA/1FTrsAp/5ajz5O+knRQp6gop1lToK1HzFVgQa12gCQL"
 }
 `
-	testAccIdentityV3CredentialKeybase = `
+	testAccIdentityV3CredentialNoPGP = `
 resource opentelekomcloud_identity_credential_v3 aksk {
   description = "This is one and unique test AK/SK"
-  pgp_key = "keybase:enrrou"
 }
 `
 	testAccIdentityV3CredentialUpdateStatus = `

--- a/opentelekomcloud/services/iam/resource_opentelekomcloud_identity_credential_v3.go
+++ b/opentelekomcloud/services/iam/resource_opentelekomcloud_identity_credential_v3.go
@@ -113,6 +113,13 @@ func resourceIdentityCredentialV3Create(ctx context.Context, d *schema.ResourceD
 		if err = mErr.ErrorOrNil(); err != nil {
 			return fmterr.Errorf("error setting identity access key fields: %s", err)
 		}
+	} else {
+		mErr := multierror.Append(nil,
+			d.Set("secret", credential.SecretKey),
+		)
+		if err = mErr.ErrorOrNil(); err != nil {
+			return fmterr.Errorf("error setting identity access key fields: %s", err)
+		}
 	}
 
 	return resourceIdentityCredentialV3Read(ctx, d, meta)

--- a/opentelekomcloud/services/iam/resource_opentelekomcloud_identity_credential_v3.go
+++ b/opentelekomcloud/services/iam/resource_opentelekomcloud_identity_credential_v3.go
@@ -115,12 +115,8 @@ func resourceIdentityCredentialV3Create(ctx context.Context, d *schema.ResourceD
 			return fmterr.Errorf("error setting identity access key fields: %s", err)
 		}
 	} else {
-		mErr := multierror.Append(nil,
-			d.Set("access", credential.AccessKey),
-			d.Set("secret", credential.SecretKey),
-		)
-		if err = mErr.ErrorOrNil(); err != nil {
-			return fmterr.Errorf("error setting identity access key fields: %s", err)
+		if err := d.Set("secret", credential.SecretKey); err != nil {
+			return fmterr.Errorf("error setting identity secret key field: %w", err)
 		}
 	}
 

--- a/opentelekomcloud/services/iam/resource_opentelekomcloud_identity_credential_v3.go
+++ b/opentelekomcloud/services/iam/resource_opentelekomcloud_identity_credential_v3.go
@@ -44,8 +44,9 @@ func ResourceIdentityCredentialV3() *schema.Resource {
 				Sensitive: true,
 			},
 			"secret": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
 			},
 			"pgp_key": {
 				Type:     schema.TypeString,
@@ -115,6 +116,7 @@ func resourceIdentityCredentialV3Create(ctx context.Context, d *schema.ResourceD
 		}
 	} else {
 		mErr := multierror.Append(nil,
+			d.Set("access", credential.AccessKey),
 			d.Set("secret", credential.SecretKey),
 		)
 		if err = mErr.ErrorOrNil(); err != nil {

--- a/releasenotes/notes/iam-encryp-opt-9b1c88ad95ce7b78.yaml
+++ b/releasenotes/notes/iam-encryp-opt-9b1c88ad95ce7b78.yaml
@@ -1,0 +1,4 @@
+---
+security:
+  - |
+    **[IAM]** Make AKSK encryption optional for ``resource/opentelekomcloud_identity_credential_v3`` (`#1869 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1869>`_)


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [x] Closes #1868
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccIdentityV3Credential_basic
--- PASS: TestAccIdentityV3Credential_basic (57.94s)
PASS

Process finished with the exit code 0
```
