### PR TITLE
[Provider]: fix plugin crashes related to `clouds.yaml` file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/jinzhu/copier v0.3.5
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.6.2-0.20230426093204-659f81d5e4c1
+	github.com/opentelekomcloud/gophertelekomcloud v0.6.2-0.20230428115358-3343441b3036
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.1.0
 	golang.org/x/sync v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -209,8 +209,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.6.2-0.20230426093204-659f81d5e4c1 h1:hP4I6VxPhjHQWmkhIyCakG+wjXmsBI3/8UNZBLefieU=
-github.com/opentelekomcloud/gophertelekomcloud v0.6.2-0.20230426093204-659f81d5e4c1/go.mod h1:9Deb3q2gJvq5dExV+aX+iO+G+mD9Zr9uFt+YY9ONmq0=
+github.com/opentelekomcloud/gophertelekomcloud v0.6.2-0.20230428115358-3343441b3036 h1:1GBcKmY74ngt+ZNI48mBsZbOUFyTqJk+yCzV7cvS4r8=
+github.com/opentelekomcloud/gophertelekomcloud v0.6.2-0.20230428115358-3343441b3036/go.mod h1:9Deb3q2gJvq5dExV+aX+iO+G+mD9Zr9uFt+YY9ONmq0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/releasenotes/notes/provider_crash-e0024b4aee850889.yaml
+++ b/releasenotes/notes/provider_crash-e0024b4aee850889.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    **[Provider]** Fix provider plugin crash in cases when `clouds.yaml` file is improperly formatted (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[Provider]** Fix provider plugin crash in cases when `clouds.yaml` file is improperly formatted (`#2154 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2154>`_)

--- a/releasenotes/notes/provider_crash-e0024b4aee850889.yaml
+++ b/releasenotes/notes/provider_crash-e0024b4aee850889.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[Provider]** Fix provider plugin crash in cases when `clouds.yaml` file is improperly formatted (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Update to latest `gophertelekomcloud` with provider plugin fix.
Crashes were related to improperly formatted `clouds.yaml` file.

## PR Checklist

* [x] Refers to: #2152 
* [x] Release notes added.
