### PR TITLE
[CCE] `no_addons` addon readiness check in `resource/opentelekomcloud_cce_cluster_v3`

### DIFF
--- a/releasenotes/notes/cce-no-addons-fix-939563ec585499ef.yaml
+++ b/releasenotes/notes/cce-no-addons-fix-939563ec585499ef.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[CCE]** Addon status check at ``resource/opentelekomcloud_cce_cluster_v3`` creation (`#2140 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2140>`_)


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [x] Refers to: #2138
* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```

=== RUN   TestAccCCEClusterV3_basic
=== PAUSE TestAccCCEClusterV3_basic
=== CONT  TestAccCCEClusterV3_basic
--- PASS: TestAccCCEClusterV3_basic (589.76s)
PASS

Process finished with the exit code 0

=== RUN   TestAccCCEClusterV3NoAddons
=== PAUSE TestAccCCEClusterV3NoAddons
=== CONT  TestAccCCEClusterV3NoAddons
--- PASS: TestAccCCEClusterV3NoAddons (1129.72s)
PASS

Debugger finished with the exit code 0
```
