### PR TITLE
[ELBv3] ability to change eip bandwidth in`opentelekomcloud_lb_loadbalancer_v3`

### DIFF
--- a/docs/resources/lb_loadbalancer_v3.md
+++ b/docs/resources/lb_loadbalancer_v3.md
@@ -87,6 +87,40 @@ resource "opentelekomcloud_lb_loadbalancer_v3" "lb_1" {
 }
 ```
 
+#### Assign new bandwidth to EIP without recreating
+
+```hcl
+resource "opentelekomcloud_lb_loadbalancer_v3" "loadbalancer_1" {
+  name        = "loadbalancer_1"
+  router_id   = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  network_ids = [data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id]
+
+  availability_zones = ["eu-de-01"]
+
+  public_ip {
+    ip_type              = "5_gray"
+    bandwidth_name       = "lb_band"
+    bandwidth_size       = 10
+    bandwidth_share_type = "PER"
+  }
+
+  tags = {
+    muh = "value-create"
+    kuh = "value-create"
+  }
+}
+
+resource "opentelekomcloud_vpc_bandwidth_v2" "bw" {
+  name = "lb_band"
+  size = 20
+}
+
+resource "opentelekomcloud_vpc_bandwidth_associate_v2" "associate" {
+  bandwidth    = opentelekomcloud_vpc_bandwidth_v2.bw.id
+  floating_ips = [opentelekomcloud_lb_loadbalancer_v3.loadbalancer_1.public_ip.0.id]
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:

--- a/opentelekomcloud/services/elb/v3/resource_opentelekomcloud_lb_loadbalancer_v3.go
+++ b/opentelekomcloud/services/elb/v3/resource_opentelekomcloud_lb_loadbalancer_v3.go
@@ -132,10 +132,7 @@ func ResourceLoadBalancerV3() *schema.Resource {
 							ForceNew:              true,
 							DiffSuppressOnRefresh: true,
 							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-								if old >= new {
-									return true
-								}
-								return false
+								return old >= new
 							},
 							RequiredWith: []string{"public_ip.0.ip_type"},
 							ValidateFunc: validation.IntBetween(0, 99999),

--- a/opentelekomcloud/services/elb/v3/resource_opentelekomcloud_lb_loadbalancer_v3.go
+++ b/opentelekomcloud/services/elb/v3/resource_opentelekomcloud_lb_loadbalancer_v3.go
@@ -126,11 +126,18 @@ func ResourceLoadBalancerV3() *schema.Resource {
 							ForceNew:     true,
 						},
 						"bandwidth_size": {
-							Type:         schema.TypeInt,
-							Optional:     true,
-							Computed:     true,
+							Type:                  schema.TypeInt,
+							Optional:              true,
+							Computed:              true,
+							ForceNew:              true,
+							DiffSuppressOnRefresh: true,
+							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+								if old >= new {
+									return true
+								}
+								return false
+							},
 							RequiredWith: []string{"public_ip.0.ip_type"},
-							ForceNew:     true,
 							ValidateFunc: validation.IntBetween(0, 99999),
 						},
 						"bandwidth_charge_mode": {
@@ -143,11 +150,18 @@ func ResourceLoadBalancerV3() *schema.Resource {
 							}, false),
 						},
 						"bandwidth_share_type": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							Computed:     true,
+							Type:                  schema.TypeString,
+							Optional:              true,
+							Computed:              true,
+							ForceNew:              true,
+							DiffSuppressOnRefresh: true,
+							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+								if old == "WHOLE" && new == "PER" {
+									return true
+								}
+								return false
+							},
 							RequiredWith: []string{"public_ip.0.ip_type"},
-							ForceNew:     true,
 							ValidateFunc: validation.StringInSlice([]string{
 								"PER", "WHOLE",
 							}, false),

--- a/releasenotes/notes/elb3-bandwidth-change-b7048554e3ba21e0.yaml
+++ b/releasenotes/notes/elb3-bandwidth-change-b7048554e3ba21e0.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    **[ELB]** added suppress functions to size and type to have ability change eip bandwidth in ``opentelekomcloud_lb_loadbalancer_v3`` (`#1991 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1991>`_)


### PR DESCRIPTION
## Summary of the Pull Request
added suppress funcs to size and type to have ability change eip bandwidth in opentelekomcloud_lb_loadbalancer_v3
removed obsolete tests
possible it is breaking change

## PR Checklist

* [x] Refers to: #1989
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```

=== RUN   TestAccLBV3LoadBalancer_basic
=== PAUSE TestAccLBV3LoadBalancer_basic
=== CONT  TestAccLBV3LoadBalancer_basic
--- PASS: TestAccLBV3LoadBalancer_basic (146.58s)
=== RUN   TestAccLBV3LoadBalancer_bandwidth
=== PAUSE TestAccLBV3LoadBalancer_bandwidth
=== CONT  TestAccLBV3LoadBalancer_bandwidth
--- PASS: TestAccLBV3LoadBalancer_bandwidth (97.73s)
=== RUN   TestAccLBV3LoadBalancer_import
=== PAUSE TestAccLBV3LoadBalancer_import
=== CONT  TestAccLBV3LoadBalancer_import
--- PASS: TestAccLBV3LoadBalancer_import (123.32s)
PASS


Process finished with the exit code 0

```
