### PR TITLE
[NAT] workaround for tags in `opentelekomcloud_nat_gateway_v2` for eu-ch region

### DIFF
--- a/releasenotes/notes/nat-ch-tags-fix-0cc7f86231a31ace.yaml
+++ b/releasenotes/notes/nat-ch-tags-fix-0cc7f86231a31ace.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    **[NAT]** Not using tags assigment in eu-ch2 region, api not published for ``resource/opentelekomcloud_nat_gateway_v2`` (`#2000 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2000>`_)


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [x] Tests added/passed.
* [x] Release notes added.

## Acceptance Steps Performed

```
eu-de/nl
=== RUN   TestAccNatGateway_basic
--- PASS: TestAccNatGateway_basic (144.07s)
=== RUN   TestAccNatV2Gateway_importBasic
--- PASS: TestAccNatV2Gateway_importBasic (105.29s)
PASS

Process finished with the exit code 0

eu-ch2
=== RUN   TestAccNatGateway_basic
--- PASS: TestAccNatGateway_basic (126.45s)
PASS

Process finished with the exit code 0
```
