### PR TITLE
[DCS]: Fix config check for DCS v3 in case resource in schema hasn't been created yet

### DIFF
--- a/releasenotes/notes/dcs_version_fix-e2527a4acabbd76d.yaml
+++ b/releasenotes/notes/dcs_version_fix-e2527a4acabbd76d.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    [DCS]: Fix pre-apply check with non-existent resource for DCS `v3.0` for ``resource/opentelekomcloud_dcs_instance_v1`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+


### PR DESCRIPTION
## Summary of the Pull Request
Fix bug for DCS 3.0 where in case a `resource` was linked in schema precheck could fail.

## PR Checklist

* [x] Refers to: #2047
* [x] Tests passed.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccDcsInstancesV1_basic
=== PAUSE TestAccDcsInstancesV1_basic
=== CONT  TestAccDcsInstancesV1_basic
--- PASS: TestAccDcsInstancesV1_basic (97.54s)
=== RUN   TestAccDcsInstancesV1_basicSingleInstance
=== PAUSE TestAccDcsInstancesV1_basicSingleInstance
=== CONT  TestAccDcsInstancesV1_basicSingleInstance
--- PASS: TestAccDcsInstancesV1_basicSingleInstance (72.28s)
=== RUN   TestAccDcsInstancesV1_basicEngineV3Instance
=== PAUSE TestAccDcsInstancesV1_basicEngineV3Instance
=== CONT  TestAccDcsInstancesV1_basicEngineV3Instance
--- PASS: TestAccDcsInstancesV1_basicEngineV3Instance (412.72s)
=== RUN   TestAccASV1Configuration_invalidEngineVersion
=== PAUSE TestAccASV1Configuration_invalidEngineVersion
=== CONT  TestAccASV1Configuration_invalidEngineVersion
--- PASS: TestAccASV1Configuration_invalidEngineVersion (3.93s)
=== RUN   TestAccASV1Configuration_WhitelistValidation
=== PAUSE TestAccASV1Configuration_WhitelistValidation
=== CONT  TestAccASV1Configuration_WhitelistValidation
--- PASS: TestAccASV1Configuration_WhitelistValidation (5.27s)
=== RUN   TestAccDcsInstancesV1_Whitelist
=== PAUSE TestAccDcsInstancesV1_Whitelist
=== CONT  TestAccDcsInstancesV1_Whitelist
--- PASS: TestAccDcsInstancesV1_Whitelist (177.61s)
=== RUN   TestAccDCSInstanceV1_importBasic
--- PASS: TestAccDCSInstanceV1_importBasic (94.26s)
PASS

Process finished with the exit code 0
```
