### PR TITLE
[OBS]: fix `opentelekomcloud_obs_bucket` `force_destroy` with enabled versioning

### DIFF
--- a/opentelekomcloud/acceptance/obs/resource_opentelekomcloud_obs_bucket_test.go
+++ b/opentelekomcloud/acceptance/obs/resource_opentelekomcloud_obs_bucket_test.go
@@ -7,7 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/obs"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
@@ -36,6 +37,7 @@ func TestAccObsBucket_basic(t *testing.T) {
 			{
 				Config: testAccObsBucketUpdate(rInt),
 				Check: resource.ComposeTestCheckFunc(testAccCheckObsBucketExists(resourceName),
+					testUploadObjectToObsBucket(rInt),
 					resource.TestCheckResourceAttr(resourceName, "acl", "public-read"),
 					resource.TestCheckResourceAttr(resourceName, "storage_class", "WARM"),
 				),
@@ -43,6 +45,7 @@ func TestAccObsBucket_basic(t *testing.T) {
 			{
 				Config: testAccObsBucketSSE(rInt),
 				Check: resource.ComposeTestCheckFunc(testAccCheckObsBucketExists(resourceName),
+					testUploadDeleteObjectObsBucket(rInt),
 					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.0.kms_key_id", env.OS_KMS_ID),
 					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.0.algorithm", "kms"),
 				),
@@ -259,6 +262,63 @@ func testAccCheckObsBucketExists(n string) resource.TestCheckFunc {
 	}
 }
 
+func testUploadObjectToObsBucket(obsNumber int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		config := common.TestAccProvider.Meta().(*cfg.Config)
+		client, err := config.NewObjectStorageClient(env.OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("error creating OpenTelekomCloud OBS client: %s", err)
+		}
+
+		objectName := tools.RandomString("test-obs-", 5)
+
+		_, err = client.PutObject(&obs.PutObjectInput{
+			PutObjectBasicInput: obs.PutObjectBasicInput{
+				ObjectOperationInput: obs.ObjectOperationInput{
+					Bucket: fmt.Sprintf("tf-test-bucket-%d", obsNumber),
+					Key:    objectName,
+				},
+			},
+		})
+		if err != nil {
+			return fmt.Errorf("error uploading object to OBS bucket: %s", err)
+		}
+		return nil
+	}
+}
+
+func testUploadDeleteObjectObsBucket(obsNumber int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		config := common.TestAccProvider.Meta().(*cfg.Config)
+		client, err := config.NewObjectStorageClient(env.OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("error creating OpenTelekomCloud OBS client: %s", err)
+		}
+
+		objectName := tools.RandomString("test-obs-", 5)
+
+		_, err = client.PutObject(&obs.PutObjectInput{
+			PutObjectBasicInput: obs.PutObjectBasicInput{
+				ObjectOperationInput: obs.ObjectOperationInput{
+					Bucket: fmt.Sprintf("tf-test-bucket-%d", obsNumber),
+					Key:    objectName,
+				},
+			},
+		})
+		if err != nil {
+			return fmt.Errorf("error uploading object to OBS bucket: %s", err)
+		}
+		_, err = client.DeleteObject(&obs.DeleteObjectInput{
+			Bucket: fmt.Sprintf("tf-test-bucket-%d", obsNumber),
+			Key:    objectName,
+		})
+		if err != nil {
+			return fmt.Errorf("error deleting object from OBS bucket: %s", err)
+		}
+		return nil
+	}
+}
+
 func testAccCheckObsBucketLogging(name, target, prefix string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
@@ -315,6 +375,7 @@ resource "opentelekomcloud_obs_bucket" "bucket" {
   bucket        = "tf-test-bucket-%d"
   storage_class = "WARM"
   acl           = "public-read"
+  versioning    = true
 }
 `, randInt)
 }
@@ -325,7 +386,7 @@ resource "opentelekomcloud_obs_bucket" "bucket" {
   bucket        = "tf-test-bucket-%d"
   storage_class = "WARM"
   acl           = "public-read"
-
+  force_destroy = true
   server_side_encryption {
     algorithm  = "kms"
     kms_key_id = "%s"

--- a/releasenotes/notes/obs_destroy_fix-81f5e82bc2630412.yaml
+++ b/releasenotes/notes/obs_destroy_fix-81f5e82bc2630412.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[OBS]** Fix object deletion if versioning is enabled for ``resource/opentelekomcloud_obs_bucket`` (`#2086 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2086>`_)


### PR DESCRIPTION
## Summary of the Pull Request
This PR fixes 2 issues:

- non-empty bucket deletion with versioning enabled
- deletion of bucket with >1000 objects

## PR Checklist

* [x] Refers to: #2085
* [x] Tests added/passed.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccObsBucket_basic
=== PAUSE TestAccObsBucket_basic
=== CONT  TestAccObsBucket_basic
--- PASS: TestAccObsBucket_basic (73.93s)
=== RUN   TestAccObsBucket_tags
=== PAUSE TestAccObsBucket_tags
=== CONT  TestAccObsBucket_tags
--- PASS: TestAccObsBucket_tags (27.91s)
=== RUN   TestAccObsBucket_versioning
=== PAUSE TestAccObsBucket_versioning
=== CONT  TestAccObsBucket_versioning
--- PASS: TestAccObsBucket_versioning (51.62s)
=== RUN   TestAccObsBucket_logging
=== PAUSE TestAccObsBucket_logging
=== CONT  TestAccObsBucket_logging
--- PASS: TestAccObsBucket_logging (34.18s)
=== RUN   TestAccObsBucket_lifecycle
=== PAUSE TestAccObsBucket_lifecycle
=== CONT  TestAccObsBucket_lifecycle
--- PASS: TestAccObsBucket_lifecycle (29.14s)
=== RUN   TestAccObsBucket_website
=== PAUSE TestAccObsBucket_website
=== CONT  TestAccObsBucket_website
--- PASS: TestAccObsBucket_website (28.85s)
=== RUN   TestAccObsBucket_cors
=== PAUSE TestAccObsBucket_cors
=== CONT  TestAccObsBucket_cors
--- PASS: TestAccObsBucket_cors (28.93s)
=== RUN   TestAccObsBucket_notifications
=== PAUSE TestAccObsBucket_notifications
=== CONT  TestAccObsBucket_notifications
--- PASS: TestAccObsBucket_notifications (36.71s)
PASS

Process finished with the exit code 0
```
