### PR TITLE
[VPC] snat example in `resource/opentelekomcloud_networking_router_v2`

### DIFF
--- a/docs/resources/networking_router_v2.md
+++ b/docs/resources/networking_router_v2.md
@@ -15,6 +15,21 @@ resource "opentelekomcloud_networking_router_v2" "router_1" {
 }
 ```
 
+## Enable SNAT
+```hcl
+data "opentelekomcloud_networking_network_v2" "admin_external_net" {
+  name = "admin_external_net"
+}
+
+resource "opentelekomcloud_networking_router_v2" "router_1" {
+  name             = "my_router"
+  admin_state_up   = true
+  distributed      = false
+  external_gateway = data.opentelekomcloud_networking_network_v2.admin_external_net.id
+  enable_snat      = true
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_router_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_router_v2_test.go
@@ -89,6 +89,27 @@ func TestAccNetworkingV2Router_timeout(t *testing.T) {
 	})
 }
 
+func TestAccNetworkingV2RouterSnat(t *testing.T) {
+	var router routers.Router
+	t.Parallel()
+	quotas.BookOne(t, quotas.Router)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckNetworkingV2RouterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkingV2RouterEnableSnat,
+				Check: resource.ComposeTestCheckFunc(
+					TestAccCheckNetworkingV2RouterExists(resourceRouterName, &router),
+					resource.TestCheckResourceAttr(resourceRouterName, "enable_snat", "true"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckNetworkingV2RouterDestroy(s *terraform.State) error {
 	config := common.TestAccProvider.Meta().(*cfg.Config)
 	client, err := config.NetworkingV2Client(env.OS_REGION_NAME)
@@ -157,3 +178,15 @@ resource "opentelekomcloud_networking_router_v2" "router_1" {
   }
 }
 `
+
+var testAccNetworkingV2RouterEnableSnat = fmt.Sprintf(`
+%s
+
+resource "opentelekomcloud_networking_router_v2" "router_1" {
+  name             = "router_1_snat"
+  admin_state_up   = true
+  distributed      = false
+  external_gateway = data.opentelekomcloud_networking_network_v2.ext_network.id
+  enable_snat      = true
+}
+`, common.DataSourceExtNetwork)

--- a/releasenotes/notes/vpc-example-snat-7a743396bcf0e3a0.yaml
+++ b/releasenotes/notes/vpc-example-snat-7a743396bcf0e3a0.yaml
@@ -1,0 +1,4 @@
+---
+other:
+  - |
+    **[VPC]** Clarify usage of SNAT in ``resource/opentelekomcloud_networking_router_v2`` (`#2081 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2081>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Added test and example in doc

## PR Checklist

* [x] Refers to: #2065
* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccNetworkingV2RouterSnat
=== PAUSE TestAccNetworkingV2RouterSnat
=== CONT  TestAccNetworkingV2RouterSnat
--- PASS: TestAccNetworkingV2RouterSnat (65.08s)
PASS


Process finished with the exit code 0
```
