### PR TITLE
[throttling] client from context in `opentelekomcloud_evs` and `opentelekomcloud_compute`

### DIFF
--- a/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_volume_attach_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_volume_attach_v2_test.go
@@ -178,6 +178,7 @@ resource "opentelekomcloud_blockstorage_volume_v2" "volume_1" {
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
+  image_name      = "Standard_Debian_10_latest"
   network {
     uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
@@ -200,6 +201,7 @@ resource "opentelekomcloud_blockstorage_volume_v2" "volume_1" {
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
+  image_name      = "Standard_Debian_10_latest"
   network {
     uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
@@ -223,6 +225,7 @@ resource "opentelekomcloud_blockstorage_volume_v2" "volume_1" {
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
+  image_name      = "Standard_Debian_10_latest"
   network {
     uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }

--- a/opentelekomcloud/services/evs/resource_opentelekomcloud_evs_volume_v3.go
+++ b/opentelekomcloud/services/evs/resource_opentelekomcloud_evs_volume_v3.go
@@ -141,7 +141,9 @@ func ResourceEvsStorageVolumeV3() *schema.Resource {
 
 func resourceEvsVolumeV3Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	client, err := config.BlockStorageV3Client(config.GetRegion(d))
+	client, err := common.ClientFromCtx(ctx, keyClientV2, func() (*golangsdk.ServiceClient, error) {
+		return config.BlockStorageV3Client(config.GetRegion(d))
+	})
 	if err != nil {
 		return fmterr.Errorf(errCreationClient, err)
 	}
@@ -205,14 +207,17 @@ func resourceEvsVolumeV3Create(ctx context.Context, d *schema.ResourceData, meta
 				return fmterr.Errorf("error setting tags for EVSv3 Volume: %w", err)
 			}
 		}
-		return resourceEvsVolumeV3Read(ctx, d, meta)
+		clientCtx := common.CtxWithClient(ctx, client, keyClientV2)
+		return resourceEvsVolumeV3Read(clientCtx, d, meta)
 	}
 	return fmterr.Errorf("unexpected conversion error in resourceEvsVolumeV3Create")
 }
 
-func resourceEvsVolumeV3Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceEvsVolumeV3Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	client, err := config.BlockStorageV3Client(config.GetRegion(d))
+	client, err := common.ClientFromCtx(ctx, keyClientV2, func() (*golangsdk.ServiceClient, error) {
+		return config.BlockStorageV3Client(config.GetRegion(d))
+	})
 	if err != nil {
 		return fmterr.Errorf(errCreationClient, err)
 	}
@@ -266,7 +271,9 @@ func resourceEvsVolumeV3Read(_ context.Context, d *schema.ResourceData, meta int
 // using OpenStack Cinder API v2 to update volume resource
 func resourceEvsVolumeV3Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	client, err := config.BlockStorageV3Client(config.GetRegion(d))
+	client, err := common.ClientFromCtx(ctx, keyClientV2, func() (*golangsdk.ServiceClient, error) {
+		return config.BlockStorageV3Client(config.GetRegion(d))
+	})
 	if err != nil {
 		return fmterr.Errorf(errCreationClient, err)
 	}
@@ -308,7 +315,8 @@ func resourceEvsVolumeV3Update(ctx context.Context, d *schema.ResourceData, meta
 		}
 	}
 
-	return resourceEvsVolumeV3Read(ctx, d, meta)
+	clientCtx := common.CtxWithClient(ctx, client, keyClientV2)
+	return resourceEvsVolumeV3Read(clientCtx, d, meta)
 }
 
 func resourceVolumeAttachmentHash(v interface{}) int {

--- a/releasenotes/notes/throttling-evs-ecs-26db163aab48a4c5.yaml
+++ b/releasenotes/notes/throttling-evs-ecs-26db163aab48a4c5.yaml
@@ -1,0 +1,11 @@
+---
+enhancements:
+  - |
+    **[ECS]** Reduce amount of init client requests in ``resource/opentelekomcloud_compute_secgroup_v2.go`` (`#2025 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2025>`_)
+  - |
+    **[ECS]** Reduce amount of init client requests in ``resource/opentelekomcloud_compute_volume_attach_v2.go`` (`#2025 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2025>`_)
+  - |
+    **[EVS]** Reduce amount of init client requests in ``resource/opentelekomcloud_evs_volume_v3.go`` (`#2025 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2025>`_)
+other:
+  - |
+    **[EVS]** Fixed tests in ``acceptance/opentelekomcloud_compute_volume_attach_v2_test.go`` (`#2025 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2025>`_)


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [x] Refers to: #2012
* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccComputeV2SecGroup_basic
=== PAUSE TestAccComputeV2SecGroup_basic
=== CONT  TestAccComputeV2SecGroup_basic
--- PASS: TestAccComputeV2SecGroup_basic (72.09s)
=== RUN   TestAccComputeV2SecGroup_importBasic
=== PAUSE TestAccComputeV2SecGroup_importBasic
=== CONT  TestAccComputeV2SecGroup_importBasic
--- PASS: TestAccComputeV2SecGroup_importBasic (89.27s)
=== RUN   TestAccComputeV2SecGroup_update
=== PAUSE TestAccComputeV2SecGroup_update
=== CONT  TestAccComputeV2SecGroup_update
--- PASS: TestAccComputeV2SecGroup_update (106.53s)
=== RUN   TestAccComputeV2SecGroup_self
--- PASS: TestAccComputeV2SecGroup_self (68.14s)
=== RUN   TestAccComputeV2SecGroup_icmpZero
=== PAUSE TestAccComputeV2SecGroup_icmpZero
=== CONT  TestAccComputeV2SecGroup_icmpZero
--- PASS: TestAccComputeV2SecGroup_icmpZero (70.40s)
=== RUN   TestAccComputeV2SecGroup_timeout
=== PAUSE TestAccComputeV2SecGroup_timeout
=== CONT  TestAccComputeV2SecGroup_timeout
--- PASS: TestAccComputeV2SecGroup_timeout (73.16s)
PASS

Process finished with the exit code 0

=== RUN   TestAccComputeV2VolumeAttach_basic
=== PAUSE TestAccComputeV2VolumeAttach_basic
=== CONT  TestAccComputeV2VolumeAttach_basic
--- PASS: TestAccComputeV2VolumeAttach_basic (181.16s)
=== RUN   TestAccComputeV2VolumeAttach_importBasic
=== PAUSE TestAccComputeV2VolumeAttach_importBasic
=== CONT  TestAccComputeV2VolumeAttach_importBasic
--- PASS: TestAccComputeV2VolumeAttach_importBasic (188.94s)
=== RUN   TestAccComputeV2VolumeAttach_device
=== PAUSE TestAccComputeV2VolumeAttach_device
=== CONT  TestAccComputeV2VolumeAttach_device
--- PASS: TestAccComputeV2VolumeAttach_device (182.30s)
=== RUN   TestAccComputeV2VolumeAttach_timeout
=== PAUSE TestAccComputeV2VolumeAttach_timeout
=== CONT  TestAccComputeV2VolumeAttach_timeout
--- PASS: TestAccComputeV2VolumeAttach_timeout (181.91s)
PASS


Process finished with the exit code 0

=== RUN   TestAccEvsStorageV3Volume_basic
=== PAUSE TestAccEvsStorageV3Volume_basic

=== CONT  TestAccEvsStorageV3Volume_basic

--- PASS: TestAccEvsStorageV3Volume_basic (117.13s)
=== RUN   TestAccEvsStorageV3Volume_tags
=== PAUSE TestAccEvsStorageV3Volume_tags
=== CONT  TestAccEvsStorageV3Volume_tags
--- PASS: TestAccEvsStorageV3Volume_tags (117.21s)
=== RUN   TestAccEvsStorageV3Volume_image
=== PAUSE TestAccEvsStorageV3Volume_image
=== CONT  TestAccEvsStorageV3Volume_image
--- PASS: TestAccEvsStorageV3Volume_image (93.91s)
=== RUN   TestAccEvsStorageV3Volume_timeout
=== PAUSE TestAccEvsStorageV3Volume_timeout
=== CONT  TestAccEvsStorageV3Volume_timeout
--- PASS: TestAccEvsStorageV3Volume_timeout (91.54s)
=== RUN   TestAccEvsStorageV3Volume_volumeType
=== PAUSE TestAccEvsStorageV3Volume_volumeType
=== CONT  TestAccEvsStorageV3Volume_volumeType
--- PASS: TestAccEvsStorageV3Volume_volumeType (37.49s)
=== RUN   TestAccEvsStorageV3Volume_resize
=== PAUSE TestAccEvsStorageV3Volume_resize
=== CONT  TestAccEvsStorageV3Volume_resize
--- PASS: TestAccEvsStorageV3Volume_resize (129.36s)
PASS


Process finished with the exit code 0

```
