### PR TITLE
[VPC]: fix `0` values handling for ``opentelekomcloud_networking_secgroup_rule_v2``

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/jinzhu/copier v0.3.5
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
+	github.com/opentelekomcloud/gophertelekomcloud v0.6.2-0.20230426093204-659f81d5e4c1
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.1.0
 	golang.org/x/sync v0.1.0
@@ -52,7 +53,6 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/oklog/run v1.0.0 // indirect
-	github.com/opentelekomcloud/gophertelekomcloud v0.6.2-0.20230426093204-659f81d5e4c1 // indirect
 	github.com/rogpeppe/go-internal v1.10.0 // indirect
 	github.com/stretchr/testify v1.8.1 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/jinzhu/copier v0.3.5
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.6.2-0.20230421162655-651ce591c56f
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.1.0
 	golang.org/x/sync v0.1.0
@@ -53,6 +52,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/oklog/run v1.0.0 // indirect
+	github.com/opentelekomcloud/gophertelekomcloud v0.6.2-0.20230426093204-659f81d5e4c1 // indirect
 	github.com/rogpeppe/go-internal v1.10.0 // indirect
 	github.com/stretchr/testify v1.8.1 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -209,8 +209,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.6.2-0.20230421162655-651ce591c56f h1:kQdOtL6ZYINFdeZ0KtyI4KMzVZamR5pM8Y+syXfT8C4=
-github.com/opentelekomcloud/gophertelekomcloud v0.6.2-0.20230421162655-651ce591c56f/go.mod h1:9Deb3q2gJvq5dExV+aX+iO+G+mD9Zr9uFt+YY9ONmq0=
+github.com/opentelekomcloud/gophertelekomcloud v0.6.2-0.20230426093204-659f81d5e4c1 h1:hP4I6VxPhjHQWmkhIyCakG+wjXmsBI3/8UNZBLefieU=
+github.com/opentelekomcloud/gophertelekomcloud v0.6.2-0.20230426093204-659f81d5e4c1/go.mod h1:9Deb3q2gJvq5dExV+aX+iO+G+mD9Zr9uFt+YY9ONmq0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/opentelekomcloud/services/vpc/resource_opentelekomcloud_networking_secgroup_rule_v2.go
+++ b/opentelekomcloud/services/vpc/resource_opentelekomcloud_networking_secgroup_rule_v2.go
@@ -126,8 +126,8 @@ func resourceNetworkingSecGroupRuleV2Create(ctx context.Context, d *schema.Resou
 	opts := rules.CreateOpts{
 		Description:    d.Get("description").(string),
 		SecGroupID:     d.Get("security_group_id").(string),
-		PortRangeMin:   d.Get("port_range_min").(int),
-		PortRangeMax:   d.Get("port_range_max").(int),
+		PortRangeMin:   &portRangeMin,
+		PortRangeMax:   &portRangeMax,
 		RemoteGroupID:  d.Get("remote_group_id").(string),
 		RemoteIPPrefix: d.Get("remote_ip_prefix").(string),
 		TenantID:       d.Get("tenant_id").(string),

--- a/releasenotes/notes/networking_sg_fix-6bedf1154fd2b8bc.yaml
+++ b/releasenotes/notes/networking_sg_fix-6bedf1154fd2b8bc.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    **[VPC]** Fix `0` int values handling for ``resource/opentelekomcloud_networking_secgroup_rule_v2`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[VPC]** Fix `0` int values handling for ``resource/opentelekomcloud_networking_secgroup_rule_v2`` (`#2150 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2150>`_)

--- a/releasenotes/notes/networking_sg_fix-6bedf1154fd2b8bc.yaml
+++ b/releasenotes/notes/networking_sg_fix-6bedf1154fd2b8bc.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[VPC]** Fix `0` int values handling for ``resource/opentelekomcloud_networking_secgroup_rule_v2`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Fix `0` value handling for `port_range_min` and `port_range_min` parameters.

## PR Checklist

* [x] Refers to: #2148
* [x] Tests passed.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccNetworkingV2SecGroupRule_basic
=== PAUSE TestAccNetworkingV2SecGroupRule_basic
=== CONT  TestAccNetworkingV2SecGroupRule_basic
--- PASS: TestAccNetworkingV2SecGroupRule_basic (42.78s)
=== RUN   TestAccNetworkingV2SecGroupRule_importBasic
=== PAUSE TestAccNetworkingV2SecGroupRule_importBasic
=== CONT  TestAccNetworkingV2SecGroupRule_importBasic
--- PASS: TestAccNetworkingV2SecGroupRule_importBasic (47.08s)
=== RUN   TestAccNetworkingV2SecGroupRule_timeout
=== PAUSE TestAccNetworkingV2SecGroupRule_timeout
=== CONT  TestAccNetworkingV2SecGroupRule_timeout
--- PASS: TestAccNetworkingV2SecGroupRule_timeout (42.00s)
=== RUN   TestAccNetworkingV2SecGroupRule_numericProtocol
=== PAUSE TestAccNetworkingV2SecGroupRule_numericProtocol
=== CONT  TestAccNetworkingV2SecGroupRule_numericProtocol
--- PASS: TestAccNetworkingV2SecGroupRule_numericProtocol (41.89s)
PASS

Process finished with the exit code 0
```
