### PR TITLE
[ECS] use client from ctx in `opentelekomcloud_compute_secgroup_v2`

### DIFF
--- a/releasenotes/notes/ecs-sg-throttling-d5cc7863e613679a.yaml
+++ b/releasenotes/notes/ecs-sg-throttling-d5cc7863e613679a.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[ECS]** Reduce amount of init client requests in ``resource/opentelekomcloud_compute_secgroup_v2`` (`#2014 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2014>`_)


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [x] Refers to: #2012
* [x] Tests added/passed.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccComputeV2SecGroup_basic
=== PAUSE TestAccComputeV2SecGroup_basic
=== CONT  TestAccComputeV2SecGroup_basic
--- PASS: TestAccComputeV2SecGroup_basic (78.32s)
=== RUN   TestAccComputeV2SecGroup_importBasic
=== PAUSE TestAccComputeV2SecGroup_importBasic
=== CONT  TestAccComputeV2SecGroup_importBasic
--- PASS: TestAccComputeV2SecGroup_importBasic (87.89s)
=== RUN   TestAccComputeV2SecGroup_update
=== PAUSE TestAccComputeV2SecGroup_update
=== CONT  TestAccComputeV2SecGroup_update
--- PASS: TestAccComputeV2SecGroup_update (106.45s)
=== RUN   TestAccComputeV2SecGroup_self
--- PASS: TestAccComputeV2SecGroup_self (65.08s)
=== RUN   TestAccComputeV2SecGroup_icmpZero
=== PAUSE TestAccComputeV2SecGroup_icmpZero
=== CONT  TestAccComputeV2SecGroup_icmpZero
--- PASS: TestAccComputeV2SecGroup_icmpZero (78.31s)
=== RUN   TestAccComputeV2SecGroup_timeout
=== PAUSE TestAccComputeV2SecGroup_timeout
=== CONT  TestAccComputeV2SecGroup_timeout
--- PASS: TestAccComputeV2SecGroup_timeout (79.99s)
PASS

Process finished with the exit code 0

```
