### PR TITLE
[CCE] Support EulerOs 2.9 in `resource/opentelekomcloud_cce_node_v3`

### DIFF
--- a/docs/resources/cce_node_pool_v3.md
+++ b/docs/resources/cce_node_pool_v3.md
@@ -67,6 +67,7 @@ the AZ based on the AZ sequence. For more details see
   Supported OS depends on kubernetes version of the cluster.
   * Clusters of Kubernetes `v1.13` or later support `EulerOS 2.5`.
   * Clusters of Kubernetes `v1.17` or later support `EulerOS 2.5` and `CentOS 7.7`.
+  * Clusters of Kubernetes `v1.21` or later support `EulerOS 2.5`, `EulerOS 2.9` and `CentOS 7.7`.
 
 * `name` - (Required) Node Pool Name.
 

--- a/docs/resources/cce_node_v3.md
+++ b/docs/resources/cce_node_v3.md
@@ -52,6 +52,7 @@ The following arguments are supported:
   Supported OS depends on kubernetes version of the cluster.
   * Clusters of Kubernetes `v1.13` or later support `EulerOS 2.5`.
   * Clusters of Kubernetes `v1.17` or later support `EulerOS 2.5` and `CentOS 7.7`.
+  * Clusters of Kubernetes `v1.21` or later support `EulerOS 2.5`, `EulerOS 2.9` and `CentOS 7.7`.
 
 * `billing_mode` - (Optional) Node's billing mode: The value is `0` (on demand). Changing this parameter will create a new resource.
 

--- a/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_node_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_node_v3_test.go
@@ -19,6 +19,7 @@ import (
 const (
 	resourceNameNode  = "opentelekomcloud_cce_node_v3.node_1"
 	resourceNameNode2 = "opentelekomcloud_cce_node_v3.node_2"
+	resourceNameNode3 = "opentelekomcloud_cce_node_v3.node_3"
 )
 
 func TestAccCCENodesV3Basic(t *testing.T) {
@@ -97,6 +98,7 @@ func TestAccCCENodesV3Timeout(t *testing.T) {
 func TestAccCCENodesV3OS(t *testing.T) {
 	var node nodes.Nodes
 	var node2 nodes.Nodes
+	var node3 nodes.Nodes
 
 	t.Parallel()
 	shared.BookCluster(t)
@@ -114,8 +116,8 @@ func TestAccCCENodesV3OS(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceNameNode, "os", "EulerOS 2.5"),
 					testAccCheckCCENodeV3Exists(resourceNameNode2, shared.DataSourceClusterName, &node2),
 					resource.TestCheckResourceAttr(resourceNameNode2, "os", "CentOS 7.7"),
-					testAccCheckCCENodeV3Exists(resourceNameNode2, shared.DataSourceClusterName, &node2),
-					resource.TestCheckResourceAttr(resourceNameNode2, "os", "EulerOS 2.9"),
+					testAccCheckCCENodeV3Exists(resourceNameNode3, shared.DataSourceClusterName, &node3),
+					resource.TestCheckResourceAttr(resourceNameNode3, "os", "EulerOS 2.9"),
 				),
 			},
 		},

--- a/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_node_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_node_v3_test.go
@@ -114,6 +114,8 @@ func TestAccCCENodesV3OS(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceNameNode, "os", "EulerOS 2.5"),
 					testAccCheckCCENodeV3Exists(resourceNameNode2, shared.DataSourceClusterName, &node2),
 					resource.TestCheckResourceAttr(resourceNameNode2, "os", "CentOS 7.7"),
+					testAccCheckCCENodeV3Exists(resourceNameNode2, shared.DataSourceClusterName, &node2),
+					resource.TestCheckResourceAttr(resourceNameNode2, "os", "EulerOS 2.9"),
 				),
 			},
 		},
@@ -464,6 +466,26 @@ resource "opentelekomcloud_cce_node_v3" "node_2" {
   name       = "test-node"
   flavor_id  = "s3.medium.1"
   os         = "CentOS 7.7"
+
+  availability_zone = "%[2]s"
+  key_pair          = "%[3]s"
+
+  root_volume {
+    size       = 40
+    volumetype = "SATA"
+  }
+
+  data_volumes {
+    size       = 100
+    volumetype = "SATA"
+  }
+}
+
+resource "opentelekomcloud_cce_node_v3" "node_3" {
+  cluster_id = data.opentelekomcloud_cce_cluster_v3.cluster.id
+  name       = "test-node"
+  flavor_id  = "s3.medium.1"
+  os         = "EulerOS 2.9"
 
   availability_zone = "%[2]s"
   key_pair          = "%[3]s"

--- a/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_v3.go
+++ b/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_v3.go
@@ -120,7 +120,7 @@ func ResourceCCENodeV3() *schema.Resource {
 				ForceNew: true,
 				Computed: true,
 				ValidateFunc: validation.StringInSlice([]string{
-					"EulerOS 2.5", "CentOS 7.7",
+					"EulerOS 2.5", "CentOS 7.7", "EulerOS 2.9",
 				}, false),
 			},
 			"root_volume": {

--- a/releasenotes/notes/cce-node-euler-version-e5da19a76fee4c0f.yaml
+++ b/releasenotes/notes/cce-node-euler-version-e5da19a76fee4c0f.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    [CCE] Support ``EulerOS 2.9`` in ``resource/opentelekomcloud_cce_node_v3`` (`#1950 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1950>`_)


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [x] Refers to: #1950 and #1949
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccCCENodesV3OS
=== PAUSE TestAccCCENodesV3OS
=== CONT  TestAccCCENodesV3OS
--- PASS: TestAccCCENodesV3OS (824.18s)
PASS

Process finished with the exit code 0
```
