### PR TITLE
[IAM]: New `data/opentelekomcloud_identity_role_custom_v3` to query custom roles

### DIFF
--- a/docs/data-sources/identity_role_custom_v3.md
+++ b/docs/data-sources/identity_role_custom_v3.md
@@ -1,0 +1,77 @@
+---
+subcategory: "Identity and Access Management (IAM)"
+---
+
+# opentelekomcloud_identity_role_custom_v3
+
+Use this data source to get the info of custom OpenTelekomCloud role.
+
+-> For pre-defined user roles usage please refer to `opentelekomcloud_identity_role_v3`
+
+## Example Usage
+
+### Querying custom role by `display_name`
+
+```hcl
+data "opentelekomcloud_identity_role_custom_v3" "auth_admin" {
+  display_name = "my-custom-policy"
+}
+```
+
+### Querying custom role by resource `id`
+
+```hcl
+data "opentelekomcloud_identity_role_custom_v3" "auth_admin" {
+  id = "13f0e753101649699664672d7b7af752"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `display_name` - (Optional) The name of the role.
+
+* `type` - (Optional) Display layer of a role.
+    * `domain` - A role is displayed at the domain layer.
+    * `project` - A role is displayed at the project layer.
+
+* `id` - (Optional) The `id` of custom role.
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are exported:
+
+* `description` - Description of a role.
+
+* `catalog` - Directory where a role locates
+
+* `domain_id` - ID of the domain to which a role belongs
+
+* `name` - Name of a role
+
+* `statement` - Statement: The Statement field contains the Effect and Action
+  elements. Effect indicates whether the policy allows or denies
+  access. Action indicates authorization items. The number of
+  statements cannot exceed 8. Structure is documented below.
+
+The `statement` block supports:
+
+* `action` - Permission set, which specifies the operation permissions on
+  resources. The number of permission sets cannot exceed 100.
+  Format:  The value format is Service name:Resource type:Action,
+  for example, vpc:ports:create. Service name: indicates the
+  product name, such as ecs, evs, or vpc. Only lowercase letters
+  are allowed. Resource type and Action: The values are
+  case-insensitive, and the wildcard (*) are allowed. A wildcard
+  (*) can represent all or part of information about resource
+  types and actions for the specific service.
+
+* `effect` - The value can be Allow and Deny. If both Allow and Deny are
+  found in statements, the policy evaluation starts with Deny.
+
+* `resource` -  The resources which will be granted/denied accesses.
+  Format: `Service:*:*:resource:resource_path`.
+  Examples: `KMS:*:*:KeyId:your_key`, `OBS:*:*:bucket:your_bucket`, `OBS:*:*:object:your_object`.
+
+* `condition` - The conditions for the permission to take effect.

--- a/docs/data-sources/identity_role_v3.md
+++ b/docs/data-sources/identity_role_v3.md
@@ -6,6 +6,8 @@ subcategory: "Identity and Access Management (IAM)"
 
 Use this data source to get the ID of an OpenTelekomCloud role.
 
+-> For custom user roles usage please refer to `opentelekomcloud_identity_role_custom_v3`
+
 The Role in Terraform is the same as Policy on the console. however,
 The policy name is the display name of Role, the Role name cannot
 be found on Console. please refer to the following table to configuration

--- a/opentelekomcloud/acceptance/iam/data_source_opentelekomcloud_identity_role_custom_v3_test.go
+++ b/opentelekomcloud/acceptance/iam/data_source_opentelekomcloud_identity_role_custom_v3_test.go
@@ -1,0 +1,50 @@
+package acceptance
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+)
+
+func TestAccOpenStackIdentityV3CustomRoleDataSource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+			common.TestAccPreCheckAdminOnly(t)
+		},
+		ProviderFactories: common.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOpenStackIdentityV3CustomRoleDataSource_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIdentityV3DataSourceID("data.opentelekomcloud_identity_role_custom_v3.role_1"),
+					resource.TestCheckResourceAttr(
+						"data.opentelekomcloud_identity_role_custom_v3.role_1", "display_name", "custom_role-terraform"),
+					resource.TestCheckResourceAttr(
+						"data.opentelekomcloud_identity_role_custom_v3.role_1", "description", "role"),
+					resource.TestCheckResourceAttr(
+						"data.opentelekomcloud_identity_role_custom_v3.role_1", "type", "domain"),
+					resource.TestCheckResourceAttr(
+						"data.opentelekomcloud_identity_role_custom_v3.role_1", "statement.0.effect", "Allow"),
+				),
+			},
+		},
+	})
+}
+
+const testAccOpenStackIdentityV3CustomRoleDataSource_basic = `
+data "opentelekomcloud_identity_role_custom_v3" "role_1" {
+  display_name = opentelekomcloud_identity_role_v3.role.display_name
+}
+
+resource "opentelekomcloud_identity_role_v3" "role" {
+  description   = "role"
+  display_name  = "custom_role-terraform"
+  display_layer = "domain"
+  statement {
+    effect = "Allow"
+    action = ["ecs:*:list*"]
+  }
+}
+`

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -266,6 +266,7 @@ func Provider() *schema.Provider {
 			"opentelekomcloud_identity_project_v3":             iam.DataSourceIdentityProjectV3(),
 			"opentelekomcloud_identity_projects_v3":            iam.DataSourceIdentityProjectsV3(),
 			"opentelekomcloud_identity_role_v3":                iam.DataSourceIdentityRoleV3(),
+			"opentelekomcloud_identity_role_custom_v3":         iam.DataSourceIdentityRoleCustomV3(),
 			"opentelekomcloud_identity_user_v3":                iam.DataSourceIdentityUserV3(),
 			"opentelekomcloud_images_image_v2":                 ims.DataSourceImagesImageV2(),
 			"opentelekomcloud_kms_key_v1":                      kms.DataSourceKmsKeyV1(),

--- a/opentelekomcloud/services/iam/data_source_opentelekomcloud_identity_role_custom_v3.go
+++ b/opentelekomcloud/services/iam/data_source_opentelekomcloud_identity_role_custom_v3.go
@@ -1,0 +1,174 @@
+package iam
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/identity/v3/policies"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
+)
+
+func DataSourceIdentityRoleCustomV3() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceIdentityCustomRoleV3Read,
+
+		Schema: map[string]*schema.Schema{
+			"display_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ConflictsWith: []string{
+					"id",
+				},
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ConflictsWith: []string{
+					"id",
+				},
+				ValidateFunc: validation.StringInSlice([]string{
+					"domain", "project",
+				}, false),
+			},
+
+			"id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				ConflictsWith: []string{
+					"display_name",
+					"type",
+				},
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"domain_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"statement": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"action": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"effect": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"resource": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"condition": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// dataSourceIdentityRoleV3Read performs the role lookup.
+func dataSourceIdentityCustomRoleV3Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	identityClient, err := config.IdentityV30Client()
+	if err != nil {
+		return fmterr.Errorf("error creating OpenStack identity client: %s", err)
+	}
+
+	var roleType string
+	if v, ok := d.GetOk("type"); ok {
+		if v == "project" {
+			roleType = "XA"
+		} else {
+			roleType = "AX"
+		}
+	}
+
+	listOpts := policies.ListOpts{
+		DisplayName: d.Get("display_name").(string),
+		Type:        roleType,
+		ID:          d.Get("id").(string),
+	}
+
+	log.Printf("[DEBUG] List Options: %#v", listOpts)
+
+	var role policies.Policy
+	allPolicies, err := policies.List(identityClient, listOpts)
+	if err != nil {
+		return fmterr.Errorf("unable to query custome roles: %s", err)
+	}
+
+	if len(allPolicies.Roles) < 1 {
+		return fmterr.Errorf("your query returned no results. " +
+			"Please change your search criteria and try again.")
+	}
+
+	if len(allPolicies.Roles) > 1 {
+		log.Printf("[DEBUG] Multiple results found: %#v", allPolicies.Roles)
+		return fmterr.Errorf("your query returned more than one result. Please try a more " +
+			"specific search criteria.")
+	}
+	role = allPolicies.Roles[0]
+
+	log.Printf("[DEBUG] Single Role found: %s", role.ID)
+	return diag.FromErr(dataSourceIdentityCustomRoleV3Attributes(d, &role))
+}
+
+// dataSourceIdentityCustomRoleV3Attributes populates the fields of a custom Role resource.
+func dataSourceIdentityCustomRoleV3Attributes(d *schema.ResourceData, role *policies.Policy) error {
+	log.Printf("[DEBUG] opentelekomcloud_identity_role_v3 details: %#v", role)
+
+	d.SetId(role.ID)
+
+	displayLayer := role.Type
+	if displayLayer == "AX" {
+		displayLayer = "domain"
+	} else {
+		displayLayer = "project"
+	}
+
+	statements, err := buildStatementsSet(role)
+	if err != nil {
+		return err
+	}
+
+	mErr := multierror.Append(
+		d.Set("name", role.Name),
+		d.Set("display_name", role.DisplayName),
+		d.Set("domain_id", role.DomainId),
+		d.Set("description", role.Description),
+		d.Set("type", displayLayer),
+		d.Set("statement", statements),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/opentelekomcloud/services/iam/resource_opentelekomcloud_identity_role_v3.go
+++ b/opentelekomcloud/services/iam/resource_opentelekomcloud_identity_role_v3.go
@@ -214,22 +214,9 @@ func resourceIdentityRoleV3Read(ctx context.Context, d *schema.ResourceData, met
 		return common.CheckDeletedDiag(d, err, "custom IAM Role")
 	}
 
-	statements := make([]interface{}, len(role.Policy.Statement))
-	for i, statement := range role.Policy.Statement {
-		var condition string
-		if len(statement.Condition) > 0 {
-			jsonOutput, err := json.Marshal(statement.Condition)
-			if err != nil {
-				return diag.FromErr(err)
-			}
-			condition = string(jsonOutput)
-		}
-		statements[i] = map[string]interface{}{
-			"effect":    statement.Effect,
-			"action":    statement.Action,
-			"resource":  statement.Resource,
-			"condition": condition,
-		}
+	statements, err := buildStatementsSet(role)
+	if err != nil {
+		return fmterr.Errorf("error building policy statements(READ): %s", err)
 	}
 
 	displayLayer := role.Type

--- a/releasenotes/notes/iam_data_custom_roles-f6e440e5eb2359e3.yaml
+++ b/releasenotes/notes/iam_data_custom_roles-f6e440e5eb2359e3.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    **[IAM]** New ``data/opentelekomcloud_identity_role_custom_v3`` to query custom roles (`#1965 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1965>`_)
+other:
+  - |
+    **[IAM]** Refactoring of ``resource/opentelekomcloud_identity_role_v3`` (`#1965 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1965>`_)


### PR DESCRIPTION
## Summary of the Pull Request
New data source that enables query of custom roles.

## PR Checklist

* [x] Refers to: #1959
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccIdentityRoleV3_basic
--- PASS: TestAccIdentityRoleV3_basic (86.82s)
=== RUN   TestAccIdentityV3Role_importBasic
--- PASS: TestAccIdentityV3Role_importBasic (38.76s)
PASS

Process finished with the exit code 0


=== RUN   TestAccOpenStackIdentityV3CustomRoleDataSource_basic
--- PASS: TestAccOpenStackIdentityV3CustomRoleDataSource_basic (39.42s)
PASS

Process finished with the exit code 0

```
