### PR TITLE
[EVS] Use client from ctx in `blockstorage_volume_v2`

### DIFF
--- a/opentelekomcloud/services/evs/common.go
+++ b/opentelekomcloud/services/evs/common.go
@@ -1,6 +1,7 @@
 package evs
 
 const (
-	errCreationClient = "error creating OpenTelekomCloud BlockStorageV3 client: %w"
-	keyClientV1       = "evs-v2-client"
+	errCreationClient   = "error creating OpenTelekomCloud BlockStorageV3 client: %w"
+	errCreationClientV2 = "error creating OpenTelekomCloud BlockStorageV2 client: %w"
+	keyClientV2         = "evs-v2-client"
 )

--- a/opentelekomcloud/services/evs/common.go
+++ b/opentelekomcloud/services/evs/common.go
@@ -2,4 +2,5 @@ package evs
 
 const (
 	errCreationClient = "error creating OpenTelekomCloud BlockStorageV3 client: %w"
+	keyClientV1       = "evs-v2-client"
 )

--- a/opentelekomcloud/services/evs/resource_opentelekomcloud_blockstorage_volume_v2.go
+++ b/opentelekomcloud/services/evs/resource_opentelekomcloud_blockstorage_volume_v2.go
@@ -171,11 +171,11 @@ func resourceContainerTags(d *schema.ResourceData) map[string]string {
 
 func resourceBlockStorageVolumeV2Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	client, err := common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
+	client, err := common.ClientFromCtx(ctx, keyClientV2, func() (*golangsdk.ServiceClient, error) {
 		return config.BlockStorageV2Client(config.GetRegion(d))
 	})
 	if err != nil {
-		return fmterr.Errorf(errCreationClient, err)
+		return fmterr.Errorf(errCreationClientV2, err)
 	}
 
 	metadata := resourceContainerMetadataV2(d)
@@ -233,17 +233,17 @@ func resourceBlockStorageVolumeV2Create(ctx context.Context, d *schema.ResourceD
 	// Store the ID now
 	d.SetId(v.ID)
 
-	clientCtx := common.CtxWithClient(ctx, client, keyClientV1)
+	clientCtx := common.CtxWithClient(ctx, client, keyClientV2)
 	return resourceBlockStorageVolumeV2Read(clientCtx, d, meta)
 }
 
 func resourceBlockStorageVolumeV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	client, err := common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
+	client, err := common.ClientFromCtx(ctx, keyClientV2, func() (*golangsdk.ServiceClient, error) {
 		return config.BlockStorageV2Client(config.GetRegion(d))
 	})
 	if err != nil {
-		return fmterr.Errorf(errCreationClient, err)
+		return fmterr.Errorf(errCreationClientV2, err)
 	}
 
 	v, err := volumes.Get(client, d.Id()).Extract()
@@ -330,11 +330,11 @@ OUTER:
 
 func resourceBlockStorageVolumeV2Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	client, err := common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
+	client, err := common.ClientFromCtx(ctx, keyClientV2, func() (*golangsdk.ServiceClient, error) {
 		return config.BlockStorageV2Client(config.GetRegion(d))
 	})
 	if err != nil {
-		return fmterr.Errorf(errCreationClient, err)
+		return fmterr.Errorf(errCreationClientV2, err)
 	}
 
 	updateOpts := volumes.UpdateOpts{
@@ -378,7 +378,7 @@ func resourceBlockStorageVolumeV2Update(ctx context.Context, d *schema.ResourceD
 		}
 	}
 
-	clientCtx := common.CtxWithClient(ctx, client, keyClientV1)
+	clientCtx := common.CtxWithClient(ctx, client, keyClientV2)
 	return resourceBlockStorageVolumeV2Read(clientCtx, d, meta)
 }
 
@@ -397,11 +397,11 @@ func extendSize(d *schema.ResourceData, client *golangsdk.ServiceClient) error {
 
 func resourceBlockStorageVolumeV2Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	client, err := common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
+	client, err := common.ClientFromCtx(ctx, keyClientV2, func() (*golangsdk.ServiceClient, error) {
 		return config.BlockStorageV2Client(config.GetRegion(d))
 	})
 	if err != nil {
-		return fmterr.Errorf(errCreationClient, err)
+		return fmterr.Errorf(errCreationClientV2, err)
 	}
 
 	v, err := volumes.Get(client, d.Id()).Extract()

--- a/opentelekomcloud/services/evs/resource_opentelekomcloud_blockstorage_volume_v2.go
+++ b/opentelekomcloud/services/evs/resource_opentelekomcloud_blockstorage_volume_v2.go
@@ -171,10 +171,13 @@ func resourceContainerTags(d *schema.ResourceData) map[string]string {
 
 func resourceBlockStorageVolumeV2Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	blockStorageClient, err := config.BlockStorageV2Client(config.GetRegion(d))
+	client, err := common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
+		return config.BlockStorageV2Client(config.GetRegion(d))
+	})
 	if err != nil {
-		return fmterr.Errorf("error creating OpenTelekomCloud block storage client: %s", err)
+		return fmterr.Errorf(errCreationClient, err)
 	}
+
 	metadata := resourceContainerMetadataV2(d)
 	if d.Get("device_type").(string) == "SCSI" {
 		metadata["hw:passthrough"] = "true"
@@ -195,7 +198,7 @@ func resourceBlockStorageVolumeV2Create(ctx context.Context, d *schema.ResourceD
 	}
 
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)
-	v, err := volumes.Create(blockStorageClient, createOpts).Extract()
+	v, err := volumes.Create(client, createOpts).Extract()
 	if err != nil {
 		return fmterr.Errorf("error creating OpenTelekomCloud volume: %s", err)
 	}
@@ -207,12 +210,13 @@ func resourceBlockStorageVolumeV2Create(ctx context.Context, d *schema.ResourceD
 		v.ID)
 
 	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"downloading", "creating"},
-		Target:     []string{"available"},
-		Refresh:    VolumeV2StateRefreshFunc(blockStorageClient, v.ID),
-		Timeout:    d.Timeout(schema.TimeoutCreate),
-		Delay:      10 * time.Second,
-		MinTimeout: 3 * time.Second,
+		Pending:      []string{"downloading", "creating"},
+		Target:       []string{"available"},
+		Refresh:      VolumeV2StateRefreshFunc(client, v.ID),
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		Delay:        10 * time.Second,
+		MinTimeout:   3 * time.Second,
+		PollInterval: 2 * time.Second,
 	}
 
 	_, err = stateConf.WaitForStateContext(ctx)
@@ -229,17 +233,20 @@ func resourceBlockStorageVolumeV2Create(ctx context.Context, d *schema.ResourceD
 	// Store the ID now
 	d.SetId(v.ID)
 
-	return resourceBlockStorageVolumeV2Read(ctx, d, meta)
+	clientCtx := common.CtxWithClient(ctx, client, keyClientV1)
+	return resourceBlockStorageVolumeV2Read(clientCtx, d, meta)
 }
 
-func resourceBlockStorageVolumeV2Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBlockStorageVolumeV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	blockStorageClient, err := config.BlockStorageV2Client(config.GetRegion(d))
+	client, err := common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
+		return config.BlockStorageV2Client(config.GetRegion(d))
+	})
 	if err != nil {
-		return fmterr.Errorf("error creating OpenTelekomCloud block storage client: %s", err)
+		return fmterr.Errorf(errCreationClient, err)
 	}
 
-	v, err := volumes.Get(blockStorageClient, d.Id()).Extract()
+	v, err := volumes.Get(client, d.Id()).Extract()
 	if err != nil {
 		return common.CheckDeletedDiag(d, err, "volume")
 	}
@@ -323,9 +330,11 @@ OUTER:
 
 func resourceBlockStorageVolumeV2Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	blockStorageClient, err := config.BlockStorageV2Client(config.GetRegion(d))
+	client, err := common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
+		return config.BlockStorageV2Client(config.GetRegion(d))
+	})
 	if err != nil {
-		return fmterr.Errorf("error creating OpenTelekomCloud block storage client: %s", err)
+		return fmterr.Errorf(errCreationClient, err)
 	}
 
 	updateOpts := volumes.UpdateOpts{
@@ -337,7 +346,7 @@ func resourceBlockStorageVolumeV2Update(ctx context.Context, d *schema.ResourceD
 		updateOpts.Metadata = resourceVolumeMetadataV2(d)
 	}
 
-	_, err = volumes.Update(blockStorageClient, d.Id(), updateOpts).Extract()
+	_, err = volumes.Update(client, d.Id(), updateOpts).Extract()
 	if err != nil {
 		return fmterr.Errorf("error updating OpenTelekomCloud volume: %s", err)
 	}
@@ -349,17 +358,18 @@ func resourceBlockStorageVolumeV2Update(ctx context.Context, d *schema.ResourceD
 	}
 
 	if d.HasChange("size") {
-		if err := extendSize(d, blockStorageClient); err != nil {
+		if err := extendSize(d, client); err != nil {
 			return diag.FromErr(err)
 		}
 
 		stateConf := &resource.StateChangeConf{
-			Pending:    []string{"extending"},
-			Target:     []string{"available", "in-use"},
-			Refresh:    VolumeV2StateRefreshFunc(blockStorageClient, d.Id()),
-			Timeout:    d.Timeout(schema.TimeoutDelete),
-			Delay:      10 * time.Second,
-			MinTimeout: 3 * time.Second,
+			Pending:      []string{"extending"},
+			Target:       []string{"available", "in-use"},
+			Refresh:      VolumeV2StateRefreshFunc(client, d.Id()),
+			Timeout:      d.Timeout(schema.TimeoutDelete),
+			Delay:        10 * time.Second,
+			MinTimeout:   3 * time.Second,
+			PollInterval: 2 * time.Second,
 		}
 
 		_, err = stateConf.WaitForStateContext(ctx)
@@ -368,7 +378,8 @@ func resourceBlockStorageVolumeV2Update(ctx context.Context, d *schema.ResourceD
 		}
 	}
 
-	return resourceBlockStorageVolumeV2Read(ctx, d, meta)
+	clientCtx := common.CtxWithClient(ctx, client, keyClientV1)
+	return resourceBlockStorageVolumeV2Read(clientCtx, d, meta)
 }
 
 func extendSize(d *schema.ResourceData, client *golangsdk.ServiceClient) error {
@@ -386,12 +397,14 @@ func extendSize(d *schema.ResourceData, client *golangsdk.ServiceClient) error {
 
 func resourceBlockStorageVolumeV2Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	blockStorageClient, err := config.BlockStorageV2Client(config.GetRegion(d))
+	client, err := common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
+		return config.BlockStorageV2Client(config.GetRegion(d))
+	})
 	if err != nil {
-		return fmterr.Errorf("error creating OpenTelekomCloud block storage client: %s", err)
+		return fmterr.Errorf(errCreationClient, err)
 	}
 
-	v, err := volumes.Get(blockStorageClient, d.Id()).Extract()
+	v, err := volumes.Get(client, d.Id()).Extract()
 	if err != nil {
 		return common.CheckDeletedDiag(d, err, "volume")
 	}
@@ -410,12 +423,13 @@ func resourceBlockStorageVolumeV2Delete(ctx context.Context, d *schema.ResourceD
 			}
 
 			stateConf := &resource.StateChangeConf{
-				Pending:    []string{"in-use", "attaching", "detaching"},
-				Target:     []string{"available"},
-				Refresh:    VolumeV2StateRefreshFunc(blockStorageClient, d.Id()),
-				Timeout:    d.Timeout(schema.TimeoutDelete),
-				Delay:      10 * time.Second,
-				MinTimeout: 3 * time.Second,
+				Pending:      []string{"in-use", "attaching", "detaching"},
+				Target:       []string{"available"},
+				Refresh:      VolumeV2StateRefreshFunc(client, d.Id()),
+				Timeout:      d.Timeout(schema.TimeoutDelete),
+				Delay:        10 * time.Second,
+				MinTimeout:   3 * time.Second,
+				PollInterval: 2 * time.Second,
 			}
 
 			_, err = stateConf.WaitForStateContext(ctx)
@@ -435,7 +449,7 @@ func resourceBlockStorageVolumeV2Delete(ctx context.Context, d *schema.ResourceD
 	// in a "deleting" state from when the instance was terminated.
 	// If this is true, just move on. It'll eventually delete.
 	if v.Status != "deleting" {
-		if err := volumes.Delete(blockStorageClient, d.Id(), deleteOpts).ExtractErr(); err != nil {
+		if err := volumes.Delete(client, d.Id(), deleteOpts).ExtractErr(); err != nil {
 			return common.CheckDeletedDiag(d, err, "volume")
 		}
 	}
@@ -444,12 +458,13 @@ func resourceBlockStorageVolumeV2Delete(ctx context.Context, d *schema.ResourceD
 	log.Printf("[DEBUG] Waiting for volume (%s) to delete", d.Id())
 
 	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"deleting", "downloading", "available"},
-		Target:     []string{"deleted"},
-		Refresh:    VolumeV2StateRefreshFunc(blockStorageClient, d.Id()),
-		Timeout:    d.Timeout(schema.TimeoutDelete),
-		Delay:      10 * time.Second,
-		MinTimeout: 3 * time.Second,
+		Pending:      []string{"deleting", "downloading", "available"},
+		Target:       []string{"deleted"},
+		Refresh:      VolumeV2StateRefreshFunc(client, d.Id()),
+		Timeout:      d.Timeout(schema.TimeoutDelete),
+		Delay:        10 * time.Second,
+		MinTimeout:   3 * time.Second,
+		PollInterval: 2 * time.Second,
 	}
 
 	_, err = stateConf.WaitForStateContext(ctx)

--- a/releasenotes/notes/blockstorage-volume-client-ctx-b848f750a1870231.yaml
+++ b/releasenotes/notes/blockstorage-volume-client-ctx-b848f750a1870231.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[EVS]** Reduce amount of init client requests in ``resource/opentelekomcloud_blockstorage_volume_v2`` (`#1871 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1871>`_)


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [x] Refers to: #1848
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccBlockStorageV2Volume_basic
=== PAUSE TestAccBlockStorageV2Volume_basic
=== CONT  TestAccBlockStorageV2Volume_basic
--- PASS: TestAccBlockStorageV2Volume_basic (116.56s)
=== RUN   TestAccBlockStorageV2Volume_importBasic
=== PAUSE TestAccBlockStorageV2Volume_importBasic
=== CONT  TestAccBlockStorageV2Volume_importBasic
--- PASS: TestAccBlockStorageV2Volume_importBasic (87.06s)
=== RUN   TestAccBlockStorageV2Volume_upscaleDownScale
=== PAUSE TestAccBlockStorageV2Volume_upscaleDownScale
=== CONT  TestAccBlockStorageV2Volume_upscaleDownScale
--- PASS: TestAccBlockStorageV2Volume_upscaleDownScale (194.41s)
=== RUN   TestAccBlockStorageV2Volume_upscaleDownScaleAssigned
=== PAUSE TestAccBlockStorageV2Volume_upscaleDownScaleAssigned
=== CONT  TestAccBlockStorageV2Volume_upscaleDownScaleAssigned
--- PASS: TestAccBlockStorageV2Volume_upscaleDownScaleAssigned (337.64s)
=== RUN   TestAccBlockStorageV2Volume_tags
=== PAUSE TestAccBlockStorageV2Volume_tags
=== CONT  TestAccBlockStorageV2Volume_tags
--- PASS: TestAccBlockStorageV2Volume_tags (121.28s)
=== RUN   TestAccBlockStorageV2Volume_image
=== PAUSE TestAccBlockStorageV2Volume_image
=== CONT  TestAccBlockStorageV2Volume_image
--- PASS: TestAccBlockStorageV2Volume_image (82.82s)
=== RUN   TestAccBlockStorageV2Volume_timeout
=== PAUSE TestAccBlockStorageV2Volume_timeout
=== CONT  TestAccBlockStorageV2Volume_timeout
--- PASS: TestAccBlockStorageV2Volume_timeout (77.13s)
PASS


Process finished with the exit code 0
```
