### PR TITLE
[CCE]: Default tags fix

### DIFF
--- a/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_node_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_node_v3_test.go
@@ -42,7 +42,7 @@ func TestAccCCENodesV3Basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCCENodeV3Exists(resourceNameNode, shared.DataSourceClusterName, &node),
 					resource.TestCheckResourceAttr(resourceNameNode, "name", "test-node"),
-					resource.TestCheckResourceAttr(resourceNameNode, "flavor_id", "s3.medium.1"),
+					resource.TestCheckResourceAttr(resourceNameNode, "flavor_id", "s2.large.2"),
 					resource.TestCheckResourceAttr(resourceNameNode, "os", "EulerOS 2.9"),
 					resource.TestCheckResourceAttr(resourceNameNode, "private_ip", privateIP),
 				),
@@ -446,7 +446,7 @@ var testAccCCENodeV3OS = fmt.Sprintf(`
 resource "opentelekomcloud_cce_node_v3" "node_1" {
   cluster_id = data.opentelekomcloud_cce_cluster_v3.cluster.id
   name       = "test-node"
-  flavor_id  = "s3.medium.1"
+  flavor_id  = "s2.large.2"
   os         = "EulerOS 2.5"
 
   availability_zone = "%[2]s"
@@ -466,7 +466,7 @@ resource "opentelekomcloud_cce_node_v3" "node_1" {
 resource "opentelekomcloud_cce_node_v3" "node_2" {
   cluster_id = data.opentelekomcloud_cce_cluster_v3.cluster.id
   name       = "test-node"
-  flavor_id  = "s3.medium.1"
+  flavor_id  = "s2.large.2"
   os         = "CentOS 7.7"
 
   availability_zone = "%[2]s"
@@ -486,7 +486,7 @@ resource "opentelekomcloud_cce_node_v3" "node_2" {
 resource "opentelekomcloud_cce_node_v3" "node_3" {
   cluster_id = data.opentelekomcloud_cce_cluster_v3.cluster.id
   name       = "test-node"
-  flavor_id  = "s3.medium.1"
+  flavor_id  = "s2.large.2"
   os         = "EulerOS 2.9"
 
   availability_zone = "%[2]s"
@@ -511,7 +511,7 @@ func testAccCCENodeV3Basic(privateIP string) string {
 resource "opentelekomcloud_cce_node_v3" "node_1" {
   cluster_id = data.opentelekomcloud_cce_cluster_v3.cluster.id
   name       = "test-node"
-  flavor_id  = "s3.medium.1"
+  flavor_id  = "s2.large.2"
 
   availability_zone = "%s"
   key_pair          = "%s"
@@ -538,7 +538,7 @@ func testAccCCENodeV3Update(privateIP string) string {
 resource "opentelekomcloud_cce_node_v3" "node_1" {
   cluster_id = data.opentelekomcloud_cce_cluster_v3.cluster.id
   name       = "test-node2"
-  flavor_id  = "s3.medium.1"
+  flavor_id  = "s2.large.2"
 
   availability_zone = "%s"
   key_pair          = "%s"
@@ -563,7 +563,7 @@ var testAccCCENodeV3Multiple = fmt.Sprintf(`
 resource "opentelekomcloud_cce_node_v3" "node_1" {
   cluster_id = data.opentelekomcloud_cce_cluster_v3.cluster.id
   name       = "test-node"
-  flavor_id  = "s3.medium.1"
+  flavor_id  = "s2.large.2"
   count      = 2
 
   availability_zone = "%s"
@@ -587,7 +587,7 @@ var testAccCCENodeV3Timeout = fmt.Sprintf(`
 resource "opentelekomcloud_cce_node_v3" "node_1" {
   cluster_id        = data.opentelekomcloud_cce_cluster_v3.cluster.id
   name              = "test-node1"
-  flavor_id         = "s3.medium.1"
+  flavor_id         = "s2.large.2"
   availability_zone = "%s"
   key_pair          = "%s"
 
@@ -612,7 +612,7 @@ var testAccCCENodeV3Ip = fmt.Sprintf(`
 resource "opentelekomcloud_cce_node_v3" "node_1" {
   cluster_id        = data.opentelekomcloud_cce_cluster_v3.cluster.id
   name              = "cce-node-1"
-  flavor_id         = "s3.medium.1"
+  flavor_id         = "s2.large.2"
   availability_zone = "%s"
   key_pair          = "%s"
   root_volume {
@@ -635,7 +635,7 @@ var testAccCCENodeV3BandWidthResize = fmt.Sprintf(`
 resource "opentelekomcloud_cce_node_v3" "node_1" {
   cluster_id        = data.opentelekomcloud_cce_cluster_v3.cluster.id
   name              = "cce-node-1"
-  flavor_id         = "s3.medium.1"
+  flavor_id         = "s2.large.2"
   availability_zone = "%s"
   key_pair          = "%s"
   root_volume {
@@ -658,7 +658,7 @@ var testAccCCENodeV3IpUnset = fmt.Sprintf(`
 resource "opentelekomcloud_cce_node_v3" "node_1" {
   cluster_id        = data.opentelekomcloud_cce_cluster_v3.cluster.id
   name              = "cce-node-1"
-  flavor_id         = "s3.medium.1"
+  flavor_id         = "s2.large.2"
   availability_zone = "%s"
   key_pair          = "%s"
   root_volume {
@@ -679,7 +679,7 @@ var testAccCCENodeV3IpParams = fmt.Sprintf(`
 resource "opentelekomcloud_cce_node_v3" "node_1" {
   cluster_id        = data.opentelekomcloud_cce_cluster_v3.cluster.id
   name              = "cce-node-1"
-  flavor_id         = "s3.medium.1"
+  flavor_id         = "s2.large.2"
   availability_zone = "%s"
   key_pair          = "%s"
   root_volume {
@@ -704,7 +704,7 @@ var testAccCCENodeV3IpNull = fmt.Sprintf(`
 resource "opentelekomcloud_cce_node_v3" "node_1" {
   cluster_id        = data.opentelekomcloud_cce_cluster_v3.cluster.id
   name              = "cce-node-1"
-  flavor_id         = "s3.medium.1"
+  flavor_id         = "s2.large.2"
   availability_zone = "%s"
   key_pair          = "%s"
   root_volume {
@@ -732,7 +732,7 @@ resource "opentelekomcloud_networking_floatingip_v2" "fip_2" {}
 resource "opentelekomcloud_cce_node_v3" "node_1" {
   cluster_id        = data.opentelekomcloud_cce_cluster_v3.cluster.id
   name              = "cce-node-1"
-  flavor_id         = "s3.medium.1"
+  flavor_id         = "s2.large.2"
   availability_zone = "%s"
   key_pair          = "%s"
   root_volume {
@@ -757,7 +757,7 @@ resource "opentelekomcloud_networking_floatingip_v2" "fip_2" {}
 
 resource "opentelekomcloud_cce_node_v3" "node_1" {
   cluster_id        = data.opentelekomcloud_cce_cluster_v3.cluster.id
-  flavor_id         = "s3.medium.1"
+  flavor_id         = "s2.large.2"
   availability_zone = "%s"
   key_pair          = "%s"
   root_volume {
@@ -779,7 +779,7 @@ var testAccCCENodeV3EncryptedVolume = fmt.Sprintf(`
 
 resource "opentelekomcloud_cce_node_v3" "node_1" {
   cluster_id        = data.opentelekomcloud_cce_cluster_v3.cluster.id
-  flavor_id         = "s3.medium.1"
+  flavor_id         = "s2.large.2"
   availability_zone = "%s"
   key_pair          = "%s"
 
@@ -804,7 +804,7 @@ func testAccCCENodeV3TaintsK8sTags(privateIP string) string {
 resource "opentelekomcloud_cce_node_v3" "node_1" {
   cluster_id        = data.opentelekomcloud_cce_cluster_v3.cluster.id
   name              = "test-node"
-  flavor_id         = "s3.medium.1"
+  flavor_id         = "s2.large.2"
   availability_zone = "%s"
   key_pair          = "%s"
   root_volume {
@@ -835,7 +835,7 @@ var testAccCCENodeV3ExtendParams = fmt.Sprintf(`
 resource "opentelekomcloud_cce_node_v3" "node_1" {
   cluster_id = data.opentelekomcloud_cce_cluster_v3.cluster.id
   name       = "test-node"
-  flavor_id  = "s3.medium.1"
+  flavor_id  = "s2.large.2"
 
   availability_zone = "%s"
   key_pair          = "%s"

--- a/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_v3.go
+++ b/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_v3.go
@@ -726,6 +726,7 @@ func resourceCCENodeV3Read(ctx context.Context, d *schema.ResourceData, meta int
 	tagMap := common.TagsToMap(resourceTags)
 	// ignore "CCE-Dynamic-Provisioning-Node"
 	delete(tagMap, "CCE-Dynamic-Provisioning-Node")
+	delete(tagMap, "CCE-Cluster-ID")
 	if err := d.Set("tags", tagMap); err != nil {
 		return fmterr.Errorf("error saving tags of CCE node: %w", err)
 	}

--- a/releasenotes/notes/cce_tags_fix-61461b2bdfd8579f.yaml
+++ b/releasenotes/notes/cce_tags_fix-61461b2bdfd8579f.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[CCE]** Enable ignore of default CCE tags for ``resource/opentelekomcloud_cce_nodes_v3`` (`#2028 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2028>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Ignore default `CCE-Cluster-ID` tag which gets added to every node after creation (which leaded to resource change after `terraform plan` or `terraform apply`).

## PR Checklist

* [x] Refers to: #875
* [x] Tests passed.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccCCENodesV3Basic
=== PAUSE TestAccCCENodesV3Basic
=== CONT  TestAccCCENodesV3Basic
=== CONT  TestAccCCENodesV3Basic
    resource_opentelekomcloud_cce_node_v3_test.go:29: Cluster is required by the test. 1 test(s) are using cluster.
=== CONT  TestAccCCENodesV3Basic
--- PASS: TestAccCCENodesV3Basic (1268.56s)
=== RUN   TestAccCCENodesV3Multiple
=== PAUSE TestAccCCENodesV3Multiple
=== CONT  TestAccCCENodesV3Multiple
=== CONT  TestAccCCENodesV3Multiple
    resource_opentelekomcloud_cce_node_v3_test.go:62: Cluster is required by the test. 5 test(s) are using cluster.
=== CONT  TestAccCCENodesV3Multiple
    cluster.go:137: Cluster is released by the test. 9 test(s) are still using cluster.
--- PASS: TestAccCCENodesV3Multiple (642.55s)
=== RUN   TestAccCCENodesV3Timeout
=== PAUSE TestAccCCENodesV3Timeout
=== CONT  TestAccCCENodesV3Timeout
=== CONT  TestAccCCENodesV3Timeout
    resource_opentelekomcloud_cce_node_v3_test.go:81: Cluster is required by the test. 7 test(s) are using cluster.
=== CONT  TestAccCCENodesV3Timeout
    cluster.go:137: Cluster is released by the test. 9 test(s) are still using cluster.
--- PASS: TestAccCCENodesV3Timeout (662.71s)
=== RUN   TestAccCCENodesV3OS
=== PAUSE TestAccCCENodesV3OS
=== CONT  TestAccCCENodesV3OS
    resource_opentelekomcloud_cce_node_v3_test.go:104: Cluster is required by the test. 10 test(s) are using cluster.
=== CONT  TestAccCCENodesV3OS
    cluster.go:137: Cluster is released by the test. 2 test(s) are still using cluster.
--- PASS: TestAccCCENodesV3OS (1361.37s)
=== RUN   TestAccCCENodesV3BandWidthResize
=== PAUSE TestAccCCENodesV3BandWidthResize
=== CONT  TestAccCCENodesV3BandWidthResize
=== CONT  TestAccCCENodesV3BandWidthResize
    resource_opentelekomcloud_cce_node_v3_test.go:131: Cluster is required by the test. 3 test(s) are using cluster.
=== CONT  TestAccCCENodesV3BandWidthResize
    cluster.go:137: Cluster is released by the test. 9 test(s) are still using cluster.
--- PASS: TestAccCCENodesV3BandWidthResize (697.61s)
=== RUN   TestAccCCENodesV3_eipIds
=== PAUSE TestAccCCENodesV3_eipIds
=== CONT  TestAccCCENodesV3_eipIds
    resource_opentelekomcloud_cce_node_v3_test.go:166: Cluster is required by the test. 10 test(s) are using cluster.
=== CONT  TestAccCCENodesV3_eipIds
    cluster.go:137: Cluster is released by the test. 4 test(s) are still using cluster.
--- PASS: TestAccCCENodesV3_eipIds (354.68s)
=== RUN   TestAccCCENodesV3IpSetNull
=== PAUSE TestAccCCENodesV3IpSetNull
=== CONT  TestAccCCENodesV3IpSetNull
    resource_opentelekomcloud_cce_node_v3_test.go:196: Cluster is required by the test. 10 test(s) are using cluster.
=== CONT  TestAccCCENodesV3IpSetNull
    cluster.go:137: Cluster is released by the test. 1 test(s) are still using cluster.
--- PASS: TestAccCCENodesV3IpSetNull (763.84s)
=== RUN   TestAccCCENodesV3IpCreate
=== PAUSE TestAccCCENodesV3IpCreate
=== CONT  TestAccCCENodesV3IpCreate
=== CONT  TestAccCCENodesV3IpCreate
    resource_opentelekomcloud_cce_node_v3_test.go:229: Cluster is required by the test. 2 test(s) are using cluster.
=== CONT  TestAccCCENodesV3IpCreate
    cluster.go:49: starting creating shared cluster
2022/12/20 16:13:47 [DEBUG] Waiting for state to become: [Available]
2022/12/20 16:13:52 [TRACE] Waiting 3s before next try
2022/12/20 16:13:55 [TRACE] Waiting 6s before next try
2022/12/20 16:14:02 [TRACE] Waiting 10s before next try
2022/12/20 16:14:12 [TRACE] Waiting 10s before next try
2022/12/20 16:14:22 [TRACE] Waiting 10s before next try
2022/12/20 16:14:32 [TRACE] Waiting 10s before next try
2022/12/20 16:14:43 [TRACE] Waiting 10s before next try
2022/12/20 16:14:53 [TRACE] Waiting 10s before next try
2022/12/20 16:15:03 [TRACE] Waiting 10s before next try
2022/12/20 16:15:14 [TRACE] Waiting 10s before next try
2022/12/20 16:15:24 [TRACE] Waiting 10s before next try
2022/12/20 16:15:34 [TRACE] Waiting 10s before next try
2022/12/20 16:15:44 [TRACE] Waiting 10s before next try
2022/12/20 16:15:55 [TRACE] Waiting 10s before next try
2022/12/20 16:16:05 [TRACE] Waiting 10s before next try
2022/12/20 16:16:15 [TRACE] Waiting 10s before next try
2022/12/20 16:16:26 [TRACE] Waiting 10s before next try
2022/12/20 16:16:36 [TRACE] Waiting 10s before next try
2022/12/20 16:16:46 [TRACE] Waiting 10s before next try
2022/12/20 16:16:57 [TRACE] Waiting 10s before next try
2022/12/20 16:17:07 [TRACE] Waiting 10s before next try
2022/12/20 16:17:17 [TRACE] Waiting 10s before next try
2022/12/20 16:17:27 [TRACE] Waiting 10s before next try
2022/12/20 16:17:38 [TRACE] Waiting 10s before next try
2022/12/20 16:17:48 [TRACE] Waiting 10s before next try
2022/12/20 16:17:58 [TRACE] Waiting 10s before next try
2022/12/20 16:18:09 [TRACE] Waiting 10s before next try
2022/12/20 16:18:19 [TRACE] Waiting 10s before next try
2022/12/20 16:18:29 [TRACE] Waiting 10s before next try
2022/12/20 16:18:39 [TRACE] Waiting 10s before next try
2022/12/20 16:18:50 [TRACE] Waiting 10s before next try
2022/12/20 16:19:00 [TRACE] Waiting 10s before next try
2022/12/20 16:19:10 [TRACE] Waiting 10s before next try
2022/12/20 16:19:21 [TRACE] Waiting 10s before next try
=== CONT  TestAccCCENodesV3IpCreate
    cluster.go:137: Cluster is released by the test. 9 test(s) are still using cluster.
--- PASS: TestAccCCENodesV3IpCreate (697.37s)
=== RUN   TestAccCCENodesV3IpWithExtendedParameters
=== PAUSE TestAccCCENodesV3IpWithExtendedParameters
=== CONT  TestAccCCENodesV3IpWithExtendedParameters
=== CONT  TestAccCCENodesV3IpWithExtendedParameters
    resource_opentelekomcloud_cce_node_v3_test.go:259: Cluster is required by the test. 8 test(s) are using cluster.
=== CONT  TestAccCCENodesV3IpWithExtendedParameters
    cluster.go:137: Cluster usage is 0 now, ready to delete the cluster
    cluster.go:100: starting deleting shared cluster
--- PASS: TestAccCCENodesV3IpWithExtendedParameters (1863.49s)
=== RUN   TestAccCCENodesV3IpNulls
=== PAUSE TestAccCCENodesV3IpNulls
=== CONT  TestAccCCENodesV3IpNulls
=== CONT  TestAccCCENodesV3IpNulls
    resource_opentelekomcloud_cce_node_v3_test.go:286: Cluster is required by the test. 9 test(s) are using cluster.
=== CONT  TestAccCCENodesV3IpNulls
    cluster.go:137: Cluster is released by the test. 5 test(s) are still using cluster.
--- PASS: TestAccCCENodesV3IpNulls (1022.96s)
=== RUN   TestAccCCENodesV3EncryptedVolume
=== PAUSE TestAccCCENodesV3EncryptedVolume
=== CONT  TestAccCCENodesV3EncryptedVolume
=== CONT  TestAccCCENodesV3EncryptedVolume
    resource_opentelekomcloud_cce_node_v3_test.go:308: Cluster is required by the test. 4 test(s) are using cluster.
=== CONT  TestAccCCENodesV3EncryptedVolume
    cluster.go:137: Cluster is released by the test. 6 test(s) are still using cluster.
--- PASS: TestAccCCENodesV3EncryptedVolume (968.29s)
=== RUN   TestAccCCENodesV3TaintsK8sTags
=== PAUSE TestAccCCENodesV3TaintsK8sTags
=== CONT  TestAccCCENodesV3TaintsK8sTags
    resource_opentelekomcloud_cce_node_v3_test.go:332: Cluster is required by the test. 10 test(s) are using cluster.
=== CONT  TestAccCCENodesV3TaintsK8sTags
    cluster.go:137: Cluster is released by the test. 8 test(s) are still using cluster.
--- PASS: TestAccCCENodesV3TaintsK8sTags (304.31s)
=== RUN   TestAccCCENodesV3_extendParams
=== PAUSE TestAccCCENodesV3_extendParams
=== CONT  TestAccCCENodesV3_extendParams
=== CONT  TestAccCCENodesV3_extendParams
    resource_opentelekomcloud_cce_node_v3_test.go:360: Cluster is required by the test. 6 test(s) are using cluster.
=== CONT  TestAccCCENodesV3_extendParams
    cluster.go:137: Cluster is released by the test. 7 test(s) are still using cluster.
--- PASS: TestAccCCENodesV3_extendParams (967.79s)
PASS

Process finished with exit code 0
```
