### PR TITLE
[IMS] added test for `resource/opentelekomcloud_images_image_v2` big image upload

### DIFF
--- a/opentelekomcloud/acceptance/ims/resource_opentelekomcloud_images_image_v2_test.go
+++ b/opentelekomcloud/acceptance/ims/resource_opentelekomcloud_images_image_v2_test.go
@@ -2,6 +2,7 @@ package acceptance
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/imageservice/v2/images"
@@ -158,7 +159,9 @@ func TestAccImagesImageV2_timeout(t *testing.T) {
 }
 
 func TestAccImagesImageV2_big_image(t *testing.T) {
-	t.Skip("this test have a very long run over than 1128.64s")
+	if os.Getenv("IMS_LARGE") == "" {
+		t.Skip("this test have a very long run over than 1128.64s")
+	}
 	var image images.Image
 
 	resource.Test(t, resource.TestCase{

--- a/opentelekomcloud/acceptance/ims/resource_opentelekomcloud_images_image_v2_test.go
+++ b/opentelekomcloud/acceptance/ims/resource_opentelekomcloud_images_image_v2_test.go
@@ -157,6 +157,25 @@ func TestAccImagesImageV2_timeout(t *testing.T) {
 	})
 }
 
+func TestAccImagesImageV2_big_image(t *testing.T) {
+	t.Skip("this test have a very long run over than 1128.64s")
+	var image images.Image
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckImagesImageV2Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccImagesImageV2_upload_large,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckImagesImageV2Exists("opentelekomcloud_images_image_v2.image_1", &image),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckImagesImageV2Destroy(s *terraform.State) error {
 	config := common.TestAccProvider.Meta().(*cfg.Config)
 	imageClient, err := config.ImageV2Client(env.OS_REGION_NAME)
@@ -359,4 +378,12 @@ resource "opentelekomcloud_images_image_v2" "image_1" {
   timeouts {
     create = "10m"
   }
+}`
+
+var testAccImagesImageV2_upload_large = `
+resource "opentelekomcloud_images_image_v2" "image_1" {
+  name             = "Ubuntu Desktop TerraformAccTest"
+  image_source_url = "https://releases.ubuntu.com/22.04.1/ubuntu-22.04.1-desktop-amd64.iso?_ga=2.80151063.1266130091.1663673826-1722972329.1663673826"
+  container_format = "bare"
+  disk_format      = "iso"
 }`

--- a/releasenotes/notes/ims-big-img-d61cf99352f6fd0d.yaml
+++ b/releasenotes/notes/ims-big-img-d61cf99352f6fd0d.yaml
@@ -1,0 +1,4 @@
+---
+other:
+  - |
+    **[IMS]** Added test for uploading large image ``40gb`` for ``resource/opentelekomcloud_cbr_backup_ids_v3`` (`#1943 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1943>`_)


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [x] Refers to: #1860
* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccImagesImageV2_big_image
--- PASS: TestAccImagesImageV2_big_image (1128.64s)
PASS

Process finished with the exit code 0
```
