### PR TITLE
[IAM]: User creation fix for ``resource/opentelekomcloud_identity_user_v3``

### DIFF
--- a/opentelekomcloud/acceptance/iam/resource_opentelekomcloud_identity_user_v3_test.go
+++ b/opentelekomcloud/acceptance/iam/resource_opentelekomcloud_identity_user_v3_test.go
@@ -174,10 +174,11 @@ resource "opentelekomcloud_identity_user_v3" "user_1" {
 func testAccIdentityV3UserBasic(userName string) string {
 	return fmt.Sprintf(`
 resource "opentelekomcloud_identity_user_v3" "user_1" {
-  name     = "%s"
-  password = "password123@!"
-  enabled  = true
-  email    = "test@acme.org"
+  name               = "%s"
+  password           = "password123@!"
+  enabled            = true
+  email              = "test@acme.org"
+  send_welcome_email = true
 }
   `, userName)
 }

--- a/releasenotes/notes/iam_users_v3_fix-9ecb48ce6530f1fc.yaml
+++ b/releasenotes/notes/iam_users_v3_fix-9ecb48ce6530f1fc.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[IAM]** User creation fix for ``resource/opentelekomcloud_identity_user_v3`` after API update (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)

--- a/releasenotes/notes/iam_users_v3_fix-9ecb48ce6530f1fc.yaml
+++ b/releasenotes/notes/iam_users_v3_fix-9ecb48ce6530f1fc.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    **[IAM]** User creation fix for ``resource/opentelekomcloud_identity_user_v3`` after API update (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[IAM]** User creation fix for ``resource/opentelekomcloud_identity_user_v3`` after API update (`#1936 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1936>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Latest ``POST /v3/users`` API update has broken user creation when ``email`` is specified in the schema.
PR implements an updated logic that fixes this issue.

## PR Checklist

* [x] Refers to: #1934
* [x] Tests added/passed.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccIdentityV3User_basic
--- PASS: TestAccIdentityV3User_basic (85.85s)
=== RUN   TestAccIdentityV3User_importBasic
--- PASS: TestAccIdentityV3User_importBasic (57.60s)
=== RUN   TestAccCheckIAMV3EmailValidation
--- PASS: TestAccCheckIAMV3EmailValidation (9.62s)
=== RUN   TestAccCheckIAMV3SendEmailValidation
--- PASS: TestAccCheckIAMV3SendEmailValidation (9.67s)
PASS

Process finished with the exit code 0
```
