### PR TITLE
[CES] support slashes for metric name in `resource/opentelekomcloud_ces_alarmrule`

### DIFF
--- a/docs/resources/ces_alarmrule.md
+++ b/docs/resources/ces_alarmrule.md
@@ -82,7 +82,7 @@ The `metric` block supports:
 
 * `metric_name` - (Required) Specifies the metric name. The value can be a string
   of `1` to `64` characters that must start with a letter and can consists of uppercase
-  letters, lowercase letters, numbers, or underscores (_).
+  letters, lowercase letters, numbers, underscores (_) or slashes (/).
 
 * `dimensions` - (Required) Specifies the list of metric dimensions. Currently,
   the maximum length of the dimension list that are supported is `3`. The structure

--- a/opentelekomcloud/acceptance/ces/resource_opentelekomcloud_ces_alarmrule_test.go
+++ b/opentelekomcloud/acceptance/ces/resource_opentelekomcloud_ces_alarmrule_test.go
@@ -66,7 +66,7 @@ func TestAccCheckCESV1AlarmValidation(t *testing.T) {
 
 func TestCESAlarmRule_slashes(t *testing.T) {
 	var ar alarms.MetricAlarms
-
+	resourceName := "opentelekomcloud_ces_alarmrule.alarmrule_s"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			common.TestAccPreCheck(t)
@@ -84,7 +84,7 @@ func TestCESAlarmRule_slashes(t *testing.T) {
 			{
 				Config: testCESAlarmRuleSlashes,
 				Check: resource.ComposeTestCheckFunc(
-					testCESAlarmRuleExists(resourceAlarmRuleName, &ar),
+					testCESAlarmRuleExists(resourceName, &ar),
 				),
 			},
 		},
@@ -292,13 +292,8 @@ resource "opentelekomcloud_compute_instance_v2" "vm_1" {
   }
 }
 
-resource "opentelekomcloud_smn_topic_v2" "topic_1" {
-  name         = "topic_1"
-  display_name = "The display name of topic_1"
-}
-
-resource "opentelekomcloud_ces_alarmrule" "alarmrule_1" {
-  alarm_name = "alarm_rule1"
+resource "opentelekomcloud_ces_alarmrule" "alarmrule_s" {
+  alarm_name = "alarm_rule_s"
 
   metric {
     namespace   = "SYS.ECS"

--- a/opentelekomcloud/acceptance/ces/resource_opentelekomcloud_ces_alarmrule_test.go
+++ b/opentelekomcloud/acceptance/ces/resource_opentelekomcloud_ces_alarmrule_test.go
@@ -64,6 +64,33 @@ func TestAccCheckCESV1AlarmValidation(t *testing.T) {
 	})
 }
 
+func TestCESAlarmRule_slashes(t *testing.T) {
+	var ar alarms.MetricAlarms
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+			qts := ecs.QuotasForFlavor(env.OsFlavorID)
+			qts = append(qts,
+				&quotas.ExpectedQuota{Q: quotas.Server, Count: 1},
+				&quotas.ExpectedQuota{Q: quotas.Volume, Count: 1},
+				&quotas.ExpectedQuota{Q: quotas.VolumeSize, Count: 4},
+			)
+			quotas.BookMany(t, qts)
+		},
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testCESAlarmRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testCESAlarmRuleSlashes,
+				Check: resource.ComposeTestCheckFunc(
+					testCESAlarmRuleExists(resourceAlarmRuleName, &ar),
+				),
+			},
+		},
+	})
+}
+
 func testCESAlarmRuleDestroy(s *terraform.State) error {
 	config := common.TestAccProvider.Meta().(*cfg.Config)
 	client, err := config.CesV1Client(env.OS_REGION_NAME)
@@ -249,5 +276,46 @@ resource "opentelekomcloud_ces_alarmrule" "alarmrule_1" {
     count               = 1
   }
   alarm_action_enabled = true
+}
+`, common.DataSourceSubnet)
+
+var testCESAlarmRuleSlashes = fmt.Sprintf(`
+%s
+
+resource "opentelekomcloud_compute_instance_v2" "vm_1" {
+  name        = "instance_1"
+  image_name  = "Standard_Debian_11_latest"
+  flavor_name = "s3.large.2"
+
+  network {
+    uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  }
+}
+
+resource "opentelekomcloud_smn_topic_v2" "topic_1" {
+  name         = "topic_1"
+  display_name = "The display name of topic_1"
+}
+
+resource "opentelekomcloud_ces_alarmrule" "alarmrule_1" {
+  alarm_name = "alarm_rule1"
+
+  metric {
+    namespace   = "SYS.ECS"
+    metric_name = "/mnt/share_disk_usedPercent"
+    dimensions {
+      name  = "instance_id"
+      value = opentelekomcloud_compute_instance_v2.vm_1.id
+    }
+  }
+  condition {
+    period              = 1
+    filter              = "sum"
+    comparison_operator = ">="
+    value               = 90
+    unit                = "%%"
+    count               = 3
+  }
+  alarm_action_enabled = false
 }
 `, common.DataSourceSubnet)

--- a/opentelekomcloud/services/ces/resource_opentelekomcloud_ces_alarmrule.go
+++ b/opentelekomcloud/services/ces/resource_opentelekomcloud_ces_alarmrule.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -79,11 +80,8 @@ func ResourceAlarmRule() *schema.Resource {
 							ValidateFunc: validation.All(
 								validation.StringLenBetween(1, 64),
 								validation.StringMatch(
-									regexp.MustCompile(`^[a-zA-Z].+`),
-									"Must start with a letter."),
-								validation.StringMatch(
-									regexp.MustCompile(`^\w+$`),
-									"Only lowercase/uppercase letters, digits, periods (.), underscores (_), and hyphens (-) are allowed.",
+									regexp.MustCompile(`^[a-zA-Z\][a-z0-9\/_]+[a-z0-9]+$`),
+									"Only lowercase/uppercase letters, digits, underscores (_) and slashes (/) are allowed.",
 								),
 							),
 						},
@@ -265,10 +263,11 @@ func getMetricOpts(d *schema.ResourceData) alarms.MetricForAlarm {
 			Value: dimension["value"].(string),
 		}
 	}
-
+	metricName := metricElement["metric_name"].(string)
+	metricName = strings.Replace(metricName, "/", "SlAsH", -1)
 	return alarms.MetricForAlarm{
 		Namespace:  metricElement["namespace"].(string),
-		MetricName: metricElement["metric_name"].(string),
+		MetricName: metricName,
 		Dimensions: dimensionOpts,
 	}
 }
@@ -372,10 +371,12 @@ func resourceAlarmRuleRead(ctx context.Context, d *schema.ResourceData, meta int
 		}
 		dimensionInfoList[i] = dimensionInfoItem
 	}
+	metricName := alarm.Metric.MetricName
+	metricName = strings.Replace(metricName, "SlAsH", "/", -1)
 	metricInfo := []map[string]interface{}{
 		{
 			"namespace":   alarm.Metric.Namespace,
-			"metric_name": alarm.Metric.MetricName,
+			"metric_name": metricName,
 			"dimensions":  dimensionInfoList,
 		},
 	}

--- a/opentelekomcloud/services/ces/resource_opentelekomcloud_ces_alarmrule.go
+++ b/opentelekomcloud/services/ces/resource_opentelekomcloud_ces_alarmrule.go
@@ -264,7 +264,7 @@ func getMetricOpts(d *schema.ResourceData) alarms.MetricForAlarm {
 		}
 	}
 	metricName := metricElement["metric_name"].(string)
-	metricName = strings.Replace(metricName, "/", "SlAsH", -1)
+	metricName = strings.ReplaceAll(metricName, "/", "SlAsH")
 	return alarms.MetricForAlarm{
 		Namespace:  metricElement["namespace"].(string),
 		MetricName: metricName,
@@ -372,7 +372,7 @@ func resourceAlarmRuleRead(ctx context.Context, d *schema.ResourceData, meta int
 		dimensionInfoList[i] = dimensionInfoItem
 	}
 	metricName := alarm.Metric.MetricName
-	metricName = strings.Replace(metricName, "SlAsH", "/", -1)
+	metricName = strings.ReplaceAll(metricName, "SlAsH", "/")
 	metricInfo := []map[string]interface{}{
 		{
 			"namespace":   alarm.Metric.Namespace,

--- a/releasenotes/notes/ces-metric-name-slashes-941660aa24b681c2.yaml
+++ b/releasenotes/notes/ces-metric-name-slashes-941660aa24b681c2.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[CES]** Add slashes support for metric name in ``resource/opentelekomcloud_ces_alarmrule`` (`#2084 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2084>`_)


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [x] Refers to: #2078
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestCESAlarmRule_basic
=== PAUSE TestCESAlarmRule_basic
=== CONT  TestCESAlarmRule_basic
--- PASS: TestCESAlarmRule_basic (150.95s)
=== RUN   TestAccCheckCESV1AlarmValidation
--- PASS: TestAccCheckCESV1AlarmValidation (22.09s)
=== RUN   TestCESAlarmRule_slashes
=== PAUSE TestCESAlarmRule_slashes
=== CONT  TestCESAlarmRule_slashes
--- PASS: TestCESAlarmRule_slashes (103.15s)
PASS

Process finished with the exit code 0

```
