### PR TITLE
[VPC] eip v1 merge error fix

### DIFF
--- a/opentelekomcloud/services/vpc/resource_opentelekomcloud_vpc_eip_v1.go
+++ b/opentelekomcloud/services/vpc/resource_opentelekomcloud_vpc_eip_v1.go
@@ -62,6 +62,7 @@ func ResourceVpcEIPV1() *schema.Resource {
 						"port_id": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Computed: true,
 						},
 					},
 				},

--- a/releasenotes/notes/eip-merge-error-42e85d488432bfa5.yaml
+++ b/releasenotes/notes/eip-merge-error-42e85d488432bfa5.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[VPC]** Merge error in #1957 ``port_id`` should be ``computed`` in ``resource/opentelekomcloud_vpc_eip_v1`` (`#1971 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1971>`_)


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [x] Refers to: #1956
* [x] Tests added/passed.
* [ ] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccVpcEipV1DataSource_basic
=== PAUSE TestAccVpcEipV1DataSource_basic
=== CONT  TestAccVpcEipV1DataSource_basic
--- PASS: TestAccVpcEipV1DataSource_basic (172.22s)
PASS


Process finished with the exit code 0

=== RUN   TestAccVpcV1EIP_basic
=== PAUSE TestAccVpcV1EIP_basic
=== CONT  TestAccVpcV1EIP_basic
--- PASS: TestAccVpcV1EIP_basic (133.36s)
=== RUN   TestAccVpcV1EIP_UnAssing
=== PAUSE TestAccVpcV1EIP_UnAssing
=== CONT  TestAccVpcV1EIP_UnAssing
--- PASS: TestAccVpcV1EIP_UnAssing (170.06s)
=== RUN   TestAccVpcV1EIP_timeout
=== PAUSE TestAccVpcV1EIP_timeout
=== CONT  TestAccVpcV1EIP_timeout
--- PASS: TestAccVpcV1EIP_timeout (85.82s)
PASS


Process finished with the exit code 0


=== RUN   TestAccCCENodesV3Basic
=== PAUSE TestAccCCENodesV3Basic
=== CONT  TestAccCCENodesV3Basic
=== CONT  TestAccCCENodesV3Basic
=== CONT  TestAccCCENodesV3Basic
--- PASS: TestAccCCENodesV3Basic (875.59s)
=== RUN   TestAccCCENodesV3OS
=== PAUSE TestAccCCENodesV3OS
=== CONT  TestAccCCENodesV3OS
=== CONT  TestAccCCENodesV3OS
=== CONT  TestAccCCENodesV3OS
--- PASS: TestAccCCENodesV3OS (747.40s)
=== RUN   TestAccCCENodesV3TaintsK8sTags
=== PAUSE TestAccCCENodesV3TaintsK8sTags
=== CONT  TestAccCCENodesV3TaintsK8sTags
=== CONT  TestAccCCENodesV3TaintsK8sTags
=== CONT  TestAccCCENodesV3TaintsK8sTags
--- PASS: TestAccCCENodesV3TaintsK8sTags (738.81s)
=== RUN   TestAccCCENodesV3Multiple
=== PAUSE TestAccCCENodesV3Multiple
=== CONT  TestAccCCENodesV3Multiple
=== CONT  TestAccCCENodesV3Multiple
--- PASS: TestAccCCENodesV3Multiple (419.20s)
=== RUN   TestAccCCENodesV3Timeout
=== PAUSE TestAccCCENodesV3Timeout
=== CONT  TestAccCCENodesV3Timeout
=== CONT  TestAccCCENodesV3Timeout
--- PASS: TestAccCCENodesV3Timeout (361.45s)
=== RUN   TestAccCCENodesV3BandWidthResize
=== PAUSE TestAccCCENodesV3BandWidthResize
=== CONT  TestAccCCENodesV3BandWidthResize
=== CONT  TestAccCCENodesV3BandWidthResize
=== CONT  TestAccCCENodesV3BandWidthResize
--- PASS: TestAccCCENodesV3BandWidthResize (1242.17s)
=== RUN   TestAccCCENodesV3_eipIds
=== PAUSE TestAccCCENodesV3_eipIds
=== CONT  TestAccCCENodesV3_eipIds
=== CONT  TestAccCCENodesV3_eipIds
--- PASS: TestAccCCENodesV3_eipIds (539.64s)
=== RUN   TestAccCCENodesV3IpSetNull
=== PAUSE TestAccCCENodesV3IpSetNull
=== CONT  TestAccCCENodesV3IpSetNull
=== CONT  TestAccCCENodesV3IpSetNull
--- PASS: TestAccCCENodesV3IpSetNull (900.66s)
=== RUN   TestAccCCENodesV3IpCreate
=== PAUSE TestAccCCENodesV3IpCreate
=== CONT  TestAccCCENodesV3IpCreate
=== CONT  TestAccCCENodesV3IpCreate
=== CONT  TestAccCCENodesV3IpCreate
--- PASS: TestAccCCENodesV3IpCreate (784.18s)
=== RUN   TestAccCCENodesV3IpWithExtendedParameters
=== PAUSE TestAccCCENodesV3IpWithExtendedParameters
=== CONT  TestAccCCENodesV3IpWithExtendedParameters
=== CONT  TestAccCCENodesV3IpWithExtendedParameters
=== CONT  TestAccCCENodesV3IpWithExtendedParameters
--- PASS: TestAccCCENodesV3IpWithExtendedParameters (725.10s)
=== RUN   TestAccCCENodesV3IpNulls
=== PAUSE TestAccCCENodesV3IpNulls
=== CONT  TestAccCCENodesV3IpNulls
=== CONT  TestAccCCENodesV3IpNulls
--- PASS: TestAccCCENodesV3IpNulls (1447.66s)
=== RUN   TestAccCCENodesV3EncryptedVolume
=== PAUSE TestAccCCENodesV3EncryptedVolume
=== CONT  TestAccCCENodesV3EncryptedVolume
=== CONT  TestAccCCENodesV3EncryptedVolume
--- PASS: TestAccCCENodesV3EncryptedVolume (1085.86s)
=== RUN   TestAccCCENodesV3_extendParams
=== PAUSE TestAccCCENodesV3_extendParams
=== CONT  TestAccCCENodesV3_extendParams
=== CONT  TestAccCCENodesV3_extendParams
--- PASS: TestAccCCENodesV3_extendParams (696.01s)
PASS

Process finished with the exit code 0
```
