### PR TITLE
[AS] metadata refactoring

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/jinzhu/copier v0.3.5
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.5.25-0.20221107112842-5be4290a1792
+	github.com/opentelekomcloud/gophertelekomcloud v0.5.25-0.20221107160958-e38c57188b09
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.0.0-20220517005047-85d78b3ac167
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9

--- a/go.sum
+++ b/go.sum
@@ -207,10 +207,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.5.24 h1:USIgICBugcdRjfo3qbWRvvPGxqY8kX3EqQ/hZsCKbSA=
-github.com/opentelekomcloud/gophertelekomcloud v0.5.24/go.mod h1:pzEP1kduNwv+hrI9R6/DFU/NiX7Kr9NiFjpQ7kJQTsM=
-github.com/opentelekomcloud/gophertelekomcloud v0.5.25-0.20221107112842-5be4290a1792 h1:fYVd/gVdvka1K8ry8/csW12OzCHUo4G4HOohf5kmfqg=
-github.com/opentelekomcloud/gophertelekomcloud v0.5.25-0.20221107112842-5be4290a1792/go.mod h1:/QD0ZIzm3zMdE0iBSAP3+Z9eCViU2PgnQqp4KGrpR/M=
+github.com/opentelekomcloud/gophertelekomcloud v0.5.25-0.20221107160958-e38c57188b09 h1:DFeZD5mTw08YbECIvgBGyU+RoaTAUjoElt/+1DiIOA4=
+github.com/opentelekomcloud/gophertelekomcloud v0.5.25-0.20221107160958-e38c57188b09/go.mod h1:/QD0ZIzm3zMdE0iBSAP3+Z9eCViU2PgnQqp4KGrpR/M=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/opentelekomcloud/acceptance/as/resource_opentelekomcloud_as_group_v1_test.go
+++ b/opentelekomcloud/acceptance/as/resource_opentelekomcloud_as_group_v1_test.go
@@ -393,8 +393,8 @@ resource "opentelekomcloud_as_group_v1" "as_group" {
   scaling_group_name       = "as_group"
   scaling_configuration_id = opentelekomcloud_as_configuration_v1.as_config.id
   available_zones          = ["%s"]
-  desire_instance_number   = 3
-  min_instance_number      = 1
+  desire_instance_number   = 0
+  min_instance_number      = 0
   max_instance_number      = 10
   vpc_id                   = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
   delete_publicip          = true

--- a/releasenotes/notes/as-ref-meta-2b796900c94ded31.yaml
+++ b/releasenotes/notes/as-ref-meta-2b796900c94ded31.yaml
@@ -1,0 +1,3 @@
+other:
+  - |
+    **[AS]** Metadata type, and other struct changes in ``resource/opentelekomcloud_as_*`` (`#1988 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1988>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Metadata have type now 

## PR Checklist

* [x] Tests added/passed.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccASV1Group_basic
=== PAUSE TestAccASV1Group_basic
=== CONT  TestAccASV1Group_basic
--- PASS: TestAccASV1Group_basic (260.07s)
=== RUN   TestAccASV1Group_RemoveWithSetMinNumber
=== PAUSE TestAccASV1Group_RemoveWithSetMinNumber
=== CONT  TestAccASV1Group_RemoveWithSetMinNumber
--- PASS: TestAccASV1Group_RemoveWithSetMinNumber (247.19s)
=== RUN   TestAccASV1Group_WithoutSecurityGroups
=== PAUSE TestAccASV1Group_WithoutSecurityGroups
=== CONT  TestAccASV1Group_WithoutSecurityGroups
--- PASS: TestAccASV1Group_WithoutSecurityGroups (109.83s)


Process finished with the exit code 0

== RUN   TestAccASV1Configuration_basic
=== PAUSE TestAccASV1Configuration_basic
=== CONT  TestAccASV1Configuration_basic
--- PASS: TestAccASV1Configuration_basic (160.78s)
=== RUN   TestAccASV1Configuration_publicIP
=== PAUSE TestAccASV1Configuration_publicIP
=== CONT  TestAccASV1Configuration_publicIP
--- PASS: TestAccASV1Configuration_publicIP (211.84s)
=== RUN   TestAccASV1Configuration_invalidDiskSize
=== PAUSE TestAccASV1Configuration_invalidDiskSize
=== CONT  TestAccASV1Configuration_invalidDiskSize
--- PASS: TestAccASV1Configuration_invalidDiskSize (153.74s)
=== RUN   TestAccASV1Configuration_multipleSecurityGroups
=== PAUSE TestAccASV1Configuration_multipleSecurityGroups
=== CONT  TestAccASV1Configuration_multipleSecurityGroups
--- PASS: TestAccASV1Configuration_multipleSecurityGroups (219.13s)
PASS


Process finished with the exit code 0

=== RUN   TestAccASV1Policy_basic
=== PAUSE TestAccASV1Policy_basic
=== CONT  TestAccASV1Policy_basic
--- PASS: TestAccASV1Policy_basic (95.89s)
PASS


Process finished with the exit code 0

=== RUN   TestAccASPolicyV2_basic
=== PAUSE TestAccASPolicyV2_basic
=== CONT  TestAccASPolicyV2_basic
=== RUN   TestAccASPolicyV2_withSize
=== PAUSE TestAccASPolicyV2_withSize
=== CONT  TestAccASPolicyV2_withSize
--- PASS: TestAccASPolicyV2_withSize (120.94s)
=== RUN   TestAccASPolicyV2_conflictsAction
--- PASS: TestAccASPolicyV2_conflictsAction (29.21s)
--- PASS: TestAccASPolicyV2_basic (172.68s)
PASS


Process finished with the exit code 0

```
