### PR TITLE
[OBS]: Fix bucket creation for ``Swisscloud``

### DIFF
--- a/opentelekomcloud/services/obs/resource_opentelekomcloud_obs_bucket.go
+++ b/opentelekomcloud/services/obs/resource_opentelekomcloud_obs_bucket.go
@@ -40,6 +40,7 @@ func ResourceObsBucket() *schema.Resource {
 			"storage_class": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Default:  "STANDARD",
 				ValidateFunc: validation.StringInSlice([]string{
 					"STANDARD", "WARM", "COLD",
 				}, true),
@@ -323,7 +324,12 @@ func resourceObsBucketCreate(ctx context.Context, d *schema.ResourceData, meta i
 
 	bucket := d.Get("bucket").(string)
 	acl := d.Get("acl").(string)
-	class := d.Get("storage_class").(string)
+
+	var class string
+	if config.GetRegion(d) != "eu-ch2" {
+		class = d.Get("storage_class").(string)
+	}
+
 	opts := &obs.CreateBucketInput{
 		Bucket:       bucket,
 		ACL:          obs.AclType(acl),
@@ -356,7 +362,7 @@ func resourceObsBucketUpdate(ctx context.Context, d *schema.ResourceData, meta i
 		}
 	}
 
-	if d.HasChange("storage_class") && !d.IsNewResource() {
+	if d.HasChange("storage_class") && !d.IsNewResource() && config.GetRegion(d) != "eu-ch2" {
 		if err := resourceObsBucketClassUpdate(client, d); err != nil {
 			return diag.FromErr(err)
 		}
@@ -453,8 +459,8 @@ func resourceObsBucketRead(_ context.Context, d *schema.ResourceData, meta inter
 	}
 
 	// Read storage class
-	if err := setObsBucketStorageClass(client, d); err != nil {
-		if region != "eu-ch2" {
+	if region != "eu-ch2" {
+		if err := setObsBucketStorageClass(client, d); err != nil {
 			return diag.FromErr(err)
 		}
 	}

--- a/opentelekomcloud/services/obs/resource_opentelekomcloud_obs_bucket.go
+++ b/opentelekomcloud/services/obs/resource_opentelekomcloud_obs_bucket.go
@@ -40,7 +40,6 @@ func ResourceObsBucket() *schema.Resource {
 			"storage_class": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "STANDARD",
 				ValidateFunc: validation.StringInSlice([]string{
 					"STANDARD", "WARM", "COLD",
 				}, true),
@@ -455,7 +454,9 @@ func resourceObsBucketRead(_ context.Context, d *schema.ResourceData, meta inter
 
 	// Read storage class
 	if err := setObsBucketStorageClass(client, d); err != nil {
-		return diag.FromErr(err)
+		if region != "eu-ch2" {
+			return diag.FromErr(err)
+		}
 	}
 
 	// Read the versioning

--- a/releasenotes/notes/obs_swisscloud_fix-47c9d9c86fb69827.yaml
+++ b/releasenotes/notes/obs_swisscloud_fix-47c9d9c86fb69827.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    **[OBS]** Fix bucket creation on Swisscloud for ``resource/opentelekomcloud_obs_bucket`` (`# <>`_)
+    **[OBS]** Fix bucket creation on Swisscloud for ``resource/opentelekomcloud_obs_bucket`` (`#1904 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1904>`_)

--- a/releasenotes/notes/obs_swisscloud_fix-47c9d9c86fb69827.yaml
+++ b/releasenotes/notes/obs_swisscloud_fix-47c9d9c86fb69827.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[OBS]** Fix bucket creation on Swisscloud for ``resource/opentelekomcloud_obs_bucket`` (`# <>`_)


### PR DESCRIPTION
## Summary of the Pull Request
PR fixes bucket creation (OBS - Huawei API) on ``Swisscloud`` region.

## PR Checklist

* [x] Refers to: #1886 
* [x] Refers to: #1872
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed (Passed on both ``eu-de`` and ``eu-ch2``)
=== RUN   TestAccObsBucket_basic
=== PAUSE TestAccObsBucket_basic
=== CONT  TestAccObsBucket_basic
--- PASS: TestAccObsBucket_basic (100.00s)
=== RUN   TestAccObsBucket_tags
=== PAUSE TestAccObsBucket_tags
=== CONT  TestAccObsBucket_tags
--- PASS: TestAccObsBucket_tags (37.46s)
=== RUN   TestAccObsBucket_versioning
=== PAUSE TestAccObsBucket_versioning
=== CONT  TestAccObsBucket_versioning
--- PASS: TestAccObsBucket_versioning (70.11s)
=== RUN   TestAccObsBucket_logging
=== PAUSE TestAccObsBucket_logging
=== CONT  TestAccObsBucket_logging
--- PASS: TestAccObsBucket_logging (45.85s)
=== RUN   TestAccObsBucket_lifecycle
=== PAUSE TestAccObsBucket_lifecycle
=== CONT  TestAccObsBucket_lifecycle
--- PASS: TestAccObsBucket_lifecycle (39.04s)
=== RUN   TestAccObsBucket_website
=== PAUSE TestAccObsBucket_website
=== CONT  TestAccObsBucket_website
--- PASS: TestAccObsBucket_website (38.98s)
=== RUN   TestAccObsBucket_cors
=== PAUSE TestAccObsBucket_cors
=== CONT  TestAccObsBucket_cors
--- PASS: TestAccObsBucket_cors (38.57s)
=== RUN   TestAccObsBucket_notifications
=== PAUSE TestAccObsBucket_notifications
=== CONT  TestAccObsBucket_notifications
--- PASS: TestAccObsBucket_notifications (49.23s)
PASS

Process finished with the exit code 0



=== RUN   TestAccObsBucketPolicyBasic
=== PAUSE TestAccObsBucketPolicyBasic
=== CONT  TestAccObsBucketPolicyBasic
--- PASS: TestAccObsBucketPolicyBasic (41.80s)
=== RUN   TestAccObsBucketPolicyUpdate
=== PAUSE TestAccObsBucketPolicyUpdate
=== CONT  TestAccObsBucketPolicyUpdate
--- PASS: TestAccObsBucketPolicyUpdate (73.73s)
=== RUN   TestAccObsBucketPolicyMalformed
=== PAUSE TestAccObsBucketPolicyMalformed
=== CONT  TestAccObsBucketPolicyMalformed
--- PASS: TestAccObsBucketPolicyMalformed (82.70s)
PASS

Process finished with the exit code 0

=== RUN   TestAccDataSourceObsBucketObject_basic
=== PAUSE TestAccDataSourceObsBucketObject_basic
=== CONT  TestAccDataSourceObsBucketObject_basic
--- PASS: TestAccDataSourceObsBucketObject_basic (73.56s)
=== RUN   TestAccDataSourceObsBucketObject_readableBody
=== PAUSE TestAccDataSourceObsBucketObject_readableBody
=== CONT  TestAccDataSourceObsBucketObject_readableBody
--- PASS: TestAccDataSourceObsBucketObject_readableBody (74.63s)
=== RUN   TestAccDataSourceObsBucketObject_allParams
=== PAUSE TestAccDataSourceObsBucketObject_allParams
=== CONT  TestAccDataSourceObsBucketObject_allParams
--- PASS: TestAccDataSourceObsBucketObject_allParams (73.66s)
PASS

Process finished with the exit code 0
```
