### PR TITLE
[CCE] runtime force replacement fix

### DIFF
--- a/docs/resources/cce_node_pool_v3.md
+++ b/docs/resources/cce_node_pool_v3.md
@@ -114,9 +114,10 @@ the AZ based on the AZ sequence. For more details see
 
 * `k8s_tags` - (Optional) Tags of a Kubernetes node, key/value pair format.
 
-* `runtime` - (Optional) Container runtime. Changing this parameter will create a new resource. Options are:
-             `docker` - Docker
-             `containerd` - Containerd
+* `runtime` - (Optional) Container runtime. Changing this parameter will create a new resource.
+              Use with high-caution, may trigger resource recreation. Options are:
+              `docker` - Docker
+              `containerd` - Containerd
 
 * `taints` - (Optional) Taints to created nodes to configure anti-affinity.
   * `key` - (Required) A key must contain 1 to 63 characters starting with a letter or digit. Only letters, digits, hyphens (-), underscores (_), and periods (.) are allowed. A DNS subdomain name can be used as the prefix of a key.

--- a/docs/resources/cce_node_v3.md
+++ b/docs/resources/cce_node_v3.md
@@ -76,7 +76,8 @@ The following arguments are supported:
 
 * `annotations` - (Optional) Node annotation, key/value pair format. Changing this parameter will create a new resource
 
-* `runtime` - (Optional) Container runtime. Changing this parameter will create a new resource. Options are:
+* `runtime` - (Optional) Container runtime. Changing this parameter will create a new resource.
+              Use with high-caution, may trigger resource recreation. Options are:
               `docker` - Docker
               `containerd` - Containerd
 

--- a/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_pool_v3.go
+++ b/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_pool_v3.go
@@ -370,11 +370,14 @@ func resourceCCENodePoolV3Create(ctx context.Context, d *schema.ResourceData, me
 				Taints:   resourceCCENodeTaints(d),
 				K8sTags:  resourceCCENodeK8sTags(d),
 				UserTags: resourceCCENodePoolUserTags(d),
-				Runtime: nodes.RuntimeSpec{
-					Name: d.Get("runtime").(string),
-				},
 			},
 		},
+	}
+
+	if v, ok := d.GetOk("runtime"); ok {
+		createOpts.Spec.NodeTemplate.Runtime = nodes.RuntimeSpec{
+			Name: v.(string),
+		}
 	}
 
 	clusterID := d.Get("cluster_id").(string)

--- a/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_pool_v3.go
+++ b/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_pool_v3.go
@@ -468,7 +468,6 @@ func resourceCCENodePoolV3Read(ctx context.Context, d *schema.ResourceData, meta
 	if s.Spec.NodeTemplate.Runtime.Name == "null" {
 		if v, ok := d.GetOk("runtime"); ok {
 			mErr = multierror.Append(mErr, d.Set("runtime", v.(string)))
-
 		}
 	} else {
 		mErr = multierror.Append(mErr, d.Set("runtime", "docker"))

--- a/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_pool_v3.go
+++ b/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_pool_v3.go
@@ -50,7 +50,7 @@ func ResourceCCENodePoolV3() *schema.Resource {
 		},
 
 		Importer: &schema.ResourceImporter{
-			StateContext: common.ImportByPath("cluster_id", "id"),
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		CustomizeDiff: common.MultipleCustomizeDiffs(

--- a/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_pool_v3.go
+++ b/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_pool_v3.go
@@ -211,6 +211,7 @@ func ResourceCCENodePoolV3() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					"docker", "containerd",
 				}, false),

--- a/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_pool_v3.go
+++ b/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_pool_v3.go
@@ -210,7 +210,7 @@ func ResourceCCENodePoolV3() *schema.Resource {
 			"runtime": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
+				Computed: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					"docker", "containerd",
 				}, false),

--- a/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_pool_v3.go
+++ b/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_pool_v3.go
@@ -50,7 +50,7 @@ func ResourceCCENodePoolV3() *schema.Resource {
 		},
 
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: common.ImportByPath("cluster_id", "id"),
 		},
 
 		CustomizeDiff: common.MultipleCustomizeDiffs(
@@ -464,6 +464,15 @@ func resourceCCENodePoolV3Read(ctx context.Context, d *schema.ResourceData, meta
 		d.Set("root_volume", rootVolume),
 		d.Set("status", s.Status.Phase),
 	)
+
+	if s.Spec.NodeTemplate.Runtime.Name == "null" {
+		if v, ok := d.GetOk("runtime"); ok {
+			mErr = multierror.Append(mErr, d.Set("runtime", v.(string)))
+
+		}
+	} else {
+		mErr = multierror.Append(mErr, d.Set("runtime", "docker"))
+	}
 
 	if s.Spec.NodeTemplate.Runtime.Name != "" {
 		mErr = multierror.Append(mErr, d.Set("runtime", s.Spec.NodeTemplate.Runtime.Name))

--- a/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_pool_v3.go
+++ b/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_pool_v3.go
@@ -211,7 +211,9 @@ func ResourceCCENodePoolV3() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
-				Default:  "docker",
+				ValidateFunc: validation.StringInSlice([]string{
+					"docker", "containerd",
+				}, false),
 			},
 			"key_pair": {
 				Type:         schema.TypeString,
@@ -457,6 +459,7 @@ func resourceCCENodePoolV3Read(ctx context.Context, d *schema.ResourceData, meta
 		d.Set("scale_enable", s.Spec.Autoscaling.Enable),
 		d.Set("root_volume", rootVolume),
 		d.Set("status", s.Status.Phase),
+		d.Set("runtime", s.Spec.NodeTemplate.Runtime.Name),
 	)
 
 	if s.Spec.Autoscaling.Enable {

--- a/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_pool_v3.go
+++ b/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_pool_v3.go
@@ -459,8 +459,11 @@ func resourceCCENodePoolV3Read(ctx context.Context, d *schema.ResourceData, meta
 		d.Set("scale_enable", s.Spec.Autoscaling.Enable),
 		d.Set("root_volume", rootVolume),
 		d.Set("status", s.Status.Phase),
-		d.Set("runtime", s.Spec.NodeTemplate.Runtime.Name),
 	)
+
+	if s.Spec.NodeTemplate.Runtime.Name != "" {
+		mErr = multierror.Append(mErr, d.Set("runtime", s.Spec.NodeTemplate.Runtime.Name))
+	}
 
 	if s.Spec.Autoscaling.Enable {
 		mErr = multierror.Append(mErr,

--- a/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_v3.go
+++ b/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_v3.go
@@ -383,7 +383,7 @@ func ResourceCCENodeV3() *schema.Resource {
 			"runtime": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
+				Computed: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					"docker", "containerd",
 				}, false),

--- a/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_v3.go
+++ b/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_v3.go
@@ -384,6 +384,7 @@ func ResourceCCENodeV3() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					"docker", "containerd",
 				}, false),
@@ -700,10 +701,13 @@ func resourceCCENodeV3Read(ctx context.Context, d *schema.ResourceData, meta int
 		d.Set("public_ip", node.Status.PublicIP),
 		d.Set("status", node.Status.Phase),
 		d.Set("subnet_id", node.Spec.NodeNicSpec.PrimaryNic.SubnetId),
-		d.Set("runtime", node.Spec.Runtime.Name),
 	)
 	if err := mErr.ErrorOrNil(); err != nil {
 		return fmterr.Errorf("[DEBUG] Error saving main conf to state for OpenTelekomCloud Node (%s): %w", d.Id(), err)
+	}
+
+	if node.Spec.Runtime.Name != "" {
+		mErr = multierror.Append(mErr, d.Set("runtime", node.Spec.Runtime.Name))
 	}
 
 	var volumes []map[string]interface{}

--- a/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_v3.go
+++ b/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_v3.go
@@ -715,6 +715,10 @@ func resourceCCENodeV3Read(ctx context.Context, d *schema.ResourceData, meta int
 		mErr = multierror.Append(mErr, d.Set("runtime", node.Spec.Runtime.Name))
 	}
 
+	if err := mErr.ErrorOrNil(); err != nil {
+		return fmterr.Errorf("Error setting 'runtime' for OpenTelekomCloud Node (%s): %w", d.Id(), err)
+	}
+
 	var volumes []map[string]interface{}
 	for _, dataVolume := range node.Spec.DataVolumes {
 		volume := make(map[string]interface{})

--- a/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_v3.go
+++ b/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_v3.go
@@ -549,7 +549,6 @@ func resourceCCENodeV3Create(ctx context.Context, d *schema.ResourceData, meta i
 			},
 			BillingMode: d.Get("billing_mode").(int),
 			Count:       1,
-			Runtime:     nodes.RuntimeSpec{Name: d.Get("runtime").(string)},
 			ExtendParam: nodes.ExtendParam{
 				ChargingMode:            d.Get("extend_param_charging_mode").(int),
 				EcsPerformanceType:      d.Get("ecs_performance_type").(string),
@@ -566,6 +565,12 @@ func resourceCCENodeV3Create(ctx context.Context, d *schema.ResourceData, meta i
 			K8sTags:  resourceCCENodeK8sTags(d),
 			Taints:   resourceCCENodeTaints(d),
 		},
+	}
+
+	if v, ok := d.GetOk("runtime"); ok {
+		createOpts.Spec.Runtime = nodes.RuntimeSpec{
+			Name: v.(string),
+		}
 	}
 
 	if ip := d.Get("private_ip").(string); ip != "" {

--- a/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_v3.go
+++ b/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_v3.go
@@ -384,7 +384,9 @@ func ResourceCCENodeV3() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
-				Default:  "docker",
+				ValidateFunc: validation.StringInSlice([]string{
+					"docker", "containerd",
+				}, false),
 			},
 		},
 	}
@@ -698,6 +700,7 @@ func resourceCCENodeV3Read(ctx context.Context, d *schema.ResourceData, meta int
 		d.Set("public_ip", node.Status.PublicIP),
 		d.Set("status", node.Status.Phase),
 		d.Set("subnet_id", node.Spec.NodeNicSpec.PrimaryNic.SubnetId),
+		d.Set("runtime", node.Spec.Runtime.Name),
 	)
 	if err := mErr.ErrorOrNil(); err != nil {
 		return fmterr.Errorf("[DEBUG] Error saving main conf to state for OpenTelekomCloud Node (%s): %w", d.Id(), err)

--- a/releasenotes/notes/cce-runtime-fix-329806fa6f0274dc.yaml
+++ b/releasenotes/notes/cce-runtime-fix-329806fa6f0274dc.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    **[CCE]** Fix for runtime trigger recreation of ``resource/opentelekomcloud_cce_node_pool_v3``, ``resource/opentelekomcloud_cce_node_v3``
+    (`#2146 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2153>`_)
+    Anyway, handle with high caution, as it may cause recreation of existing resources if runtime is changed.

--- a/releasenotes/notes/cce-runtime-fix-329806fa6f0274dc.yaml
+++ b/releasenotes/notes/cce-runtime-fix-329806fa6f0274dc.yaml
@@ -2,5 +2,5 @@
 fixes:
   - |
     **[CCE]** Fix for runtime trigger recreation of ``resource/opentelekomcloud_cce_node_pool_v3``, ``resource/opentelekomcloud_cce_node_v3``
-    (`#2146 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2153>`_)
+    (`#2153 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2153>`_)
     Anyway, handle with high caution, as it may cause recreation of existing resources if runtime is changed.


### PR DESCRIPTION
## Summary of the Pull Request
Fix for backward compatibility of runtime option, removed forcenew.
This issue is impossible to check in acceptance tests because we need 2 versions of provider.
Tests were run in the local environment.

## PR Checklist

* [x] Closes #2141
* [x] Documentation updated.
* [x] Release notes added.
