### PR TITLE
[VPC] unassign port in `resource/opentelekomcloud_vpc_eip_v1`

### DIFF
--- a/opentelekomcloud/acceptance/elb/v2/resource_opentelekomcloud_lb_loadbalancer_v2_test.go
+++ b/opentelekomcloud/acceptance/elb/v2/resource_opentelekomcloud_lb_loadbalancer_v2_test.go
@@ -45,6 +45,7 @@ func TestAccLBV2LoadBalancer_basic(t *testing.T) {
 		},
 	})
 }
+
 func TestAccLBV2LoadBalancer_import(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {

--- a/opentelekomcloud/services/vpc/resource_opentelekomcloud_vpc_eip_v1.go
+++ b/opentelekomcloud/services/vpc/resource_opentelekomcloud_vpc_eip_v1.go
@@ -63,7 +63,6 @@ func ResourceVpcEIPV1() *schema.Resource {
 						"port_id": {
 							Type:     schema.TypeString,
 							Optional: true,
-							Computed: true,
 						},
 					},
 				},

--- a/releasenotes/notes/vpc-eip-v1-port-dd00cc3427b2184b.yaml
+++ b/releasenotes/notes/vpc-eip-v1-port-dd00cc3427b2184b.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[VPC]** Remove compute from ``port_id`` for possibility to un assign port in ``resource/opentelekomcloud_vpc_eip_v1`` (`#1946 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1946>`_)


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [x] Refers to: #1945
* [x] Tests added/passed.
* [ ] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccVpcV1EIP_basic
=== PAUSE TestAccVpcV1EIP_basic
=== CONT  TestAccVpcV1EIP_basic
--- PASS: TestAccVpcV1EIP_basic (158.37s)
=== RUN   TestAccVpcV1EIP_UnAssing
=== PAUSE TestAccVpcV1EIP_UnAssing
=== CONT  TestAccVpcV1EIP_UnAssing
--- PASS: TestAccVpcV1EIP_UnAssing (186.69s)
=== RUN   TestAccVpcV1EIP_timeout
=== PAUSE TestAccVpcV1EIP_timeout
=== CONT  TestAccVpcV1EIP_timeout
--- PASS: TestAccVpcV1EIP_timeout (137.59s)
PASS


Process finished with the exit code 0

```
