### PR TITLE
[CSBS] tags schema fix for old versions

### DIFF
--- a/opentelekomcloud/acceptance/csbs/data_source_opentelekomcloud_csbs_backup_policy_v1_test.go
+++ b/opentelekomcloud/acceptance/csbs/data_source_opentelekomcloud_csbs_backup_policy_v1_test.go
@@ -78,6 +78,10 @@ resource "opentelekomcloud_csbs_backup_policy_v1" "backup_policy_v1" {
     max_backups     = "2"
     trigger_pattern = "BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nRRULE:FREQ=WEEKLY;BYDAY=TH;BYHOUR=12;BYMINUTE=27\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n"
   }
+  tags {
+    key   = "kuh"
+    value = "muh"
+  }
 }
 
 data "opentelekomcloud_csbs_backup_policy_v1" "csbs_policy" {

--- a/opentelekomcloud/acceptance/csbs/data_source_opentelekomcloud_csbs_backup_v1_test.go
+++ b/opentelekomcloud/acceptance/csbs/data_source_opentelekomcloud_csbs_backup_v1_test.go
@@ -73,8 +73,9 @@ resource "opentelekomcloud_csbs_backup_v1" "csbs" {
   resource_id   = opentelekomcloud_compute_instance_v2.instance_1.id
   resource_type = "OS::Nova::Server"
 
-  tags = {
-    muh = "kuh"
+  tags {
+    key   = "kuh"
+    value = "muh"
   }
 }
 

--- a/opentelekomcloud/acceptance/csbs/resource_opentelekomcloud_csbs_backup_policy_v1_test.go
+++ b/opentelekomcloud/acceptance/csbs/resource_opentelekomcloud_csbs_backup_policy_v1_test.go
@@ -320,8 +320,9 @@ resource "opentelekomcloud_csbs_backup_policy_v1" "backup_policy_v1" {
     month_backups   = "2"
     timezone        = "UTC+03:00"
   }
-  tags = {
-    muh = "kuh"
+  tags {
+    key   = "kuh"
+    value = "muh"
   }
 }
 `, common.DataSourceImage, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, env.OsFlavorID)

--- a/opentelekomcloud/acceptance/csbs/resource_opentelekomcloud_csbs_backup_v1_test.go
+++ b/opentelekomcloud/acceptance/csbs/resource_opentelekomcloud_csbs_backup_v1_test.go
@@ -160,8 +160,9 @@ resource "opentelekomcloud_csbs_backup_v1" "csbs" {
   resource_id   = opentelekomcloud_compute_instance_v2.instance_1.id
   resource_type = "OS::Nova::Server"
 
-  tags = {
-    muh = "kuh"
+  tags {
+    key   = "kuh"
+    value = "muh"
   }
 }
 `, common.DataSourceImage, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, env.OsFlavorID)

--- a/opentelekomcloud/services/csbs/common.go
+++ b/opentelekomcloud/services/csbs/common.go
@@ -6,10 +6,27 @@ import (
 )
 
 func resourceCSBSTagsV1(d *schema.ResourceData) []tags.ResourceTag {
-	backupTags := d.Get("tags").(map[string]interface{})
-	var tagSlice []tags.ResourceTag
-	for k, v := range backupTags {
-		tagSlice = append(tagSlice, tags.ResourceTag{Key: k, Value: v.(string)})
+	rawTags := d.Get("tags").(*schema.Set).List()
+	tagsRaw := make([]tags.ResourceTag, len(rawTags))
+	for i, raw := range rawTags {
+		rawMap := raw.(map[string]interface{})
+		tagsRaw[i] = tags.ResourceTag{
+			Key:   rawMap["key"].(string),
+			Value: rawMap["value"].(string),
+		}
 	}
-	return tagSlice
+	return tagsRaw
+}
+
+func flattenCSBSTags(resourceTags []tags.ResourceTag) []map[string]interface{} {
+	var tagsList []map[string]interface{}
+	for _, tag := range resourceTags {
+		mapping := map[string]interface{}{
+			"key":   tag.Key,
+			"value": tag.Value,
+		}
+		tagsList = append(tagsList, mapping)
+	}
+
+	return tagsList
 }

--- a/releasenotes/notes/csbs-tags-schema-fix-434ac207d5bce914.yaml
+++ b/releasenotes/notes/csbs-tags-schema-fix-434ac207d5bce914.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[CSBS]** Schema fix for ``tags`` parameter for ``resource/opentelekomcloud_csbs_*`` resources (`#2136 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2136>`_)


### PR DESCRIPTION
## Summary of the Pull Request
After refactoring backward compatibility was broken, here is the fix

## PR Checklist

* [x] Refers to: #2127
* [x] Tests added/passed.
* [ ] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccCSBSBackupV1_basic
=== PAUSE TestAccCSBSBackupV1_basic
=== CONT  TestAccCSBSBackupV1_basic
--- PASS: TestAccCSBSBackupV1_basic (619.59s)
=== RUN   TestAccCSBSBackupV1_importBasic
=== PAUSE TestAccCSBSBackupV1_importBasic
=== CONT  TestAccCSBSBackupV1_importBasic
=== RUN   TestAccCSBSBackupV1_timeout
=== PAUSE TestAccCSBSBackupV1_timeout
=== CONT  TestAccCSBSBackupV1_timeout
--- PASS: TestAccCSBSBackupV1_timeout (617.96s)

--- PASS: TestAccCSBSBackupV1_importBasic (636.32s)
PASS


Process finished with the exit code 0


=== RUN   TestAccCSBSBackupPolicyV1_basic
=== PAUSE TestAccCSBSBackupPolicyV1_basic
=== CONT  TestAccCSBSBackupPolicyV1_basic
=== RUN   TestAccCSBSBackupPolicyV1_importWeekMonth
=== PAUSE TestAccCSBSBackupPolicyV1_importWeekMonth
=== CONT  TestAccCSBSBackupPolicyV1_importWeekMonth
--- PASS: TestAccCSBSBackupPolicyV1_importWeekMonth (113.62s)
=== RUN   TestAccCSBSBackupPolicyV1_timeout
=== PAUSE TestAccCSBSBackupPolicyV1_timeout
=== CONT  TestAccCSBSBackupPolicyV1_timeout
--- PASS: TestAccCSBSBackupPolicyV1_timeout (103.02s)
=== RUN   TestAccCSBSBackupPolicyV1_weekMonth
=== PAUSE TestAccCSBSBackupPolicyV1_weekMonth
=== CONT  TestAccCSBSBackupPolicyV1_weekMonth
--- PASS: TestAccCSBSBackupPolicyV1_weekMonth (102.72s)
--- PASS: TestAccCSBSBackupPolicyV1_basic (145.05s)
PASS


Process finished with the exit code 0

=== RUN   TestAccCSBSBackupPolicyV1DataSource_basic
=== PAUSE TestAccCSBSBackupPolicyV1DataSource_basic
=== CONT  TestAccCSBSBackupPolicyV1DataSource_basic
--- PASS: TestAccCSBSBackupPolicyV1DataSource_basic (108.43s)
PASS

Process finished with the exit code 0

=== RUN   TestAccCSBSBackupV1DataSource_basic
=== PAUSE TestAccCSBSBackupV1DataSource_basic
=== CONT  TestAccCSBSBackupV1DataSource_basic
--- PASS: TestAccCSBSBackupV1DataSource_basic (610.77s)
PASS


Process finished with the exit code 0
```
