### PR TITLE
[NAT]: New `data_source/opentelekomcloud_nat_gateway_v2`

### DIFF
--- a/docs/data-sources/nat_gateway_v2.md
+++ b/docs/data-sources/nat_gateway_v2.md
@@ -1,0 +1,47 @@
+---
+subcategory: "NAT"
+---
+
+# opentelekomcloud_nat_gateway_v2
+
+Use this data source to get the info about an existing V2 NAT Gateway resource within OpenTelekomCloud.
+
+## Example Usage
+
+```hcl
+data "opentelekomcloud_nat_gateway_v2" "this" {
+  name = "tf_nat"
+  spec = "1"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `nat_id` - (Optional) The ID of the NAT Gateway.
+
+* `name` - (Optional) The name of the NAT Gateway.
+
+* `description` - (Optional) The description of the NAT Gateway.
+
+* `spec` - (Optional) The specification of the NAT Gateway, valid values are `"1"`, `"2"`, `"3"`, `"4"`.
+
+* `tenant_id` - (Optional) The target tenant ID in which to allocate the NAT
+  Gateway.
+
+* `router_id` - (Optional) ID of the router (or VPC) this NAT Gateway belongs to.
+
+* `internal_network_id` - (Optional) ID of the network this NAT Gateway connects to.
+
+* `status` - (Optional) Specifies the NAT gateway status.
+
+* `admin_state_up` - (Optional) Specifies whether the NAT gateway is up or down. Possible values are:
+  * `true` refers to NAT gateway being up.
+  * `false` refers to NAT gateway being down.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attribute is exported:
+
+* `region` - Region of NAT gateway.

--- a/docs/data-sources/nat_gateway_v2.md
+++ b/docs/data-sources/nat_gateway_v2.md
@@ -44,4 +44,6 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attribute is exported:
 
+* `id` - ID of NAT gateway.
+
 * `region` - Region of NAT gateway.

--- a/opentelekomcloud/acceptance/nat/data_source_opentelekomcloud_nat_gateway_v2_test.go
+++ b/opentelekomcloud/acceptance/nat/data_source_opentelekomcloud_nat_gateway_v2_test.go
@@ -1,0 +1,47 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+)
+
+func TestAccDataNatGateway_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckNatV2GatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNatV2GatewayBasic,
+			},
+			{
+				Config: testAccDataNatV2GatewayBasic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.opentelekomcloud_nat_gateway_v2.nat_1", "name", "nat_1"),
+					resource.TestCheckResourceAttr("data.opentelekomcloud_nat_gateway_v2.nat_1", "description", "test for terraform"),
+					resource.TestCheckResourceAttr("data.opentelekomcloud_nat_gateway_v2.nat_1", "spec", "1"),
+					resource.TestCheckResourceAttrSet(
+						"data.opentelekomcloud_nat_gateway_v2.nat_1", "tenant_id"),
+					resource.TestCheckResourceAttrSet(
+						"data.opentelekomcloud_nat_gateway_v2.nat_1", "internal_network_id"),
+					resource.TestCheckResourceAttrSet(
+						"data.opentelekomcloud_nat_gateway_v2.nat_1", "router_id"),
+					resource.TestCheckResourceAttrSet(
+						"data.opentelekomcloud_nat_gateway_v2.nat_1", "status"),
+				),
+			},
+		},
+	})
+}
+
+var testAccDataNatV2GatewayBasic = fmt.Sprintf(`
+%s
+
+data "opentelekomcloud_nat_gateway_v2" "nat_1" {
+  name           = "nat_1"
+  admin_state_up = true
+}
+`, testAccNatV2GatewayBasic)

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -281,6 +281,7 @@ func Provider() *schema.Provider {
 			"opentelekomcloud_lb_loadbalancer_v3":              elbv3.DataSourceLoadBalancerV3(),
 			"opentelekomcloud_lb_listener_v3":                  elbv3.DataSourceListenerV3(),
 			"opentelekomcloud_lb_member_ids_v2":                elbv2.DataSourceLBMemberIDsV2(),
+			"opentelekomcloud_nat_gateway_v2":                  nat.DataSourceNatGatewayV2(),
 			"opentelekomcloud_networking_network_v2":           vpc.DataSourceNetworkingNetworkV2(),
 			"opentelekomcloud_networking_port_v2":              vpc.DataSourceNetworkingPortV2(),
 			"opentelekomcloud_networking_secgroup_v2":          vpc.DataSourceNetworkingSecGroupV2(),

--- a/opentelekomcloud/services/nat/data_source_opentelekomcloud_nat_gateway_v2.go
+++ b/opentelekomcloud/services/nat/data_source_opentelekomcloud_nat_gateway_v2.go
@@ -115,7 +115,6 @@ func dataSourceNatGatewayV2Read(_ context.Context, d *schema.ResourceData, meta 
 	d.SetId(natGateway.ID)
 
 	mErr := multierror.Append(
-		d.Set("nat_id", natGateway.ID),
 		d.Set("tenant_id", natGateway.TenantID),
 		d.Set("name", natGateway.Name),
 		d.Set("description", natGateway.Description),

--- a/opentelekomcloud/services/nat/data_source_opentelekomcloud_nat_gateway_v2.go
+++ b/opentelekomcloud/services/nat/data_source_opentelekomcloud_nat_gateway_v2.go
@@ -1,0 +1,135 @@
+package nat
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/natgateways"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
+)
+
+func DataSourceNatGatewayV2() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceNatGatewayV2Read,
+
+		Schema: map[string]*schema.Schema{
+			"nat_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"tenant_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"spec": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"router_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"internal_network_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"admin_state_up": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceNatGatewayV2Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := config.NatV2Client(config.GetRegion(d))
+	if err != nil {
+		return fmterr.Errorf(ErrCreationClient, err)
+	}
+
+	listOpts := natgateways.ListOpts{
+		ID:                d.Get("nat_id").(string),
+		TenantId:          d.Get("tenant_id").(string),
+		Name:              d.Get("name").(string),
+		Description:       d.Get("description").(string),
+		Spec:              d.Get("spec").(string),
+		RouterID:          d.Get("router_id").(string),
+		InternalNetworkID: d.Get("internal_network_id").(string),
+		Status:            d.Get("status").(string),
+	}
+
+	if adminState, ok := d.GetOk("admin_state_up"); ok {
+		adminState := adminState.(bool)
+		listOpts.AdminStateUp = &adminState
+	}
+
+	natGateways, err := natgateways.List(client, listOpts).AllPages()
+	if err != nil {
+		return fmterr.Errorf("unable to retrieve NAT gateway pages: %w", err)
+	}
+
+	refinedGateways, err := natgateways.ExtractNatGateways(natGateways)
+	if err != nil {
+		return fmterr.Errorf("error extracting NAT gateways: %w", err)
+	}
+
+	if len(refinedGateways) < 1 {
+		return fmterr.Errorf("Your query returned no results. Please change your search criteria and try again.")
+	} else if len(refinedGateways) > 1 {
+		return fmterr.Errorf("your query returned more than one result. Please try a more " +
+			"specific search criteria")
+	}
+
+	natGateway := refinedGateways[0]
+
+	d.SetId(natGateway.ID)
+
+	mErr := multierror.Append(
+		d.Set("nat_id", natGateway.ID),
+		d.Set("tenant_id", natGateway.TenantID),
+		d.Set("name", natGateway.Name),
+		d.Set("description", natGateway.Description),
+		d.Set("spec", natGateway.Spec),
+		d.Set("router_id", natGateway.RouterID),
+		d.Set("internal_network_id", natGateway.InternalNetworkID),
+		d.Set("status", natGateway.Status),
+		d.Set("admin_state_up", natGateway.AdminStateUp),
+		d.Set("region", config.GetRegion(d)),
+	)
+
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}

--- a/releasenotes/notes/nat_v2_data-7a86a2c1035665ab.yaml
+++ b/releasenotes/notes/nat_v2_data-7a86a2c1035665ab.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    **New Data Source:** ``opentelekomcloud_nat_gateway_v2``
+    (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)

--- a/releasenotes/notes/nat_v2_data-7a86a2c1035665ab.yaml
+++ b/releasenotes/notes/nat_v2_data-7a86a2c1035665ab.yaml
@@ -2,4 +2,4 @@
 features:
   - |
     **New Data Source:** ``opentelekomcloud_nat_gateway_v2``
-    (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    (`#2145 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2145>`_)


### PR DESCRIPTION
## Summary of the Pull Request
New `data_source/nat_gateway_v2` implemented to query the existing NAT Gateway resources.

## PR Checklist

* [x] Refers to: #2131
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccDataNatGateway_basic
--- PASS: TestAccDataNatGateway_basic (86.13s)
PASS

Process finished with the exit code 0
```
