### PR TITLE
[SDSR]: Documentation fix related to ``active-active domain`` resources, tests update

### DIFF
--- a/docs/data-sources/sdrs_domain_v1.md
+++ b/docs/data-sources/sdrs_domain_v1.md
@@ -6,7 +6,15 @@ subcategory: "Storage Disaster Recovery Service (SDRS)"
 
 Use this data source to get the ID of an available OpenTelekomcloud SDRS domain.
 
+~>
+    OTC supports a single ``active-active domain`` with default name ``domain_001``.
+
 ## Example Usage
+
+~>
+  **Result of both examples will be the same.**
+
+### Querying ``active-active domain`` with ``name`` parameter.
 
 ```hcl
 data "opentelekomcloud_sdrs_domain_v1" "dom_1" {
@@ -15,9 +23,18 @@ data "opentelekomcloud_sdrs_domain_v1" "dom_1" {
 
 ```
 
+### Querying ``active-active domain`` without ``name`` parameter.
+
+
+```hcl
+data "opentelekomcloud_sdrs_domain_v1" "dom_1" {}
+
+```
+
 ## Argument Reference
 
 * `name` - (Optional) Specifies the name of an active-active domain.
+  This parameter serves as filter for querying ``active-active`` domains and can be skipped in current version.
 
 ## Attributes Reference
 

--- a/docs/resources/sdrs_protectiongroup_v1.md
+++ b/docs/resources/sdrs_protectiongroup_v1.md
@@ -9,6 +9,8 @@ Manages a SDRS protection group resource within OpenTelekomCloud.
 ## Example Usage
 
 ```hcl
+data "opentelekomcloud_sdrs_domain_v1" "dom_1" {}
+
 resource "opentelekomcloud_sdrs_protectiongroup_v1" "group_1" {
   name        = "group_1"
   description = "test description"
@@ -16,7 +18,7 @@ resource "opentelekomcloud_sdrs_protectiongroup_v1" "group_1" {
   source_availability_zone = "eu-de-01"
   target_availability_zone = "eu-de-02"
 
-  domain_id     = var.domain_id
+  domain_id     = data.opentelekomcloud_sdrs_domain_v1.dom_1.id
   source_vpc_id = var.vpc_id
   dr_type       = "migration"
 }
@@ -34,7 +36,9 @@ The following arguments are supported:
 
 * `target_availability_zone` - (Required) Specifies the target AZ of a protection group. Changing this creates a new group.
 
-* `domain_id` - (Required) Specifies the ID of an active-active domain. Changing this creates a new group.
+* `domain_id` - (Required) Specifies the ID of an ``active-active domain``. Changing this creates a new group.
+  An ``active-active domain`` id can be extracted from ``data/opentelekomcloud_sdrs_domain_v1`` and shouldn't be confused
+  with tenant ``domain``.
 
 * `source_vpc_id` - (Required) Specifies the ID of the source VPC. Changing this creates a new group.
 

--- a/opentelekomcloud/acceptance/sdrs/data_source_opentelekomcloud_sdrs_domain_v1_test.go
+++ b/opentelekomcloud/acceptance/sdrs/data_source_opentelekomcloud_sdrs_domain_v1_test.go
@@ -28,6 +28,22 @@ func TestAccSdrsDomainV1DataSource_basic(t *testing.T) {
 	})
 }
 
+func TestAccSdrsDomainV1DataSource_withoutName(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSdrsDomainV1DataSource_withoutName,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSdrsDomainV1DataSourceID(domainDataName),
+					resource.TestCheckResourceAttr(domainDataName, "name", "domain_001"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckSdrsDomainV1DataSourceID(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -46,5 +62,10 @@ func testAccCheckSdrsDomainV1DataSourceID(n string) resource.TestCheckFunc {
 const testAccSdrsDomainV1DataSource_basic = `
 data "opentelekomcloud_sdrs_domain_v1" "domain_1" {
   name = "domain_001"
+}
+`
+
+const testAccSdrsDomainV1DataSource_withoutName = `
+data "opentelekomcloud_sdrs_domain_v1" "domain_1" {
 }
 `

--- a/opentelekomcloud/acceptance/sdrs/resource_opentelekomcloud_sdrs_protectiongroup_v1_test.go
+++ b/opentelekomcloud/acceptance/sdrs/resource_opentelekomcloud_sdrs_protectiongroup_v1_test.go
@@ -98,12 +98,14 @@ func testAccCheckSdrsProtectionGroupV1Exists(n string, group *protectiongroups.G
 var testAccSdrsProtectionGroupV1Basic = fmt.Sprintf(`
 %s
 
+data "opentelekomcloud_sdrs_domain_v1" "domain_1" {}
+
 resource "opentelekomcloud_sdrs_protectiongroup_v1" "group_1" {
   name                     = "group_1"
   description              = "test description"
   source_availability_zone = "eu-de-02"
   target_availability_zone = "eu-de-01"
-  domain_id                = "cdba26b2-cc35-4988-a904-82b7abf20094"
+  domain_id                = data.opentelekomcloud_sdrs_domain_v1.domain_1.id
   source_vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
   dr_type                  = "migration"
 }
@@ -112,12 +114,14 @@ resource "opentelekomcloud_sdrs_protectiongroup_v1" "group_1" {
 var testAccSdrsProtectionGroupV1Update = fmt.Sprintf(`
 %s
 
+data "opentelekomcloud_sdrs_domain_v1" "domain_1" {}
+
 resource "opentelekomcloud_sdrs_protectiongroup_v1" "group_1" {
   name                     = "group_updated"
   description              = "test description"
   source_availability_zone = "eu-de-02"
   target_availability_zone = "eu-de-01"
-  domain_id                = "cdba26b2-cc35-4988-a904-82b7abf20094"
+  domain_id                = data.opentelekomcloud_sdrs_domain_v1.domain_1.id
   source_vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
   dr_type                  = "migration"
 }

--- a/releasenotes/notes/sdrs_domain_documentation-cbca3c81e254fef0.yaml
+++ b/releasenotes/notes/sdrs_domain_documentation-cbca3c81e254fef0.yaml
@@ -1,6 +1,6 @@
 ---
 other:
   - |
-    **[SDRS]** Documentation and tests update for  ``data_source/opentelekomcloud_sdrs_domain_v1` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[SDRS]** Documentation and tests update for  ``data_source/opentelekomcloud_sdrs_domain_v1` (`#1932 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1932>`_)
   - |
-    **[SDRS]** Documentation and tests update for  ``resource/opentelekomcloud_sdrs_protectiongroup_v1` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[SDRS]** Documentation and tests update for  ``resource/opentelekomcloud_sdrs_protectiongroup_v1` (`#1932 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1932>`_)

--- a/releasenotes/notes/sdrs_domain_documentation-cbca3c81e254fef0.yaml
+++ b/releasenotes/notes/sdrs_domain_documentation-cbca3c81e254fef0.yaml
@@ -1,6 +1,6 @@
 ---
 other:
   - |
-    **[SDRS]** Documentation and tests update for  ``data_source/opentelekomcloud_sdrs_domain_v1` (`#1932 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1932>`_)
+    **[SDRS]** Documentation and tests update for ``data_source/opentelekomcloud_sdrs_domain_v1` (`#1932 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1932>`_)
   - |
-    **[SDRS]** Documentation and tests update for  ``resource/opentelekomcloud_sdrs_protectiongroup_v1` (`#1932 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1932>`_)
+    **[SDRS]** Documentation and tests update for ``resource/opentelekomcloud_sdrs_protectiongroup_v1` (`#1932 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1932>`_)

--- a/releasenotes/notes/sdrs_domain_documentation-cbca3c81e254fef0.yaml
+++ b/releasenotes/notes/sdrs_domain_documentation-cbca3c81e254fef0.yaml
@@ -1,0 +1,6 @@
+---
+other:
+  - |
+    **[SDRS]** Documentation and tests update for  ``data_source/opentelekomcloud_sdrs_domain_v1` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+  - |
+    **[SDRS]** Documentation and tests update for  ``resource/opentelekomcloud_sdrs_protectiongroup_v1` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)

--- a/releasenotes/notes/sdrs_domain_documentation-cbca3c81e254fef0.yaml
+++ b/releasenotes/notes/sdrs_domain_documentation-cbca3c81e254fef0.yaml
@@ -1,6 +1,6 @@
 ---
 other:
   - |
-    **[SDRS]** Documentation and tests update for ``data_source/opentelekomcloud_sdrs_domain_v1` (`#1932 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1932>`_)
+    **[SDRS]** Documentation and tests update for ``data_source/opentelekomcloud_sdrs_domain_v1`` (`#1932 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1932>`_)
   - |
-    **[SDRS]** Documentation and tests update for ``resource/opentelekomcloud_sdrs_protectiongroup_v1` (`#1932 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1932>`_)
+    **[SDRS]** Documentation and tests update for ``resource/opentelekomcloud_sdrs_protectiongroup_v1`` (`#1932 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1932>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Documentation update of resources dependant from ``active-active domain``.
Additional examples provided for ``data/opentelekomcloud_sdrs_domain_v1``.
Updated tests for ``data/opentelekomcloud_sdrs_domain_v1``, ``resource/opentelekomcloud_sdrs_protectiongroup_v1``.

## PR Checklist

* [x] Refers to: #1930 
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccSdrsDomainV1DataSource_basic
--- PASS: TestAccSdrsDomainV1DataSource_basic (31.60s)
=== RUN   TestAccSdrsDomainV1DataSource_withoutName
--- PASS: TestAccSdrsDomainV1DataSource_withoutName (31.53s)
PASS

Process finished with the exit code 0

=== RUN   TestAccSdrsProtectionGroupV1_basic
--- PASS: TestAccSdrsProtectionGroupV1_basic (80.60s)
PASS

Process finished with the exit code 0
```
