### PR TITLE
[RDS]: PostgreSql 13/14 workaround fix to enable `parameters`

### DIFF
--- a/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
+++ b/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
@@ -402,8 +402,8 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
     kuh = "value-create"
   }
   parameters = {
-      max_prepared_transactions = "200"
-      max_connections = "250"
+      max_files_per_process = "100"
+      max_parallel_workers = "10"
    }
 }
 `, common.DataSourceSecGroupDefault, common.DataSourceSubnet, postfix, env.OS_AVAILABILITY_ZONE)

--- a/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
+++ b/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
@@ -74,7 +74,6 @@ func TestAccRdsPostgre13V3Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(instanceV3ResourceName, "db.0.type", "PostgreSQL"),
 					resource.TestCheckResourceAttr(instanceV3ResourceName, "db.0.port", "8635"),
 					resource.TestCheckResourceAttr(instanceV3ResourceName, "volume.0.size", "40"),
-					resource.TestCheckResourceAttr(instanceV3ResourceName, "backup_strategy.0.keep_days", "1"),
 					resource.TestCheckResourceAttr(instanceV3ResourceName, "tags.muh", "value-create"),
 					resource.TestCheckResourceAttr(instanceV3ResourceName, "tags.kuh", "value-create"),
 				),
@@ -402,6 +401,10 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
     muh = "value-create"
     kuh = "value-create"
   }
+  parameters = {
+      max_prepared_transactions = "200"
+      max_connections = "250"
+   }
 }
 `, common.DataSourceSecGroupDefault, common.DataSourceSubnet, postfix, env.OS_AVAILABILITY_ZONE)
 }

--- a/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
+++ b/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
@@ -906,9 +906,9 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
     kuh = "value-create"
   }
   parameters = {
-      max_prepared_transactions = "200"
-      max_connections = "250"
-   }
+    max_prepared_transactions = "200"
+    max_connections           = "250"
+  }
 }
 `, common.DataSourceSecGroupDefault, common.DataSourceSubnet, postfix, env.OS_AVAILABILITY_ZONE)
 }

--- a/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
+++ b/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
@@ -401,10 +401,6 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
     muh = "value-create"
     kuh = "value-create"
   }
-  parameters = {
-      max_files_per_process = "100"
-      max_parallel_workers = "10"
-   }
 }
 `, common.DataSourceSecGroupDefault, common.DataSourceSubnet, postfix, env.OS_AVAILABILITY_ZONE)
 }

--- a/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
+++ b/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
@@ -55,6 +55,34 @@ func TestAccRdsInstanceV3Basic(t *testing.T) {
 	})
 }
 
+func TestAccRdsPostgre13V3Basic(t *testing.T) {
+	postfix := acctest.RandString(3)
+	var rdsInstance instances.InstanceResponse
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckRdsInstanceV3Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRdsPostrgre13V3Basic(postfix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRdsInstanceV3Exists(instanceV3ResourceName, &rdsInstance),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "flavor", "rds.pg.c2.large"),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "db.0.port", "8635"),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "name", "tf_rds_instance_"+postfix),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "db.0.type", "PostgreSQL"),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "db.0.port", "8635"),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "volume.0.size", "40"),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "backup_strategy.0.keep_days", "1"),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "tags.muh", "value-create"),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "tags.kuh", "value-create"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccRdsInstanceV3RestoreBackup(t *testing.T) {
 	postfix := acctest.RandString(3)
 	var rdsInstance instances.InstanceResponse
@@ -849,5 +877,39 @@ resource "opentelekomcloud_rds_parametergroup_v3" "pg_1" {
 }
 
 
+`, common.DataSourceSecGroupDefault, common.DataSourceSubnet, postfix, env.OS_AVAILABILITY_ZONE)
+}
+
+func testAccRdsPostrgre13V3Basic(postfix string) string {
+	return fmt.Sprintf(`
+%s
+%s
+
+resource "opentelekomcloud_rds_instance_v3" "instance" {
+  name              = "tf_rds_instance_%s"
+  availability_zone = ["%s"]
+  db {
+    password = "Postgres!120521"
+    type     = "PostgreSQL"
+    version  = "13"
+    port     = "8635"
+  }
+  security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
+  subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  volume {
+    type = "COMMON"
+    size = 40
+  }
+  flavor = "rds.pg.c2.large"
+  tags = {
+    muh = "value-create"
+    kuh = "value-create"
+  }
+  parameters = {
+      max_prepared_transactions = "200"
+      max_connections = "250"
+   }
+}
 `, common.DataSourceSecGroupDefault, common.DataSourceSubnet, postfix, env.OS_AVAILABILITY_ZONE)
 }

--- a/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_instance_v3.go
+++ b/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_instance_v3.go
@@ -427,6 +427,11 @@ func resourceRdsInstanceV3Create(ctx context.Context, d *schema.ResourceData, me
 
 	d.SetId(r.Instance.Id)
 
+	err = instances.WaitForStateAvailable(client, 1200, d.Id())
+	if err != nil {
+		return fmterr.Errorf("error waiting for instance to become available: %w", err)
+	}
+
 	if common.HasFilledOpt(d, "tag") {
 		rdsInstance, err := GetRdsInstance(client, r.Instance.Id)
 		if err != nil {

--- a/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_instance_v3.go
+++ b/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_instance_v3.go
@@ -492,7 +492,7 @@ func resourceRdsInstanceV3Create(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	paramRestart := false
-	if _, paramRestart = d.GetOk("parameters"); paramRestart {
+	if _, ok := d.GetOk("parameters"); ok {
 		stateConf := &resource.StateChangeConf{
 			Pending:      []string{"PENDING"},
 			Target:       []string{"SUCCESS"},
@@ -501,10 +501,11 @@ func resourceRdsInstanceV3Create(ctx context.Context, d *schema.ResourceData, me
 			PollInterval: 10 * time.Second,
 		}
 
-		_, err = stateConf.WaitForStateContext(ctx)
+		result, err := stateConf.WaitForStateContext(ctx)
 		if err != nil {
 			return diag.FromErr(err)
 		}
+		paramRestart = result.(bool)
 	}
 
 	if templateRestart || paramRestart {

--- a/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_instance_v3.go
+++ b/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_instance_v3.go
@@ -958,7 +958,7 @@ func resourceRdsInstanceV3Update(ctx context.Context, d *schema.ResourceData, me
 			Refresh:      rdsInstanceStateRefreshFunc(client, d.Id()),
 			Timeout:      d.Timeout(schema.TimeoutUpdate),
 			Delay:        5 * time.Second,
-			PollInterval: 5 * time.Second,
+			PollInterval: 10 * time.Second,
 		}
 		if _, err = stateConf.WaitForStateContext(ctx); err != nil {
 			return fmterr.Errorf("error waiting for RDS instance (%s) creation completed: %s", d.Id(), err)
@@ -1286,11 +1286,11 @@ func updateInstanceParameters(d *schema.ResourceData, client *golangsdk.ServiceC
 		Values:     d.Get("parameters").(map[string]interface{}),
 		InstanceId: d.Id(),
 	}
-	status, err := configurations.UpdateInstanceConfiguration(client, opts)
+	_, err := configurations.UpdateInstanceConfiguration(client, opts)
 	if err != nil {
 		return false, err
 	}
-	return status.RestartRequired, err
+	return true, err
 }
 
 func rdsInstanceStateRefreshFunc(client *golangsdk.ServiceClient, instanceID string) resource.StateRefreshFunc {
@@ -1318,6 +1318,6 @@ func waitForParameterApply(d *schema.ResourceData, client *golangsdk.ServiceClie
 			return nil, "", fmt.Errorf("error applying configuration parameters: %w", err)
 		}
 
-		return nil, "SUCCESS", nil
+		return r, "SUCCESS", nil
 	}
 }

--- a/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_instance_v3.go
+++ b/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_instance_v3.go
@@ -427,11 +427,6 @@ func resourceRdsInstanceV3Create(ctx context.Context, d *schema.ResourceData, me
 
 	d.SetId(r.Instance.Id)
 
-	err = instances.WaitForStateAvailable(client, 1200, d.Id())
-	if err != nil {
-		return fmterr.Errorf("error waiting for instance to become available: %w", err)
-	}
-
 	if common.HasFilledOpt(d, "tag") {
 		rdsInstance, err := GetRdsInstance(client, r.Instance.Id)
 		if err != nil {
@@ -496,9 +491,20 @@ func resourceRdsInstanceV3Create(ctx context.Context, d *schema.ResourceData, me
 		return fmterr.Errorf("error making sure configuration template is applied: %w", err)
 	}
 
-	paramRestart, err := updateInstanceParameters(d, client)
-	if err != nil {
-		return fmterr.Errorf("error applying parameters to the instance: %w", err)
+	paramRestart := false
+	if _, paramRestart = d.GetOk("parameters"); paramRestart {
+		stateConf := &resource.StateChangeConf{
+			Pending:      []string{"PENDING"},
+			Target:       []string{"SUCCESS"},
+			Refresh:      waitForParameterApply(d, client),
+			Timeout:      d.Timeout(schema.TimeoutUpdate),
+			PollInterval: 10 * time.Second,
+		}
+
+		_, err = stateConf.WaitForStateContext(ctx)
+		if err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	if templateRestart || paramRestart {
@@ -1276,17 +1282,13 @@ func validateRDSv3Flavor(argName string) schema.CustomizeDiffFunc {
 }
 
 func updateInstanceParameters(d *schema.ResourceData, client *golangsdk.ServiceClient) (bool, error) {
-	if _, ok := d.GetOk("parameters"); !ok {
-		return false, nil
-	}
-
 	opts := configurations.UpdateInstanceConfigurationOpts{
 		Values:     d.Get("parameters").(map[string]interface{}),
 		InstanceId: d.Id(),
 	}
 	status, err := configurations.UpdateInstanceConfiguration(client, opts)
 	if err != nil {
-		return false, fmt.Errorf("error applying configuration parameters: %w", err)
+		return false, err
 	}
 	return status.RestartRequired, err
 }
@@ -1302,5 +1304,20 @@ func rdsInstanceStateRefreshFunc(client *golangsdk.ServiceClient, instanceID str
 		}
 
 		return instance, instance.Status, nil
+	}
+}
+
+func waitForParameterApply(d *schema.ResourceData, client *golangsdk.ServiceClient) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		r, err := updateInstanceParameters(d, client)
+
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault403); ok {
+				return r, "PENDING", nil
+			}
+			return nil, "", fmt.Errorf("error applying configuration parameters: %w", err)
+		}
+
+		return nil, "SUCCESS", nil
 	}
 }

--- a/releasenotes/notes/rds_postgre-2edb3b31019c43b1.yaml
+++ b/releasenotes/notes/rds_postgre-2edb3b31019c43b1.yaml
@@ -1,5 +1,5 @@
 ---
 other:
   - |
-    **[RDS]** PostgreSQL 13/14 `parameters` workaround for ``resource/opentelekomcloud_rds_instance_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[RDS]** PostgreSQL 13/14 `parameters` workaround for ``resource/opentelekomcloud_rds_instance_v3`` (`#2068 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2068>`_)
 

--- a/releasenotes/notes/rds_postgre-2edb3b31019c43b1.yaml
+++ b/releasenotes/notes/rds_postgre-2edb3b31019c43b1.yaml
@@ -1,0 +1,5 @@
+---
+other:
+  - |
+    **[RDS]** PostgreSQL 13/14 `parameters` workaround for ``resource/opentelekomcloud_rds_instance_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+


### PR DESCRIPTION
## Summary of the Pull Request
PostgreSql 13/14 have issues which leads to an error when applying parameters.
This PR is a workaround meant to fix this issue.

## PR Checklist

* [x] Refers to: #2051
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccRdsInstanceV3RestoreBackup
--- PASS: TestAccRdsInstanceV3RestoreBackup (869.82s)
PASS

Process finished with the exit code 0

=== RUN   TestAccRdsInstanceV3ElasticIP
--- PASS: TestAccRdsInstanceV3ElasticIP (454.12s)
PASS

Process finished with the exit code 0

=== RUN   TestAccRdsInstanceV3Basic
--- PASS: TestAccRdsInstanceV3Basic (715.05s)
PASS

Process finished with the exit code 0

=== RUN   TestAccRdsPostgre13V3Basic
--- PASS: TestAccRdsPostgre13V3Basic (446.41s)
PASS

Process finished with the exit code 0
```
