### PR TITLE
[RDS]: New security features for `opentelekomcloud_rds_instance_v3`

### DIFF
--- a/docs/resources/rds_instance_v3.md
+++ b/docs/resources/rds_instance_v3.md
@@ -362,6 +362,8 @@ The following arguments are supported:
 
 * `restore_point` - (Optional) Specifies the restoration information.
 
+* `ssl_enable` - (Optional) Specifies whether SSL should be enabled for MySql instances.
+
 The `db` block supports:
 
 * `password` - (Required) Specifies the database password. The value cannot be

--- a/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
+++ b/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
@@ -271,6 +271,7 @@ func TestAccRdsInstanceV3_configurationParameters(t *testing.T) {
 func TestAccRdsInstanceV3TimeZone(t *testing.T) {
 	// Test is failing on deletion because RDSv3 SSL switchover doesn't change instance `action` status / doesn't
 	// return job_id but still blocks the instance from performing other actions like port_change/instance_deletion
+	// https://jira.tsi-dev.otc-service.com/browse/OTCDB-3026
 	postfix := acctest.RandString(3)
 	var rdsInstance instances.InstanceResponse
 

--- a/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
+++ b/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
@@ -268,7 +268,7 @@ func TestAccRdsInstanceV3_configurationParameters(t *testing.T) {
 	})
 }
 
-func TestAccRdsInstanceV3TimeZone(t *testing.T) {
+func TestAccRdsInstanceV3TimeZoneAndSSL(t *testing.T) {
 	// Test is failing on deletion because RDSv3 SSL switchover doesn't change instance `action` status / doesn't
 	// return job_id but still blocks the instance from performing other actions like port_change/instance_deletion
 	// https://jira.tsi-dev.otc-service.com/browse/OTCDB-3026

--- a/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_instance_v3.go
+++ b/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_instance_v3.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
@@ -23,6 +24,7 @@ import (
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/rds/v3/configurations"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/rds/v3/flavors"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/rds/v3/instances"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/rds/v3/security"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
@@ -41,7 +43,7 @@ func ResourceRdsInstanceV3() *schema.Resource {
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),
-			Update: schema.DefaultTimeout(30 * time.Minute),
+			Update: schema.DefaultTimeout(40 * time.Minute),
 		},
 
 		CustomizeDiff: customdiff.All(
@@ -119,7 +121,6 @@ func ResourceRdsInstanceV3() *schema.Resource {
 							Type:     schema.TypeInt,
 							Computed: true,
 							Optional: true,
-							ForceNew: true,
 						},
 						"user_name": {
 							Type:     schema.TypeString,
@@ -140,7 +141,6 @@ func ResourceRdsInstanceV3() *schema.Resource {
 			"security_group_id": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
 			},
 			"subnet_id": {
 				Type:     schema.TypeString,
@@ -277,6 +277,10 @@ func ResourceRdsInstanceV3() *schema.Resource {
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
+			},
+			"ssl_enable": {
+				Type:     schema.TypeBool,
+				Optional: true,
 			},
 		},
 	}
@@ -500,6 +504,23 @@ func resourceRdsInstanceV3Create(ctx context.Context, d *schema.ResourceData, me
 		}
 	}
 
+	if sslEnable := d.Get("ssl_enable").(bool); sslEnable {
+		if dbType := d.Get("db.0.type").(string); strings.ToLower(dbType) == "mysql" {
+			updateOpts := security.SwitchSslOpts{
+				SslOption:  sslEnable,
+				InstanceId: d.Id(),
+			}
+			log.Printf("[DEBUG] Update opts of SSL configuration: %+v", updateOpts)
+			err := security.SwitchSsl(client, updateOpts)
+			if err != nil {
+				return fmterr.Errorf("error updating instance SSL configuration: %s ", err)
+			}
+			return nil
+		} else {
+			return diag.Errorf("only MySQL database support SSL enable and disable")
+		}
+	}
+
 	return resourceRdsInstanceV3Read(clientCtx, d, meta)
 }
 
@@ -720,6 +741,18 @@ func resourceRdsInstanceV3Update(ctx context.Context, d *schema.ResourceData, me
 	if err != nil {
 		return fmterr.Errorf(errCreateClient, err)
 	}
+
+	if d.HasChange("security_group_id") {
+		updateOpts := security.SetSecurityGroupOpts{
+			InstanceId:      d.Id(),
+			SecurityGroupId: d.Get("security_group_id").(string),
+		}
+		_, err := security.SetSecurityGroup(client, updateOpts)
+		if err != nil {
+			return fmterr.Errorf("error updating instance security group: %s ", err)
+		}
+	}
+
 	var updateBackupOpts backups.UpdateOpts
 
 	if d.HasChange("backup_strategy") {
@@ -896,6 +929,31 @@ func resourceRdsInstanceV3Update(ctx context.Context, d *schema.ResourceData, me
 		restartRequired = restartRequired || paramRestart
 	}
 
+	if d.HasChange("db.0.port") {
+		udpateOpts := security.UpdatePortOpts{
+			Port:       int32(d.Get("db.0.port").(int)),
+			InstanceId: d.Id(),
+		}
+		log.Printf("[DEBUG] Update opts of Database port: %+v", udpateOpts)
+		_, err := security.UpdatePort(client, udpateOpts)
+		if err != nil {
+			return fmterr.Errorf("error updating instance database port: %s ", err)
+		}
+
+		stateConf := &resource.StateChangeConf{
+			Pending:      []string{"MODIFYING DATABASE PORT"},
+			Target:       []string{"ACTIVE"},
+			Refresh:      rdsInstanceStateRefreshFunc(client, d.Id()),
+			Timeout:      d.Timeout(schema.TimeoutUpdate),
+			Delay:        5 * time.Second,
+			PollInterval: 5 * time.Second,
+		}
+		if _, err = stateConf.WaitForStateContext(ctx); err != nil {
+			return fmterr.Errorf("error waiting for RDS instance (%s) creation completed: %s", d.Id(), err)
+		}
+		restartRequired = true
+	}
+
 	err = instances.WaitForStateAvailable(client, 1200, d.Id())
 	if err != nil {
 		return fmterr.Errorf("error waiting for instance to become available: %w", err)
@@ -908,6 +966,23 @@ func resourceRdsInstanceV3Update(ctx context.Context, d *schema.ResourceData, me
 		waitSeconds := int(d.Timeout(schema.TimeoutUpdate).Seconds())
 		if err := instances.WaitForStateAvailable(client, waitSeconds, d.Id()); err != nil {
 			return fmterr.Errorf("error waiting for instance to become available: %w", err)
+		}
+	}
+
+	if d.HasChange("ssl_enable") {
+		if dbType := d.Get("db.0.type").(string); strings.ToLower(dbType) == "mysql" {
+			updateOpts := security.SwitchSslOpts{
+				SslOption:  d.Get("ssl_enable").(bool),
+				InstanceId: d.Id(),
+			}
+			log.Printf("[DEBUG] Update opts of SSL configuration: %+v", updateOpts)
+			err := security.SwitchSsl(client, updateOpts)
+			if err != nil {
+				return fmterr.Errorf("error updating instance SSL configuration: %s ", err)
+			}
+			return nil
+		} else {
+			return diag.Errorf("only MySQL database support SSL enable and disable")
 		}
 	}
 
@@ -1194,4 +1269,18 @@ func updateInstanceParameters(d *schema.ResourceData, client *golangsdk.ServiceC
 		return false, fmt.Errorf("error applying configuration parameters: %w", err)
 	}
 	return status.RestartRequired, err
+}
+
+func rdsInstanceStateRefreshFunc(client *golangsdk.ServiceClient, instanceID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		instance, err := GetRdsInstance(client, instanceID)
+		if err != nil {
+			return nil, "Error retrieving RDSv3 Instance", err
+		}
+		if instance.Id == "" {
+			return instance, "DELETED", nil
+		}
+
+		return instance, instance.Status, nil
+	}
 }

--- a/releasenotes/notes/rds_security_api-d21e719930f3a7be.yaml
+++ b/releasenotes/notes/rds_security_api-d21e719930f3a7be.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   - |
-    **[RDS]** Add security features for ``resource/opentelekomcloud_rds_instance_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[RDS]** Add security features for ``resource/opentelekomcloud_rds_instance_v3`` (`#2049 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2049>`_)

--- a/releasenotes/notes/rds_security_api-d21e719930f3a7be.yaml
+++ b/releasenotes/notes/rds_security_api-d21e719930f3a7be.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    **[RDS]** Add security features for ``resource/opentelekomcloud_rds_instance_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Features include:

- security group change without forcenew
- port change without forcenew
- enable of ssl for MySql instances

`TestAccRdsInstanceV3TimeZone` is failing due to bug on RDSv3 side. RDSv3 SSL switchover doesn't change instance `action` status / doesn't return job_id but still blocks the instance from performing other actions like port_change/instance_deletion
Ticket №: https://jira.tsi-dev.otc-service.com/browse/OTCDB-3026
No changes are currently done to prevent the bug because enabling SSL is the last action provider will try to do, therefore unless user tries to delete instance/change port right after enabling ssl then this bug won't affect delivery.
## PR Checklist

* [x] Refers to: #2046, 
#936
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccRdsInstanceV3Basic
--- PASS: TestAccRdsInstanceV3Basic (779.14s)
=== RUN   TestAccRdsInstanceV3RestoreBackup
--- PASS: TestAccRdsInstanceV3RestoreBackup (993.10s)
=== RUN   TestAccRdsInstanceV3ElasticIP
--- PASS: TestAccRdsInstanceV3ElasticIP (407.56s)
=== RUN   TestAccRdsInstanceV3OptionalParams
--- PASS: TestAccRdsInstanceV3OptionalParams (286.47s)
=== RUN   TestAccRdsInstanceV3Backup
--- PASS: TestAccRdsInstanceV3Backup (139.85s)
=== RUN   TestAccRdsInstanceV3InvalidDBVersion
--- PASS: TestAccRdsInstanceV3InvalidDBVersion (7.23s)
=== RUN   TestAccRdsInstanceV3InvalidFlavor
--- PASS: TestAccRdsInstanceV3InvalidFlavor (7.19s)
=== RUN   TestAccRdsInstanceV3_configurationParameters
--- PASS: TestAccRdsInstanceV3_configurationParameters (218.97s)
PASS

Process finished with exit code 0
```
