### PR TITLE
[Provider]: `GetRegion` method fix on provider level

### DIFF
--- a/opentelekomcloud/common/cfg/config.go
+++ b/opentelekomcloud/common/cfg/config.go
@@ -1009,7 +1009,11 @@ func (c *Config) GetRegion(d SchemaOrDiff) string {
 		return v
 	}
 	tenantName := string(c.GetProjectName(d))
-	return strings.Split(tenantName, "_")[0]
+	if region := strings.Split(tenantName, "_")[0]; region != "" {
+		return region
+	}
+
+	return strings.Split(c.IdentityEndpoint, ".")[1]
 }
 
 type ProjectName string

--- a/releasenotes/notes/provider_getregion-4e2d84e93abe8ac1.yaml
+++ b/releasenotes/notes/provider_getregion-4e2d84e93abe8ac1.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[Provider]** Fix ``GetRegion`` method for ``provider`` in case AK/SK is used with region (`#1955 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1955>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Region wasn't digested in case provider auth used:

- `AK/SK`
- `region` 
- `tenant_id`

## PR Checklist

* [x] Refers to: #1951
* [x] Tests passed.
* [x] Release notes added.

## Acceptance Steps Performed

```
2022/10/06 11:31:14 [INFO] Building Swift S3 auth structure
2022/10/06 11:31:14 [INFO] Setting AWS metadata API timeout to 100ms
2022/10/06 11:31:15 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2022/10/06 11:31:15 [INFO] Swift S3 Auth provider used: "StaticProvider"
=== RUN   TestAccRdsInstanceV3Basic
--- PASS: TestAccRdsInstanceV3Basic (598.45s)
PASS

Process finished with the exit code 0

2022/10/06 11:50:45 [INFO] Building Swift S3 auth structure
2022/10/06 11:50:45 [INFO] Setting AWS metadata API timeout to 100ms
2022/10/06 11:50:46 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2022/10/06 11:50:46 [INFO] Swift S3 Auth provider used: "StaticProvider"
=== RUN   TestAccRdsInstanceV3ElasticIP
--- PASS: TestAccRdsInstanceV3ElasticIP (561.17s)
PASS

Process finished with the exit code 0
```
