### PR TITLE
[DCS]: Documentation fix and schema validations

### DIFF
--- a/docs/resources/dcs_instance_v1.md
+++ b/docs/resources/dcs_instance_v1.md
@@ -97,7 +97,7 @@ The following arguments are supported:
 * `engine` - (Required) Indicates a cache engine. Only `Redis` is supported. Changing this
   creates a new instance.
 
-* `engine_version` - (Required) Indicates the version of a cache engine, which is `3.0.7`.
+* `engine_version` - (Required) Indicates the version of a cache engine, which can be `3.0`/`4.0`/`5.0`.
   Changing this creates a new instance.
 
 * `capacity` - (Required) Indicates the Cache capacity. Unit: GB.

--- a/opentelekomcloud/acceptance/dcs/resource_opentelekomcloud_dcs_instance_v1_test.go
+++ b/opentelekomcloud/acceptance/dcs/resource_opentelekomcloud_dcs_instance_v1_test.go
@@ -106,6 +106,21 @@ func TestAccASV1Configuration_invalidSecurityGroup(t *testing.T) {
 	})
 }
 
+func TestAccASV1Configuration_invalidEngineVersion(t *testing.T) {
+	var instanceName = fmt.Sprintf("dcs_instance_%s", acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDcsV1InstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDcsV1InstanceEngineValidation(instanceName),
+				ExpectError: regexp.MustCompile(`expected engine_version to be one of \[3.0 4.0 5.0\].+`),
+			},
+		},
+	})
+}
+
 func TestAccASV1Configuration_WhitelistValidation(t *testing.T) {
 	var instanceName = fmt.Sprintf("dcs_instance_%s", acctest.RandString(5))
 	resource.ParallelTest(t, resource.TestCase{
@@ -358,6 +373,36 @@ resource "opentelekomcloud_dcs_instance_v1" "instance_1" {
   subnet_id       = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   available_zones = [data.opentelekomcloud_dcs_az_v1.az_1.id]
   product_id      = data.opentelekomcloud_dcs_product_v1.product_1.id
+}
+`, common.DataSourceSecGroupDefault, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, instanceName)
+}
+
+func testAccDcsV1InstanceEngineValidation(instanceName string) string {
+	return fmt.Sprintf(`
+%s
+
+%s
+
+data "opentelekomcloud_dcs_az_v1" "az_1" {
+  port = "8002"
+  code = "%s"
+}
+
+data "opentelekomcloud_dcs_product_v1" "product_1" {
+  spec_code = "redis.single.xu1.tiny.128"
+}
+
+resource "opentelekomcloud_dcs_instance_v1" "instance_1" {
+  name              = "%s"
+  engine_version    = "3.0.7"
+  password          = "Hungarian_rapsody"
+  engine            = "Redis"
+  capacity          = 0.125
+  vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  available_zones   = [data.opentelekomcloud_dcs_az_v1.az_1.id]
+  product_id        = data.opentelekomcloud_dcs_product_v1.product_1.id
+  security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
 }
 `, common.DataSourceSecGroupDefault, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, instanceName)
 }

--- a/opentelekomcloud/services/dcs/resource_opentelekomcloud_dcs_instance_v1.go
+++ b/opentelekomcloud/services/dcs/resource_opentelekomcloud_dcs_instance_v1.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/dcs/v1/configs"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/dcs/v1/instances"
@@ -58,6 +59,9 @@ func ResourceDcsInstanceV1() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"3.0", "4.0", "5.0",
+				}, false),
 			},
 			"capacity": {
 				Type:     schema.TypeFloat,
@@ -492,6 +496,7 @@ func resourceDcsInstancesV1Read(_ context.Context, d *schema.ResourceData, meta 
 	mErr := multierror.Append(
 		d.Set("name", v.Name),
 		d.Set("engine", v.Engine),
+		d.Set("engine_version", v.EngineVersion),
 		d.Set("capacity", capacity),
 		d.Set("used_memory", v.UsedMemory),
 		d.Set("max_memory", v.MaxMemory),
@@ -715,7 +720,7 @@ func validateEngine(_ context.Context, d *schema.ResourceDiff, _ interface{}) er
 	if _, ok := d.GetOk("security_group_id"); !ok && engineVersion == "3.0" {
 		mErr = multierror.Append(mErr, fmt.Errorf("'security_group_id' should be set with engine_version==3.0"))
 	} else if ok && engineVersion != "3.0" {
-		mErr = multierror.Append(mErr, fmt.Errorf("DCS Redis 4.0 and 5.0 instances do not support security groups"))
+		mErr = multierror.Append(mErr, fmt.Errorf("only DCS Redis 3.0 supports security groups"))
 	}
 
 	if _, ok := d.GetOk("whitelist"); ok && engineVersion == "3.0" {

--- a/releasenotes/notes/dcs_minor_fix-25ddfd5a7e05b3c2.yaml
+++ b/releasenotes/notes/dcs_minor_fix-25ddfd5a7e05b3c2.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    **[DCS]** Fixed schema validation and documentation for ``resource/opentelekomcloud_dcs_instance_v1`` (`#1960 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1960>`_)
+


### PR DESCRIPTION
## Summary of the Pull Request
Engine version fix for documentation and additional validation.

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccASV1Configuration_WhitelistValidation
=== PAUSE TestAccASV1Configuration_WhitelistValidation
=== CONT  TestAccASV1Configuration_WhitelistValidation
--- PASS: TestAccASV1Configuration_WhitelistValidation (7.59s)
PASS

Process finished with the exit code 0

=== RUN   TestAccASV1Configuration_invalidEngineVersion
=== PAUSE TestAccASV1Configuration_invalidEngineVersion
=== CONT  TestAccASV1Configuration_invalidEngineVersion
--- PASS: TestAccASV1Configuration_invalidEngineVersion (6.24s)
PASS

Process finished with the exit code 0

=== RUN   TestAccASV1Configuration_invalidSecurityGroup
=== PAUSE TestAccASV1Configuration_invalidSecurityGroup
=== CONT  TestAccASV1Configuration_invalidSecurityGroup
--- PASS: TestAccASV1Configuration_invalidSecurityGroup (7.82s)
PASS

Process finished with the exit code 0

=== RUN   TestAccDcsInstancesV1_basicSingleInstance
=== PAUSE TestAccDcsInstancesV1_basicSingleInstance
=== CONT  TestAccDcsInstancesV1_basicSingleInstance
--- PASS: TestAccDcsInstancesV1_basicSingleInstance (67.37s)
PASS

Process finished with the exit code 0

=== RUN   TestAccDcsInstancesV1_basic
=== PAUSE TestAccDcsInstancesV1_basic
=== CONT  TestAccDcsInstancesV1_basic
--- PASS: TestAccDcsInstancesV1_basic (120.46s)
PASS

Process finished with the exit code 0

=== RUN   TestAccDcsInstancesV1_Whitelist
=== PAUSE TestAccDcsInstancesV1_Whitelist
=== CONT  TestAccDcsInstancesV1_Whitelist
--- PASS: TestAccDcsInstancesV1_Whitelist (201.99s)
PASS

Process finished with the exit code 0

=== RUN   TestAccDcsInstancesV1_basicEngineV3Instance
=== PAUSE TestAccDcsInstancesV1_basicEngineV3Instance
=== CONT  TestAccDcsInstancesV1_basicEngineV3Instance
--- PASS: TestAccDcsInstancesV1_basicEngineV3Instance (378.03s)
```
