### PR TITLE
Change VPC subnet default secondary DNS to OTC DNS

### DIFF
--- a/docs/resources/networking_subnet_v2.md
+++ b/docs/resources/networking_subnet_v2.md
@@ -57,7 +57,7 @@ The following arguments are supported:
 
 * `dns_nameservers` - (Optional) An array of DNS name server names used by hosts
   in this subnet. Changing this updates the DNS name servers for the existing
-  subnet. Default value is `["100.125.4.25", "1.1.1.1"]`
+  subnet. Default value is `["100.125.4.25", "100.125.129.199"]`
 
 * `host_routes` - (Optional) An array of routes that should be used by devices
   with IPs from this subnet (not including local subnet route). The host_route

--- a/docs/resources/vpc_subnet_v1.md
+++ b/docs/resources/vpc_subnet_v1.md
@@ -69,7 +69,7 @@ The following arguments are supported:
   valid IP address. Default is `100.125.4.25`, OpenTelekomCloud internal DNS server.
 
 * `secondary_dns` - (Optional) Specifies the IP address of DNS server 2 on the subnet. The value must be a
-  valid IP address. Default is `1.1.1.1`, `Cloudflare`/`APNIC` public DNS server.
+  valid IP address. Default is `100.125.129.199`, OpenTelekomCloud secondary internal DNS server.
 
 * `dns_list` - (Optional) Specifies the DNS server address list of a subnet. This field is required if you
   need to use more than two DNS servers. This parameter value is the superset of both DNS server address

--- a/opentelekomcloud/services/vpc/utils.go
+++ b/opentelekomcloud/services/vpc/utils.go
@@ -5,4 +5,4 @@ import "github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentele
 // This is a global MutexKV for use within this plugin.
 var osMutexKV = mutexkv.NewMutexKV()
 
-var defaultDNS = []string{"100.125.4.25", "1.1.1.1"}
+var defaultDNS = []string{"100.125.4.25", "100.125.129.199"}

--- a/releasenotes/notes/doc-vpc-secondary-dns-update-af003c93b9505cd7.yaml
+++ b/releasenotes/notes/doc-vpc-secondary-dns-update-af003c93b9505cd7.yaml
@@ -1,0 +1,4 @@
+---
+other:
+  - |
+    **[VPC]** Change VPC subnet default secondary DNS to OTC DNS in ``services/vpc/utils.go`` and docs ``docs/resources/networking_subnet_v2.md`` ``docs/resources/vpc_subnet_v1.md`` (`#1964 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1964>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Change VPC subnet default secondary DNS to OTC DNS

by using OTC secondary DNS as default we prevent issues for customers using private DNS zones as these cannot be resolved by public DNS providers like cloudflare.

