### PR TITLE
[CCE]: Fix ``kube_proxy_mode`` parameter for ``resource/opentelekomcloud_cce_cluster_v3``

### DIFF
--- a/docs/resources/cce_cluster_v3.md
+++ b/docs/resources/cce_cluster_v3.md
@@ -33,6 +33,7 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   subnet_id              = var.subnet_id
   container_network_type = "overlay_l2"
   authentication_mode    = "rbac"
+  kube_proxy_mode        = "ipvs"
 }
 ```
 
@@ -151,6 +152,15 @@ The following arguments are supported:
 
 * `ignore_addons` - (Optional) Skip all cluster addons operations.
 
+* `kube_proxy_mode` - Service forwarding mode. Two modes are available:
+  * `iptables`: Traditional kube-proxy uses iptables rules to implement service load balancing.
+    In this mode, too many iptables rules will be generated when many services are deployed.
+    In addition, non-incremental updates will cause a latency and even obvious performance issues
+    in the case of heavy service traffic.
+  * `ipvs`: Optimized kube-proxy mode with higher throughput and faster speed.
+    This mode supports incremental updates and can keep connections uninterrupted during service updates.
+    It is suitable for large-sized clusters.
+
 ## Attributes Reference
 
 All above argument parameters can be exported as attribute parameters along with attribute reference.
@@ -176,15 +186,6 @@ All above argument parameters can be exported as attribute parameters along with
 * `certificate_users/client_certificate_data` - The client certificate data.
 
 * `certificate_users/client_key_data` - The client key data.
-
-* `kube_proxy_mode` - Service forwarding mode. Two modes are available:
-  * `iptables`: Traditional kube-proxy uses iptables rules to implement service load balancing.
-  In this mode, too many iptables rules will be generated when many services are deployed.
-  In addition, non-incremental updates will cause a latency and even obvious performance issues
-  in the case of heavy service traffic.
-  * `ipvs`: Optimized kube-proxy mode with higher throughput and faster speed.
-  This mode supports incremental updates and can keep connections uninterrupted during service updates.
-  It is suitable for large-sized clusters.
 
 * `installed_addons` - List of installed addon IDs. Empty if `ignore_addons` is `true`.
 

--- a/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_cluster_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_cluster_v3_test.go
@@ -39,7 +39,7 @@ func TestAccCCEClusterV3_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceClusterName, "flavor_id", "cce.s1.small"),
 					resource.TestCheckResourceAttr(resourceClusterName, "container_network_type", "overlay_l2"),
 					resource.TestCheckResourceAttr(resourceClusterName, "authentication_mode", "x509"),
-					resource.TestCheckResourceAttr(resourceClusterName, "kube_proxy_mode", "iptables"),
+					resource.TestCheckResourceAttr(resourceClusterName, "kube_proxy_mode", "ipvs"),
 					resource.TestCheckResourceAttr(resourceClusterName, "kubernetes_svc_ip_range", "10.247.0.0/16"),
 					resource.TestCheckResourceAttrSet(resourceClusterName, "security_group_control"),
 					resource.TestCheckResourceAttrSet(resourceClusterName, "security_group_node"),
@@ -49,6 +49,7 @@ func TestAccCCEClusterV3_basic(t *testing.T) {
 				Config: testAccCCEClusterV3Update(clusterName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceClusterName, "description", "new description"),
+					resource.TestCheckResourceAttr(resourceClusterName, "kube_proxy_mode", "ipvs"),
 				),
 			},
 		},
@@ -76,7 +77,7 @@ func TestAccCCEClusterV3_turbo_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceClusterName, "flavor_id", "cce.s1.small"),
 					resource.TestCheckResourceAttr(resourceClusterName, "container_network_type", "eni"),
 					resource.TestCheckResourceAttr(resourceClusterName, "authentication_mode", "rbac"),
-					resource.TestCheckResourceAttr(resourceClusterName, "kube_proxy_mode", "ipvs"),
+					resource.TestCheckResourceAttr(resourceClusterName, "kube_proxy_mode", "iptables"),
 					resource.TestCheckResourceAttr(resourceClusterName, "kubernetes_svc_ip_range", "10.247.0.0/16"),
 					resource.TestCheckResourceAttrSet(resourceClusterName, "security_group_control"),
 					resource.TestCheckResourceAttrSet(resourceClusterName, "security_group_node"),
@@ -294,6 +295,7 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   container_network_type  = "overlay_l2"
   kubernetes_svc_ip_range = "10.247.0.0/16"
   ignore_addons           = true
+  kube_proxy_mode         = "ipvs"
 }
 `, common.DataSourceSubnet, clusterName)
 }
@@ -331,6 +333,7 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   description             = "new description"
   kubernetes_svc_ip_range = "10.247.0.0/16"
   ignore_addons           = true
+  kube_proxy_mode         = "ipvs"
 }
 `, common.DataSourceSubnet, clusterName)
 }

--- a/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_cluster_v3.go
+++ b/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_cluster_v3.go
@@ -197,9 +197,13 @@ func ResourceCCEClusterV3() *schema.Resource {
 				Computed: true,
 				ForceNew: true,
 			},
-			"kube_proxy_mode": { // can't be set via API currently
+			"kube_proxy_mode": {
 				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
 				Computed: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"ipvs", "iptables"}, true),
 			},
 			"multi_az": {
 				Type:     schema.TypeBool,

--- a/releasenotes/notes/cce_kubeproxy-704685ec06e55cdf.yaml
+++ b/releasenotes/notes/cce_kubeproxy-704685ec06e55cdf.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[CCE]** Fix ``kube_proxy_mode`` after CCE update for ``resource/opentelekomcloud_cce_cluster_v3`` (`# <>`_)

--- a/releasenotes/notes/cce_kubeproxy-704685ec06e55cdf.yaml
+++ b/releasenotes/notes/cce_kubeproxy-704685ec06e55cdf.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    **[CCE]** Fix ``kube_proxy_mode`` after CCE update for ``resource/opentelekomcloud_cce_cluster_v3`` (`# <>`_)
+    **[CCE]** Fix ``kube_proxy_mode`` after CCE update for ``resource/opentelekomcloud_cce_cluster_v3`` (`#1920 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1920>`_)


### PR DESCRIPTION
## Summary of the Pull Request
After CCE update ``kube_proxy_mode`` can be managed by users through API.
This PR enables this management.

## PR Checklist

* [x] Refers to: #1025 
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

=== RUN   TestAccCCEClusterV3_invalidNetwork
=== PAUSE TestAccCCEClusterV3_invalidNetwork
=== CONT  TestAccCCEClusterV3_invalidNetwork
--- PASS: TestAccCCEClusterV3_invalidNetwork (30.37s)
PASS

Process finished with the exit code 0

=== RUN   TestAccCCEClusterV3_importBasic
=== PAUSE TestAccCCEClusterV3_importBasic
=== CONT  TestAccCCEClusterV3_importBasic
--- PASS: TestAccCCEClusterV3_importBasic (469.85s)
PASS

Process finished with the exit code 0

=== RUN   TestAccCCEClusterV3_proxyAuth
=== PAUSE TestAccCCEClusterV3_proxyAuth
=== CONT  TestAccCCEClusterV3_proxyAuth
--- PASS: TestAccCCEClusterV3_proxyAuth (530.74s)
PASS

Process finished with the exit code 0

=== RUN   TestAccCCEClusterV3_basic
=== PAUSE TestAccCCEClusterV3_basic
=== CONT  TestAccCCEClusterV3_basic
--- PASS: TestAccCCEClusterV3_basic (498.87s)
PASS

Process finished with the exit code 0

=== RUN   TestAccCCEClusterV3_timeout
=== PAUSE TestAccCCEClusterV3_timeout
=== CONT  TestAccCCEClusterV3_timeout
--- PASS: TestAccCCEClusterV3_timeout (501.57s)
PASS

Process finished with the exit code 0

=== RUN   TestAccCCEClusterV3NoAddons
=== PAUSE TestAccCCEClusterV3NoAddons
=== CONT  TestAccCCEClusterV3NoAddons
--- PASS: TestAccCCEClusterV3NoAddons (487.48s)
PASS

Process finished with the exit code 0

=== RUN   TestAccCCEClusterV3_withVersionDiff
=== PAUSE TestAccCCEClusterV3_withVersionDiff
=== CONT  TestAccCCEClusterV3_withVersionDiff
--- PASS: TestAccCCEClusterV3_withVersionDiff (470.68s)
PASS

Process finished with the exit code 0
```
