### PR TITLE
[AutoScaling] refactoring `resource/opentelekomcloud_as_*`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,3 +34,7 @@ linters-settings:
   misspell:
     ignore-words:
       - unknwon
+  staticcheck:
+    checks:
+      - all
+      - '-SA1019' # disable the rule SA1019

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/jinzhu/copier v0.3.5
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.5.23-0.20220921110146-fa37d7f29866
+	github.com/opentelekomcloud/gophertelekomcloud v0.5.23-0.20221006091234-40be4b181d4d
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9

--- a/go.sum
+++ b/go.sum
@@ -204,8 +204,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.5.23-0.20220921110146-fa37d7f29866 h1:TgZRIYIHHtGjDprCGXtviW4hecQWhSzj1bPe0hFWPW0=
-github.com/opentelekomcloud/gophertelekomcloud v0.5.23-0.20220921110146-fa37d7f29866/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
+github.com/opentelekomcloud/gophertelekomcloud v0.5.23-0.20221006091234-40be4b181d4d h1:p4MgHl4p6On3v2cTiBwcC/rqtoQRN+li9EIc6EbA6Bw=
+github.com/opentelekomcloud/gophertelekomcloud v0.5.23-0.20221006091234-40be4b181d4d/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/opentelekomcloud/acceptance/as/resource_opentelekomcloud_as_configuration_v1_test.go
+++ b/opentelekomcloud/acceptance/as/resource_opentelekomcloud_as_configuration_v1_test.go
@@ -119,7 +119,7 @@ func testAccCheckASV1ConfigurationDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := configurations.Get(client, rs.Primary.ID).Extract()
+		_, err := configurations.Get(client, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("AS configuration still exists")
 		}
@@ -145,7 +145,7 @@ func testAccCheckASV1ConfigurationExists(n string, configuration *configurations
 			return fmt.Errorf("error creating OpenTelekomCloud AutoScalingV1 client: %w", err)
 		}
 
-		found, err := configurations.Get(client, rs.Primary.ID).Extract()
+		found, err := configurations.Get(client, rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -153,7 +153,7 @@ func testAccCheckASV1ConfigurationExists(n string, configuration *configurations
 		if found.ID != rs.Primary.ID {
 			return fmt.Errorf("autoscaling Configuration not found")
 		}
-		configuration = &found
+		configuration = found
 
 		return nil
 	}
@@ -190,17 +190,17 @@ resource "opentelekomcloud_as_configuration_v1" "as_config"{
   instance_config {
     image = data.opentelekomcloud_images_image_v2.latest_image.id
     disk {
-      size        = 32768
+      size        = 1000
       volume_type = "uh-l1"
       disk_type   = "SYS"
     }
     disk {
-      size        = 32768
+      size        = 1000
       volume_type = "co-p1"
       disk_type   = "DATA"
     }
     disk {
-      size        = 32768
+      size        = 1000
       volume_type = "uh-l1"
       disk_type   = "DATA"
     }

--- a/opentelekomcloud/acceptance/as/resource_opentelekomcloud_as_group_v1_test.go
+++ b/opentelekomcloud/acceptance/as/resource_opentelekomcloud_as_group_v1_test.go
@@ -126,7 +126,7 @@ func testAccCheckASV1GroupDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := groups.Get(client, rs.Primary.ID).Extract()
+		_, err := groups.Get(client, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("AS group still exists")
 		}
@@ -152,7 +152,7 @@ func testAccCheckASV1GroupExists(n string, group *groups.Group) resource.TestChe
 			return fmt.Errorf("error creating OpenTelekomCloud AutoScalingV1 client: %w", err)
 		}
 
-		found, err := groups.Get(client, rs.Primary.ID).Extract()
+		found, err := groups.Get(client, rs.Primary.ID)
 		if err != nil {
 			return err
 		}

--- a/opentelekomcloud/acceptance/as/resource_opentelekomcloud_as_policy_v1_test.go
+++ b/opentelekomcloud/acceptance/as/resource_opentelekomcloud_as_policy_v1_test.go
@@ -52,7 +52,7 @@ func testAccCheckASV1PolicyDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := policies.Get(client, rs.Primary.ID).Extract()
+		_, err := policies.Get(client, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("AS policy still exists")
 		}
@@ -78,12 +78,12 @@ func testAccCheckASV1PolicyExists(n string, policy *policies.Policy) resource.Te
 			return fmt.Errorf("error creating OpenTelekomCloud AutoScalingV1 client: %w", err)
 		}
 
-		found, err := policies.Get(client, rs.Primary.ID).Extract()
+		found, err := policies.Get(client, rs.Primary.ID)
 		if err != nil {
 			return err
 		}
 
-		policy = &found
+		policy = found
 
 		return nil
 	}
@@ -115,6 +115,8 @@ resource "opentelekomcloud_as_configuration_v1" "as_config"{
 resource "opentelekomcloud_as_group_v1" "as_group"{
   scaling_group_name       = "as_group"
   scaling_configuration_id = opentelekomcloud_as_configuration_v1.as_config.id
+  delete_instances         = "yes"
+  delete_publicip          = true
   networks {
     id = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }

--- a/opentelekomcloud/acceptance/as/resource_opentelekomcloud_as_policy_v2_test.go
+++ b/opentelekomcloud/acceptance/as/resource_opentelekomcloud_as_policy_v2_test.go
@@ -110,7 +110,7 @@ func testAccCheckASV2PolicyDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := policies.Get(client, rs.Primary.ID).Extract()
+		_, err := policies.Get(client, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("AS policyV2 still exists")
 		}
@@ -136,12 +136,12 @@ func testAccCheckASV2PolicyExists(n string, policy *policies.Policy) resource.Te
 			return fmt.Errorf("error creating OpenTelekomCloud AutoScalingV2 client: %w", err)
 		}
 
-		found, err := policies.Get(asClient, rs.Primary.ID).Extract()
+		found, err := policies.Get(asClient, rs.Primary.ID)
 		if err != nil {
 			return err
 		}
 
-		policy = &found
+		policy = found
 
 		return nil
 	}

--- a/opentelekomcloud/services/as/resource_opentelekomcloud_as_policy_v1.go
+++ b/opentelekomcloud/services/as/resource_opentelekomcloud_as_policy_v1.go
@@ -218,7 +218,7 @@ func resourceASPolicyCreate(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	log.Printf("[DEBUG] Create AS policy Options: %#v", createOpts)
-	asPolicyId, err := policies.Create(asClient, createOpts).Extract()
+	asPolicyId, err := policies.Create(asClient, createOpts)
 	if err != nil {
 		return fmterr.Errorf("error creating ASPolicy: %s", err)
 	}
@@ -234,7 +234,7 @@ func resourceASPolicyRead(_ context.Context, d *schema.ResourceData, meta interf
 		return fmterr.Errorf("error creating OpenTelekomCloud autoscaling client: %s", err)
 	}
 
-	asPolicy, err := policies.Get(asClient, d.Id()).Extract()
+	asPolicy, err := policies.Get(asClient, d.Id())
 	if err != nil {
 		return common.CheckDeletedDiag(d, err, "AS Policy")
 	}
@@ -302,7 +302,7 @@ func resourceASPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		updateOpts.Action = policyAction
 	}
 	log.Printf("[DEBUG] Update AS policy Options: %#v", updateOpts)
-	asPolicyID, err := policies.Update(asClient, d.Id(), updateOpts).Extract()
+	asPolicyID, err := policies.Update(asClient, d.Id(), updateOpts)
 	if err != nil {
 		return fmterr.Errorf("error updating ASPolicy %q: %s", asPolicyID, err)
 	}
@@ -317,7 +317,7 @@ func resourceASPolicyDelete(_ context.Context, d *schema.ResourceData, meta inte
 		return fmterr.Errorf("error creating OpenTelekomCloud autoscaling client: %s", err)
 	}
 	log.Printf("[DEBUG] Begin to delete AS policy %q", d.Id())
-	if delErr := policies.Delete(asClient, d.Id()).ExtractErr(); delErr != nil {
+	if delErr := policies.Delete(asClient, d.Id()); delErr != nil {
 		return fmterr.Errorf("error deleting AS policy: %s", delErr)
 	}
 

--- a/opentelekomcloud/services/as/resource_opentelekomcloud_as_policy_v2.go
+++ b/opentelekomcloud/services/as/resource_opentelekomcloud_as_policy_v2.go
@@ -203,7 +203,7 @@ func resourceASPolicyV2Create(ctx context.Context, d *schema.ResourceData, meta 
 		return fmterr.Errorf(errCreationV2Client, err)
 	}
 
-	createOpts := policies.CreateOpts{
+	createOpts := policies.PolicyOpts{
 		PolicyName:     d.Get("scaling_policy_name").(string),
 		PolicyType:     d.Get("scaling_policy_type").(string),
 		ResourceID:     d.Get("scaling_resource_id").(string),
@@ -213,7 +213,7 @@ func resourceASPolicyV2Create(ctx context.Context, d *schema.ResourceData, meta 
 		PolicyAction:   resourceASPolicyScalingAction(d),
 		CoolDownTime:   d.Get("cool_down_time").(int),
 	}
-	asPolicyID, err := policies.Create(client, createOpts).Extract()
+	asPolicyID, err := policies.Create(client, createOpts)
 	if err != nil {
 		return fmterr.Errorf("error creating AS Policy: %w", err)
 	}
@@ -229,7 +229,7 @@ func resourceASPolicyV2Read(_ context.Context, d *schema.ResourceData, meta inte
 		return fmterr.Errorf(errCreationV2Client, err)
 	}
 
-	asPolicy, err := policies.Get(client, d.Id()).Extract()
+	asPolicy, err := policies.Get(client, d.Id())
 	if err != nil {
 		return common.CheckDeletedDiag(d, err, "AS Policy")
 	}
@@ -289,18 +289,18 @@ func resourceASPolicyV2Update(ctx context.Context, d *schema.ResourceData, meta 
 		return fmterr.Errorf(errCreationV2Client, err)
 	}
 
-	updateOpts := policies.UpdateOpts{
+	updateOpts := policies.PolicyOpts{
 		PolicyName:     d.Get("scaling_policy_name").(string),
 		PolicyType:     d.Get("scaling_policy_type").(string),
 		ResourceID:     d.Get("scaling_resource_id").(string),
 		ResourceType:   d.Get("scaling_resource_type").(string),
 		AlarmID:        d.Get("alarm_id").(string),
 		SchedulePolicy: resourceASPolicyScheduledPolicy(d),
-		Action:         resourceASPolicyScalingAction(d),
+		PolicyAction:   resourceASPolicyScalingAction(d),
 		CoolDownTime:   d.Get("cool_down_time").(int),
 	}
 
-	asPolicyID, err := policies.Update(client, d.Id(), updateOpts).Extract()
+	asPolicyID, err := policies.Update(client, d.Id(), updateOpts)
 	if err != nil {
 		return fmterr.Errorf("error updating ASPolicy %q: %w", asPolicyID, err)
 	}
@@ -315,7 +315,7 @@ func resourceASPolicyV2Delete(_ context.Context, d *schema.ResourceData, meta in
 		return fmterr.Errorf(errCreationV1Client, err)
 	}
 
-	if err := policies.Delete(client, d.Id()).ExtractErr(); err != nil {
+	if err := policies.Delete(client, d.Id()); err != nil {
 		return fmterr.Errorf("error deleting AS Policy: %w", err)
 	}
 

--- a/releasenotes/notes/as-ref-update-678c978b0615be9e.yaml
+++ b/releasenotes/notes/as-ref-update-678c978b0615be9e.yaml
@@ -1,0 +1,3 @@
+other:
+  - |
+    **[AS]** Get rid of inline Extracts and refactoring for ``resource/opentelekomcloud_as_*`` (`#1963 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1963>`_)


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccASPolicyV2_basic
=== PAUSE TestAccASPolicyV2_basic
=== CONT  TestAccASPolicyV2_basic
--- PASS: TestAccASPolicyV2_basic (326.88s)
=== RUN   TestAccASPolicyV2_withSize
=== PAUSE TestAccASPolicyV2_withSize
=== CONT  TestAccASPolicyV2_withSize
--- PASS: TestAccASPolicyV2_withSize (246.98s)
=== RUN   TestAccASPolicyV2_conflictsAction
--- PASS: TestAccASPolicyV2_conflictsAction (99.42s)
PASS

=== RUN   TestAccASV1Policy_basic
=== PAUSE TestAccASV1Policy_basic
=== CONT  TestAccASV1Policy_basic
--- PASS: TestAccASV1Policy_basic (100.68s)
PASS

=== RUN   TestAccASV1Group_basic
=== PAUSE TestAccASV1Group_basic
=== CONT  TestAccASV1Group_basic
--- PASS: TestAccASV1Group_basic (254.86s)
=== RUN   TestAccASV1Group_RemoveWithSetMinNumber
=== PAUSE TestAccASV1Group_RemoveWithSetMinNumber
=== CONT  TestAccASV1Group_RemoveWithSetMinNumber
--- PASS: TestAccASV1Group_RemoveWithSetMinNumber (210.36s)
=== RUN   TestAccASV1Group_WithoutSecurityGroups
=== PAUSE TestAccASV1Group_WithoutSecurityGroups
=== CONT  TestAccASV1Group_WithoutSecurityGroups
--- PASS: TestAccASV1Group_WithoutSecurityGroups (210.36s)
PASS


=== RUN   TestAccASV1Configuration_basic
=== PAUSE TestAccASV1Configuration_basic
=== CONT  TestAccASV1Configuration_basic
--- PASS: TestAccASV1Configuration_basic (137.26s)
=== RUN   TestAccASV1Configuration_publicIP
=== PAUSE TestAccASV1Configuration_publicIP
=== CONT  TestAccASV1Configuration_publicIP
--- PASS: TestAccASV1Configuration_publicIP (145.24s)
=== RUN   TestAccASV1Configuration_invalidDiskSize
=== PAUSE TestAccASV1Configuration_invalidDiskSize
=== CONT  TestAccASV1Configuration_invalidDiskSize
--- PASS: TestAccASV1Configuration_invalidDiskSize (84.72s)
=== RUN   TestAccASV1Configuration_multipleSecurityGroups
=== PAUSE TestAccASV1Configuration_multipleSecurityGroups
=== CONT  TestAccASV1Configuration_multipleSecurityGroups
--- PASS: TestAccASV1Configuration_multipleSecurityGroups (160.15s)
PASS

Process finished with the exit code 0
```
