### PR TITLE
[DCS]: `whitelist` feature implemented

### DIFF
--- a/docs/resources/dcs_instance_v1.md
+++ b/docs/resources/dcs_instance_v1.md
@@ -8,6 +8,8 @@ Manages a DCSv1 instance in the OpenTelekomCloud DCS Service.
 
 ## Example Usage
 
+### Engine version 3.0 (`security_group_id` is required):
+
 ```hcl
 variable "network_id" {}
 variable "vpc_id" {}
@@ -27,7 +29,7 @@ data "opentelekomcloud_dcs_product_v1" "product_1" {
 
 resource "opentelekomcloud_dcs_instance_v1" "instance_1" {
   name           = "test_dcs_instance"
-  engine_version = "3.0.7"
+  engine_version = "3.0"
   password       = "0TCTestP@ssw0rd"
   engine         = "Redis"
   capacity       = 2
@@ -66,10 +68,19 @@ resource "opentelekomcloud_dcs_instance_v1" "instance_1" {
   engine            = "Redis"
   capacity          = 0.125
   vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
-  security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
   subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   available_zones   = [data.opentelekomcloud_dcs_az_v1.az_1.id]
   product_id        = data.opentelekomcloud_dcs_product_v1.product_1.id
+
+  enable_whitelist = true
+  whitelist {
+    group_name = "test-group-name"
+    ip_list    = ["10.10.10.1", "10.10.10.2"]
+  }
+  whitelist {
+    group_name = "test-group-name-2"
+    ip_list    = ["10.10.10.11", "10.10.10.3", "10.10.10.4"]
+  }
 }
 ```
 
@@ -107,7 +118,7 @@ The following arguments are supported:
 
 * `vpc_id` - (Required) Specifies the VPC ID. Changing this creates a new instance.
 
-* `security_group_id` - (Required) Security group ID.
+* `security_group_id` - (Optional) Security group ID. This parameter is mandatory when `engine_version` is `3.0`.
 
 * `subnet_id` - (Required) Specifies the subnet Network ID. Changing this creates a new instance.
 
@@ -151,6 +162,17 @@ the default start time `02:00` and the default end time `06:00`.
   * `parameter_id` - (Required) Configuration item ID.
   * `parameter_name` - (Required) Configuration item name.
   * `parameter_value` - (Required) Value of the configuration item.
+
+* `enable_whitelist` - (Optional) Specifies whether to enable or disable `whitelist`. Only available when
+  `engine_version` is set to `4.0`/`5.0`. Parameter have to be used together with `whitelist`.
+
+* `whitelist` - (Optional) Describes the `whitelist` groups to be used with the instance. Only available when
+  `engine_version` is set to `4.0`/`5.0`. Parameter have to be used together with `enable_whitelist`.
+  Resource fields:
+  * `group_name` - (Optional) Whitelist group name. A maximum of four groups can be created for each instance.
+  * `ip_list` - (Optional) List of IP addresses in the whitelist group. A maximum of 20 IP addresses or IP address
+  ranges can be added to an instance. Separate multiple IP addresses or IP address ranges with commas (,).
+  IP address 0.0.0.0 and IP address range 0.0.0/0 are not supported.
 
 ## Attributes Reference
 

--- a/docs/resources/dcs_instance_v1.md
+++ b/docs/resources/dcs_instance_v1.md
@@ -62,15 +62,15 @@ data "opentelekomcloud_dcs_product_v1" "product_1" {
 }
 
 resource "opentelekomcloud_dcs_instance_v1" "instance_1" {
-  name              = "test_dcs_instance_5.0"
-  engine_version    = "5.0"
-  password          = "0TCTestP@ssw0rd"
-  engine            = "Redis"
-  capacity          = 0.125
-  vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
-  subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
-  available_zones   = [data.opentelekomcloud_dcs_az_v1.az_1.id]
-  product_id        = data.opentelekomcloud_dcs_product_v1.product_1.id
+  name            = "test_dcs_instance_5.0"
+  engine_version  = "5.0"
+  password        = "0TCTestP@ssw0rd"
+  engine          = "Redis"
+  capacity        = 0.125
+  vpc_id          = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  subnet_id       = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  available_zones = [data.opentelekomcloud_dcs_az_v1.az_1.id]
+  product_id      = data.opentelekomcloud_dcs_product_v1.product_1.id
 
   enable_whitelist = true
   whitelist {

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/jinzhu/copier v0.3.5
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.5.23-0.20220919120036-62ee4b4b59d7
+	github.com/opentelekomcloud/gophertelekomcloud v0.5.23-0.20220921110146-fa37d7f29866
 	github.com/unknwon/com v1.0.1
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -210,6 +210,8 @@ github.com/opentelekomcloud/gophertelekomcloud v0.5.23-0.20220915113255-792b017e
 github.com/opentelekomcloud/gophertelekomcloud v0.5.23-0.20220915113255-792b017ebb56/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
 github.com/opentelekomcloud/gophertelekomcloud v0.5.23-0.20220919120036-62ee4b4b59d7 h1:x2zcEjwLar9dmizOizxuDv2qbxSsCa0efsjXy2QmcNQ=
 github.com/opentelekomcloud/gophertelekomcloud v0.5.23-0.20220919120036-62ee4b4b59d7/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
+github.com/opentelekomcloud/gophertelekomcloud v0.5.23-0.20220921110146-fa37d7f29866 h1:TgZRIYIHHtGjDprCGXtviW4hecQWhSzj1bPe0hFWPW0=
+github.com/opentelekomcloud/gophertelekomcloud v0.5.23-0.20220921110146-fa37d7f29866/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/opentelekomcloud/acceptance/dcs/resource_opentelekomcloud_dcs_instance_v1_test.go
+++ b/opentelekomcloud/acceptance/dcs/resource_opentelekomcloud_dcs_instance_v1_test.go
@@ -68,7 +68,7 @@ func TestAccDcsInstancesV1_basicSingleInstance(t *testing.T) {
 	})
 }
 
-func TestAccDcsInstancesV1_basicEngineV3Instace(t *testing.T) {
+func TestAccDcsInstancesV1_basicEngineV3Instance(t *testing.T) {
 	var instance instances.Instance
 	var instanceName = fmt.Sprintf("dcs_instance_%s", acctest.RandString(5))
 

--- a/opentelekomcloud/acceptance/dcs/resource_opentelekomcloud_dcs_instance_v1_test.go
+++ b/opentelekomcloud/acceptance/dcs/resource_opentelekomcloud_dcs_instance_v1_test.go
@@ -156,8 +156,6 @@ func TestAccDcsInstancesV1_Whitelist(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceInstanceName, "name", instanceName),
 					resource.TestCheckResourceAttr(resourceInstanceName, "engine", "Redis"),
 					resource.TestCheckResourceAttr(resourceInstanceName, "enable_whitelist", "true"),
-					resource.TestCheckResourceAttr(resourceInstanceName, "whitelist.0.group_name", "test-group-name"),
-					resource.TestCheckResourceAttr(resourceInstanceName, "whitelist.1.group_name", "test-group-name-2"),
 				),
 			},
 		},

--- a/opentelekomcloud/acceptance/dcs/resource_opentelekomcloud_dcs_instance_v1_test.go
+++ b/opentelekomcloud/acceptance/dcs/resource_opentelekomcloud_dcs_instance_v1_test.go
@@ -2,13 +2,13 @@ package acceptance
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/dcs/v1/instances"
-
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
@@ -62,6 +62,102 @@ func TestAccDcsInstancesV1_basicSingleInstance(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceInstanceName, "name", instanceName),
 					resource.TestCheckResourceAttr(resourceInstanceName, "engine", "Redis"),
 					resource.TestCheckResourceAttr(resourceInstanceName, "resource_spec_code", "redis.single.xu1.tiny.128"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDcsInstancesV1_basicEngineV3Instace(t *testing.T) {
+	var instance instances.Instance
+	var instanceName = fmt.Sprintf("dcs_instance_%s", acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDcsV1InstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDcsV1InstanceEngineV3(instanceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDcsV1InstanceExists(resourceInstanceName, instance),
+					resource.TestCheckResourceAttr(resourceInstanceName, "name", instanceName),
+					resource.TestCheckResourceAttr(resourceInstanceName, "engine", "Redis"),
+					resource.TestCheckResourceAttr(resourceInstanceName, "resource_spec_code", "dcs.master_standby"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccASV1Configuration_invalidSecurityGroup(t *testing.T) {
+	var instanceName = fmt.Sprintf("dcs_instance_%s", acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDcsV1InstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDcsV1InstanceValidation(instanceName),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`'security_group_id' should be set.+`),
+			},
+		},
+	})
+}
+
+func TestAccASV1Configuration_WhitelistValidation(t *testing.T) {
+	var instanceName = fmt.Sprintf("dcs_instance_%s", acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDcsV1InstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDcsV1InstanceWhitelistValidation(instanceName),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`DCS Redis 3.0 instance does not support.+`),
+			},
+		},
+	})
+}
+
+func TestAccDcsInstancesV1_Whitelist(t *testing.T) {
+	var instance instances.Instance
+	var instanceName = fmt.Sprintf("dcs_instance_%s", acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDcsV1InstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDcsV1InstanceWhitelist(instanceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDcsV1InstanceExists(resourceInstanceName, instance),
+					resource.TestCheckResourceAttr(resourceInstanceName, "name", instanceName),
+					resource.TestCheckResourceAttr(resourceInstanceName, "engine", "Redis"),
+					resource.TestCheckResourceAttr(resourceInstanceName, "enable_whitelist", "false"),
+					resource.TestCheckResourceAttr(resourceInstanceName, "whitelist.0.group_name", "test-group-name"),
+				),
+			},
+			{
+				Config: testAccDcsV1InstanceWhitelistUpdate(instanceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDcsV1InstanceExists(resourceInstanceName, instance),
+					resource.TestCheckResourceAttr(resourceInstanceName, "name", instanceName),
+					resource.TestCheckResourceAttr(resourceInstanceName, "engine", "Redis"),
+				),
+			},
+			{
+				Config: testAccDcsV1InstanceWhitelistSecondUpdate(instanceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDcsV1InstanceExists(resourceInstanceName, instance),
+					resource.TestCheckResourceAttr(resourceInstanceName, "name", instanceName),
+					resource.TestCheckResourceAttr(resourceInstanceName, "engine", "Redis"),
+					resource.TestCheckResourceAttr(resourceInstanceName, "enable_whitelist", "true"),
+					resource.TestCheckResourceAttr(resourceInstanceName, "whitelist.0.group_name", "test-group-name"),
+					resource.TestCheckResourceAttr(resourceInstanceName, "whitelist.1.group_name", "test-group-name-2"),
 				),
 			},
 		},
@@ -134,16 +230,15 @@ data "opentelekomcloud_dcs_product_v1" "product_1" {
 }
 
 resource "opentelekomcloud_dcs_instance_v1" "instance_1" {
-  name              = "%s"
-  engine_version    = "5.0"
-  password          = "Hungarian_rapsody"
-  engine            = "Redis"
-  capacity          = 0.125
-  vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
-  security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
-  subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
-  available_zones   = [data.opentelekomcloud_dcs_az_v1.az_1.id]
-  product_id        = data.opentelekomcloud_dcs_product_v1.product_1.id
+  name            = "%s"
+  engine_version  = "5.0"
+  password        = "Hungarian_rapsody"
+  engine          = "Redis"
+  capacity        = 0.125
+  vpc_id          = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  subnet_id       = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  available_zones = [data.opentelekomcloud_dcs_az_v1.az_1.id]
+  product_id      = data.opentelekomcloud_dcs_product_v1.product_1.id
   backup_policy {
     backup_type = "manual"
     begin_at    = "00:00-01:00"
@@ -176,16 +271,15 @@ data "opentelekomcloud_dcs_product_v1" "product_1" {
 }
 
 resource "opentelekomcloud_dcs_instance_v1" "instance_1" {
-  name              = "%s"
-  engine_version    = "5.0"
-  password          = "Hungarian_rapsody"
-  engine            = "Redis"
-  capacity          = 0.125
-  vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
-  security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
-  subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
-  available_zones   = [data.opentelekomcloud_dcs_az_v1.az_1.id]
-  product_id        = data.opentelekomcloud_dcs_product_v1.product_1.id
+  name            = "%s"
+  engine_version  = "5.0"
+  password        = "Hungarian_rapsody"
+  engine          = "Redis"
+  capacity        = 0.125
+  vpc_id          = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  subnet_id       = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  available_zones = [data.opentelekomcloud_dcs_az_v1.az_1.id]
+  product_id      = data.opentelekomcloud_dcs_product_v1.product_1.id
   backup_policy {
     backup_type = "manual"
     begin_at    = "01:00-02:00"
@@ -219,16 +313,245 @@ data "opentelekomcloud_dcs_product_v1" "product_1" {
 }
 
 resource "opentelekomcloud_dcs_instance_v1" "instance_1" {
+  name            = "%s"
+  engine_version  = "4.0"
+  password        = "Hungarian_rapsody"
+  engine          = "Redis"
+  capacity        = 0.125
+  vpc_id          = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  subnet_id       = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  available_zones = [data.opentelekomcloud_dcs_az_v1.az_1.id]
+  product_id      = data.opentelekomcloud_dcs_product_v1.product_1.id
+}
+`, common.DataSourceSecGroupDefault, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, instanceName)
+}
+
+func testAccDcsV1InstanceValidation(instanceName string) string {
+	return fmt.Sprintf(`
+%s
+
+%s
+
+data "opentelekomcloud_dcs_az_v1" "az_1" {
+  port = "8002"
+  code = "%s"
+}
+
+data "opentelekomcloud_dcs_product_v1" "product_1" {
+  spec_code = "redis.single.xu1.tiny.128"
+}
+
+resource "opentelekomcloud_dcs_instance_v1" "instance_1" {
+  name            = "%s"
+  engine_version  = "3.0"
+  password        = "Hungarian_rapsody"
+  engine          = "Redis"
+  capacity        = 0.125
+  vpc_id          = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  subnet_id       = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  available_zones = [data.opentelekomcloud_dcs_az_v1.az_1.id]
+  product_id      = data.opentelekomcloud_dcs_product_v1.product_1.id
+}
+`, common.DataSourceSecGroupDefault, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, instanceName)
+}
+
+func testAccDcsV1InstanceWhitelistValidation(instanceName string) string {
+	return fmt.Sprintf(`
+%s
+
+%s
+
+data "opentelekomcloud_dcs_az_v1" "az_1" {
+  port = "8002"
+  code = "%s"
+}
+
+data "opentelekomcloud_dcs_product_v1" "product_1" {
+  spec_code = "redis.single.xu1.tiny.128"
+}
+
+resource "opentelekomcloud_dcs_instance_v1" "instance_1" {
+  name            = "%s"
+  engine_version  = "3.0"
+  password        = "Hungarian_rapsody"
+  engine          = "Redis"
+  capacity        = 0.125
+  vpc_id          = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  subnet_id       = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  available_zones = [data.opentelekomcloud_dcs_az_v1.az_1.id]
+  product_id      = data.opentelekomcloud_dcs_product_v1.product_1.id
+
+  enable_whitelist = true
+  whitelist {
+    group_name = "test-group-name"
+    ip_list    = ["10.10.10.1", "10.10.10.2"]
+  }
+}
+`, common.DataSourceSecGroupDefault, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, instanceName)
+}
+
+func testAccDcsV1InstanceEngineV3(instanceName string) string {
+	return fmt.Sprintf(`
+%s
+
+%s
+
+data "opentelekomcloud_dcs_az_v1" "az_1" {
+  port = "8002"
+  code = "%s"
+}
+
+data "opentelekomcloud_dcs_product_v1" "product_1" {
+  spec_code = "dcs.master_standby"
+}
+
+resource "opentelekomcloud_dcs_instance_v1" "instance_1" {
   name              = "%s"
-  engine_version    = "5.0"
+  engine_version    = "3.0"
   password          = "Hungarian_rapsody"
   engine            = "Redis"
-  capacity          = 0.125
+  capacity          = 2
   vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
-  security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
   subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
   available_zones   = [data.opentelekomcloud_dcs_az_v1.az_1.id]
   product_id        = data.opentelekomcloud_dcs_product_v1.product_1.id
+}
+`, common.DataSourceSecGroupDefault, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, instanceName)
+}
+
+func testAccDcsV1InstanceWhitelist(instanceName string) string {
+	return fmt.Sprintf(`
+%s
+
+%s
+
+data "opentelekomcloud_dcs_az_v1" "az_1" {
+  port = "8002"
+  code = "%s"
+}
+
+data "opentelekomcloud_dcs_product_v1" "product_1" {
+  spec_code = "redis.ha.xu1.tiny.r2.128"
+}
+
+resource "opentelekomcloud_dcs_instance_v1" "instance_1" {
+  name            = "%s"
+  engine_version  = "5.0"
+  password        = "Hungarian_rapsody"
+  engine          = "Redis"
+  capacity        = 0.125
+  vpc_id          = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  subnet_id       = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  available_zones = [data.opentelekomcloud_dcs_az_v1.az_1.id]
+  product_id      = data.opentelekomcloud_dcs_product_v1.product_1.id
+  backup_policy {
+    backup_type = "manual"
+    begin_at    = "00:00-01:00"
+    period_type = "weekly"
+    backup_at   = [4]
+    save_days   = 1
+  }
+
+  configuration {
+    parameter_id    = "1"
+    parameter_name  = "timeout"
+    parameter_value = "100"
+  }
+
+  enable_whitelist = false
+  whitelist {
+    group_name = "test-group-name"
+    ip_list    = ["10.10.10.1", "10.10.10.2"]
+  }
+}
+`, common.DataSourceSecGroupDefault, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, instanceName)
+}
+
+func testAccDcsV1InstanceWhitelistUpdate(instanceName string) string {
+	return fmt.Sprintf(`
+%s
+
+%s
+
+data "opentelekomcloud_dcs_az_v1" "az_1" {
+  port = "8002"
+  code = "%s"
+}
+
+data "opentelekomcloud_dcs_product_v1" "product_1" {
+  spec_code = "redis.ha.xu1.tiny.r2.128"
+}
+
+resource "opentelekomcloud_dcs_instance_v1" "instance_1" {
+  name            = "%s"
+  engine_version  = "5.0"
+  password        = "Hungarian_rapsody"
+  engine          = "Redis"
+  capacity        = 0.125
+  vpc_id          = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  subnet_id       = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  available_zones = [data.opentelekomcloud_dcs_az_v1.az_1.id]
+  product_id      = data.opentelekomcloud_dcs_product_v1.product_1.id
+  backup_policy {
+    backup_type = "manual"
+    begin_at    = "00:00-01:00"
+    period_type = "weekly"
+    backup_at   = [4]
+    save_days   = 1
+  }
+}
+`, common.DataSourceSecGroupDefault, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, instanceName)
+}
+
+func testAccDcsV1InstanceWhitelistSecondUpdate(instanceName string) string {
+	return fmt.Sprintf(`
+%s
+
+%s
+
+data "opentelekomcloud_dcs_az_v1" "az_1" {
+  port = "8002"
+  code = "%s"
+}
+
+data "opentelekomcloud_dcs_product_v1" "product_1" {
+  spec_code = "redis.ha.xu1.tiny.r2.128"
+}
+
+resource "opentelekomcloud_dcs_instance_v1" "instance_1" {
+  name            = "%s"
+  engine_version  = "5.0"
+  password        = "Hungarian_rapsody"
+  engine          = "Redis"
+  capacity        = 0.125
+  vpc_id          = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  subnet_id       = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  available_zones = [data.opentelekomcloud_dcs_az_v1.az_1.id]
+  product_id      = data.opentelekomcloud_dcs_product_v1.product_1.id
+  backup_policy {
+    backup_type = "manual"
+    begin_at    = "00:00-01:00"
+    period_type = "weekly"
+    backup_at   = [4]
+    save_days   = 1
+  }
+
+  configuration {
+    parameter_id    = "1"
+    parameter_name  = "timeout"
+    parameter_value = "100"
+  }
+
+  enable_whitelist = true
+  whitelist {
+    group_name = "test-group-name"
+    ip_list    = ["10.10.10.1", "10.10.10.2"]
+  }
+  whitelist {
+    group_name = "test-group-name-2"
+    ip_list    = ["10.10.10.11", "10.10.10.3", "10.10.10.4"]
+  }
 }
 `, common.DataSourceSecGroupDefault, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, instanceName)
 }

--- a/releasenotes/notes/dcs_whitelist-7df23f530b41a2e7.yaml
+++ b/releasenotes/notes/dcs_whitelist-7df23f530b41a2e7.yaml
@@ -1,0 +1,7 @@
+---
+enhancements:
+  - |
+    **[DCS]** `Whitelist` feature implemented for ``resource/opentelekomcloud_dcs_instance_v1`` (`#1944 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1944>`_)
+fixes:
+  - |
+    **[DCS]** Fixed `security_group_id` dependencies for ``resource/opentelekomcloud_dcs_instance_v1`` (`#1944 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1944>`_)


### PR DESCRIPTION
## Summary of the Pull Request

- `whitelist` feature implemented for Redis v`4.0`/`5.0`
- `security_group_id` changed to `Optional`, mandatory when `engine_version` = `3.0`
- Validations added
- Tests

## PR Checklist

* [x] Closes: #1883
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccDcsInstancesV1_basic
=== PAUSE TestAccDcsInstancesV1_basic
=== CONT  TestAccDcsInstancesV1_basic
--- PASS: TestAccDcsInstancesV1_basic (120.35s)
=== RUN   TestAccDcsInstancesV1_basicSingleInstance
=== PAUSE TestAccDcsInstancesV1_basicSingleInstance
=== CONT  TestAccDcsInstancesV1_basicSingleInstance
--- PASS: TestAccDcsInstancesV1_basicSingleInstance (71.99s)
=== RUN   TestAccDcsInstancesV1_basicEngineV3Instace
=== PAUSE TestAccDcsInstancesV1_basicEngineV3Instace
=== CONT  TestAccDcsInstancesV1_basicEngineV3Instace
--- PASS: TestAccDcsInstancesV1_basicEngineV3Instace (381.26s)
=== RUN   TestAccASV1Configuration_invalidSecurityGroup
=== PAUSE TestAccASV1Configuration_invalidSecurityGroup
=== CONT  TestAccASV1Configuration_invalidSecurityGroup
--- PASS: TestAccASV1Configuration_invalidSecurityGroup (8.92s)
=== RUN   TestAccASV1Configuration_WhitelistValidation
=== PAUSE TestAccASV1Configuration_WhitelistValidation
=== CONT  TestAccASV1Configuration_WhitelistValidation
--- PASS: TestAccASV1Configuration_WhitelistValidation (8.92s)
=== RUN   TestAccDcsInstancesV1_Whitelist
=== PAUSE TestAccDcsInstancesV1_Whitelist
=== CONT  TestAccDcsInstancesV1_Whitelist
--- PASS: TestAccDcsInstancesV1_Whitelist (167.80s)
PASS

Process finished with the exit code 0
```
