### PR TITLE
[SWR] repo name with slashes in `resource/opentelekomcloud_swr_domain_v2`

### DIFF
--- a/opentelekomcloud/services/swr/common.go
+++ b/opentelekomcloud/services/swr/common.go
@@ -12,6 +12,6 @@ func organization(d *schema.ResourceData) string {
 	return d.Get("organization").(string)
 }
 
-func repository(d *schema.ResourceData) string {
-	return strings.ReplaceAll(d.Id(), "/", "$")
+func repository(name string) string {
+	return strings.ReplaceAll(name, "/", "$")
 }

--- a/opentelekomcloud/services/swr/resource_opentelekomcloud_swr_domain_v2.go
+++ b/opentelekomcloud/services/swr/resource_opentelekomcloud_swr_domain_v2.go
@@ -89,7 +89,7 @@ func resourceSwrDomainCreate(ctx context.Context, d *schema.ResourceData, meta i
 
 	opts := domains.CreateOpts{
 		Namespace:    d.Get("organization").(string),
-		Repository:   d.Get("repository").(string),
+		Repository:   repository(d.Get("repository").(string)),
 		AccessDomain: d.Get("access_domain").(string),
 		Permit:       d.Get("permission").(string),
 		Deadline:     d.Get("deadline").(string),
@@ -114,7 +114,7 @@ func resourceSwrDomainRead(_ context.Context, d *schema.ResourceData, meta inter
 
 	opts := domains.GetOpts{
 		Namespace:    d.Get("organization").(string),
-		Repository:   d.Get("repository").(string),
+		Repository:   repository(d.Get("repository").(string)),
 		AccessDomain: d.Get("access_domain").(string),
 	}
 	domain, err := domains.Get(client, opts)
@@ -150,7 +150,7 @@ func resourceSwrDomainUpdate(ctx context.Context, d *schema.ResourceData, meta i
 
 	opts := domains.UpdateOpts{
 		Namespace:   d.Get("organization").(string),
-		Repository:  d.Get("repository").(string),
+		Repository:  repository(d.Get("repository").(string)),
 		Permit:      d.Get("permission").(string),
 		Deadline:    d.Get("deadline").(string),
 		Description: d.Get("description").(string),
@@ -173,7 +173,7 @@ func resourceSwrDomainDelete(_ context.Context, d *schema.ResourceData, meta int
 
 	opts := domains.GetOpts{
 		Namespace:    d.Get("organization").(string),
-		Repository:   d.Get("repository").(string),
+		Repository:   repository(d.Get("repository").(string)),
 		AccessDomain: d.Get("access_domain").(string),
 	}
 	err = domains.Delete(client, opts)

--- a/opentelekomcloud/services/swr/resource_opentelekomcloud_swr_repository_v2.go
+++ b/opentelekomcloud/services/swr/resource_opentelekomcloud_swr_repository_v2.go
@@ -123,7 +123,7 @@ func resourceRepositoryRead(_ context.Context, d *schema.ResourceData, meta inte
 		return fmterr.Errorf(ClientError, err)
 	}
 
-	repo, err := repositories.Get(client, organization(d), repository(d))
+	repo, err := repositories.Get(client, organization(d), repository(d.Id()))
 	if err != nil {
 		return fmterr.Errorf("error reading repository: %w", err)
 	}
@@ -175,7 +175,7 @@ func resourceRepositoryDelete(_ context.Context, d *schema.ResourceData, meta in
 		return fmterr.Errorf(ClientError, err)
 	}
 
-	err = repositories.Delete(client, organization(d), repository(d))
+	err = repositories.Delete(client, organization(d), repository(d.Id()))
 	if err != nil {
 		fmterr.Errorf("error deleting repository: %w", err)
 	}

--- a/releasenotes/notes/swr-repo-name-slash-fix-2d754dac81061219.yaml
+++ b/releasenotes/notes/swr-repo-name-slash-fix-2d754dac81061219.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[SWR]** forward slash ``/`` support for repository name in ``opentelekomcloud_swr_domain_v2`` (`#2052 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2052>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Fix for repositories with names repo/sub_repo

## PR Checklist

* [x] Refers to: #2043
* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestSwrOrganizationV2_import
--- PASS: TestSwrOrganizationV2_import (51.92s)
PASS


Process finished with the exit code 0

=== RUN   TestSwrRepositoryV2_import
--- PASS: TestSwrRepositoryV2_import (57.32s)
PASS


Process finished with the exit code 0

=== RUN   TestSwrDomainV2Basic
--- PASS: TestSwrDomainV2Basic (47.21s)
=== RUN   TestSwrDomainV2Slashes
--- PASS: TestSwrDomainV2Slashes (44.70s)
PASS


Process finished with the exit code 0

=== RUN   TestSwrOrganizationPermissionsV2_basic
--- PASS: TestSwrOrganizationPermissionsV2_basic (43.30s)
PASS


Process finished with the exit code 0

=== RUN   TestSwrOrganizationV2_basic
--- PASS: TestSwrOrganizationV2_basic (40.26s)
=== RUN   TestSwrOrganizationV2_validateName
--- PASS: TestSwrOrganizationV2_validateName (17.20s)
PASS


Process finished with the exit code 0

=== RUN   TestSwrRepositoryV2_basic
--- PASS: TestSwrRepositoryV2_basic (44.24s)
PASS


Process finished with the exit code 0
```
