### PR TITLE
[ECS] Add ``password`` attribute to ``opentelekomcloud_compute_instance_v2`` resource  for Windows instances

### DIFF
--- a/docs/data-sources/compute_instance_v2.md
+++ b/docs/data-sources/compute_instance_v2.md
@@ -24,6 +24,9 @@ data "opentelekomcloud_compute_instance_v2" "instance" {
 
 * `id` - (Required) The UUID of the instance
 
+* `ssh_private_key_path` - (Optional) The path to the private key to use for SSH access. Required only if you want to
+  get the password from the windows instance.
+
 
 ## Attributes Reference
 
@@ -57,9 +60,12 @@ In addition to the above, the following attributes are exported:
 
 * `metadata` - A set of key/value pairs made available to the server.
 
-* `ssh_private_key_path` - (Optional) The path to the private key to use for SSH access. Required only if you want to
-  get the password from the windows instance.
+* `password` - The password of the server. This is only available if the server is a Windows server.
+   If privateKey != nil the password is decrypted with the private key.
 
+* `encrypted_password` - The encrypted password of the server. This is only available if the server is a Windows server.
+  If privateKey == nil the encrypted password is returned and can be decrypted with:
+    echo '<pwd>' | base64 -D | openssl rsautl -decrypt -inkey <private_key>
 
 The `network` block is defined as:
 

--- a/docs/data-sources/compute_instance_v2.md
+++ b/docs/data-sources/compute_instance_v2.md
@@ -57,6 +57,9 @@ In addition to the above, the following attributes are exported:
 
 * `metadata` - A set of key/value pairs made available to the server.
 
+* `ssh_private_key_path` - (Optional) The path to the private key to use for SSH access. Required only if you want to
+  get the password from the windows instance.
+
 
 The `network` block is defined as:
 

--- a/docs/resources/compute_instance_v2.md
+++ b/docs/resources/compute_instance_v2.md
@@ -300,6 +300,9 @@ The following arguments are supported:
 
 * `user_data` - (Optional) The user data to provide when launching the instance. Changing this creates a new server.
 
+* `ssh_private_key_path` - (Optional) The path to the private key to use for SSH access. Required only if you want to
+  get the password from the windows instance.
+
 * `security_groups` - (Optional) An array of one or more security group names to associate with the server. Changing
   this results in adding/removing security groups from the existing server.
 

--- a/docs/resources/compute_instance_v2.md
+++ b/docs/resources/compute_instance_v2.md
@@ -454,6 +454,13 @@ The following attributes are exported:
 
 * `auto_recovery` - See Argument Reference above.
 
+* `password` - The password of the server. This is only available if the server is a Windows server.
+  If privateKey != nil the password is decrypted with the private key.
+
+* `encrypted_password` - The encrypted password of the server. This is only available if the server is a Windows server.
+  If privateKey == nil the encrypted password is returned and can be decrypted with:
+  echo '<pwd>' | base64 -D | openssl rsautl -decrypt -inkey <private_key>
+
 ## Notes
 
 ### Multiple Ephemeral Disks

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/opentelekomcloud/gophertelekomcloud v0.5.23-0.20220921110146-fa37d7f29866
 	github.com/unknwon/com v1.0.1
+	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
 	gopkg.in/yaml.v2 v2.4.0
 )
@@ -55,7 +56,6 @@ require (
 	github.com/vmihailenco/msgpack/v4 v4.3.12 // indirect
 	github.com/vmihailenco/tagparser v0.1.1 // indirect
 	github.com/zclconf/go-cty v1.10.0 // indirect
-	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4 // indirect
 	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect
 	golang.org/x/sys v0.0.0-20220405210540-1e041c57c461 // indirect
 	golang.org/x/text v0.3.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -204,12 +204,6 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.5.23-0.20220907195812-efeca53f22aa h1:EQqvKcia1RwBWJ0dVtYJkd+QBcbBJ9tbmT6AL1AWlnc=
-github.com/opentelekomcloud/gophertelekomcloud v0.5.23-0.20220907195812-efeca53f22aa/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
-github.com/opentelekomcloud/gophertelekomcloud v0.5.23-0.20220915113255-792b017ebb56 h1:4UIPMMFivUnxu+WEyZRn820NTcO6l0S61NEhmyAt9o4=
-github.com/opentelekomcloud/gophertelekomcloud v0.5.23-0.20220915113255-792b017ebb56/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
-github.com/opentelekomcloud/gophertelekomcloud v0.5.23-0.20220919120036-62ee4b4b59d7 h1:x2zcEjwLar9dmizOizxuDv2qbxSsCa0efsjXy2QmcNQ=
-github.com/opentelekomcloud/gophertelekomcloud v0.5.23-0.20220919120036-62ee4b4b59d7/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
 github.com/opentelekomcloud/gophertelekomcloud v0.5.23-0.20220921110146-fa37d7f29866 h1:TgZRIYIHHtGjDprCGXtviW4hecQWhSzj1bPe0hFWPW0=
 github.com/opentelekomcloud/gophertelekomcloud v0.5.23-0.20220921110146-fa37d7f29866/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/opentelekomcloud/acceptance/ecs/data_source_opentelekomcloud_compute_instance_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/data_source_opentelekomcloud_compute_instance_v2_test.go
@@ -25,6 +25,7 @@ func TestAccComputeV2InstanceDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.opentelekomcloud_compute_instance_v2.source_1", "name", "instance_1"),
 					resource.TestCheckResourceAttrPair("data.opentelekomcloud_compute_instance_v2.source_1", "metadata", "opentelekomcloud_compute_instance_v2.instance_1", "metadata"),
 					resource.TestCheckResourceAttrSet("data.opentelekomcloud_compute_instance_v2.source_1", "network.0.name"),
+					resource.TestCheckResourceAttrSet("data.opentelekomcloud_compute_instance_v2.source_1", "admin_pass"),
 				),
 			},
 			{

--- a/opentelekomcloud/acceptance/ecs/data_source_opentelekomcloud_compute_instance_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/data_source_opentelekomcloud_compute_instance_v2_test.go
@@ -25,7 +25,16 @@ func TestAccComputeV2InstanceDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.opentelekomcloud_compute_instance_v2.source_1", "name", "instance_1"),
 					resource.TestCheckResourceAttrPair("data.opentelekomcloud_compute_instance_v2.source_1", "metadata", "opentelekomcloud_compute_instance_v2.instance_1", "metadata"),
 					resource.TestCheckResourceAttrSet("data.opentelekomcloud_compute_instance_v2.source_1", "network.0.name"),
-					resource.TestCheckResourceAttrSet("data.opentelekomcloud_compute_instance_v2.source_1", "admin_pass"),
+				),
+			},
+			{
+				Config: testAccComputeV2InstanceDataSourceWindowsPassword(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceV2DataSourceID("data.opentelekomcloud_compute_instance_v2.source_1"),
+					resource.TestCheckResourceAttr("data.opentelekomcloud_compute_instance_v2.source_1", "name", "instance_1"),
+					resource.TestCheckResourceAttrPair("data.opentelekomcloud_compute_instance_v2.source_1", "metadata", "opentelekomcloud_compute_instance_v2.instance_1", "metadata"),
+					resource.TestCheckResourceAttrSet("data.opentelekomcloud_compute_instance_v2.source_1", "network.0.name"),
+					resource.TestCheckResourceAttrSet("data.opentelekomcloud_compute_instance_v2.source_1", "encrypted_password"),
 				),
 			},
 			{
@@ -89,6 +98,24 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
 `, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE)
 }
 
+func testAccComputeV2InstanceDataSourceWindows() string {
+	return fmt.Sprintf(`
+%s
+
+resource "opentelekomcloud_compute_instance_v2" "instance_1" {
+  name              = "instance_1"
+  availability_zone = "%s"
+  image_name        = "Enterprise_Windows_STD_2019_CORE_KVM"
+  metadata = {
+    foo = "bar"
+  }
+  network {
+    uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  }
+}
+`, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE)
+}
+
 func testAccComputeV2InstanceDataSourceID() string {
 	return fmt.Sprintf(`
 %s
@@ -107,4 +134,14 @@ data "opentelekomcloud_compute_instance_v2" "source_1" {
   name = "${opentelekomcloud_compute_instance_v2.instance_1.name}"
 }
 `, testAccComputeV2InstanceDataSourceBasic())
+}
+
+func testAccComputeV2InstanceDataSourceWindowsPassword() string {
+	return fmt.Sprintf(`
+%s
+
+data "opentelekomcloud_compute_instance_v2" "source_1" {
+  name = "${opentelekomcloud_compute_instance_v2.instance_1.name}"
+}
+`, testAccComputeV2InstanceDataSourceWindows())
 }

--- a/opentelekomcloud/services/ecs/data_source_opentelekomcloud_compute_instance_v2.go
+++ b/opentelekomcloud/services/ecs/data_source_opentelekomcloud_compute_instance_v2.go
@@ -67,6 +67,11 @@ func DataSourceComputeInstanceV2() *schema.Resource {
 				Computed:  true,
 				Sensitive: true,
 			},
+			"encrypted_password": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
 			"user_data": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -278,6 +283,12 @@ func dataSourceComputeInstanceV2Read(_ context.Context, d *schema.ResourceData, 
 			return fmterr.Errorf("error getting password: %w", err)
 		}
 		mErr = multierror.Append(mErr, d.Set("password", pass))
+	} else {
+		pass, err := servers.GetPassword(client, d.Id()).ExtractPassword(nil)
+		if err != nil {
+			return fmterr.Errorf("error getting password: %w", err)
+		}
+		mErr = multierror.Append(mErr, d.Set("encrypted_password", pass))
 	}
 
 	mErr = multierror.Append(mErr,

--- a/opentelekomcloud/services/ecs/data_source_opentelekomcloud_compute_instance_v2.go
+++ b/opentelekomcloud/services/ecs/data_source_opentelekomcloud_compute_instance_v2.go
@@ -57,7 +57,7 @@ func DataSourceComputeInstanceV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"ssh_private_key": {
+			"ssh_private_key_path": {
 				Type:      schema.TypeString,
 				Optional:  true,
 				Sensitive: true,
@@ -264,10 +264,10 @@ func dataSourceComputeInstanceV2Read(_ context.Context, d *schema.ResourceData, 
 	}
 
 	// Set win instance password
-	if v, ok := d.GetOk("ssh_private_key"); ok {
+	if v, ok := d.GetOk("ssh_private_key_path"); ok {
 		readFile, err := os.ReadFile(v.(string))
 		if err != nil {
-			return fmterr.Errorf("error reading private key file: %w", err, v)
+			return fmterr.Errorf("error reading private key file: %w", err)
 		}
 		privateKey, err := ssh.ParseRawPrivateKey(readFile)
 		if err != nil {

--- a/opentelekomcloud/services/ecs/data_source_opentelekomcloud_compute_instance_v2.go
+++ b/opentelekomcloud/services/ecs/data_source_opentelekomcloud_compute_instance_v2.go
@@ -115,6 +115,11 @@ func DataSourceComputeInstanceV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"admin_pass": {
+				Type:     schema.TypeString,
+				Computed: true,
+				// Sensitive: true,
+			},
 			"metadata": {
 				Type:     schema.TypeMap,
 				Computed: true,
@@ -243,6 +248,12 @@ func dataSourceComputeInstanceV2Read(_ context.Context, d *schema.ResourceData, 
 		mErr = multierror.Append(mErr, d.Set("power_state", currentStatus))
 	default:
 		return fmterr.Errorf("invalid power_state for instance %s: %s", d.Id(), server.Status)
+	}
+
+	// Set instance password
+	pass, err := servers.GetPassword(client, d.Id()).Extract()
+	if err != nil {
+		mErr = multierror.Append(mErr, d.Set("admin_pass", pass))
 	}
 
 	mErr = multierror.Append(mErr,

--- a/opentelekomcloud/services/ecs/data_source_opentelekomcloud_compute_instance_v2.go
+++ b/opentelekomcloud/services/ecs/data_source_opentelekomcloud_compute_instance_v2.go
@@ -134,9 +134,9 @@ func DataSourceComputeInstanceV2() *schema.Resource {
 				Computed: true,
 			},
 			"admin_pass": {
-				Type:     schema.TypeString,
-				Computed: true,
-				// Sensitive: true,
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
 			},
 			"metadata": {
 				Type:     schema.TypeMap,

--- a/opentelekomcloud/services/ecs/resource_opentelekomcloud_compute_instance_v2.go
+++ b/opentelekomcloud/services/ecs/resource_opentelekomcloud_compute_instance_v2.go
@@ -177,9 +177,10 @@ func ResourceComputeInstanceV2() *schema.Resource {
 				ForceNew: true,
 			},
 			"admin_pass": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: false,
+				Type:      schema.TypeString,
+				Optional:  true,
+				ForceNew:  false,
+				Sensitive: true,
 			},
 			"access_ip_v4": {
 				Type:     schema.TypeString,
@@ -668,6 +669,12 @@ func resourceComputeInstanceV2Read(ctx context.Context, d *schema.ResourceData, 
 	}
 	tagMap := common.TagsToMap(resourceTags)
 	mErr = multierror.Append(mErr, d.Set("tags", tagMap))
+
+	// Set instance password
+	pass, err := servers.GetPassword(client, d.Id()).Extract()
+	if err != nil {
+		mErr = multierror.Append(mErr, d.Set("admin_pass", pass))
+	}
 
 	if err := mErr.ErrorOrNil(); err != nil {
 		return fmterr.Errorf("error setting opentelekomcloud_compute_instance_v2 values: %w", err)

--- a/opentelekomcloud/services/ecs/resource_opentelekomcloud_compute_instance_v2.go
+++ b/opentelekomcloud/services/ecs/resource_opentelekomcloud_compute_instance_v2.go
@@ -107,7 +107,7 @@ func ResourceComputeInstanceV2() *schema.Resource {
 					}
 				},
 			},
-			"ssh_private_key": {
+			"ssh_private_key_path": {
 				Type:      schema.TypeString,
 				Optional:  true,
 				ForceNew:  false,
@@ -685,10 +685,10 @@ func resourceComputeInstanceV2Read(ctx context.Context, d *schema.ResourceData, 
 	mErr = multierror.Append(mErr, d.Set("tags", tagMap))
 
 	// Set win instance password
-	if v, ok := d.GetOk("ssh_private_key"); ok {
+	if v, ok := d.GetOk("ssh_private_key_path"); ok {
 		readFile, err := os.ReadFile(v.(string))
 		if err != nil {
-			return fmterr.Errorf("error reading private key file: %w", err, v)
+			return fmterr.Errorf("error reading private key file: %w", err)
 		}
 		privateKey, err := ssh.ParseRawPrivateKey(readFile)
 		if err != nil {

--- a/opentelekomcloud/services/ecs/resource_opentelekomcloud_compute_instance_v2.go
+++ b/opentelekomcloud/services/ecs/resource_opentelekomcloud_compute_instance_v2.go
@@ -190,6 +190,11 @@ func ResourceComputeInstanceV2() *schema.Resource {
 				Computed:  true,
 				Sensitive: true,
 			},
+			"encrypted_password": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
 			"admin_pass": {
 				Type:      schema.TypeString,
 				Optional:  true,
@@ -699,6 +704,12 @@ func resourceComputeInstanceV2Read(ctx context.Context, d *schema.ResourceData, 
 			return fmterr.Errorf("error getting password: %w", err)
 		}
 		mErr = multierror.Append(mErr, d.Set("password", pass))
+	} else {
+		pass, err := servers.GetPassword(client, d.Id()).ExtractPassword(nil)
+		if err != nil {
+			return fmterr.Errorf("error getting password: %w", err)
+		}
+		mErr = multierror.Append(mErr, d.Set("encrypted_password", pass))
 	}
 
 	if err := mErr.ErrorOrNil(); err != nil {

--- a/releasenotes/notes/compute-instance-windows-pass-e0337d5b3dd81d5d.yaml
+++ b/releasenotes/notes/compute-instance-windows-pass-e0337d5b3dd81d5d.yaml
@@ -1,0 +1,7 @@
+---
+enhancements:
+  - |
+    **[ECS]** Added ``password`` attribute to ``opentelekomcloud_compute_instance_v2`` resource
+    for Windows instances
+    (`#1947 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1947>`_)
+


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [x] Refers to: #1777
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccComputeV2InstanceDataSource_basic
--- PASS: TestAccComputeV2InstanceDataSource_basic (290.46s)

PASS

Process finished with exit code 0
```
