### PR TITLE
[SDK] gophertelekomcloud to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/jinzhu/copier v0.3.5
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.5.24-0.20221031193406-2d00dbd02425
+	github.com/opentelekomcloud/gophertelekomcloud v0.5.24
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.0.0-20220517005047-85d78b3ac167
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9

--- a/go.sum
+++ b/go.sum
@@ -207,8 +207,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.5.24-0.20221031193406-2d00dbd02425 h1:gNKjPHX+9vMZ9pPNy97Q4DTaplAE0UFhbCwFN0DnjCM=
-github.com/opentelekomcloud/gophertelekomcloud v0.5.24-0.20221031193406-2d00dbd02425/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
+github.com/opentelekomcloud/gophertelekomcloud v0.5.24 h1:USIgICBugcdRjfo3qbWRvvPGxqY8kX3EqQ/hZsCKbSA=
+github.com/opentelekomcloud/gophertelekomcloud v0.5.24/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
## Summary of the Pull Request
After obs refactoring

## Acceptance Steps Performed

```
=== RUN   TestAccDataSourceObsBucketObject_basic
=== PAUSE TestAccDataSourceObsBucketObject_basic
=== CONT  TestAccDataSourceObsBucketObject_basic
--- PASS: TestAccDataSourceObsBucketObject_basic (134.34s)
=== RUN   TestAccDataSourceObsBucketObject_readableBody
=== PAUSE TestAccDataSourceObsBucketObject_readableBody
=== CONT  TestAccDataSourceObsBucketObject_readableBody
--- PASS: TestAccDataSourceObsBucketObject_readableBody (137.73s)
=== RUN   TestAccDataSourceObsBucketObject_allParams
=== PAUSE TestAccDataSourceObsBucketObject_allParams
=== CONT  TestAccDataSourceObsBucketObject_allParams
--- PASS: TestAccDataSourceObsBucketObject_allParams (131.20s)
PASS


Process finished with the exit code 0

=== RUN   TestAccDataSourceObsBucket_basic
=== PAUSE TestAccDataSourceObsBucket_basic
=== CONT  TestAccDataSourceObsBucket_basic
--- PASS: TestAccDataSourceObsBucket_basic (111.28s)
PASS


Process finished with the exit code 0

=== RUN   TestAccObsBucketObject_content
=== PAUSE TestAccObsBucketObject_content
=== CONT  TestAccObsBucketObject_content
--- PASS: TestAccObsBucketObject_content (102.61s)
=== RUN   TestAccObsBucketObject_withVersionedContent
=== PAUSE TestAccObsBucketObject_withVersionedContent
=== CONT  TestAccObsBucketObject_withVersionedContent
--- PASS: TestAccObsBucketObject_withVersionedContent (103.23s)
=== RUN   TestAccObsBucketObject_nothing
=== PAUSE TestAccObsBucketObject_nothing
=== CONT  TestAccObsBucketObject_nothing
--- PASS: TestAccObsBucketObject_nothing (55.82s)
PASS


Process finished with the exit code 0

=== RUN   TestAccObsBucketPolicyBasic
=== PAUSE TestAccObsBucketPolicyBasic
=== CONT  TestAccObsBucketPolicyBasic
--- PASS: TestAccObsBucketPolicyBasic (95.21s)
=== RUN   TestAccObsBucketPolicyUpdate
=== PAUSE TestAccObsBucketPolicyUpdate
=== CONT  TestAccObsBucketPolicyUpdate
=== RUN   TestAccObsBucketPolicyMalformed
=== PAUSE TestAccObsBucketPolicyMalformed
=== CONT  TestAccObsBucketPolicyMalformed
--- PASS: TestAccObsBucketPolicyMalformed (124.43s)
--- PASS: TestAccObsBucketPolicyUpdate (142.37s)
PASS


Process finished with the exit code 0


=== RUN   TestAccObsBucket_basic
=== PAUSE TestAccObsBucket_basic
=== CONT  TestAccObsBucket_basic
=== RUN   TestAccObsBucket_tags
=== PAUSE TestAccObsBucket_tags
=== CONT  TestAccObsBucket_tags
=== RUN   TestAccObsBucket_versioning
=== PAUSE TestAccObsBucket_versioning
=== CONT  TestAccObsBucket_versioning
=== RUN   TestAccObsBucket_logging
=== PAUSE TestAccObsBucket_logging
=== CONT  TestAccObsBucket_logging
=== RUN   TestAccObsBucket_lifecycle
=== PAUSE TestAccObsBucket_lifecycle
=== CONT  TestAccObsBucket_lifecycle
=== RUN   TestAccObsBucket_website
=== PAUSE TestAccObsBucket_website
=== CONT  TestAccObsBucket_website
=== RUN   TestAccObsBucket_cors
=== PAUSE TestAccObsBucket_cors
=== CONT  TestAccObsBucket_cors
=== RUN   TestAccObsBucket_notifications
=== PAUSE TestAccObsBucket_notifications
=== CONT  TestAccObsBucket_notifications
--- PASS: TestAccObsBucket_tags (124.26s)
--- PASS: TestAccObsBucket_logging (131.52s)
--- PASS: TestAccObsBucket_lifecycle (136.19s)
--- PASS: TestAccObsBucket_website (138.59s)
--- PASS: TestAccObsBucket_cors (141.06s)
--- PASS: TestAccObsBucket_notifications (144.46s)
--- PASS: TestAccObsBucket_versioning (170.59s)

--- PASS: TestAccObsBucket_basic (208.82s)
PASS


Process finished with the exit code 0
```
