### PR TITLE
[VPC] regex filtering in `data-source/opentelekomcloud_networking_secgroup_v2`

### DIFF
--- a/docs/data-sources/networking_secgroup_v2.md
+++ b/docs/data-sources/networking_secgroup_v2.md
@@ -14,11 +14,23 @@ data "opentelekomcloud_networking_secgroup_v2" "secgroup" {
 }
 ```
 
+## Example Filter by regex
+
+```hcl
+data "opentelekomcloud_networking_secgroup_v2" "secgroup_1" {
+  name_regex  = "^secgroup_1.+"
+}
+```
+
 ## Argument Reference
 
 * `secgroup_id` - (Optional) The ID of the security group.
 
 * `name` - (Optional) The name of the security group.
+
+* `name_regex` - (Optional) A regex string to apply to the security group list.
+  This allows more advanced filtering not supported from the OpenTelekomCloud API.
+  This filtering is done locally on what OpenTelekomCloud returns.
 
 * `tenant_id` - (Optional) The owner of the security group.
 

--- a/docs/data-sources/networking_secgroup_v2.md
+++ b/docs/data-sources/networking_secgroup_v2.md
@@ -18,7 +18,7 @@ data "opentelekomcloud_networking_secgroup_v2" "secgroup" {
 
 ```hcl
 data "opentelekomcloud_networking_secgroup_v2" "secgroup_1" {
-  name_regex  = "^secgroup_1.+"
+  name_regex = "^secgroup_1.+"
 }
 ```
 

--- a/opentelekomcloud/acceptance/vpc/data_source_opentelekomcloud_networking_secgroup_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/data_source_opentelekomcloud_networking_secgroup_v2_test.go
@@ -105,6 +105,6 @@ var testAccOpenTelekomCloudNetworkingSecGroupV2DataSourceRegex = fmt.Sprintf(`
 %s
 
 data "opentelekomcloud_networking_secgroup_v2" "secgroup_1" {
-  name_regex  = "^secgroup_1.+"
+  name_regex = "^secgroup_1.+"
 }
 `, testAccNetworkingSecGroupV2DataSourceGroup)

--- a/opentelekomcloud/acceptance/vpc/data_source_opentelekomcloud_networking_secgroup_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/data_source_opentelekomcloud_networking_secgroup_v2_test.go
@@ -20,7 +20,7 @@ func TestAccOpenTelekomCloudNetworkingSecGroupV2DataSource_basic(t *testing.T) {
 		ProviderFactories: common.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccOpenTelekomCloudNetworkingSecGroupV2DataSourceGroup,
+				Config: testAccNetworkingSecGroupV2DataSourceGroup,
 			},
 			{
 				Config: testAccOpenTelekomCloudNetworkingSecGroupV2DataSourceBasic,
@@ -42,6 +42,27 @@ func TestAccOpenTelekomCloudNetworkingSecGroupV2DataSource_basic(t *testing.T) {
 	})
 }
 
+func TestAccOpenTelekomCloudNetworkingSecGroupV2DataSource_regex(t *testing.T) {
+	dataSourceName := "data.opentelekomcloud_networking_secgroup_v2.secgroup_1"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkingSecGroupV2DataSourceGroup,
+			},
+			{
+				Config: testAccOpenTelekomCloudNetworkingSecGroupV2DataSourceRegex,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingSecGroupV2DataSourceID(dataSourceName),
+					resource.TestCheckResourceAttr(dataSourceName, "name", "secgroup_1_ds"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckNetworkingSecGroupV2DataSourceID(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -57,7 +78,7 @@ func testAccCheckNetworkingSecGroupV2DataSourceID(n string) resource.TestCheckFu
 	}
 }
 
-const testAccOpenTelekomCloudNetworkingSecGroupV2DataSourceGroup = `
+const testAccNetworkingSecGroupV2DataSourceGroup = `
 resource "opentelekomcloud_networking_secgroup_v2" "secgroup_1" {
   name        = "secgroup_1_ds"
   description = "My neutron security group"
@@ -70,7 +91,7 @@ var testAccOpenTelekomCloudNetworkingSecGroupV2DataSourceBasic = fmt.Sprintf(`
 data "opentelekomcloud_networking_secgroup_v2" "secgroup_1" {
   name = opentelekomcloud_networking_secgroup_v2.secgroup_1.name
 }
-`, testAccOpenTelekomCloudNetworkingSecGroupV2DataSourceGroup)
+`, testAccNetworkingSecGroupV2DataSourceGroup)
 
 var testAccOpenTelekomCloudNetworkingSecGroupV2DataSourceSecGroupID = fmt.Sprintf(`
 %s
@@ -78,4 +99,12 @@ var testAccOpenTelekomCloudNetworkingSecGroupV2DataSourceSecGroupID = fmt.Sprint
 data "opentelekomcloud_networking_secgroup_v2" "secgroup_1" {
   secgroup_id = opentelekomcloud_networking_secgroup_v2.secgroup_1.id
 }
-`, testAccOpenTelekomCloudNetworkingSecGroupV2DataSourceGroup)
+`, testAccNetworkingSecGroupV2DataSourceGroup)
+
+var testAccOpenTelekomCloudNetworkingSecGroupV2DataSourceRegex = fmt.Sprintf(`
+%s
+
+data "opentelekomcloud_networking_secgroup_v2" "secgroup_1" {
+  name_regex  = "^secgroup_1.+"
+}
+`, testAccNetworkingSecGroupV2DataSourceGroup)

--- a/releasenotes/notes/sg-ds-regex-861870527f419c20.yaml
+++ b/releasenotes/notes/sg-ds-regex-861870527f419c20.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[VPC]** Add ``name_regex`` attribute for filtering in ``data-source/opentelekomcloud_networking_secgroup_v2`` (`#2133 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2133>`_)


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [x] Refers to: #2130
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccOpenTelekomCloudNetworkingSecGroupV2DataSource_basic
=== PAUSE TestAccOpenTelekomCloudNetworkingSecGroupV2DataSource_basic
=== CONT  TestAccOpenTelekomCloudNetworkingSecGroupV2DataSource_basic
--- PASS: TestAccOpenTelekomCloudNetworkingSecGroupV2DataSource_basic (114.63s)
=== RUN   TestAccOpenTelekomCloudNetworkingSecGroupV2DataSource_regex
--- PASS: TestAccOpenTelekomCloudNetworkingSecGroupV2DataSource_regex (79.31s)
PASS


Process finished with the exit code 0
```
