### PR TITLE
[CSS]: Schema fix for ``datastore`` parameter of ``resource/opentelekomcloud_css_cluster_v1`` 

### DIFF
--- a/opentelekomcloud/acceptance/css/resource_opentelekomcloud_css_cluster_v1_test.go
+++ b/opentelekomcloud/acceptance/css/resource_opentelekomcloud_css_cluster_v1_test.go
@@ -207,9 +207,7 @@ resource "opentelekomcloud_css_cluster_v1" "cluster" {
 
     availability_zone = "%s"
   }
-  datastore {
-    version = "7.6.2"
-  }
+
   enable_https     = true
   enable_authority = true
   admin_pass       = "QwertyUI!"

--- a/opentelekomcloud/services/css/resource_opentelekomcloud_css_cluster_v1.go
+++ b/opentelekomcloud/services/css/resource_opentelekomcloud_css_cluster_v1.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/css/v1/clusters"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/css/v1/flavors"
@@ -155,8 +156,11 @@ func ResourceCssClusterV1() *schema.Resource {
 						"version": {
 							Type:     schema.TypeString,
 							Optional: true,
-							Computed: true,
 							ForceNew: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"7.6.2", "7.9.3",
+							}, false),
+							Default: "7.6.2",
 						},
 					},
 				},
@@ -243,6 +247,8 @@ func resourceCssClusterV1Create(ctx context.Context, d *schema.ResourceData, met
 			Version: d.Get("datastore.0.version").(string),
 			Type:    d.Get("datastore.0.type").(string),
 		}
+	} else {
+		opts.Datastore = &defaultDatastore
 	}
 
 	created, err := clusters.Create(client, opts).Extract()

--- a/opentelekomcloud/services/css/utils.go
+++ b/opentelekomcloud/services/css/utils.go
@@ -1,3 +1,10 @@
 package css
 
+import "github.com/opentelekomcloud/gophertelekomcloud/openstack/css/v1/clusters"
+
 const clientError = `error creating CSSv1 client: %w`
+
+var defaultDatastore = clusters.Datastore{
+	Version: "7.6.2",
+	Type:    "elasticsearch",
+}

--- a/releasenotes/notes/css_datastore_fix-af49733981fbc5d9.yaml
+++ b/releasenotes/notes/css_datastore_fix-af49733981fbc5d9.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[CSS]** Schema ``version`` fix for ``resource/opentelekomcloud_ccss_cluster_v1`` documentation (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)

--- a/releasenotes/notes/css_datastore_fix-af49733981fbc5d9.yaml
+++ b/releasenotes/notes/css_datastore_fix-af49733981fbc5d9.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    **[CSS]** Schema ``version`` fix for ``resource/opentelekomcloud_ccss_cluster_v1`` documentation (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[CSS]** Schema ``version`` fix for ``resource/opentelekomcloud_ccss_cluster_v1`` documentation (`#1931 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1931>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Fix for ``resource/opentelekomcloud_ccss_cluster_v1`` creation when ``datastore`` fields is not set

## PR Checklist

* [x] Closes: #1929 
* [x] Tests added/passed.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccCssClusterV1_tags
=== PAUSE TestAccCssClusterV1_tags
=== CONT  TestAccCssClusterV1_tags
--- PASS: TestAccCssClusterV1_tags (984.92s)

Process finished with the exit code 0

=== RUN   TestAccCssClusterV1_basic
=== PAUSE TestAccCssClusterV1_basic
=== CONT  TestAccCssClusterV1_basic
--- PASS: TestAccCssClusterV1_basic (1957.16s)

Process finished with the exit code 0

=== RUN   TestAccCssClusterV1_validateDiskAndFlavor
=== PAUSE TestAccCssClusterV1_validateDiskAndFlavor
=== CONT  TestAccCssClusterV1_validateDiskAndFlavor
--- PASS: TestAccCssClusterV1_validateDiskAndFlavor (50.87s)
PASS

Process finished with the exit code 0

=== RUN   TestAccCssClusterV1_encrypted
=== PAUSE TestAccCssClusterV1_encrypted
=== CONT  TestAccCssClusterV1_encrypted
--- PASS: TestAccCssClusterV1_encrypted (920.05s)
PASS

Process finished with the exit code 0
```
