### PR TITLE
[ELB] ip_group attribute in `data_source/opentelekomcloud_lb_listener_v3`

### DIFF
--- a/docs/data-sources/lb_listener_v3.md
+++ b/docs/data-sources/lb_listener_v3.md
@@ -79,12 +79,14 @@ In addition, the following attributes are exported:
 
 * `sni_container_refs` - Lists the IDs of SNI certificates (server certificates with domain names) used by the listener.
 
-* `advanced_forwarding` - (Optional) Specifies whether to enable advanced forwarding.
+* `advanced_forwarding` - Specifies whether to enable advanced forwarding.
 
-* `sni_match_algo` - (Optional) Specifies how wildcard domain name matches with the SNI certificates
+* `sni_match_algo` - Specifies how wildcard domain name matches with the SNI certificates
   used by the listener.
 
-* `security_policy_id` - (Optional) Specifies the ID of the custom security policy.
+* `security_policy_id` - Specifies the ID of the custom security policy.
+
+* `ip_group` - Specifies the IP address group associated with the listener.
 
 * `tags` - Tags key/value pairs to associate with the loadbalancer listener.
 

--- a/opentelekomcloud/services/elb/v3/data_source_opentelekomcloud_lb_listener_v3.go
+++ b/opentelekomcloud/services/elb/v3/data_source_opentelekomcloud_lb_listener_v3.go
@@ -151,6 +151,26 @@ func DataSourceListenerV3() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"ip_group": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"enable": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 		},
 	}
 }

--- a/releasenotes/notes/elb-v3-listener-ds-ipgroup-fix-353ebef349caef6c.yaml
+++ b/releasenotes/notes/elb-v3-listener-ds-ipgroup-fix-353ebef349caef6c.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[ELB]** Fix setting `ip_group` field in ``data/opentelekomcloud_lb_listener_v3`` (`#2126 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2126>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Fix error with Invalid address to set: []string{"ip_group"}

## PR Checklist

* [x] Refers to: #2125
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestDataSourceListenerV3_basic
=== PAUSE TestDataSourceListenerV3_basic
=== CONT  TestDataSourceListenerV3_basic
--- PASS: TestDataSourceListenerV3_basic (44.31s)
=== RUN   TestDataSourceListenerV3_byID
=== PAUSE TestDataSourceListenerV3_byID
=== CONT  TestDataSourceListenerV3_byID
--- PASS: TestDataSourceListenerV3_byID (43.54s)
PASS


Process finished with the exit code 0
```
