### PR TITLE
CBR: SFSTurbo support for ``resource/opentelekomcloud_cbr_vault_v3``

### DIFF
--- a/docs/resources/cbr_vault_v3.md
+++ b/docs/resources/cbr_vault_v3.md
@@ -74,6 +74,7 @@ resource "opentelekomcloud_cbr_vault_v3" "vault" {
   }
 }
 ```
+
 ### Vault with associated resource (volume)
 
 ```hcl
@@ -99,6 +100,43 @@ resource "opentelekomcloud_cbr_vault_v3" "vault" {
   resource {
     id   = opentelekomcloud_blockstorage_volume_v2.volume.id
     type = "OS::Cinder::Volume"
+  }
+}
+```
+
+### Vault with associated resource (sfs-turbo)
+
+```hcl
+variable "vpc_id" {}
+variable "subnet_id" {}
+variable "sg_id" {}
+variable "az" {}
+
+resource "opentelekomcloud_sfs_turbo_share_v1" "sfs-turbo" {
+  name              = "sfs-turbo-share"
+  size              = 500
+  share_proto       = "NFS"
+  vpc_id            = var.vpc_id
+  subnet_id         = var.subnet_id
+  security_group_id = var.sg_id
+  availability_zone = var.az
+}
+
+resource "opentelekomcloud_cbr_vault_v3" "vault" {
+  name = "cbr-vault-test"
+
+  description = "CBR vault for terraform provider test"
+
+  billing {
+    size          = 1000
+    object_type   = "turbo"
+    protect_type  = "backup"
+    charging_mode = "post_paid"
+  }
+
+  resource {
+    id   = opentelekomcloud_sfs_turbo_share_v1.sfs-turbo.id
+    type = "OS::Sfs::Turbo"
   }
 }
 ```
@@ -175,7 +213,7 @@ The following arguments are supported:
 
     * `consistent_level` - (Optional) Backup specifications. The default value is `crash_consistent`
 
-    * `object_type` - Object type. One of `server`, `disk`.
+    * `object_type` - Object type. One of `server`, `disk`, `turbo`.
 
     * `protect_type` - Operation type. One of `backup`, `replication`
 
@@ -204,7 +242,7 @@ The following arguments are supported:
 
     * `id` - ID of the resource to be backed up.
 
-    * `type` - Type of the resource to be backed up. Possible values are `OS::Nova::Server` and `OS::Cinder::Volume`.
+    * `type` - Type of the resource to be backed up. Possible values are `OS::Nova::Server`, `OS::Cinder::Volume` and `OS::Sfs::Turbo`.
 
     * `name` - (Optional) Resource name.
 

--- a/opentelekomcloud/services/cbr/resource_opentelekomcloud_cbr_vault_v3.go
+++ b/opentelekomcloud/services/cbr/resource_opentelekomcloud_cbr_vault_v3.go
@@ -60,7 +60,7 @@ func ResourceCBRVaultV3() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 							ValidateFunc: validation.StringInSlice([]string{
-								"OS::Nova::Server", "OS::Cinder::Volume",
+								"OS::Nova::Server", "OS::Cinder::Volume", "OS::Sfs::Turbo",
 							}, false),
 						},
 						"exclude_volumes": {

--- a/releasenotes/notes/cbr_turbo-c0035bd89cabb4f8.yaml
+++ b/releasenotes/notes/cbr_turbo-c0035bd89cabb4f8.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    **[CBR]** Implement sfs-turbo support for ``resource/opentelekomcloud_cbr_vault_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/>`_)

--- a/releasenotes/notes/cbr_turbo-c0035bd89cabb4f8.yaml
+++ b/releasenotes/notes/cbr_turbo-c0035bd89cabb4f8.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   - |
-    **[CBR]** Implement sfs-turbo support for ``resource/opentelekomcloud_cbr_vault_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/>`_)
+    **[CBR]** Implement sfs-turbo support for ``resource/opentelekomcloud_cbr_vault_v3`` (`#2080 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/2080>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Added SFSTURBO support for ``resource/opentelekomcloud_cbr_vault_v3``.

## PR Checklist

* [x] Refers to: #2073, #2074
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccCBRPolicyV3_basic
=== PAUSE TestAccCBRPolicyV3_basic
=== CONT  TestAccCBRPolicyV3_basic
--- PASS: TestAccCBRPolicyV3_basic (69.91s)
=== RUN   TestAccCBRPolicyV3_minConfig
=== PAUSE TestAccCBRPolicyV3_minConfig
=== CONT  TestAccCBRPolicyV3_minConfig
--- PASS: TestAccCBRPolicyV3_minConfig (68.42s)
=== RUN   TestAccCBRVaultV3_basic
=== PAUSE TestAccCBRVaultV3_basic
=== CONT  TestAccCBRVaultV3_basic
--- PASS: TestAccCBRVaultV3_basic (152.84s)
=== RUN   TestAccCBRVaultV3_unAssign
=== PAUSE TestAccCBRVaultV3_unAssign
=== CONT  TestAccCBRVaultV3_unAssign
--- PASS: TestAccCBRVaultV3_unAssign (384.57s)
=== RUN   TestAccCBRVaultV3_instance
=== PAUSE TestAccCBRVaultV3_instance
=== CONT  TestAccCBRVaultV3_instance
--- PASS: TestAccCBRVaultV3_instance (128.46s)
=== RUN   TestAccCBRVaultV3_SfsTurbo
=== PAUSE TestAccCBRVaultV3_SfsTurbo
=== CONT  TestAccCBRVaultV3_SfsTurbo
--- PASS: TestAccCBRVaultV3_SfsTurbo (382.60s)
=== RUN   TestAccCBRVaultV3_extraInfoExclude
=== PAUSE TestAccCBRVaultV3_extraInfoExclude
=== CONT  TestAccCBRVaultV3_extraInfoExclude
--- PASS: TestAccCBRVaultV3_extraInfoExclude (451.07s)
=== RUN   TestAccCBRVaultV3_bind_rules
=== PAUSE TestAccCBRVaultV3_bind_rules
=== CONT  TestAccCBRVaultV3_bind_rules
--- PASS: TestAccCBRVaultV3_bind_rules (36.97s)
PASS

Process finished with the exit code 0
```
