### PR TITLE
[RDS] remove workaround for postgre14 get flavors in `resource/opentelekomcloud_rds_instance_v3`

### DIFF
--- a/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_instance_v3.go
+++ b/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_instance_v3.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -1243,22 +1242,8 @@ func validateRDSv3Flavor(argName string) schema.CustomizeDiffFunc {
 		dataStoreInfo := d.Get("db").([]interface{})[0].(map[string]interface{})
 		flavor := d.Get(argName).(string)
 
-		dataStoreVersion := dataStoreInfo["version"].(string)
-		// TODO: need to be removed when https://jira.tsi-dev.otc-service.com/browse/OTCDB-2757 done
-		newVersion, err := version.NewVersion(dataStoreVersion)
-		if err != nil {
-			return fmt.Errorf("error while version conversion: %w", err)
-		}
-		versionConstraints, err := version.NewConstraint(">= 14, < 15")
-		if err != nil {
-			return fmt.Errorf("error while constraint creation: %w", err)
-		}
-		if versionConstraints.Check(newVersion) {
-			dataStoreVersion = "14.4"
-		}
-		// END
 		listOpts := flavors.ListOpts{
-			VersionName:  dataStoreVersion,
+			VersionName:  dataStoreInfo["version"].(string),
 			DatabaseName: dataStoreInfo["type"].(string),
 		}
 		flavorList, err := flavors.ListFlavors(client, listOpts)

--- a/releasenotes/notes/rds-postgre14-get-flavors-09f1b09f5acf8d51.yaml
+++ b/releasenotes/notes/rds-postgre14-get-flavors-09f1b09f5acf8d51.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[RDS]** PostgreSQL 14 ``flavor`` check fix for ``resource/opentelekomcloud_rds_instance_v3`` (`#2087 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2087>`_)


### PR DESCRIPTION
## Summary of the Pull Request
API was fixed workaround now obsolete

## PR Checklist

* [x] Refers to: #2083
* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccRdsInstanceV3Basic
--- PASS: TestAccRdsInstanceV3Basic (811.66s)
PASS


Process finished with the exit code 0
```
