### PR TITLE
[ELB] fix `data_source/opentelekomcloud_lb_loadbalancer_v3` `_managed` field assignment for manually created loadbalancers

### DIFF
--- a/docs/resources/lb_loadbalancer_v3.md
+++ b/docs/resources/lb_loadbalancer_v3.md
@@ -162,7 +162,7 @@ The `public_ip` block supports:
 
 * `id` - (Optional) ID of an existing elastic IP. Required when using existing EIP.
 
-* `ip_type` - (Optional) Elastic IP type. The value can be `5_gray` and `5_mailbgp`.
+* `ip_type` - (Optional) Elastic IP type. The value can be `5_gray`, `5_bgp` and `5_mailbgp`.
   Required when creating a new EIP.
 
 ->

--- a/opentelekomcloud/services/elb/v3/resource_opentelekomcloud_lb_loadbalancer_v3.go
+++ b/opentelekomcloud/services/elb/v3/resource_opentelekomcloud_lb_loadbalancer_v3.go
@@ -374,7 +374,9 @@ func setLoadBalancerFields(d *schema.ResourceData, meta interface{}, lb *loadbal
 		if err != nil {
 			return diag.FromErr(err)
 		}
-		info["_managed"] = d.Get("public_ip.0._managed")
+		if v, ok := d.GetOk("public_ip.0._managed"); ok {
+			info["_managed"] = v
+		}
 		publicIpInfo[0] = info
 	}
 	tagMap := common.TagsToMap(lb.Tags)

--- a/releasenotes/notes/elb-v3-managed-fix-ed77a89827acef5f.yaml
+++ b/releasenotes/notes/elb-v3-managed-fix-ed77a89827acef5f.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[ELB]** Fix setting `_managed` field for manually created resources in ``data/opentelekomcloud_lb_loadbalancer_v3`` (`#2116 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2116>`_)


### PR DESCRIPTION
## Summary of the Pull Request
fix `data_source/opentelekomcloud_lb_loadbalancer_v3` `_managed` field assignment for manually created loadbalancers

## PR Checklist

* [x] Refers to: #2114
* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestDataSourceLoadBalancerV3_basic
--- PASS: TestDataSourceLoadBalancerV3_basic (166.63s)
=== RUN   TestAccLBV3LoadBalancer_basic
=== PAUSE TestAccLBV3LoadBalancer_basic
=== CONT  TestAccLBV3LoadBalancer_basic
--- PASS: TestAccLBV3LoadBalancer_basic (165.46s)
=== RUN   TestAccLBV3LoadBalancer_bandwidth
=== PAUSE TestAccLBV3LoadBalancer_bandwidth
=== CONT  TestAccLBV3LoadBalancer_bandwidth
--- PASS: TestAccLBV3LoadBalancer_bandwidth (128.82s)
PASS

Debugger finished with the exit code 0
```
