### PR TITLE
[EVS]: extracts removal after gophertelecomcloud refactoring

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/jinzhu/copier v0.3.5
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.5.23-0.20220907162645-a6afe2392377
+	github.com/opentelekomcloud/gophertelekomcloud v0.5.23-0.20220907195812-efeca53f22aa
 	github.com/unknwon/com v1.0.1
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -204,10 +204,6 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.5.22 h1:7Wbs2Vw5SUWTvRBmsyusVth0nEcxloEaYSRBdpUDwl8=
-github.com/opentelekomcloud/gophertelekomcloud v0.5.22/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
-github.com/opentelekomcloud/gophertelekomcloud v0.5.23-0.20220907162645-a6afe2392377 h1:ggNKm5z6LBSag5MCfYeXoCG1AshK3PNDhkgYXGmSm+w=
-github.com/opentelekomcloud/gophertelekomcloud v0.5.23-0.20220907162645-a6afe2392377/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
 github.com/opentelekomcloud/gophertelekomcloud v0.5.23-0.20220907195812-efeca53f22aa h1:EQqvKcia1RwBWJ0dVtYJkd+QBcbBJ9tbmT6AL1AWlnc=
 github.com/opentelekomcloud/gophertelekomcloud v0.5.23-0.20220907195812-efeca53f22aa/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/opentelekomcloud/common/customize_diffs.go
+++ b/opentelekomcloud/common/customize_diffs.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/opentelekomcloud/gophertelekomcloud/openstack/blockstorage/v1/volumetypes"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/evs/v1/volumetypes"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v1/subnets"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v1/vpcs"
 
@@ -65,13 +65,9 @@ func ValidateVolumeType(argName string) schema.CustomizeDiffFunc {
 			return fmt.Errorf("error creating blockstorage v3 client: %s", err)
 		}
 
-		pages, err := volumetypes.List(client).AllPages()
+		types, err := volumetypes.List(client)
 		if err != nil {
 			return fmt.Errorf("error retrieving volume types: %s", err)
-		}
-		types, err := volumetypes.ExtractVolumeTypes(pages)
-		if err != nil {
-			return err
 		}
 		typeAZs := make(map[string][]string) // map of type name (lower case) -> az list
 		for _, volumeType := range types {

--- a/releasenotes/notes/evs_v1_refactoring-fdf6e66f3e4a4ecd.yaml
+++ b/releasenotes/notes/evs_v1_refactoring-fdf6e66f3e4a4ecd.yaml
@@ -1,0 +1,4 @@
+---
+other:
+  - |
+    **[EVS]** Get rid of inline Extracts for ``common/customize_diffs`` after gophertelekomcloud refactoring (`# <>`_)

--- a/releasenotes/notes/evs_v1_refactoring-fdf6e66f3e4a4ecd.yaml
+++ b/releasenotes/notes/evs_v1_refactoring-fdf6e66f3e4a4ecd.yaml
@@ -1,4 +1,4 @@
 ---
 other:
   - |
-    **[EVS]** Get rid of inline Extracts for ``common/customize_diffs`` after gophertelekomcloud refactoring (`# <>`_)
+    **[EVS]** Get rid of inline Extracts for ``common/customize_diffs`` after gophertelekomcloud refactoring (`#1924 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1924>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Terraform update after ``blockstorage/v1/volumetypes `` refactoring for gophertelecomcloud.

## PR Checklist

* [x] Tests added/passed.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccEvsStorageV3Volume_basic
=== PAUSE TestAccEvsStorageV3Volume_basic
=== CONT  TestAccEvsStorageV3Volume_basic
--- PASS: TestAccEvsStorageV3Volume_basic (109.28s)
=== RUN   TestAccEvsStorageV3Volume_tags
=== PAUSE TestAccEvsStorageV3Volume_tags
=== CONT  TestAccEvsStorageV3Volume_tags
--- PASS: TestAccEvsStorageV3Volume_tags (106.46s)
=== RUN   TestAccEvsStorageV3Volume_image
=== PAUSE TestAccEvsStorageV3Volume_image
=== CONT  TestAccEvsStorageV3Volume_image
--- PASS: TestAccEvsStorageV3Volume_image (76.39s)
=== RUN   TestAccEvsStorageV3Volume_timeout
=== PAUSE TestAccEvsStorageV3Volume_timeout
=== CONT  TestAccEvsStorageV3Volume_timeout
--- PASS: TestAccEvsStorageV3Volume_timeout (65.62s)
=== RUN   TestAccEvsStorageV3Volume_volumeType
=== PAUSE TestAccEvsStorageV3Volume_volumeType
=== CONT  TestAccEvsStorageV3Volume_volumeType
--- PASS: TestAccEvsStorageV3Volume_volumeType (11.93s)
=== RUN   TestAccEvsStorageV3Volume_resize
=== PAUSE TestAccEvsStorageV3Volume_resize
=== CONT  TestAccEvsStorageV3Volume_resize
--- PASS: TestAccEvsStorageV3Volume_resize (122.04s)
PASS

Process finished with the exit code 0
```
