### PR TITLE
CCE: `data/opentelekomcloud_cce_node_v3` volume fix

### DIFF
--- a/opentelekomcloud/acceptance/cce/data_source_opentelekomcloud_cce_node_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/data_source_opentelekomcloud_cce_node_v3_test.go
@@ -32,7 +32,7 @@ func TestAccCCENodesV3DataSource_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCCENodeV3DataSourceID(dataSourceNodesName),
 					resource.TestCheckResourceAttr(dataSourceNodesName, "name", cceNodeName),
-					resource.TestCheckResourceAttr(dataSourceNodesName, "flavor_id", "s3.medium.1"),
+					resource.TestCheckResourceAttr(dataSourceNodesName, "flavor_id", "s2.large.2"),
 				),
 			},
 		},
@@ -61,7 +61,7 @@ func testAccCCENodeV3DataSourceInit(cceNodeName string) string {
 resource "opentelekomcloud_cce_node_v3" "node_1" {
   cluster_id        = data.opentelekomcloud_cce_cluster_v3.cluster.id
   name              = "%s"
-  flavor_id         = "s3.medium.1"
+  flavor_id         = "s2.large.2"
   availability_zone = "%s"
   key_pair          = "%s"
   root_volume {
@@ -83,7 +83,7 @@ func testAccCCENodeV3DataSourceBasic(cceNodeName string) string {
 resource "opentelekomcloud_cce_node_v3" "node_1" {
   cluster_id        = data.opentelekomcloud_cce_cluster_v3.cluster.id
   name              = "%s"
-  flavor_id         = "s3.medium.1"
+  flavor_id         = "s2.large.2"
   availability_zone = "%s"
   key_pair          = "%s"
   root_volume {

--- a/opentelekomcloud/services/cce/data_source_opentelekomcloud_cce_node_v3.go
+++ b/opentelekomcloud/services/cce/data_source_opentelekomcloud_cce_node_v3.go
@@ -85,9 +85,10 @@ func DataSourceCceNodesV3() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"extend_param": {
-							Type:     schema.TypeString,
+						"extend_params": {
+							Type:     schema.TypeMap,
 							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 						"kms_id": {
 							Type:     schema.TypeString,
@@ -175,10 +176,10 @@ func dataSourceCceNodesV3Read(_ context.Context, d *schema.ResourceData, meta in
 	var dataVolumes []map[string]interface{}
 	for _, volume := range Node.Spec.DataVolumes {
 		mapping := map[string]interface{}{
-			"disk_size":    volume.Size,
-			"volume_type":  volume.VolumeType,
-			"extend_param": volume.ExtendParam,
-			"kms_id":       volume.Metadata["__system__cmkid"],
+			"disk_size":     volume.Size,
+			"volume_type":   volume.VolumeType,
+			"extend_params": volume.ExtendParam,
+			"kms_id":        volume.Metadata["__system__cmkid"],
 		}
 		dataVolumes = append(dataVolumes, mapping)
 	}

--- a/releasenotes/notes/cce_node_data_fix-5a13543504e41825.yaml
+++ b/releasenotes/notes/cce_node_data_fix-5a13543504e41825.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[CCE]** Fix `extend_params` for ``data_source/opentelekomcloud_cce_node_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)

--- a/releasenotes/notes/cce_node_data_fix-5a13543504e41825.yaml
+++ b/releasenotes/notes/cce_node_data_fix-5a13543504e41825.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    **[CCE]** Fix `extend_params` for ``data_source/opentelekomcloud_cce_node_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[CCE]** Fix `extend_params` for ``data_source/opentelekomcloud_cce_node_v3`` (`#2077 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2077>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Fix `data_source/opentelekomcloud_cce_node_v3` volume convertions

## PR Checklist

* [x] Refers to: #2072
* [x] Tests passed.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccCCENodesV3DataSource_basic
=== PAUSE TestAccCCENodesV3DataSource_basic
=== CONT  TestAccCCENodesV3DataSource_basic
    data_source_opentelekomcloud_cce_node_v3_test.go:21: Cluster is required by the test. 1 test(s) are using cluster.
    cluster.go:49: starting creating shared cluster
    cluster.go:137: Cluster usage is 0 now, ready to delete the cluster
    cluster.go:100: starting deleting shared cluster
--- PASS: TestAccCCENodesV3DataSource_basic (892.69s)
PASS

Process finished with the exit code 0
```
