### PR TITLE
CSS: `opentelekomcloud_css_snapshot_configuration_v1` validation added

### DIFF
--- a/docs/resources/css_snapshot_configuration_v1.md
+++ b/docs/resources/css_snapshot_configuration_v1.md
@@ -60,7 +60,7 @@ The following arguments are supported:
 * `cluster_id` - (Required) ID of the CSS cluster.
 
 * `automatic` - (Optional) Use automatic configuration for CCS cluster screenshots.
-  Mutually exclusive with `configuration`.
+  Mutually exclusive with `configuration`/`creation_policy`.
 
 * `configuration` - (Optional) The basic configurations of a cluster snapshot. Structure is documented below.
   Mutually exclusive with `automatic`.

--- a/docs/resources/css_snapshot_configuration_v1.md
+++ b/docs/resources/css_snapshot_configuration_v1.md
@@ -59,13 +59,14 @@ The following arguments are supported:
 
 * `cluster_id` - (Required) ID of the CSS cluster.
 
-* `automatic` **DEPRECATED** - (Optional) Use automatic configuration for CCS cluster screenshots.
-  Setting this parameter to `true` will make configuration and policy ignored.
-  Please fill `configuration` parameter instead.
+* `automatic` - (Optional) Use automatic configuration for CCS cluster screenshots.
+  Mutually exclusive with `configuration`.
 
 * `configuration` - (Optional) The basic configurations of a cluster snapshot. Structure is documented below.
+  Mutually exclusive with `automatic`.
 
 * `creation_policy` - (Optional) Parameters related to automatic snapshot creation. Structure is documented below.
+  Mutually exclusive with `automatic`.
 
 The `configuration` block supports:
 

--- a/docs/resources/css_snapshot_configuration_v1.md
+++ b/docs/resources/css_snapshot_configuration_v1.md
@@ -59,8 +59,9 @@ The following arguments are supported:
 
 * `cluster_id` - (Required) ID of the CSS cluster.
 
-* `automatic` - (Optional) Use automatic configuration for CCS cluster screenshots.
+* `automatic` **DEPRECATED** - (Optional) Use automatic configuration for CCS cluster screenshots.
   Setting this parameter to `true` will make configuration and policy ignored.
+  Please fill `configuration` parameter instead.
 
 * `configuration` - (Optional) The basic configurations of a cluster snapshot. Structure is documented below.
 

--- a/opentelekomcloud/services/css/resource_opentelekomcloud_css_snapshot_configuration_v1.go
+++ b/opentelekomcloud/services/css/resource_opentelekomcloud_css_snapshot_configuration_v1.go
@@ -34,8 +34,9 @@ func ResourceCssSnapshotConfigurationV1() *schema.Resource {
 				ForceNew: true,
 			},
 			"automatic": {
-				Type:     schema.TypeBool,
-				Optional: true,
+				Type:       schema.TypeBool,
+				Optional:   true,
+				Deprecated: "Please use `configuration` instead",
 			},
 			"configuration": {
 				Type:     schema.TypeList,
@@ -199,13 +200,6 @@ func updateSnapshotConfigurationResource(_ context.Context, d *schema.ResourceDa
 	client, err := config.CssV1Client(config.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf(clientError, err)
-	}
-
-	if d.Get("automatic").(bool) {
-		if err := snapshots.Enable(client, d.Id()); err != nil {
-			return fmt.Errorf("error using automatic config for snapshots: %w", err)
-		}
-		return nil
 	}
 
 	if d.Get("configuration.#") != 0 {

--- a/releasenotes/notes/css_snapshot-d7a6b35e12e2009b.yaml
+++ b/releasenotes/notes/css_snapshot-d7a6b35e12e2009b.yaml
@@ -1,0 +1,4 @@
+---
+deprecations:
+  - |
+    **[CSS]** Deprecate of `automatic` parameter for ``resource/opentelekomcloud_css_snapshot_configuration_v1`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)

--- a/releasenotes/notes/css_snapshot-d7a6b35e12e2009b.yaml
+++ b/releasenotes/notes/css_snapshot-d7a6b35e12e2009b.yaml
@@ -1,4 +1,4 @@
 ---
 deprecations:
   - |
-    **[CSS]** Deprecate of `automatic` parameter for ``resource/opentelekomcloud_css_snapshot_configuration_v1`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[CSS]** Added `ConflictsWith` setting for `configuration` and `automatic` parameters in ``resource/opentelekomcloud_css_snapshot_configuration_v1`` (`#2057 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2057>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Added new validation to make fields `automatic` and `configuration`/`creation_policy` mutually exclusive.

## PR Checklist

* [x] Refers to: #2054
* [x] Tests added.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestResourceCSSSnapshotConfigurationV1_basic
=== PAUSE TestResourceCSSSnapshotConfigurationV1_basic
=== CONT  TestResourceCSSSnapshotConfigurationV1_basic
--- PASS: TestResourceCSSSnapshotConfigurationV1_basic (977.14s)
=== RUN   TestAccCheckCSSV1Validation
--- PASS: TestAccCheckCSSV1Validation (5.74s)
PASS

Process finished with the exit code 0
```
