### PR TITLE
[CCE] Add new predefined tag in `resource/opentelekomcloud_cce_node_v3`

### DIFF
--- a/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_v3.go
+++ b/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_v3.go
@@ -30,6 +30,7 @@ import (
 var (
 	predefinedTags = []string{
 		"beta.kubernetes.io/arch",
+		"beta.kubernetes.io/instance-type",
 		"beta.kubernetes.io/os",
 		"failure-domain.beta.kubernetes.io/region",
 		"failure-domain.beta.kubernetes.io/zone",

--- a/releasenotes/notes/cce_nodes_tags-de594b0037176303.yaml
+++ b/releasenotes/notes/cce_nodes_tags-de594b0037176303.yaml
@@ -1,0 +1,4 @@
+---
+other:
+  - |
+    **[CCE]** Add pre-defined tag ignore for ``resource/opentelekomcloud_cce_node_v3`` (`#2042 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2042>`_)


### PR DESCRIPTION
## Summary of the Pull Request

Add new predefined tag which should be ignored in resource/opentelekomcloud_cce_node_v3
CCE version 1.23
```tf
  # opentelekomcloud_cce_node_v3.node-dev-shared-kubernetes-shared-node-1 must be replaced
-/+ resource "opentelekomcloud_cce_node_v3" "node-dev-shared-kubernetes-shared-node-1" {
      + bandwidth_charge_mode = (known after apply)
      ~ billing_mode          = 0 -> (known after apply)
      + eip_count             = (known after apply)
      ~ id                    = "xxx" -> (known after apply)
      + iptype                = (known after apply)
      ~ k8s_tags              = {
          - "beta.kubernetes.io/instance-type" = "s3.large.4"
        } -> (known after apply) # forces replacement
        name                  = "node-dev-shared-kubernetes-shared-node-1"
      ~ os                    = "EulerOS 2.9" -> (known after apply)
      ~ private_ip            = "xxx" -> (known after apply)
      + public_ip             = (known after apply)
      ~ region                = "eu-de" -> (known after apply)
      ~ server_id             = "xxx" -> (known after apply)
      + sharetype             = (known after apply)
      ~ status                = "Active" -> (known after apply)
      ~ subnet_id             = "xxx" -> (known after apply)
      - tags                  = {} -> null
        # (4 unchanged attributes hidden)

      ~ data_volumes {
            # (2 unchanged attributes hidden)
        }

      ~ root_volume {
            # (2 unchanged attributes hidden)
        }
    }
```

## PR Checklist

* [x] Refers to: #1707 #2024 
* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (101.71s)
=== RUN   TestAccSomethingV0_timeout
--- PASS: TestAccSomethingV0_timeout (128.67s)
PASS

Process finished with exit code 0
```
