### PR TITLE
[IMS] create from volume in `resource/opentelekomcloud_ims_image_v2`

### DIFF
--- a/docs/resources/ims_image_v2.md
+++ b/docs/resources/ims_image_v2.md
@@ -39,6 +39,22 @@ resource "opentelekomcloud_ims_image_v2" "ims_test_file" {
 }
 ```
 
+###  Creating an image using an Volume
+
+```hcl
+resource "opentelekomcloud_ims_image_v2" "image_volume" {
+  name        = "image_volume"
+  volume_id   = "54a6c3a4-8511-4d01-818f-3fe5177cbb07"
+  os_version  = "Debian GNU/Linux 10.0.0 64bit"
+  description = "created by Terraform"
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -57,7 +73,11 @@ The following arguments are supported:
 * `tags` - (Optional) The tags of the image.
 
 * `instance_id` - (Optional) The ID of the ECS that needs to be converted into an image.
-  This parameter is mandatory when you create a privete image from an ECS.
+  This parameter is mandatory when you create a private image from an ECS.
+  Changing this creates a new image.
+
+* `volume_id` - (Optional) Specifies the data disk ID.
+  This parameter is mandatory when you create a private image from a volume.
   Changing this creates a new image.
 
 * `image_url` - (Optional) The URL of the external image file in the OBS bucket.
@@ -71,7 +91,8 @@ The following arguments are supported:
   Changing this creates a new image.
 
 * `os_version` - (Optional) The OS version.
-  This parameter is valid when you create a private image from an external file
+  This parameter is valid when you create a private image from an external file.
+  This parameter is mandatory when you create a private image from a volume.
   uploaded to an OBS bucket. Changing this creates a new image.
 
 * `is_config` - (Optional) If automatic configuration is required, set the value to true.

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/jinzhu/copier v0.3.5
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.5.29-0.20230216150304-047811eef0c3
+	github.com/opentelekomcloud/gophertelekomcloud v0.5.29-0.20230222140928-6887550d10ef
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.0.0-20220517005047-85d78b3ac167
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9

--- a/go.sum
+++ b/go.sum
@@ -207,8 +207,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.5.29-0.20230216150304-047811eef0c3 h1:BcVgSL06gZzspCHQKTeTwgv3m4+xNzGcGoubevfv8t0=
-github.com/opentelekomcloud/gophertelekomcloud v0.5.29-0.20230216150304-047811eef0c3/go.mod h1:/QD0ZIzm3zMdE0iBSAP3+Z9eCViU2PgnQqp4KGrpR/M=
+github.com/opentelekomcloud/gophertelekomcloud v0.5.29-0.20230222140928-6887550d10ef h1:UKmGE1eMfGznL4G+llx1k9B9ZH2NxBJnqIulFlNwNe8=
+github.com/opentelekomcloud/gophertelekomcloud v0.5.29-0.20230222140928-6887550d10ef/go.mod h1:/QD0ZIzm3zMdE0iBSAP3+Z9eCViU2PgnQqp4KGrpR/M=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/opentelekomcloud/services/ims/resource_opentelekomcloud_ims_image_v2.go
+++ b/opentelekomcloud/services/ims/resource_opentelekomcloud_ims_image_v2.go
@@ -67,14 +67,20 @@ func ResourceImsImageV2() *schema.Resource {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ForceNew:      true,
-				ConflictsWith: []string{"image_url"},
+				ConflictsWith: []string{"image_url", "volume_id"},
+			},
+			"volume_id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"instance_id", "image_url"},
 			},
 			// image_url and min_disk are required for creating an image from an OBS
 			"image_url": {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ForceNew:      true,
-				ConflictsWith: []string{"instance_id"},
+				ConflictsWith: []string{"instance_id", "volume_id"},
 			},
 			"min_disk": {
 				Type:          schema.TypeInt,
@@ -153,9 +159,9 @@ func resourceImsImageV2Create(ctx context.Context, d *schema.ResourceData, meta 
 		return fmterr.Errorf("error creating OpenTelekomCloud image client: %s", err)
 	}
 
-	if !common.HasFilledOpt(d, "instance_id") && !common.HasFilledOpt(d, "image_url") {
+	if !common.HasFilledOpt(d, "instance_id") && !common.HasFilledOpt(d, "image_url") && !common.HasFilledOpt(d, "volume_id") {
 		return fmterr.Errorf("error creating OpenTelekomCloud IMS: " +
-			"Either 'instance_id' or 'image_url' must be specified")
+			"Either 'instance_id', 'volume_id' or 'image_url' must be specified")
 	}
 
 	var v *cloudimages.JobResponse
@@ -171,6 +177,19 @@ func resourceImsImageV2Create(ctx context.Context, d *schema.ResourceData, meta 
 		}
 		log.Printf("[DEBUG] Create Options: %#v", createOpts)
 		v, err = cloudimages.CreateImageByServer(client, createOpts).ExtractJobResponse()
+	} else if common.HasFilledOpt(d, "volume_id") {
+		createOpts := &cloudimages.CreateByVolumeOpts{
+			Name:        d.Get("name").(string),
+			Description: d.Get("description").(string),
+			VolumeId:    d.Get("volume_id").(string),
+			OsVersion:   d.Get("os_version").(string),
+			Type:        d.Get("type").(string),
+			MaxRam:      d.Get("max_ram").(int),
+			MinRam:      d.Get("min_ram").(int),
+			ImageTags:   imageTags,
+		}
+		log.Printf("[DEBUG] Create Options: %#v", createOpts)
+		v, err = cloudimages.CreateImageByVolume(client, createOpts).ExtractJobResponse()
 	} else {
 		if !common.HasFilledOpt(d, "min_disk") {
 			return fmterr.Errorf("error creating OpenTelekomCloud IMS: 'min_disk' must be specified")

--- a/opentelekomcloud/services/ims/resource_opentelekomcloud_ims_image_v2.go
+++ b/opentelekomcloud/services/ims/resource_opentelekomcloud_ims_image_v2.go
@@ -166,7 +166,8 @@ func resourceImsImageV2Create(ctx context.Context, d *schema.ResourceData, meta 
 
 	var v *cloudimages.JobResponse
 	imageTags := resourceContainerImageTags(d)
-	if common.HasFilledOpt(d, "instance_id") {
+	switch {
+	case common.HasFilledOpt(d, "instance_id"):
 		createOpts := &cloudimages.CreateByServerOpts{
 			Name:        d.Get("name").(string),
 			Description: d.Get("description").(string),
@@ -177,7 +178,7 @@ func resourceImsImageV2Create(ctx context.Context, d *schema.ResourceData, meta 
 		}
 		log.Printf("[DEBUG] Create Options: %#v", createOpts)
 		v, err = cloudimages.CreateImageByServer(client, createOpts).ExtractJobResponse()
-	} else if common.HasFilledOpt(d, "volume_id") {
+	case common.HasFilledOpt(d, "volume_id"):
 		createOpts := &cloudimages.CreateByVolumeOpts{
 			Name:        d.Get("name").(string),
 			Description: d.Get("description").(string),
@@ -190,7 +191,7 @@ func resourceImsImageV2Create(ctx context.Context, d *schema.ResourceData, meta 
 		}
 		log.Printf("[DEBUG] Create Options: %#v", createOpts)
 		v, err = cloudimages.CreateImageByVolume(client, createOpts).ExtractJobResponse()
-	} else {
+	case common.HasFilledOpt(d, "image_url"):
 		if !common.HasFilledOpt(d, "min_disk") {
 			return fmterr.Errorf("error creating OpenTelekomCloud IMS: 'min_disk' must be specified")
 		}

--- a/releasenotes/notes/ims-data-image-volume-8fd41440df3a1a90.yaml
+++ b/releasenotes/notes/ims-data-image-volume-8fd41440df3a1a90.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    **[IMS]** Added possibility to create image from an data volume in ``resource/opentelekomcloud_ims_image_v2`` (`#2096 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2096>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Now possible to create a system image from an data volume.

## PR Checklist

* [x] Refers to: #2067
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccImsImageV2_basic
--- PASS: TestAccImsImageV2_basic (251.24s)
=== RUN   TestAccImsImageV2_volume
--- PASS: TestAccImsImageV2_volume (188.76s)
PASS


Process finished with the exit code 0
```
