### PR TITLE
[IAM]: Backwards compatibility for ``resource/opentelekomcloud_identity_role_assignment_v3``

### DIFF
--- a/opentelekomcloud/services/iam/resource_opentelekomcloud_identity_role_assignment_v3.go
+++ b/opentelekomcloud/services/iam/resource_opentelekomcloud_identity_role_assignment_v3.go
@@ -177,9 +177,9 @@ func buildRoleAssignmentID(domainID, projectID, groupID, roleID string) string {
 
 func ExtractRoleAssignmentID(roleAssignmentID string) (string, string, string, string) {
 	split := strings.Split(roleAssignmentID, "/")
-	if len(split) == 4 {
-		return split[0], split[1], split[2], split[3]
+	if len(split) != 4 {
+		// Otherwise previous role assignments in tfstate file won't be backwards compatible
+		return split[0], split[1], split[2], split[4]
 	}
-	// Otherwise previous role assignments in tfstate file won't be backwards compatible
-	return split[0], split[1], split[2], split[4]
+	return split[0], split[1], split[2], split[3]
 }

--- a/opentelekomcloud/services/iam/resource_opentelekomcloud_identity_role_assignment_v3.go
+++ b/opentelekomcloud/services/iam/resource_opentelekomcloud_identity_role_assignment_v3.go
@@ -177,5 +177,9 @@ func buildRoleAssignmentID(domainID, projectID, groupID, roleID string) string {
 
 func ExtractRoleAssignmentID(roleAssignmentID string) (string, string, string, string) {
 	split := strings.Split(roleAssignmentID, "/")
-	return split[0], split[1], split[2], split[3]
+	if len(split) == 4 {
+		return split[0], split[1], split[2], split[3]
+	}
+	// Otherwise previous role assignments in tfstate file won't be backwards compatible
+	return split[0], split[1], split[2], split[4]
 }

--- a/releasenotes/notes/iam_role_assign_compat-1993ff910c3bbda5.yaml
+++ b/releasenotes/notes/iam_role_assign_compat-1993ff910c3bbda5.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    **[IAM]** Backwards compatibility for ``resource/opentelekomcloud_identity_role_assignment_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[IAM]** Backwards compatibility for ``resource/opentelekomcloud_identity_role_assignment_v3`` (`#1938 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1938>`_)

--- a/releasenotes/notes/iam_role_assign_compat-1993ff910c3bbda5.yaml
+++ b/releasenotes/notes/iam_role_assign_compat-1993ff910c3bbda5.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[IAM]** Backwards compatibility for ``resource/opentelekomcloud_identity_role_assignment_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Small fix for ``resource/opentelekomcloud_identity_role_assignment_v3`` to be backward compatible with older provider versions.
Initial ``id`` of resource was saved as ``fmt.Sprintf("%s/%s/%s/%s", domainID, projectID, groupID, userID, roleID)``, whereas assignment via ``userID`` doesn't work in OTC and was removed.

Current ``id`` buildup have ``fmt.Sprintf("%s/%s/%s/%s", domainID, projectID, groupID, roleID)`` setup therefore id should be processed differently.

## PR Checklist

* [x] Tests passed.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccIdentityV3RoleAssignment_basic
--- PASS: TestAccIdentityV3RoleAssignment_basic (104.19s)
PASS

Process finished with the exit code 0
```
