### PR TITLE
[CSS] refactoring `resource/opentelekomcloud_css_*`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/jinzhu/copier v0.3.5
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.5.23-0.20221006091234-40be4b181d4d
+	github.com/opentelekomcloud/gophertelekomcloud v0.5.23-0.20221013115335-1a9bd8636a56
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9

--- a/go.sum
+++ b/go.sum
@@ -204,8 +204,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.5.23-0.20221006091234-40be4b181d4d h1:p4MgHl4p6On3v2cTiBwcC/rqtoQRN+li9EIc6EbA6Bw=
-github.com/opentelekomcloud/gophertelekomcloud v0.5.23-0.20221006091234-40be4b181d4d/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
+github.com/opentelekomcloud/gophertelekomcloud v0.5.23-0.20221013115335-1a9bd8636a56 h1:PVHKG+c1QxlSKFrZ8Wq63oC/XfchnHLQ5/SDWANI874=
+github.com/opentelekomcloud/gophertelekomcloud v0.5.23-0.20221013115335-1a9bd8636a56/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/opentelekomcloud/acceptance/css/resource_opentelekomcloud_css_cluster_v1_test.go
+++ b/opentelekomcloud/acceptance/css/resource_opentelekomcloud_css_cluster_v1_test.go
@@ -143,7 +143,7 @@ func testAccCheckCssClusterV1Destroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := clusters.Get(client, rs.Primary.ID).Extract()
+		_, err := clusters.Get(client, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("cluster still exists")
 		}
@@ -169,7 +169,7 @@ func testAccCheckCssClusterV1Exists(n string, cluster *clusters.Cluster) resourc
 			return fmt.Errorf("error creating CSSv1 client: %w", err)
 		}
 
-		found, err := clusters.Get(client, rs.Primary.ID).Extract()
+		found, err := clusters.Get(client, rs.Primary.ID)
 		if err != nil {
 			return err
 		}

--- a/opentelekomcloud/acceptance/css/utils.go
+++ b/opentelekomcloud/acceptance/css/utils.go
@@ -32,12 +32,7 @@ func findSharedFlavor(t *testing.T) {
 			t.Fatalf("error creating CSSv1 client: %s", err)
 		}
 
-		pages, err := flavors.List(client).AllPages()
-		if err != nil {
-			t.Fatalf("error reading cluster value: %s", err)
-		}
-
-		versions, err := flavors.ExtractVersions(pages)
+		versions, err := flavors.List(client)
 		if err != nil {
 			t.Fatalf("error extracting versions: %s", err)
 		}

--- a/opentelekomcloud/services/as/resource_opentelekomcloud_as_policy_v1.go
+++ b/opentelekomcloud/services/as/resource_opentelekomcloud_as_policy_v1.go
@@ -178,8 +178,8 @@ func getScheduledPolicy(rawScheduledPolicy map[string]interface{}) policies.Sche
 	return scheduledPolicy
 }
 
-func getPolicyAction(rawPolicyAction map[string]interface{}) policies.ActionOpts {
-	policyAction := policies.ActionOpts{
+func getPolicyAction(rawPolicyAction map[string]interface{}) policies.Action {
+	policyAction := policies.Action{
 		Operation:   rawPolicyAction["operation"].(string),
 		InstanceNum: rawPolicyAction["instance_number"].(int),
 	}

--- a/opentelekomcloud/services/css/data_source_opentelekomcloud_css_flavor_v1.go
+++ b/opentelekomcloud/services/css/data_source_opentelekomcloud_css_flavor_v1.go
@@ -97,12 +97,7 @@ func dataSourceCSSFlavorV1Read(_ context.Context, d *schema.ResourceData, meta i
 		return fmterr.Errorf("error creating CSS v1 client: %s", err)
 	}
 
-	pages, err := flavors.List(client).AllPages()
-	if err != nil {
-		return fmterr.Errorf("error reading cluster value: %s", err)
-	}
-
-	versions, err := flavors.ExtractVersions(pages)
+	versions, err := flavors.List(client)
 	if err != nil {
 		return fmterr.Errorf("error extracting versions")
 	}

--- a/opentelekomcloud/services/css/resource_opentelekomcloud_css_snapshot_configuration_v1.go
+++ b/opentelekomcloud/services/css/resource_opentelekomcloud_css_snapshot_configuration_v1.go
@@ -114,7 +114,7 @@ func readResourceCssSnapshotConfigurationV1(_ context.Context, d *schema.Resourc
 	}
 	clusterID := d.Id()
 
-	info, err := snapshots.PolicyGet(client, clusterID).Extract()
+	info, err := snapshots.PolicyGet(client, clusterID)
 	if err != nil {
 		return fmterr.Errorf("error retrieving CSS cluster automatic snapshot configuration")
 	}
@@ -157,7 +157,7 @@ func deleteResourceCssSnapshotConfigurationV1(_ context.Context, d *schema.Resou
 	}
 	clusterID := d.Id()
 
-	if err := snapshots.Disable(client, clusterID).ExtractErr(); err != nil {
+	if err := snapshots.Disable(client, clusterID); err != nil {
 		return fmterr.Errorf("error disabling automatic snapshots: %w", err)
 	}
 
@@ -174,7 +174,7 @@ func updateSnapshotPolicy(client *golangsdk.ServiceClient, d *schema.ResourceDat
 	}
 
 	clusterID := d.Get("cluster_id").(string)
-	err := snapshots.PolicyCreate(client, policyOpts, clusterID).ExtractErr()
+	err := snapshots.PolicyCreate(client, policyOpts, clusterID)
 	if err != nil {
 		return fmt.Errorf("error creating snapshot creating policy: %w", err)
 	}
@@ -187,7 +187,7 @@ func updateSnapshotConfiguration(client *golangsdk.ServiceClient, d *schema.Reso
 		Agency:        d.Get("configuration.0.agency").(string),
 		SnapshotCmkID: d.Get("configuration.0.kms_id").(string),
 	}
-	err := snapshots.UpdateConfiguration(client, d.Id(), opts).ExtractErr()
+	err := snapshots.UpdateConfiguration(client, d.Id(), opts)
 	if err != nil {
 		return fmt.Errorf("error updating cluster automatic snapshot configuration: %w", err)
 	}
@@ -202,7 +202,7 @@ func updateSnapshotConfigurationResource(_ context.Context, d *schema.ResourceDa
 	}
 
 	if d.Get("automatic").(bool) {
-		if err := snapshots.Enable(client, d.Id()).ExtractErr(); err != nil {
+		if err := snapshots.Enable(client, d.Id()); err != nil {
 			return fmt.Errorf("error using automatic config for snapshots: %w", err)
 		}
 		return nil

--- a/releasenotes/notes/css-ref-sdk-ab2d975388125527.yaml
+++ b/releasenotes/notes/css-ref-sdk-ab2d975388125527.yaml
@@ -1,0 +1,3 @@
+other:
+  - |
+    **[CSS]** Get rid of inline Extracts and refactoring for ``resource/opentelekomcloud_css_*`` (`#1966 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1966>`_)


### PR DESCRIPTION
## Summary of the Pull Request
CSS refactoring, little AS policy_v2 refactoring

## PR Checklist

* [x] Tests added/passed.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccCSSFlavorV1DataSource_basic
=== PAUSE TestAccCSSFlavorV1DataSource_basic
=== CONT  TestAccCSSFlavorV1DataSource_basic
--- PASS: TestAccCSSFlavorV1DataSource_basic (74.58s)
=== RUN   TestAccCSSFlavorV1DataSource_byName
=== PAUSE TestAccCSSFlavorV1DataSource_byName
=== CONT  TestAccCSSFlavorV1DataSource_byName
--- PASS: TestAccCSSFlavorV1DataSource_byName (75.88s)
PASS

=== RUN   TestAccCssClusterV1_basic
=== PAUSE TestAccCssClusterV1_basic
=== CONT  TestAccCssClusterV1_basic
--- PASS: TestAccCssClusterV1_basic (2029.90s)
=== RUN   TestAccCssClusterV1_tags
=== PAUSE TestAccCssClusterV1_tags
=== CONT  TestAccCssClusterV1_tags
--- PASS: TestAccCssClusterV1_tags (1044.57s)
=== RUN   TestAccCssClusterV1_validateDiskAndFlavor
=== PAUSE TestAccCssClusterV1_validateDiskAndFlavor
=== CONT  TestAccCssClusterV1_validateDiskAndFlavor
--- PASS: TestAccCssClusterV1_validateDiskAndFlavor (125.87s)

=== RUN   TestResourceCSSSnapshotConfigurationV1_basic
=== PAUSE TestResourceCSSSnapshotConfigurationV1_basic
=== CONT  TestResourceCSSSnapshotConfigurationV1_basic
--- PASS: TestResourceCSSSnapshotConfigurationV1_basic (1024.81s)
PASS

Process finished with the exit code 0

=== RUN   TestAccASV1Configuration_basic
=== PAUSE TestAccASV1Configuration_basic
=== CONT  TestAccASV1Configuration_basic
--- PASS: TestAccASV1Configuration_basic (81.78s)
=== RUN   TestAccASV1Configuration_publicIP
=== PAUSE TestAccASV1Configuration_publicIP
=== CONT  TestAccASV1Configuration_publicIP
--- PASS: TestAccASV1Configuration_publicIP (89.73s)
=== RUN   TestAccASV1Configuration_invalidDiskSize
=== PAUSE TestAccASV1Configuration_invalidDiskSize
=== CONT  TestAccASV1Configuration_invalidDiskSize
--- PASS: TestAccASV1Configuration_invalidDiskSize (50.90s)
=== RUN   TestAccASV1Configuration_multipleSecurityGroups
=== PAUSE TestAccASV1Configuration_multipleSecurityGroups
=== CONT  TestAccASV1Configuration_multipleSecurityGroups
--- PASS: TestAccASV1Configuration_multipleSecurityGroups (105.52s)
PASS

=== RUN   TestAccASV1Group_basic
=== PAUSE TestAccASV1Group_basic
=== RUN   TestAccASV1Group_RemoveWithSetMinNumber
=== PAUSE TestAccASV1Group_RemoveWithSetMinNumber
=== CONT  TestAccASV1Group_RemoveWithSetMinNumber
--- PASS: TestAccASV1Group_RemoveWithSetMinNumber (210.67s)
--- PASS: TestAccASV1Group_basic (230.13s)
=== RUN   TestAccASV1Group_WithoutSecurityGroups
=== PAUSE TestAccASV1Group_WithoutSecurityGroups
=== CONT  TestAccASV1Group_WithoutSecurityGroups
--- PASS: TestAccASV1Group_WithoutSecurityGroups (188.55s)
PASS

=== RUN   TestAccASV1Policy_basic
=== PAUSE TestAccASV1Policy_basic
=== CONT  TestAccASV1Policy_basic
--- PASS: TestAccASV1Policy_basic (79.22s)
PASS

=== RUN   TestAccASPolicyV2_basic
=== PAUSE TestAccASPolicyV2_basic
=== CONT  TestAccASPolicyV2_basic
--- PASS: TestAccASPolicyV2_basic (99.12s)
=== RUN   TestAccASPolicyV2_withSize
=== PAUSE TestAccASPolicyV2_withSize
=== CONT  TestAccASPolicyV2_withSize
--- PASS: TestAccASPolicyV2_withSize (59.16s)
=== RUN   TestAccASPolicyV2_conflictsAction
--- PASS: TestAccASPolicyV2_conflictsAction (23.39s)
PASS

Process finished with the exit code 0

```
