### PR TITLE
[IAM]: fix `data_source/opentelekomcloud_identity_user_v3` MFA setting

### DIFF
--- a/opentelekomcloud/services/iam/data_source_opentelekomcloud_identity_user_v3.go
+++ b/opentelekomcloud/services/iam/data_source_opentelekomcloud_identity_user_v3.go
@@ -100,7 +100,11 @@ func dataSourceIdentityUserV3Read(_ context.Context, d *schema.ResourceData, met
 	case golangsdk.ErrDefault403:
 		log.Printf("[DEBUG] Security administrator permissions needed to set MFA")
 	case nil, golangsdk.ErrDefault404:
-		mErr = multierror.Append(mErr, d.Set("mfa_device", mfa))
+		if mfa == nil {
+			mErr = multierror.Append(mErr, d.Set("mfa_device", ""))
+		} else {
+			mErr = multierror.Append(mErr, d.Set("mfa_device", mfa.SerialNumber))
+		}
 	default:
 		log.Printf("[DEBUG] Error getting MFA info: %v", err.Error())
 	}

--- a/releasenotes/notes/user_mfa_fix-9a6bbcc9e4835550.yaml
+++ b/releasenotes/notes/user_mfa_fix-9a6bbcc9e4835550.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    **[IAM]** Fix `mfa` setting for ``data_source/opentelekomcloud_identity_user_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[IAM]** Fix `mfa` setting for ``data_source/opentelekomcloud_identity_user_v3`` (`#2094 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2094>`_)

--- a/releasenotes/notes/user_mfa_fix-9a6bbcc9e4835550.yaml
+++ b/releasenotes/notes/user_mfa_fix-9a6bbcc9e4835550.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[IAM]** Fix `mfa` setting for ``data_source/opentelekomcloud_identity_user_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Fix `mfa` parameter set for `data_source/opentelekomcloud_identity_user_v3`.

## PR Checklist

* [x] Refers to: #2093
* [x] Tests passed.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccOpenStackIdentityV3UserDataSource_basic
--- PASS: TestAccOpenStackIdentityV3UserDataSource_basic (50.56s)
PASS

Process finished with the exit code 0
```
