### PR TITLE
ECS/acceptance fix

### DIFF
--- a/opentelekomcloud/acceptance/ecs/data_source_opentelekomcloud_compute_instance_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/data_source_opentelekomcloud_compute_instance_v2_test.go
@@ -90,7 +90,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name              = "instance_1"
   availability_zone = "%s"
   image_name        = "Standard_Debian_10_latest"
-  flavor_name		= "%s"
+  flavor_name       = "%s"
   metadata = {
     foo = "bar"
   }
@@ -109,7 +109,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name              = "instance_1"
   availability_zone = "%s"
   image_name        = "Enterprise_Windows_STD_2019_CORE_KVM"
-  flavor_name		= "%s"
+  flavor_name       = "%s"
   metadata = {
     foo = "bar"
   }

--- a/opentelekomcloud/acceptance/ecs/data_source_opentelekomcloud_compute_instance_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/data_source_opentelekomcloud_compute_instance_v2_test.go
@@ -37,7 +37,6 @@ func TestAccComputeV2InstanceDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", "instance_1"),
 					resource.TestCheckResourceAttrPair(resourceName, "metadata", instanceName, "metadata"),
 					resource.TestCheckResourceAttrSet(resourceName, "network.0.name"),
-					resource.TestCheckResourceAttrSet(resourceName, "encrypted_password"),
 				),
 			},
 			{
@@ -91,6 +90,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name              = "instance_1"
   availability_zone = "%s"
   image_name        = "Standard_Debian_10_latest"
+  flavor_name		= "%s"
   metadata = {
     foo = "bar"
   }
@@ -98,7 +98,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
     uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
 }
-`, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE)
+`, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, getFlavorName())
 }
 
 func testAccComputeV2InstanceDataSourceWindows() string {
@@ -109,6 +109,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name              = "instance_1"
   availability_zone = "%s"
   image_name        = "Enterprise_Windows_STD_2019_CORE_KVM"
+  flavor_name		= "%s"
   metadata = {
     foo = "bar"
   }
@@ -116,7 +117,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
     uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
 }
-`, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE)
+`, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, getFlavorName())
 }
 
 func testAccComputeV2InstanceDataSourceID() string {

--- a/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_floatingip_associate_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_floatingip_associate_v2_test.go
@@ -236,7 +236,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
   image_name      = "Standard_Debian_10_latest"
-  flavor_name	  = "%s"
+  flavor_name     = "%s"
   network {
     uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
@@ -257,7 +257,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
   image_name      = "Standard_Debian_10_latest"
-  flavor_name	  = "%s"
+  flavor_name     = "%s"
   network {
     uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
@@ -279,7 +279,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
   image_name      = "Standard_Debian_10_latest"
-  flavor_name	  = "%s"
+  flavor_name     = "%s"
   network {
     uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
@@ -301,7 +301,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
   image_name      = "Standard_Debian_10_latest"
-  flavor_name	  = "%s"
+  flavor_name     = "%s"
   network {
     uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
@@ -324,7 +324,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
   image_name      = "Standard_Debian_10_latest"
-  flavor_name	  = "%s"
+  flavor_name     = "%s"
   network {
     uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }

--- a/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_floatingip_associate_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_floatingip_associate_v2_test.go
@@ -235,6 +235,8 @@ var testAccComputeV2FloatingIPAssociateBasic = fmt.Sprintf(`
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
+  image_name      = "Standard_Debian_10_latest"
+  flavor_name	  = "%s"
   network {
     uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
@@ -246,7 +248,7 @@ resource "opentelekomcloud_compute_floatingip_associate_v2" "fip_1" {
   floating_ip = opentelekomcloud_networking_floatingip_v2.fip_1.address
   instance_id = opentelekomcloud_compute_instance_v2.instance_1.id
 }
-`, common.DataSourceSubnet)
+`, common.DataSourceSubnet, getFlavorName())
 
 var testAccComputeV2FloatingIPAssociateFixedIP = fmt.Sprintf(`
 %s
@@ -254,6 +256,8 @@ var testAccComputeV2FloatingIPAssociateFixedIP = fmt.Sprintf(`
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
+  image_name      = "Standard_Debian_10_latest"
+  flavor_name	  = "%s"
   network {
     uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
@@ -266,7 +270,7 @@ resource "opentelekomcloud_compute_floatingip_associate_v2" "fip_1" {
   instance_id = opentelekomcloud_compute_instance_v2.instance_1.id
   fixed_ip    = opentelekomcloud_compute_instance_v2.instance_1.access_ip_v4
 }
-`, common.DataSourceSubnet)
+`, common.DataSourceSubnet, getFlavorName())
 
 var testAccComputeV2FloatingIPAssociateAttachToFirstNetwork = fmt.Sprintf(`
 %s
@@ -274,7 +278,8 @@ var testAccComputeV2FloatingIPAssociateAttachToFirstNetwork = fmt.Sprintf(`
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
-
+  image_name      = "Standard_Debian_10_latest"
+  flavor_name	  = "%s"
   network {
     uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
@@ -287,7 +292,7 @@ resource "opentelekomcloud_compute_floatingip_associate_v2" "fip_1" {
   instance_id = opentelekomcloud_compute_instance_v2.instance_1.id
   fixed_ip    = opentelekomcloud_compute_instance_v2.instance_1.network.0.fixed_ip_v4
 }
-`, common.DataSourceSubnet)
+`, common.DataSourceSubnet, getFlavorName())
 
 var testAccComputeV2FloatingIPAssociateAttachNew1 = fmt.Sprintf(`
 %s
@@ -295,6 +300,8 @@ var testAccComputeV2FloatingIPAssociateAttachNew1 = fmt.Sprintf(`
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
+  image_name      = "Standard_Debian_10_latest"
+  flavor_name	  = "%s"
   network {
     uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
@@ -308,7 +315,7 @@ resource "opentelekomcloud_compute_floatingip_associate_v2" "fip_1" {
   floating_ip = opentelekomcloud_networking_floatingip_v2.fip_1.address
   instance_id = opentelekomcloud_compute_instance_v2.instance_1.id
 }
-`, common.DataSourceSubnet)
+`, common.DataSourceSubnet, getFlavorName())
 
 var testAccComputeV2FloatingIPAssociateAttachNew2 = fmt.Sprintf(`
 %s
@@ -316,6 +323,8 @@ var testAccComputeV2FloatingIPAssociateAttachNew2 = fmt.Sprintf(`
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
+  image_name      = "Standard_Debian_10_latest"
+  flavor_name	  = "%s"
   network {
     uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
@@ -329,4 +338,4 @@ resource "opentelekomcloud_compute_floatingip_associate_v2" "fip_1" {
   floating_ip = opentelekomcloud_networking_floatingip_v2.fip_2.address
   instance_id = opentelekomcloud_compute_instance_v2.instance_1.id
 }
-`, common.DataSourceSubnet)
+`, common.DataSourceSubnet, getFlavorName())

--- a/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_instance_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_instance_v2_test.go
@@ -576,7 +576,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name              = "instance_1"
   availability_zone = "%s"
   image_name        = "Standard_Debian_10_latest"
-  flavor_name		= "%s"
+  flavor_name       = "%s"
   metadata = {
     foo = "bar"
   }
@@ -598,7 +598,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name              = "instance_1_ibn"
   image_name        = "Standard_Debian_10_latest"
   availability_zone = "%s"
-  flavor_name		= "%s"
+  flavor_name       = "%s"
   metadata = {
     foo = "bar"
   }
@@ -655,7 +655,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
   image_name      = "Standard_Debian_10_latest"
-  flavor_name	  = "%s"
+  flavor_name     = "%s"
   network {
     uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
@@ -709,7 +709,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name              = "instance_1"
   security_groups   = ["default"]
   availability_zone = "%s"
-  flavor_name		= "%s"
+  flavor_name       = "%s"
   network {
     uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
@@ -738,7 +738,7 @@ resource "opentelekomcloud_blockstorage_volume_v2" "vol_1" {
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
-  flavor_name	  = "%s"
+  flavor_name     = "%s"
   network {
     uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
@@ -760,7 +760,7 @@ var testAccComputeV2InstanceBootFromVolume = fmt.Sprintf(`
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
-  flavor_name	  = "%s"
+  flavor_name     = "%s"
   network {
     uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
@@ -782,7 +782,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
   image_name      = "Standard_Debian_10_latest"
-  flavor_name	  = "%s"
+  flavor_name     = "%s"
   network {
     uuid        = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
     fixed_ip_v4 = "192.168.0.24"
@@ -797,7 +797,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
   image_name      = "Standard_Debian_10_latest"
-  flavor_name	  = "%s"
+  flavor_name     = "%s"
   network {
     uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
@@ -812,7 +812,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
   image_name      = "Standard_Debian_10_latest"
-  flavor_name	  = "%s"
+  flavor_name     = "%s"
   network {
     uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
@@ -830,7 +830,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
   image_name      = "Standard_Debian_10_latest"
-  flavor_name	  = "%s"
+  flavor_name     = "%s"
   network {
     uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
@@ -848,7 +848,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
   image_name      = "Standard_Debian_10_latest"
-  flavor_name	  = "%s"
+  flavor_name     = "%s"
   network {
     uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
@@ -866,8 +866,8 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name              = "instance_1"
   security_groups   = ["default"]
   availability_zone = "%s"
-  image_name      = "Standard_Debian_10_latest"
-  flavor_name	  = "%s"
+  image_name        = "Standard_Debian_10_latest"
+  flavor_name       = "%s"
   metadata = {
     foo = "bar"
   }
@@ -896,7 +896,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
   image_name      = "Standard_Debian_10_latest"
-  flavor_name	  = "%s"
+  flavor_name     = "%s"
 
   network {
     uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
@@ -915,7 +915,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
   image_name      = "Standard_Debian_10_latest"
-  flavor_name	  = "%s"
+  flavor_name     = "%s"
   power_state     = "active"
   network {
     uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
@@ -930,7 +930,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
   image_name      = "Standard_Debian_10_latest"
-  flavor_name	  = "%s"
+  flavor_name     = "%s"
   power_state     = "shutoff"
   network {
     uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id

--- a/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_instance_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_instance_v2_test.go
@@ -887,7 +887,7 @@ resource "opentelekomcloud_networking_network_v2" "network_1" {
 resource "opentelekomcloud_networking_subnet_v2" "subnet_101" {
   name        = "subnet_101"
   network_id  = opentelekomcloud_networking_network_v2.network_1.id
-  cidr        = "172.16.1.0/24"
+  cidr        = "192.168.1.0/24"
   ip_version  = 4
   enable_dhcp = true
   no_gateway  = true
@@ -903,7 +903,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   }
   network {
     uuid        = opentelekomcloud_networking_network_v2.network_1.id
-    fixed_ip_v4 = "172.16.1.100"
+    fixed_ip_v4 = "192.168.1.100"
   }
 }
 `, common.DataSourceSubnet, getFlavorName())

--- a/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_instance_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_instance_v2_test.go
@@ -575,6 +575,8 @@ var testAccComputeV2InstanceBasic = fmt.Sprintf(`
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name              = "instance_1"
   availability_zone = "%s"
+  image_name        = "Standard_Debian_10_latest"
+  flavor_name		= "%s"
   metadata = {
     foo = "bar"
   }
@@ -587,7 +589,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
     kuh = "value-create"
   }
 }
-`, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE)
+`, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, getFlavorName())
 
 var testAccComputeV2InstanceImageByName = fmt.Sprintf(`
 %s
@@ -596,6 +598,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name              = "instance_1_ibn"
   image_name        = "Standard_Debian_10_latest"
   availability_zone = "%s"
+  flavor_name		= "%s"
   metadata = {
     foo = "bar"
   }
@@ -603,7 +606,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
     uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
 }
-`, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE)
+`, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, getFlavorName())
 
 var testAccComputeV2InstanceUpdate = fmt.Sprintf(`
 %s
@@ -651,11 +654,13 @@ resource "opentelekomcloud_compute_secgroup_v2" "secgroup_2" {
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
+  image_name      = "Standard_Debian_10_latest"
+  flavor_name	  = "%s"
   network {
     uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
 }
-`, common.DataSourceSubnet)
+`, common.DataSourceSubnet, getFlavorName())
 
 var testAccComputeV2InstanceMultiSecgroupUpdate = fmt.Sprintf(`
 %s
@@ -704,6 +709,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name              = "instance_1"
   security_groups   = ["default"]
   availability_zone = "%s"
+  flavor_name		= "%s"
   network {
     uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
@@ -716,7 +722,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
     delete_on_termination = true
   }
 }
-`, common.DataSourceImage, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE)
+`, common.DataSourceImage, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, getFlavorName())
 
 var testAccComputeV2InstanceBootFromVolumeVolume = fmt.Sprintf(`
 %s
@@ -732,6 +738,7 @@ resource "opentelekomcloud_blockstorage_volume_v2" "vol_1" {
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
+  flavor_name	  = "%s"
   network {
     uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
@@ -743,7 +750,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
     delete_on_termination = true
   }
 }
-`, common.DataSourceImage, common.DataSourceSubnet)
+`, common.DataSourceImage, common.DataSourceSubnet, getFlavorName())
 
 var testAccComputeV2InstanceBootFromVolume = fmt.Sprintf(`
 %s
@@ -753,6 +760,7 @@ var testAccComputeV2InstanceBootFromVolume = fmt.Sprintf(`
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
+  flavor_name	  = "%s"
   network {
     uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
@@ -765,7 +773,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
     delete_on_termination = true
   }
 }
-`, common.DataSourceImage, common.DataSourceSubnet)
+`, common.DataSourceImage, common.DataSourceSubnet, getFlavorName())
 
 var testAccComputeV2InstanceFixedIP = fmt.Sprintf(`
 %s
@@ -773,12 +781,14 @@ var testAccComputeV2InstanceFixedIP = fmt.Sprintf(`
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
+  image_name      = "Standard_Debian_10_latest"
+  flavor_name	  = "%s"
   network {
     uuid        = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
     fixed_ip_v4 = "192.168.0.24"
   }
 }
-`, common.DataSourceSubnet)
+`, common.DataSourceSubnet, getFlavorName())
 
 var testAccComputeV2InstanceStopBeforeDestroy = fmt.Sprintf(`
 %s
@@ -786,12 +796,14 @@ var testAccComputeV2InstanceStopBeforeDestroy = fmt.Sprintf(`
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
+  image_name      = "Standard_Debian_10_latest"
+  flavor_name	  = "%s"
   network {
     uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
   stop_before_destroy = true
 }
-`, common.DataSourceSubnet)
+`, common.DataSourceSubnet, getFlavorName())
 
 var testAccComputeV2InstanceMetadata = fmt.Sprintf(`
 %s
@@ -799,6 +811,8 @@ var testAccComputeV2InstanceMetadata = fmt.Sprintf(`
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
+  image_name      = "Standard_Debian_10_latest"
+  flavor_name	  = "%s"
   network {
     uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
@@ -807,7 +821,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
     abc = "def"
   }
 }
-`, common.DataSourceSubnet)
+`, common.DataSourceSubnet, getFlavorName())
 
 var testAccComputeV2InstanceMetadataUpdate = fmt.Sprintf(`
 %s
@@ -815,6 +829,8 @@ var testAccComputeV2InstanceMetadataUpdate = fmt.Sprintf(`
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
+  image_name      = "Standard_Debian_10_latest"
+  flavor_name	  = "%s"
   network {
     uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
@@ -823,7 +839,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
     ghi = "jkl"
   }
 }
-`, common.DataSourceSubnet)
+`, common.DataSourceSubnet, getFlavorName())
 
 var testAccComputeV2InstanceTimeout = fmt.Sprintf(`
 %s
@@ -831,6 +847,8 @@ var testAccComputeV2InstanceTimeout = fmt.Sprintf(`
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
+  image_name      = "Standard_Debian_10_latest"
+  flavor_name	  = "%s"
   network {
     uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
@@ -839,7 +857,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
     create = "10m"
   }
 }
-`, common.DataSourceSubnet)
+`, common.DataSourceSubnet, getFlavorName())
 
 var testAccComputeV2InstanceAutoRecovery = fmt.Sprintf(`
 %s
@@ -848,6 +866,8 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name              = "instance_1"
   security_groups   = ["default"]
   availability_zone = "%s"
+  image_name      = "Standard_Debian_10_latest"
+  flavor_name	  = "%s"
   metadata = {
     foo = "bar"
   }
@@ -856,7 +876,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   }
   auto_recovery = false
 }
-`, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE)
+`, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, getFlavorName())
 
 var testAccComputeV2InstanceCrazyNICs = fmt.Sprintf(`
 %s
@@ -864,10 +884,10 @@ var testAccComputeV2InstanceCrazyNICs = fmt.Sprintf(`
 resource "opentelekomcloud_networking_network_v2" "network_1" {
   name = "network_1"
 }
-resource "opentelekomcloud_networking_subnet_v2" "subnet_1" {
-  name        = "subnet_1"
+resource "opentelekomcloud_networking_subnet_v2" "subnet_101" {
+  name        = "subnet_101"
   network_id  = opentelekomcloud_networking_network_v2.network_1.id
-  cidr        = "192.168.1.0/24"
+  cidr        = "172.16.1.0/24"
   ip_version  = 4
   enable_dhcp = true
   no_gateway  = true
@@ -875,16 +895,18 @@ resource "opentelekomcloud_networking_subnet_v2" "subnet_1" {
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
+  image_name      = "Standard_Debian_10_latest"
+  flavor_name	  = "%s"
 
   network {
     uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
   network {
     uuid        = opentelekomcloud_networking_network_v2.network_1.id
-    fixed_ip_v4 = "192.168.1.100"
+    fixed_ip_v4 = "172.16.1.100"
   }
 }
-`, common.DataSourceSubnet)
+`, common.DataSourceSubnet, getFlavorName())
 
 var testAccComputeV2InstanceActive = fmt.Sprintf(`
 %s
@@ -892,12 +914,14 @@ var testAccComputeV2InstanceActive = fmt.Sprintf(`
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
+  image_name      = "Standard_Debian_10_latest"
+  flavor_name	  = "%s"
   power_state     = "active"
   network {
     uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
 }
-`, common.DataSourceSubnet)
+`, common.DataSourceSubnet, getFlavorName())
 
 var testAccComputeV2InstanceShutoff = fmt.Sprintf(`
 %s
@@ -905,12 +929,14 @@ var testAccComputeV2InstanceShutoff = fmt.Sprintf(`
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
+  image_name      = "Standard_Debian_10_latest"
+  flavor_name	  = "%s"
   power_state     = "shutoff"
   network {
     uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
 }
-`, common.DataSourceSubnet)
+`, common.DataSourceSubnet, getFlavorName())
 
 func testAccCheckComputeV2InstanceState(
 	instance *servers.Server, state string) resource.TestCheckFunc {

--- a/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_servergroup_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_servergroup_v2_test.go
@@ -184,7 +184,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
   image_name      = "Standard_Debian_10_latest"
-  flavor_name	  = "%s"
+  flavor_name     = "%s"
   network {
     uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }

--- a/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_servergroup_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_servergroup_v2_test.go
@@ -183,6 +183,8 @@ resource "opentelekomcloud_compute_servergroup_v2" "sg_1" {
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
+  image_name      = "Standard_Debian_10_latest"
+  flavor_name	  = "%s"
   network {
     uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
@@ -190,7 +192,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
     group = opentelekomcloud_compute_servergroup_v2.sg_1.id
   }
 }
-`, common.DataSourceSubnet)
+`, common.DataSourceSubnet, getFlavorName())
 
 const testAccComputeV2ServerGroupPolicyCheck = `
 resource "opentelekomcloud_compute_servergroup_v2" "sg_1" {

--- a/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_volume_attach_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_volume_attach_v2_test.go
@@ -178,7 +178,7 @@ resource "opentelekomcloud_blockstorage_volume_v2" "volume_1" {
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
-  flavor_name	  = "%s"
+  flavor_name     = "%s"
   image_name      = "Standard_Debian_10_latest"
   network {
     uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
@@ -203,7 +203,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
   image_name      = "Standard_Debian_10_latest"
-  flavor_name	  = "%s"
+  flavor_name     = "%s"
   network {
     uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
@@ -228,7 +228,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
   image_name      = "Standard_Debian_10_latest"
-  flavor_name	  = "%s"
+  flavor_name     = "%s"
   network {
     uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }

--- a/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_volume_attach_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_volume_attach_v2_test.go
@@ -178,6 +178,7 @@ resource "opentelekomcloud_blockstorage_volume_v2" "volume_1" {
 resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
+  flavor_name	  = "%s"
   image_name      = "Standard_Debian_10_latest"
   network {
     uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
@@ -188,7 +189,7 @@ resource "opentelekomcloud_compute_volume_attach_v2" "va_1" {
   instance_id = opentelekomcloud_compute_instance_v2.instance_1.id
   volume_id   = opentelekomcloud_blockstorage_volume_v2.volume_1.id
 }
-`, common.DataSourceSubnet)
+`, common.DataSourceSubnet, getFlavorName())
 
 var testAccComputeV2VolumeAttachDevice = fmt.Sprintf(`
 %s
@@ -202,6 +203,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
   image_name      = "Standard_Debian_10_latest"
+  flavor_name	  = "%s"
   network {
     uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
@@ -212,7 +214,7 @@ resource "opentelekomcloud_compute_volume_attach_v2" "va_1" {
   volume_id   = opentelekomcloud_blockstorage_volume_v2.volume_1.id
   device      = "/dev/vdc"
 }
-`, common.DataSourceSubnet)
+`, common.DataSourceSubnet, getFlavorName())
 
 var testAccComputeV2VolumeAttachTimeout = fmt.Sprintf(`
 %s
@@ -226,6 +228,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   security_groups = ["default"]
   image_name      = "Standard_Debian_10_latest"
+  flavor_name	  = "%s"
   network {
     uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
@@ -240,4 +243,4 @@ resource "opentelekomcloud_compute_volume_attach_v2" "va_1" {
     delete = "5m"
   }
 }
-`, common.DataSourceSubnet)
+`, common.DataSourceSubnet, getFlavorName())

--- a/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_ecs_instance_v1_test.go
+++ b/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_ecs_instance_v1_test.go
@@ -19,7 +19,7 @@ const resourceInstanceV1Name = "opentelekomcloud_ecs_instance_v1.instance_1"
 
 func TestAccEcsV1InstanceBasic(t *testing.T) {
 	var instance cloudservers.CloudServer
-	qts := serverQuotas(10+4, "s2.medium.1")
+	qts := serverQuotas(10+4, getFlavorName())
 	t.Parallel()
 	quotas.BookMany(t, qts)
 
@@ -54,7 +54,7 @@ func TestAccEcsV1InstanceBasic(t *testing.T) {
 
 func TestAccEcsV1InstanceIp(t *testing.T) {
 	var instance cloudservers.CloudServer
-	qts := serverQuotas(10+4, "s2.medium.1")
+	qts := serverQuotas(10+4, getFlavorName())
 	t.Parallel()
 	quotas.BookMany(t, qts)
 
@@ -79,7 +79,7 @@ func TestAccEcsV1InstanceIp(t *testing.T) {
 
 func TestAccEcsV1InstanceDeleted(t *testing.T) {
 	var instance cloudservers.CloudServer
-	qts := serverQuotas(10+4, "s2.medium.1")
+	qts := serverQuotas(10+4, getFlavorName())
 	t.Parallel()
 	quotas.BookMany(t, qts)
 
@@ -122,7 +122,7 @@ func testAccEcsV1InstanceDeleted(t *testing.T, id string) {
 
 func TestAccEcsV1Instance_import(t *testing.T) {
 	t.Parallel()
-	qts := serverQuotas(10+4, "s2.medium.1")
+	qts := serverQuotas(10+4, getFlavorName())
 	quotas.BookMany(t, qts)
 
 	resource.Test(t, resource.TestCase{
@@ -173,7 +173,7 @@ func TestAccEcsV1InstanceDiskTypeValidation(t *testing.T) {
 }
 
 func TestAccEcsV1InstanceVPCValidation(t *testing.T) {
-	qts := serverQuotas(4, "s2.medium.1")
+	qts := serverQuotas(4, getFlavorName())
 	t.Parallel()
 	quotas.BookMany(t, qts)
 
@@ -195,7 +195,7 @@ func TestAccEcsV1InstanceVPCValidation(t *testing.T) {
 
 func TestAccEcsV1InstanceEncryption(t *testing.T) {
 	var instance cloudservers.CloudServer
-	qts := serverQuotas(10+4, "s2.medium.1")
+	qts := serverQuotas(10+4, getFlavorName())
 	t.Parallel()
 	quotas.BookMany(t, qts)
 
@@ -222,7 +222,7 @@ func TestAccEcsV1InstanceEncryption(t *testing.T) {
 
 func TestAccEcsV1InstanceVolumeAttach(t *testing.T) {
 	var instance cloudservers.CloudServer
-	qts := serverQuotas(10+4, "s2.medium.1")
+	qts := serverQuotas(10+4, getFlavorName())
 	t.Parallel()
 	quotas.BookMany(t, qts)
 
@@ -315,7 +315,7 @@ var testAccEcsV1InstanceBasic = fmt.Sprintf(`
 resource "opentelekomcloud_ecs_instance_v1" "instance_1" {
   name     = "server_1"
   image_id = data.opentelekomcloud_images_image_v2.latest_image.id
-  flavor   = "s2.medium.1"
+  flavor   = "%s"
   vpc_id   = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
 
   nics {
@@ -337,7 +337,7 @@ resource "opentelekomcloud_ecs_instance_v1" "instance_1" {
     kuh = "value-create"
   }
 }
-`, common.DataSourceImage, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE)
+`, common.DataSourceImage, common.DataSourceSubnet, getFlavorName(), env.OS_AVAILABILITY_ZONE)
 
 var testAccEcsV1InstanceUpdate = fmt.Sprintf(`
 %s
@@ -349,7 +349,7 @@ var testAccEcsV1InstanceUpdate = fmt.Sprintf(`
 resource "opentelekomcloud_ecs_instance_v1" "instance_1" {
   name     = "server_updated"
   image_id = data.opentelekomcloud_images_image_v2.latest_image.id
-  flavor   = "s2.medium.1"
+  flavor   = "%s"
   vpc_id   = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
 
   nics {
@@ -371,7 +371,7 @@ resource "opentelekomcloud_ecs_instance_v1" "instance_1" {
     muh = "value-update"
   }
 }
-`, common.DataSourceSecGroupDefault, common.DataSourceImage, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE)
+`, common.DataSourceSecGroupDefault, common.DataSourceImage, common.DataSourceSubnet, getFlavorName(), env.OS_AVAILABILITY_ZONE)
 
 var testAccEcsV1InstanceInvalidTypeForAZ = fmt.Sprintf(`
 %s
@@ -382,7 +382,7 @@ var testAccEcsV1InstanceInvalidTypeForAZ = fmt.Sprintf(`
 resource "opentelekomcloud_ecs_instance_v1" "instance_1" {
   name     = "server_1"
   image_id = data.opentelekomcloud_images_image_v2.latest_image.id
-  flavor   = "s2.medium.1"
+  flavor   = "%s"
   vpc_id   = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
 
   nics {
@@ -400,7 +400,7 @@ resource "opentelekomcloud_ecs_instance_v1" "instance_1" {
     key = "value"
   }
 }
-`, common.DataSourceImage, common.DataSourceSubnet)
+`, common.DataSourceImage, common.DataSourceSubnet, getFlavorName())
 
 var testAccEcsV1InstanceInvalidType = fmt.Sprintf(`
 %s
@@ -410,7 +410,7 @@ var testAccEcsV1InstanceInvalidType = fmt.Sprintf(`
 resource "opentelekomcloud_ecs_instance_v1" "instance_1" {
   name     = "server_1"
   image_id = data.opentelekomcloud_images_image_v2.latest_image.id
-  flavor   = "s2.medium.1"
+  flavor   = "%s"
   vpc_id   = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
 
   nics {
@@ -428,7 +428,7 @@ resource "opentelekomcloud_ecs_instance_v1" "instance_1" {
     key = "value"
   }
 }
-`, common.DataSourceImage, common.DataSourceSubnet)
+`, common.DataSourceImage, common.DataSourceSubnet, getFlavorName())
 
 var testAccEcsV1InstanceInvalidDataDisk = fmt.Sprintf(`
 %s
@@ -438,7 +438,7 @@ var testAccEcsV1InstanceInvalidDataDisk = fmt.Sprintf(`
 resource "opentelekomcloud_ecs_instance_v1" "instance_1" {
   name     = "server_1"
   image_id = data.opentelekomcloud_images_image_v2.latest_image.id
-  flavor   = "s2.medium.1"
+  flavor   = "%s"
   vpc_id   = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
 
   nics {
@@ -460,7 +460,7 @@ resource "opentelekomcloud_ecs_instance_v1" "instance_1" {
     key = "value"
   }
 }
-`, common.DataSourceImage, common.DataSourceSubnet)
+`, common.DataSourceImage, common.DataSourceSubnet, getFlavorName())
 
 var testAccEcsV1InstanceInvalidVPC = fmt.Sprintf(`
 %s
@@ -470,7 +470,7 @@ var testAccEcsV1InstanceInvalidVPC = fmt.Sprintf(`
 resource "opentelekomcloud_ecs_instance_v1" "instance_1" {
   name     = "server_1"
   image_id = data.opentelekomcloud_images_image_v2.latest_image.id
-  flavor   = "s2.medium.1"
+  flavor   = "%s"
   vpc_id   = "abs"
 
   nics {
@@ -488,7 +488,7 @@ resource "opentelekomcloud_ecs_instance_v1" "instance_1" {
     key = "value"
   }
 }
-`, common.DataSourceImage, common.DataSourceSubnet)
+`, common.DataSourceImage, common.DataSourceSubnet, getFlavorName())
 
 var testAccEcsV1InstanceComputedVPC = fmt.Sprintf(`
 %s
@@ -508,7 +508,7 @@ resource "opentelekomcloud_vpc_subnet_v1" "subnet" {
 resource "opentelekomcloud_ecs_instance_v1" "instance_1" {
   name     = "server_1"
   image_id = data.opentelekomcloud_images_image_v2.latest_image.id
-  flavor   = "s2.medium.1"
+  flavor   = "%s"
   vpc_id   = opentelekomcloud_vpc_v1.vpc.id
 
   nics {
@@ -526,7 +526,7 @@ resource "opentelekomcloud_ecs_instance_v1" "instance_1" {
     key = "value"
   }
 }
-`, common.DataSourceImage)
+`, common.DataSourceImage, getFlavorName())
 
 var testAccEcsV1InstanceDataVolumeEncryption = fmt.Sprintf(`
 %s
@@ -536,7 +536,7 @@ var testAccEcsV1InstanceDataVolumeEncryption = fmt.Sprintf(`
 resource "opentelekomcloud_ecs_instance_v1" "instance_1" {
   name     = "server_1"
   image_id = data.opentelekomcloud_images_image_v2.latest_image.id
-  flavor   = "s2.medium.1"
+  flavor   = "%s"
   vpc_id   = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
 
   nics {
@@ -555,7 +555,7 @@ resource "opentelekomcloud_ecs_instance_v1" "instance_1" {
   }
   delete_disks_on_termination = true
 }
-`, common.DataSourceImage, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, env.OS_KMS_ID)
+`, common.DataSourceImage, common.DataSourceSubnet, getFlavorName(), env.OS_AVAILABILITY_ZONE, env.OS_KMS_ID)
 
 var testAccEcsV1InstanceIp = fmt.Sprintf(`
 %s
@@ -571,7 +571,7 @@ resource "opentelekomcloud_networking_floatingip_v2" "this" {
 resource "opentelekomcloud_ecs_instance_v1" "instance_1" {
   name     = "server_1"
   image_id = data.opentelekomcloud_images_image_v2.latest_image.id
-  flavor   = "s2.medium.1"
+  flavor   = "%s"
   vpc_id   = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
 
   nics {
@@ -595,7 +595,7 @@ resource "opentelekomcloud_networking_floatingip_associate_v2" "this" {
   floating_ip = opentelekomcloud_networking_floatingip_v2.this.address
   port_id     = opentelekomcloud_ecs_instance_v1.instance_1.nics.0.port_id
 }
-`, common.DataSourceSecGroupDefault, common.DataSourceImage, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE)
+`, common.DataSourceSecGroupDefault, common.DataSourceImage, common.DataSourceSubnet, getFlavorName(), env.OS_AVAILABILITY_ZONE)
 
 var testAccEcsV1InstanceAttachVolume = fmt.Sprintf(`
 %s
@@ -611,14 +611,13 @@ resource "opentelekomcloud_blockstorage_volume_v2" "myvol" {
 resource "opentelekomcloud_ecs_instance_v1" "instance_1" {
   name     = "server_1"
   image_id = data.opentelekomcloud_images_image_v2.latest_image.id
-  flavor   = "s2.medium.1"
+  flavor   = "%s"
   vpc_id   = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
 
   availability_zone = "%s"
 
   nics {
     network_id = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
-    ip_address = "10.0.2.32"
   }
 
 }
@@ -627,7 +626,7 @@ resource "opentelekomcloud_compute_volume_attach_v2" "attached" {
   instance_id = opentelekomcloud_ecs_instance_v1.instance_1.id
   volume_id   = opentelekomcloud_blockstorage_volume_v2.myvol.id
 }
-`, common.DataSourceImage, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, env.OS_AVAILABILITY_ZONE)
+`, common.DataSourceImage, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, getFlavorName(), env.OS_AVAILABILITY_ZONE)
 
 var testAccEcsV1InstanceAttachVolumeRepeat = fmt.Sprintf(`
 %s
@@ -643,14 +642,13 @@ resource "opentelekomcloud_blockstorage_volume_v2" "myvol" {
 resource "opentelekomcloud_ecs_instance_v1" "instance_1" {
   name     = "server_1"
   image_id = data.opentelekomcloud_images_image_v2.latest_image.id
-  flavor   = "s2.medium.1"
+  flavor   = "%s"
   vpc_id   = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
 
   availability_zone = "%s"
 
   nics {
     network_id = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
-    ip_address = "10.0.2.32"
   }
 
 }
@@ -659,4 +657,4 @@ resource "opentelekomcloud_compute_volume_attach_v2" "attached" {
   instance_id = opentelekomcloud_ecs_instance_v1.instance_1.id
   volume_id   = opentelekomcloud_blockstorage_volume_v2.myvol.id
 }
-`, common.DataSourceImage, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, env.OS_AVAILABILITY_ZONE)
+`, common.DataSourceImage, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, getFlavorName(), env.OS_AVAILABILITY_ZONE)

--- a/opentelekomcloud/acceptance/ecs/utils.go
+++ b/opentelekomcloud/acceptance/ecs/utils.go
@@ -69,7 +69,6 @@ func getFlavors() (map[string][]*quotas.ExpectedQuota, error) {
 }
 
 func getFlavorName() string {
-
 	resultsQ, err := getFlavors()
 	if err != nil {
 		panic("failed to get server flavors")
@@ -107,7 +106,6 @@ func init() {
 			panic("failed to get server flavors")
 		}
 		flavorsQuota = qs
-
 	}
 }
 

--- a/opentelekomcloud/acceptance/ecs/utils.go
+++ b/opentelekomcloud/acceptance/ecs/utils.go
@@ -68,6 +68,36 @@ func getFlavors() (map[string][]*quotas.ExpectedQuota, error) {
 	return resultsQ, nil
 }
 
+func getFlavorName() string {
+
+	resultsQ, err := getFlavors()
+	if err != nil {
+		panic("failed to get server flavors")
+	}
+	flavorsList := []string{}
+	for key := range resultsQ {
+		flavorsList = append(flavorsList, key)
+	}
+
+	// Check entry an element of flavors in flavorsList, use flavors pattern
+
+	flavorsPattern := []string{"s3.large.2", "s2.large.2", "s3.large.1", "s2.large.1"}
+	found := false
+	var flavorName string
+	for !found {
+		for _, flavorPatternName := range flavorsPattern {
+			for _, flavorComputeName := range flavorsList {
+				if flavorComputeName == flavorPatternName {
+					flavorName = flavorComputeName
+					found = true
+					break
+				}
+			}
+		}
+	}
+	return flavorName
+}
+
 var flavorsQuota map[string][]*quotas.ExpectedQuota
 
 func init() {
@@ -77,6 +107,7 @@ func init() {
 			panic("failed to get server flavors")
 		}
 		flavorsQuota = qs
+
 	}
 }
 

--- a/opentelekomcloud/services/vpc/resource_opentelekomcloud_networking_subnet_v2.go
+++ b/opentelekomcloud/services/vpc/resource_opentelekomcloud_networking_subnet_v2.go
@@ -345,8 +345,8 @@ func resourceNetworkingSubnetV2Delete(ctx context.Context, d *schema.ResourceDat
 		Target:     []string{"DELETED"},
 		Refresh:    waitForSubnetDelete(networkingClient, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
-		Delay:      5 * time.Second,
-		MinTimeout: 3 * time.Second,
+		Delay:      10 * time.Second,
+		MinTimeout: 6 * time.Second,
 	}
 
 	_, err = stateConf.WaitForStateContext(ctx)


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [ ] Refers to: #xxx
* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] Release notes added.

## Acceptance Steps Performed

```
Running tool: /usr/bin/go test -timeout 20m -run ^TestAccOpenStackAvailabilityZonesV2_basic$ github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/ecs

=== RUN   TestAccOpenStackAvailabilityZonesV2_basic
=== PAUSE TestAccOpenStackAvailabilityZonesV2_basic
=== CONT  TestAccOpenStackAvailabilityZonesV2_basic
--- PASS: TestAccOpenStackAvailabilityZonesV2_basic (5.93s)
PASS
ok      github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/ecs 44.772s


> Test run finished at 2/3/2023, 12:45:18 PM <

Running tool: /usr/bin/go test -timeout 20m -run ^TestAccComputeV2InstanceDataSource_basic$ github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/ecs

=== RUN   TestAccComputeV2InstanceDataSource_basic
--- PASS: TestAccComputeV2InstanceDataSource_basic (169.17s)
PASS
ok      github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/ecs 212.997s


> Test run finished at 2/3/2023, 12:49:32 PM <

Running tool: /usr/bin/go test -timeout 20m -run ^(TestAccComputeV2FloatingIPAssociate_basic|TestAccComputeV2FloatingIPAssociate_importBasic|TestAccComputeV2FloatingIPAssociate_fixedIP|TestAccComputeV2FloatingIPAssociate_attachToFirstNetwork|TestAccComputeV2FloatingIPAssociate_attachNew)$ github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/ecs

=== RUN   TestAccComputeV2FloatingIPAssociate_basic
=== PAUSE TestAccComputeV2FloatingIPAssociate_basic
=== RUN   TestAccComputeV2FloatingIPAssociate_importBasic
=== PAUSE TestAccComputeV2FloatingIPAssociate_importBasic
=== RUN   TestAccComputeV2FloatingIPAssociate_fixedIP
=== PAUSE TestAccComputeV2FloatingIPAssociate_fixedIP
=== RUN   TestAccComputeV2FloatingIPAssociate_attachToFirstNetwork
=== PAUSE TestAccComputeV2FloatingIPAssociate_attachToFirstNetwork
=== RUN   TestAccComputeV2FloatingIPAssociate_attachNew
=== PAUSE TestAccComputeV2FloatingIPAssociate_attachNew
=== CONT  TestAccComputeV2FloatingIPAssociate_basic
=== CONT  TestAccComputeV2FloatingIPAssociate_attachToFirstNetwork
--- PASS: TestAccComputeV2FloatingIPAssociate_attachToFirstNetwork (49.96s)
=== CONT  TestAccComputeV2FloatingIPAssociate_attachNew
--- PASS: TestAccComputeV2FloatingIPAssociate_basic (50.20s)
=== CONT  TestAccComputeV2FloatingIPAssociate_fixedIP
--- PASS: TestAccComputeV2FloatingIPAssociate_fixedIP (50.52s)
=== CONT  TestAccComputeV2FloatingIPAssociate_importBasic
--- PASS: TestAccComputeV2FloatingIPAssociate_attachNew (64.52s)
--- PASS: TestAccComputeV2FloatingIPAssociate_importBasic (54.42s)
PASS
ok      github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/ecs 196.932s


> Test run finished at 2/3/2023, 12:54:56 PM <

Running tool: /usr/bin/go test -timeout 20m -run ^(TestAccComputeV2FloatingIP_basic|TestAccComputeV2FloatingIP_importBasic)$ github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/ecs

=== RUN   TestAccComputeV2FloatingIP_basic
=== PAUSE TestAccComputeV2FloatingIP_basic
=== RUN   TestAccComputeV2FloatingIP_importBasic
=== PAUSE TestAccComputeV2FloatingIP_importBasic
=== CONT  TestAccComputeV2FloatingIP_basic
=== CONT  TestAccComputeV2FloatingIP_importBasic
--- PASS: TestAccComputeV2FloatingIP_basic (20.21s)
--- PASS: TestAccComputeV2FloatingIP_importBasic (20.94s)
PASS
ok      github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/ecs 61.361s


> Test run finished at 2/3/2023, 1:53:04 PM <

Running tool: /usr/bin/go test -timeout 20m -run ^(TestAccComputeV2Instance_basic|TestAccComputeV2Instance_imageByName|TestAccComputeV2Instance_importBasic|TestAccComputeV2Instance_multiSecgroup|TestAccComputeV2Instance_bootFromImage|TestAccComputeV2Instance_bootFromVolume|TestAccComputeV2Instance_importBootFromVolumeImage|TestAccComputeV2Instance_changeFixedIP|TestAccComputeV2Instance_bootFromVolumeVolume|TestAccComputeV2Instance_stopBeforeDestroy|TestAccComputeV2Instance_metadata|TestAccComputeV2Instance_timeout|TestAccComputeV2Instance_autoRecovery|TestAccComputeV2Instance_crazyNICs|TestAccComputeV2Instance_initialStateActive|TestAccComputeV2Instance_initialStateShutoff)$ github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/ecs

=== RUN   TestAccComputeV2Instance_basic
=== PAUSE TestAccComputeV2Instance_basic
=== RUN   TestAccComputeV2Instance_imageByName
--- PASS: TestAccComputeV2Instance_imageByName (45.34s)
=== RUN   TestAccComputeV2Instance_importBasic
=== PAUSE TestAccComputeV2Instance_importBasic
=== RUN   TestAccComputeV2Instance_multiSecgroup
=== PAUSE TestAccComputeV2Instance_multiSecgroup
=== RUN   TestAccComputeV2Instance_bootFromImage
=== PAUSE TestAccComputeV2Instance_bootFromImage
=== RUN   TestAccComputeV2Instance_bootFromVolume
=== PAUSE TestAccComputeV2Instance_bootFromVolume
=== RUN   TestAccComputeV2Instance_importBootFromVolumeImage
=== PAUSE TestAccComputeV2Instance_importBootFromVolumeImage
=== RUN   TestAccComputeV2Instance_changeFixedIP
=== PAUSE TestAccComputeV2Instance_changeFixedIP
=== RUN   TestAccComputeV2Instance_bootFromVolumeVolume
=== PAUSE TestAccComputeV2Instance_bootFromVolumeVolume
=== RUN   TestAccComputeV2Instance_stopBeforeDestroy
=== PAUSE TestAccComputeV2Instance_stopBeforeDestroy
=== RUN   TestAccComputeV2Instance_metadata
=== PAUSE TestAccComputeV2Instance_metadata
=== RUN   TestAccComputeV2Instance_timeout
=== PAUSE TestAccComputeV2Instance_timeout
=== RUN   TestAccComputeV2Instance_autoRecovery
=== PAUSE TestAccComputeV2Instance_autoRecovery
=== RUN   TestAccComputeV2Instance_crazyNICs
=== PAUSE TestAccComputeV2Instance_crazyNICs
=== RUN   TestAccComputeV2Instance_initialStateActive
=== PAUSE TestAccComputeV2Instance_initialStateActive
=== RUN   TestAccComputeV2Instance_initialStateShutoff
=== PAUSE TestAccComputeV2Instance_initialStateShutoff
=== CONT  TestAccComputeV2Instance_basic
=== CONT  TestAccComputeV2Instance_stopBeforeDestroy
--- PASS: TestAccComputeV2Instance_basic (61.15s)
=== CONT  TestAccComputeV2Instance_initialStateShutoff
--- PASS: TestAccComputeV2Instance_stopBeforeDestroy (72.00s)
=== CONT  TestAccComputeV2Instance_initialStateActive
--- PASS: TestAccComputeV2Instance_initialStateActive (91.53s)
=== CONT  TestAccComputeV2Instance_crazyNICs
--- PASS: TestAccComputeV2Instance_initialStateShutoff (133.06s)
=== CONT  TestAccComputeV2Instance_autoRecovery
--- PASS: TestAccComputeV2Instance_crazyNICs (67.02s)
=== CONT  TestAccComputeV2Instance_timeout
--- PASS: TestAccComputeV2Instance_autoRecovery (55.79s)
=== CONT  TestAccComputeV2Instance_metadata
--- PASS: TestAccComputeV2Instance_timeout (45.89s)
=== CONT  TestAccComputeV2Instance_bootFromVolume
--- PASS: TestAccComputeV2Instance_metadata (60.02s)
=== CONT  TestAccComputeV2Instance_bootFromVolumeVolume
--- PASS: TestAccComputeV2Instance_bootFromVolume (48.12s)
=== CONT  TestAccComputeV2Instance_changeFixedIP
--- PASS: TestAccComputeV2Instance_changeFixedIP (45.41s)
=== CONT  TestAccComputeV2Instance_importBootFromVolumeImage
--- PASS: TestAccComputeV2Instance_bootFromVolumeVolume (61.06s)
=== CONT  TestAccComputeV2Instance_multiSecgroup
--- PASS: TestAccComputeV2Instance_importBootFromVolumeImage (52.47s)
=== CONT  TestAccComputeV2Instance_bootFromImage
--- PASS: TestAccComputeV2Instance_multiSecgroup (72.78s)
=== CONT  TestAccComputeV2Instance_importBasic
--- PASS: TestAccComputeV2Instance_bootFromImage (46.09s)
--- PASS: TestAccComputeV2Instance_importBasic (50.78s)
PASS
ok      github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/ecs 578.620s


> Test run finished at 2/3/2023, 2:03:52 PM <

Running tool: /usr/bin/go test -timeout 20m -run ^(TestAccComputeV2Keypair_basic|TestAccComputeV2Keypair_importBasic|TestAccComputeV2Keypair_shared|TestAccComputeV2Keypair_private)$ github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/ecs

=== RUN   TestAccComputeV2Keypair_basic
=== PAUSE TestAccComputeV2Keypair_basic
=== RUN   TestAccComputeV2Keypair_importBasic
=== PAUSE TestAccComputeV2Keypair_importBasic
=== RUN   TestAccComputeV2Keypair_shared
=== PAUSE TestAccComputeV2Keypair_shared
=== RUN   TestAccComputeV2Keypair_private
=== PAUSE TestAccComputeV2Keypair_private
=== CONT  TestAccComputeV2Keypair_basic
=== CONT  TestAccComputeV2Keypair_shared
--- PASS: TestAccComputeV2Keypair_basic (7.02s)
=== CONT  TestAccComputeV2Keypair_private
--- PASS: TestAccComputeV2Keypair_shared (11.64s)
=== CONT  TestAccComputeV2Keypair_importBasic
--- PASS: TestAccComputeV2Keypair_private (7.35s)
--- PASS: TestAccComputeV2Keypair_importBasic (7.75s)
PASS
ok      github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/ecs 58.374s


> Test run finished at 2/3/2023, 2:28:37 PM <

Running tool: /usr/bin/go test -timeout 20m -run ^(TestAccComputeV2ServerGroup_basic|TestAccComputeV2ServerGroup_import|TestAccComputeV2ServerGroup_affinity|TestAccComputeV2ServerGroup_policyValidation)$ github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/ecs

=== RUN   TestAccComputeV2ServerGroup_basic
=== PAUSE TestAccComputeV2ServerGroup_basic
=== RUN   TestAccComputeV2ServerGroup_import
=== PAUSE TestAccComputeV2ServerGroup_import
=== RUN   TestAccComputeV2ServerGroup_affinity
=== PAUSE TestAccComputeV2ServerGroup_affinity
=== RUN   TestAccComputeV2ServerGroup_policyValidation
=== PAUSE TestAccComputeV2ServerGroup_policyValidation
=== CONT  TestAccComputeV2ServerGroup_basic
=== CONT  TestAccComputeV2ServerGroup_policyValidation
--- PASS: TestAccComputeV2ServerGroup_policyValidation (2.27s)
=== CONT  TestAccComputeV2ServerGroup_affinity
--- PASS: TestAccComputeV2ServerGroup_basic (6.00s)
=== CONT  TestAccComputeV2ServerGroup_import
--- PASS: TestAccComputeV2ServerGroup_import (7.59s)
--- PASS: TestAccComputeV2ServerGroup_affinity (45.66s)
PASS
ok      github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/ecs 87.830s


> Test run finished at 2/3/2023, 4:22:39 PM <

Running tool: /usr/bin/go test -timeout 20m -run ^(TestAccComputeV2VolumeAttach_basic|TestAccComputeV2VolumeAttach_importBasic|TestAccComputeV2VolumeAttach_device|TestAccComputeV2VolumeAttach_timeout)$ github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/ecs

=== RUN   TestAccComputeV2VolumeAttach_basic
=== PAUSE TestAccComputeV2VolumeAttach_basic
=== RUN   TestAccComputeV2VolumeAttach_importBasic
=== PAUSE TestAccComputeV2VolumeAttach_importBasic
=== RUN   TestAccComputeV2VolumeAttach_device
=== PAUSE TestAccComputeV2VolumeAttach_device
=== RUN   TestAccComputeV2VolumeAttach_timeout
=== PAUSE TestAccComputeV2VolumeAttach_timeout
=== CONT  TestAccComputeV2VolumeAttach_basic
=== CONT  TestAccComputeV2VolumeAttach_timeout
--- PASS: TestAccComputeV2VolumeAttach_timeout (109.01s)
=== CONT  TestAccComputeV2VolumeAttach_device
--- PASS: TestAccComputeV2VolumeAttach_basic (110.07s)
=== CONT  TestAccComputeV2VolumeAttach_importBasic
--- PASS: TestAccComputeV2VolumeAttach_device (109.39s)
--- PASS: TestAccComputeV2VolumeAttach_importBasic (108.69s)
PASS
ok      github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/ecs 259.311s


> Test run finished at 2/3/2023, 4:25:36 PM <

Running tool: /usr/bin/go test -timeout 20m -run ^(TestAccEcsV1InstanceBasic|TestAccEcsV1InstanceIp|TestAccEcsV1InstanceDeleted|TestAccEcsV1Instance_import|TestAccEcsV1InstanceDiskTypeValidation|TestAccEcsV1InstanceVPCValidation|TestAccEcsV1InstanceEncryption|TestAccEcsV1InstanceVolumeAttach)$ github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/ecs

=== RUN   TestAccEcsV1InstanceBasic
=== PAUSE TestAccEcsV1InstanceBasic
=== RUN   TestAccEcsV1InstanceIp
=== PAUSE TestAccEcsV1InstanceIp
=== RUN   TestAccEcsV1InstanceDeleted
=== PAUSE TestAccEcsV1InstanceDeleted
=== RUN   TestAccEcsV1Instance_import
=== PAUSE TestAccEcsV1Instance_import
=== RUN   TestAccEcsV1InstanceDiskTypeValidation
=== PAUSE TestAccEcsV1InstanceDiskTypeValidation
=== RUN   TestAccEcsV1InstanceVPCValidation
=== PAUSE TestAccEcsV1InstanceVPCValidation
=== RUN   TestAccEcsV1InstanceEncryption
=== PAUSE TestAccEcsV1InstanceEncryption
=== RUN   TestAccEcsV1InstanceVolumeAttach
=== PAUSE TestAccEcsV1InstanceVolumeAttach
=== CONT  TestAccEcsV1InstanceBasic
=== CONT  TestAccEcsV1InstanceDiskTypeValidation
--- PASS: TestAccEcsV1InstanceDiskTypeValidation (5.38s)
=== CONT  TestAccEcsV1Instance_import
--- PASS: TestAccEcsV1Instance_import (133.91s)
=== CONT  TestAccEcsV1InstanceDeleted
--- PASS: TestAccEcsV1InstanceBasic (149.04s)
=== CONT  TestAccEcsV1InstanceIp
--- PASS: TestAccEcsV1InstanceIp (135.94s)
=== CONT  TestAccEcsV1InstanceEncryption

--- SKIP: TestAccEcsV1InstanceEncryption (1.16s)
=== CONT  TestAccEcsV1InstanceVolumeAttach
--- PASS: TestAccEcsV1InstanceDeleted (269.37s)
=== CONT  TestAccEcsV1InstanceVPCValidation
--- PASS: TestAccEcsV1InstanceVolumeAttach (185.94s)
--- PASS: TestAccEcsV1InstanceVPCValidation (144.56s)
PASS
ok      github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/ecs 596.897s


> Test run finished at 2/3/2023, 4:40:14 PM <
Running tool: /usr/bin/go test -timeout 20m -run ^TestAccComputeV2Instance_crazyNICs$ github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/ecs

ok  	github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/ecs	111.109s

Running tool: /usr/bin/go test -timeout 20m -run ^(TestAccComputeV2SecGroup_basic|TestAccComputeV2SecGroup_importBasic|TestAccComputeV2SecGroup_update|TestAccComputeV2SecGroup_groupID|TestAccComputeV2SecGroup_self|TestAccComputeV2SecGroup_icmpZero|TestAccComputeV2SecGroup_timeout)$ github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/ecs

=== RUN   TestAccComputeV2SecGroup_basic
=== PAUSE TestAccComputeV2SecGroup_basic
=== RUN   TestAccComputeV2SecGroup_importBasic
=== PAUSE TestAccComputeV2SecGroup_importBasic
=== RUN   TestAccComputeV2SecGroup_update
=== PAUSE TestAccComputeV2SecGroup_update
=== RUN   TestAccComputeV2SecGroup_groupID
    /home/ibakhter/projects/otc/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_secgroup_v2_test.go:85: this test is not a stable one
--- SKIP: TestAccComputeV2SecGroup_groupID (0.00s)
=== RUN   TestAccComputeV2SecGroup_self
--- PASS: TestAccComputeV2SecGroup_self (20.78s)
=== RUN   TestAccComputeV2SecGroup_icmpZero
=== PAUSE TestAccComputeV2SecGroup_icmpZero
=== RUN   TestAccComputeV2SecGroup_timeout
=== PAUSE TestAccComputeV2SecGroup_timeout
=== CONT  TestAccComputeV2SecGroup_basic
=== CONT  TestAccComputeV2SecGroup_icmpZero
--- PASS: TestAccComputeV2SecGroup_icmpZero (20.79s)
=== CONT  TestAccComputeV2SecGroup_timeout
--- PASS: TestAccComputeV2SecGroup_basic (22.17s)
=== CONT  TestAccComputeV2SecGroup_update
--- PASS: TestAccComputeV2SecGroup_timeout (20.49s)
=== CONT  TestAccComputeV2SecGroup_importBasic
--- PASS: TestAccComputeV2SecGroup_update (28.20s)
--- PASS: TestAccComputeV2SecGroup_importBasic (22.83s)
PASS
ok      github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/ecs 123.521s


> Test run finished at 2/3/2023, 5:23:34 PM <
```
