### PR TITLE
[CCE] Add new predefined tag in resource/opentelekomcloud_cce_node_v3

### DIFF
--- a/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_v3.go
+++ b/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_v3.go
@@ -39,7 +39,7 @@ var (
 		"node.kubernetes.io/baremetal",
 		"node.kubernetes.io/subnetid",
 		"node.kubernetes.io/container-engine",
-                "node.kubernetes.io/instance-type",
+		"node.kubernetes.io/instance-type",
 		"os.architecture",
 		"os.name",
 		"os.version",

--- a/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_v3.go
+++ b/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_v3.go
@@ -39,6 +39,7 @@ var (
 		"node.kubernetes.io/baremetal",
 		"node.kubernetes.io/subnetid",
 		"node.kubernetes.io/container-engine",
+                "node.kubernetes.io/instance-type",
 		"os.architecture",
 		"os.name",
 		"os.version",

--- a/releasenotes/notes/cce-tags-fix-f518cf275b564a75.yaml
+++ b/releasenotes/notes/cce-tags-fix-f518cf275b564a75.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[CCE]** Add new predefined tag in ``resource/opentelekomcloud_cce_nodes_v3`` (`#2024 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2024>`_)


### PR DESCRIPTION
## Summary of the Pull Request

Add new predefined tag which should be ignored in resource/opentelekomcloud_cce_node_v3

```tf
  # opentelekomcloud_cce_node_v3.node-dev-xxx-app-cce-1-23-node-1 must be replaced
-/+ resource "opentelekomcloud_cce_node_v3" "node-dev-xxx-app-cce-1-23-node-1" {
      + bandwidth_charge_mode = (known after apply)
      ~ billing_mode          = 0 -> (known after apply)
      + eip_count             = (known after apply)
      ~ id                    = "xxx" -> (known after apply)
      + iptype                = (known after apply)
      ~ k8s_tags              = {
          - "node.kubernetes.io/instance-type" = "s3.2xlarge.2"
        } -> (known after apply) # forces replacement
        name                  = "node-dev-xxx-app-cce-1-23-node-1"
      ~ os                    = "EulerOS 2.9" -> (known after apply)
      ~ private_ip            = "xxx" -> (known after apply)
      + public_ip             = (known after apply)
      ~ region                = "eu-de" -> (known after apply)
      ~ server_id             = "xxx" -> (known after apply)
      + sharetype             = (known after apply)
      ~ status                = "Active" -> (known after apply)
      ~ subnet_id             = "xxx" -> (known after apply)
      - tags                  = {
          - "CCE-Cluster-ID" = "xxx"
        } -> null
        # (4 unchanged attributes hidden)

      ~ data_volumes {
            # (2 unchanged attributes hidden)
        }

      ~ root_volume {
            # (2 unchanged attributes hidden)
        }
    }
```

## PR Checklist

* [X] Refers to: #1707 
* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (101.71s)
=== RUN   TestAccSomethingV0_timeout
--- PASS: TestAccSomethingV0_timeout (128.67s)
PASS

Process finished with exit code 0
```
