### PR TITLE
[ECS]: ``opentelekomcloud_compute_servergroup_v2`` update

### DIFF
--- a/docs/resources/compute_servergroup_v2.md
+++ b/docs/resources/compute_servergroup_v2.md
@@ -31,9 +31,6 @@ The following arguments are supported:
 
 ## Policies
 
-* `affinity` - All instances/servers launched in this group will be hosted on
-  the same compute node.
-
 * `anti-affinity` - All instances/servers launched in this group will be
   hosted on different compute nodes.
 

--- a/opentelekomcloud/services/ecs/resource_opentelekomcloud_compute_servergroup_v2.go
+++ b/opentelekomcloud/services/ecs/resource_opentelekomcloud_compute_servergroup_v2.go
@@ -2,6 +2,7 @@ package ecs
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/hashicorp/go-multierror"
@@ -24,6 +25,8 @@ func ResourceComputeServerGroupV2() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
+		CustomizeDiff: validatePolicy,
+
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:     schema.TypeString,
@@ -39,7 +42,7 @@ func ResourceComputeServerGroupV2() *schema.Resource {
 			},
 			"policies": {
 				Type:     schema.TypeList,
-				Optional: true,
+				Required: true,
 				ForceNew: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
@@ -133,4 +136,12 @@ func resourceServerGroupPoliciesV2(d *schema.ResourceData) []string {
 		policies[i] = raw.(string)
 	}
 	return policies
+}
+
+func validatePolicy(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
+	policyData := d.Get("policies").([]interface{})
+	if policyData[0] != "anti-affinity" {
+		return fmt.Errorf("only 'anti-affinity' policies are supported")
+	}
+	return nil
 }

--- a/releasenotes/notes/compute_sg_fix-452802bb1d5b67cf.yaml
+++ b/releasenotes/notes/compute_sg_fix-452802bb1d5b67cf.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    **[ECS]** Documentation fixed for ``policy`` parameter in ``resource/opentelekomcloud_compute_servergroup_v2`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+other:
+  - |
+    **[ECS]** Validation/tests added for ``policy`` parameter ``resource/opentelekomcloud_compute_servergroup_v2`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)

--- a/releasenotes/notes/compute_sg_fix-452802bb1d5b67cf.yaml
+++ b/releasenotes/notes/compute_sg_fix-452802bb1d5b67cf.yaml
@@ -1,7 +1,7 @@
 ---
 fixes:
   - |
-    **[ECS]** Documentation fixed for ``policy`` parameter in ``resource/opentelekomcloud_compute_servergroup_v2`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[ECS]** Documentation fixed for ``policy`` parameter in ``resource/opentelekomcloud_compute_servergroup_v2`` (`#1933 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1933>`_)
 other:
   - |
-    **[ECS]** Validation/tests added for ``policy`` parameter ``resource/opentelekomcloud_compute_servergroup_v2`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[ECS]** Validation/tests added for ``policy`` parameter ``resource/opentelekomcloud_compute_servergroup_v2`` (`#1933 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1933>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Validation, documentation and test added for ``opentelekomcloud_compute_servergroup_v2``

## PR Checklist

* [x] Closes: #1555
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed
=== RUN   TestAccComputeV2ServerGroup_basic
=== PAUSE TestAccComputeV2ServerGroup_basic
=== CONT  TestAccComputeV2ServerGroup_basic
--- PASS: TestAccComputeV2ServerGroup_basic (33.56s)
=== RUN   TestAccComputeV2ServerGroup_import
=== PAUSE TestAccComputeV2ServerGroup_import
=== CONT  TestAccComputeV2ServerGroup_import
--- PASS: TestAccComputeV2ServerGroup_import (41.93s)
=== RUN   TestAccComputeV2ServerGroup_affinity
=== PAUSE TestAccComputeV2ServerGroup_affinity
=== CONT  TestAccComputeV2ServerGroup_affinity
--- PASS: TestAccComputeV2ServerGroup_affinity (135.03s)
=== RUN   TestAccComputeV2ServerGroup_policyValidation
=== PAUSE TestAccComputeV2ServerGroup_policyValidation
=== CONT  TestAccComputeV2ServerGroup_policyValidation
--- PASS: TestAccComputeV2ServerGroup_policyValidation (8.07s)
PASS

Process finished with the exit code 0
```