### PR TITLE
[ECS] not fail if get password returns 403 in `data_source_opentelekomcloud_compute_instance_v2`

### DIFF
--- a/opentelekomcloud/acceptance/ecs/data_source_opentelekomcloud_compute_instance_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/data_source_opentelekomcloud_compute_instance_v2_test.go
@@ -11,6 +11,9 @@ import (
 )
 
 func TestAccComputeV2InstanceDataSource_basic(t *testing.T) {
+	resourceName := "data.opentelekomcloud_compute_instance_v2.source_1"
+	instanceName := "opentelekomcloud_compute_instance_v2.instance_1"
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
@@ -21,29 +24,29 @@ func TestAccComputeV2InstanceDataSource_basic(t *testing.T) {
 			{
 				Config: testAccComputeV2InstanceDataSourceID(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceV2DataSourceID("data.opentelekomcloud_compute_instance_v2.source_1"),
-					resource.TestCheckResourceAttr("data.opentelekomcloud_compute_instance_v2.source_1", "name", "instance_1"),
-					resource.TestCheckResourceAttrPair("data.opentelekomcloud_compute_instance_v2.source_1", "metadata", "opentelekomcloud_compute_instance_v2.instance_1", "metadata"),
-					resource.TestCheckResourceAttrSet("data.opentelekomcloud_compute_instance_v2.source_1", "network.0.name"),
+					testAccCheckComputeInstanceV2DataSourceID(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", "instance_1"),
+					resource.TestCheckResourceAttrPair(resourceName, "metadata", instanceName, "metadata"),
+					resource.TestCheckResourceAttrSet(resourceName, "network.0.name"),
 				),
 			},
 			{
 				Config: testAccComputeV2InstanceDataSourceWindowsPassword(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceV2DataSourceID("data.opentelekomcloud_compute_instance_v2.source_1"),
-					resource.TestCheckResourceAttr("data.opentelekomcloud_compute_instance_v2.source_1", "name", "instance_1"),
-					resource.TestCheckResourceAttrPair("data.opentelekomcloud_compute_instance_v2.source_1", "metadata", "opentelekomcloud_compute_instance_v2.instance_1", "metadata"),
-					resource.TestCheckResourceAttrSet("data.opentelekomcloud_compute_instance_v2.source_1", "network.0.name"),
-					resource.TestCheckResourceAttrSet("data.opentelekomcloud_compute_instance_v2.source_1", "encrypted_password"),
+					testAccCheckComputeInstanceV2DataSourceID(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", "instance_1"),
+					resource.TestCheckResourceAttrPair(resourceName, "metadata", instanceName, "metadata"),
+					resource.TestCheckResourceAttrSet(resourceName, "network.0.name"),
+					resource.TestCheckResourceAttrSet(resourceName, "encrypted_password"),
 				),
 			},
 			{
 				Config: testAccComputeV2InstanceDataSourceName(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceV2DataSourceName("data.opentelekomcloud_compute_instance_v2.source_1"),
-					resource.TestCheckResourceAttr("data.opentelekomcloud_compute_instance_v2.source_1", "name", "instance_1"),
-					resource.TestCheckResourceAttrPair("data.opentelekomcloud_compute_instance_v2.source_1", "metadata", "opentelekomcloud_compute_instance_v2.instance_1", "metadata"),
-					resource.TestCheckResourceAttrSet("data.opentelekomcloud_compute_instance_v2.source_1", "network.0.name"),
+					testAccCheckComputeInstanceV2DataSourceName(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", "instance_1"),
+					resource.TestCheckResourceAttrPair(resourceName, "metadata", instanceName, "metadata"),
+					resource.TestCheckResourceAttrSet(resourceName, "network.0.name"),
 				),
 			},
 		},

--- a/opentelekomcloud/services/ecs/data_source_opentelekomcloud_compute_instance_v2.go
+++ b/opentelekomcloud/services/ecs/data_source_opentelekomcloud_compute_instance_v2.go
@@ -285,12 +285,13 @@ func dataSourceComputeInstanceV2Read(_ context.Context, d *schema.ResourceData, 
 		mErr = multierror.Append(mErr, d.Set("password", pass))
 	} else {
 		pass, err := servers.GetPassword(client, d.Id()).ExtractPassword(nil)
-		if _, ok := err.(golangsdk.ErrDefault403); ok {
+		switch err.(type) {
+		case golangsdk.ErrDefault403:
 			mErr = multierror.Append(mErr, d.Set("encrypted_password", pass))
-		} else if err != nil {
+		case nil:
+			mErr = multierror.Append(mErr, d.Set("encrypted_password", pass))
+		default:
 			return fmterr.Errorf("error getting password: %w", err)
-		} else {
-			mErr = multierror.Append(mErr, d.Set("encrypted_password", pass))
 		}
 	}
 

--- a/opentelekomcloud/services/ecs/data_source_opentelekomcloud_compute_instance_v2.go
+++ b/opentelekomcloud/services/ecs/data_source_opentelekomcloud_compute_instance_v2.go
@@ -285,10 +285,13 @@ func dataSourceComputeInstanceV2Read(_ context.Context, d *schema.ResourceData, 
 		mErr = multierror.Append(mErr, d.Set("password", pass))
 	} else {
 		pass, err := servers.GetPassword(client, d.Id()).ExtractPassword(nil)
-		if err != nil {
+		if _, ok := err.(golangsdk.ErrDefault403); ok {
+			mErr = multierror.Append(mErr, d.Set("encrypted_password", pass))
+		} else if err != nil {
 			return fmterr.Errorf("error getting password: %w", err)
+		} else {
+			mErr = multierror.Append(mErr, d.Set("encrypted_password", pass))
 		}
-		mErr = multierror.Append(mErr, d.Set("encrypted_password", pass))
 	}
 
 	mErr = multierror.Append(mErr,

--- a/releasenotes/notes/ecs-ds-password-403-81d91a3a66cd0ff5.yaml
+++ b/releasenotes/notes/ecs-ds-password-403-81d91a3a66cd0ff5.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    **[ECS]** Password permissions fix in ``data_source_opentelekomcloud_compute_instance_v2``
+    (`#1985 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1985>`_)


### PR DESCRIPTION
## Summary of the Pull Request
No need to fail if user have ecs viewer permissions

## PR Checklist

* [x] Refers to: #1983
* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccComputeV2InstanceDataSource_basic
--- PASS: TestAccComputeV2InstanceDataSource_basic (271.28s)
PASS


Process finished with the exit code 0
```
