### PR TITLE
[ECS] update for `data-source/opentelekomcloud_compute_instances_v2`

### DIFF
--- a/docs/data-sources/compute_instances_v2.md
+++ b/docs/data-sources/compute_instances_v2.md
@@ -62,14 +62,34 @@ The `instances` block supports:
 
 * `name` - The instance name.
 
-* `image_id` - The image ID of the instance.
+* `image_id` - The image ID used to create the server.
 
-* `flavor_id` - The flavor ID.
+* `image_name` - The image name used to create the server.
+
+* `flavor_id` - The flavor ID used to create the server.
 
 * `status` - The instance status.
 
 * `key_pair` - The key pair that is used to authenticate the instance.
 
-* `security_group_ids` - An array of one or more security group IDs to associate with the instance.
+* `security_groups` - An array of one or more security group Names to associate with the instance.
+
+* `availability_zone` - The availability zone of this server.
 
 * `project_id` - The instance project ID.
+
+* `network` - An array of maps, detailed below.
+
+The `network` block is defined as:
+
+* `uuid` - The UUID of the network
+
+* `name` - The name of the network
+
+* `fixed_ip_v4` - The IPv4 address assigned to this network port. Not supported.
+
+* `fixed_ip_v6` - The IPv6 address assigned to this network port. Not supported.
+
+* `port` - The port UUID for this network
+
+* `mac` - The MAC address assigned to this network interface.

--- a/opentelekomcloud/services/ecs/data_source_opentelekomcloud_compute_instances_v2.go
+++ b/opentelekomcloud/services/ecs/data_source_opentelekomcloud_compute_instances_v2.go
@@ -224,7 +224,7 @@ func dataSourceComputeInstancesV2Read(_ context.Context, d *schema.ResourceData,
 		}
 		imageName, errIms := getImageName(item.Image["id"].(string), d, meta)
 		if errIms != nil {
-			return fmterr.Errorf("unable to retrieve OpenTelekomCloud image: %w", errIms)
+			return fmterr.Errorf("unable to retrieve OpenTelekomCloud image: %s", errIms)
 		}
 		floatingIp := ""
 		var networks []map[string]interface{}
@@ -239,7 +239,7 @@ func dataSourceComputeInstancesV2Read(_ context.Context, d *schema.ResourceData,
 
 		nets, errNet := servers.GetNICs(client, item.ID).Extract()
 		if errNet != nil {
-			return fmterr.Errorf("unable to retrieve OpenTelekomCloud network: %w", errIms)
+			return fmterr.Errorf("unable to retrieve OpenTelekomCloud network: %s", errIms)
 		}
 		for _, net := range nets {
 			networks = append(networks, map[string]interface{}{
@@ -287,7 +287,7 @@ func getImageName(imageId string, d *schema.ResourceData, meta interface{}) (str
 		if _, ok := err.(golangsdk.ErrDefault404); ok {
 			return "", nil
 		}
-		return "", fmterr.Errorf("unable to retrieve OpenTelekomCloud image: %w", err)
+		return "", fmterr.Errorf("unable to retrieve OpenTelekomCloud image: %s", err)
 	}
 
 	return ims.Name, nil

--- a/opentelekomcloud/services/ecs/data_source_opentelekomcloud_compute_instances_v2.go
+++ b/opentelekomcloud/services/ecs/data_source_opentelekomcloud_compute_instances_v2.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/compute/v2/extensions/availabilityzones"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/compute/v2/servers"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/imageservice/v2/images"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/helper/hashcode"
@@ -83,10 +85,6 @@ func DataSourceComputeInstancesV2() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"flavor_name": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
 						"status": {
 							Type:     schema.TypeString,
 							Computed: true,
@@ -103,7 +101,7 @@ func DataSourceComputeInstancesV2() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"security_group_ids": {
+						"security_groups": {
 							Type:     schema.TypeList,
 							Computed: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
@@ -180,17 +178,22 @@ func dataSourceComputeInstancesV2Read(_ context.Context, d *schema.ResourceData,
 		Status:   d.Get("status").(string),
 		TenantID: d.Get("project_id").(string),
 	}
-	var allServers []servers.Server
 	allPages, err := servers.List(client, opts).AllPages()
 	if err != nil {
 		return fmterr.Errorf("unable to retrieve OpenTelekomCloud servers: %w", err)
 	}
-	allServers, err = servers.ExtractServers(allPages)
+
+	type ServerWithExt struct {
+		servers.Server
+		availabilityzones.ServerAvailabilityZoneExt
+	}
+	var allServers []ServerWithExt
+	err = servers.ExtractServersInto(allPages, &allServers)
 	if err != nil {
 		return fmterr.Errorf("unable to retrieve OpenTelekomCloud servers: %w", err)
 	}
 
-	instances := make([]servers.Server, 0, len(allServers))
+	instances := make([]ServerWithExt, 0, len(allServers))
 	ids := make([]string, 0, len(allServers))
 
 	for _, server := range allServers {
@@ -218,16 +221,46 @@ func dataSourceComputeInstancesV2Read(_ context.Context, d *schema.ResourceData,
 		for _, sg := range item.SecurityGroups {
 			secGrpNames = append(secGrpNames, sg["name"].(string))
 		}
+		imageName, errIms := getImageName(item.Image["id"].(string), d, meta)
+		if errIms != nil {
+			return fmterr.Errorf("unable to retrieve OpenTelekomCloud image: %w", errIms)
+		}
+		floatingIp := ""
+		var networks []map[string]interface{}
+		for _, ips := range item.Addresses {
+			for _, ip := range ips.([]interface{}) {
+				address := ip.(map[string]interface{})
+				if address["OS-EXT-IPS:type"] == "floating" {
+					floatingIp = address["addr"].(string)
+				}
+			}
+		}
 
+		nets, errNet := servers.GetNICs(client, item.ID).Extract()
+		if errNet != nil {
+			return fmterr.Errorf("unable to retrieve OpenTelekomCloud network: %w", errIms)
+		}
+		for _, net := range nets {
+			networks = append(networks, map[string]interface{}{
+				"uuid": net.NetID,
+				"port": net.PortID,
+				"mac":  net.MACAddress,
+			})
+		}
 		server := map[string]interface{}{
-			"id":                 item.ID,
-			"name":               item.Name,
-			"image_id":           item.Image["id"],
-			"flavor_id":          item.Flavor["id"],
-			"status":             item.Status,
-			"key_pair":           item.KeyName,
-			"security_group_ids": secGrpNames,
-			"project_id":         item.TenantID,
+			"id":                item.ID,
+			"name":              item.Name,
+			"image_id":          item.Image["id"],
+			"image_name":        imageName,
+			"flavor_id":         item.Flavor["id"],
+			"status":            item.Status,
+			"key_pair":          item.KeyName,
+			"security_groups":   secGrpNames,
+			"project_id":        item.TenantID,
+			"availability_zone": item.AvailabilityZone,
+			"public_ip":         floatingIp,
+			"system_disk_id":    item.VolumesAttached[0]["id"],
+			"network":           networks,
 		}
 
 		result[i] = server
@@ -238,4 +271,20 @@ func dataSourceComputeInstancesV2Read(_ context.Context, d *schema.ResourceData,
 	}
 
 	return nil
+}
+
+func getImageName(imageId string, d *schema.ResourceData, meta interface{}) (string, diag.Diagnostics) {
+	config := meta.(*cfg.Config)
+	log.Print("[DEBUG] Creating image client")
+	client, err := config.ImageV2Client(config.GetRegion(d))
+	if err != nil {
+		return "", fmterr.Errorf(errCreateV2Client, err)
+	}
+
+	ims, err := images.Get(client, imageId).Extract()
+	if err != nil {
+		return "", fmterr.Errorf("unable to retrieve OpenTelekomCloud image: %w", err)
+	}
+
+	return ims.Name, nil
 }

--- a/opentelekomcloud/services/ecs/data_source_opentelekomcloud_compute_instances_v2.go
+++ b/opentelekomcloud/services/ecs/data_source_opentelekomcloud_compute_instances_v2.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/compute/v2/extensions/availabilityzones"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/compute/v2/servers"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/imageservice/v2/images"
@@ -283,6 +284,9 @@ func getImageName(imageId string, d *schema.ResourceData, meta interface{}) (str
 
 	ims, err := images.Get(client, imageId).Extract()
 	if err != nil {
+		if _, ok := err.(golangsdk.ErrDefault404); ok {
+			return "", nil
+		}
 		return "", fmterr.Errorf("unable to retrieve OpenTelekomCloud image: %w", err)
 	}
 

--- a/opentelekomcloud/services/ecs/data_source_opentelekomcloud_compute_instances_v2.go
+++ b/opentelekomcloud/services/ecs/data_source_opentelekomcloud_compute_instances_v2.go
@@ -224,7 +224,7 @@ func dataSourceComputeInstancesV2Read(_ context.Context, d *schema.ResourceData,
 		}
 		imageName, errIms := getImageName(item.Image["id"].(string), d, meta)
 		if errIms != nil {
-			return fmterr.Errorf("unable to retrieve OpenTelekomCloud image: %s", errIms)
+			return diag.Errorf("unable to retrieve OpenTelekomCloud image: %s", errIms)
 		}
 		floatingIp := ""
 		var networks []map[string]interface{}
@@ -239,7 +239,7 @@ func dataSourceComputeInstancesV2Read(_ context.Context, d *schema.ResourceData,
 
 		nets, errNet := servers.GetNICs(client, item.ID).Extract()
 		if errNet != nil {
-			return fmterr.Errorf("unable to retrieve OpenTelekomCloud network: %s", errIms)
+			return diag.Errorf("unable to retrieve OpenTelekomCloud network: %s", errIms)
 		}
 		for _, net := range nets {
 			networks = append(networks, map[string]interface{}{

--- a/releasenotes/notes/ecs-ds-instances-update-669c225850dc2e7e.yaml
+++ b/releasenotes/notes/ecs-ds-instances-update-669c225850dc2e7e.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[УСЫ]** Fixed setting additional fields in ``data-source/opentelekomcloud_compute_instances_v2`` (`#2161 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2161>`_)

--- a/releasenotes/notes/ecs-ds-instances-update-669c225850dc2e7e.yaml
+++ b/releasenotes/notes/ecs-ds-instances-update-669c225850dc2e7e.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    **[УСЫ]** Fixed setting additional fields in ``data-source/opentelekomcloud_compute_instances_v2`` (`#2161 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2161>`_)
+    **[ECS]** Fixed setting additional fields in ``data-source/opentelekomcloud_compute_instances_v2`` (`#2161 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2161>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Now properly filled az, network, eip and volume

## PR Checklist

* [x] Refers to: #2155
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccComputeV2InstancesDataSource_basic
--- PASS: TestAccComputeV2InstancesDataSource_basic (168.07s)

PASS

Process finished with exit code 0
```
