### PR TITLE
[CCE] move addon installation wait to another func in `resource/opentelekomcloud_cce_cluster_v3`

### DIFF
--- a/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_cluster_v3.go
+++ b/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_cluster_v3.go
@@ -782,6 +782,15 @@ func waitForInstalledAddons(ctx context.Context, d *schema.ResourceData, config 
 		return fmt.Errorf("error waiting for addons to be assigned: %w", err)
 	}
 
+	return nil
+}
+
+func removeAddons(ctx context.Context, d *schema.ResourceData, config *cfg.Config) error {
+	client, err := config.CceV3AddonClient(config.GetRegion(d))
+	if err != nil {
+		return fmt.Errorf("error creating CCE Addon client: %w", logHttpError(err))
+	}
+
 	instances, err := addons.ListAddonInstances(client, d.Id()).Extract()
 	if err != nil {
 		return fmt.Errorf("error listing cluster addons: %w", err)
@@ -800,19 +809,7 @@ func waitForInstalledAddons(ctx context.Context, d *schema.ResourceData, config 
 			return fmt.Errorf("error waiting for addons to be installed: %w", err)
 		}
 	}
-	return nil
-}
 
-func removeAddons(ctx context.Context, d *schema.ResourceData, config *cfg.Config) error {
-	client, err := config.CceV3AddonClient(config.GetRegion(d))
-	if err != nil {
-		return fmt.Errorf("error creating CCE Addon client: %w", logHttpError(err))
-	}
-
-	instances, err := addons.ListAddonInstances(client, d.Id()).Extract()
-	if err != nil {
-		return fmt.Errorf("error listing cluster addons: %w", err)
-	}
 	for _, instance := range instances.Items {
 		addonID := instance.Metadata.ID
 		if err := addons.Delete(client, addonID, d.Id()).ExtractErr(); err != nil {

--- a/releasenotes/notes/cce-ignore-addons-wait-647c99acff55446d.yaml
+++ b/releasenotes/notes/cce-ignore-addons-wait-647c99acff55446d.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[CCE]** Move wait for complete addon installation to another function to speed up cluster provisioning in  ``resource/opentelekomcloud_cce_cluster_v3`` (`#2164 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2164>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Move addon wait for complete installation to another func

## PR Checklist

* [x] Refers to: #2158
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccCCEClusterV3_basic
=== PAUSE TestAccCCEClusterV3_basic
=== CONT  TestAccCCEClusterV3_basic
=== RUN   TestAccCCEClusterV3_turbo_basic
=== PAUSE TestAccCCEClusterV3_turbo_basic
=== CONT  TestAccCCEClusterV3_turbo_basic
=== RUN   TestAccCCEClusterV3_importBasic
=== PAUSE TestAccCCEClusterV3_importBasic
=== CONT  TestAccCCEClusterV3_importBasic
=== RUN   TestAccCCEClusterV3_invalidNetwork
=== PAUSE TestAccCCEClusterV3_invalidNetwork
=== CONT  TestAccCCEClusterV3_invalidNetwork
--- PASS: TestAccCCEClusterV3_invalidNetwork (26.42s)
=== RUN   TestAccCCEClusterV3_proxyAuth
=== PAUSE TestAccCCEClusterV3_proxyAuth
=== CONT  TestAccCCEClusterV3_proxyAuth
=== RUN   TestAccCCEClusterV3_timeout
=== PAUSE TestAccCCEClusterV3_timeout
=== CONT  TestAccCCEClusterV3_timeout
=== RUN   TestAccCCEClusterV3NoAddons
=== PAUSE TestAccCCEClusterV3NoAddons
=== CONT  TestAccCCEClusterV3NoAddons
=== RUN   TestAccCCEClusterV3_withVersionDiff
=== PAUSE TestAccCCEClusterV3_withVersionDiff
=== CONT  TestAccCCEClusterV3_withVersionDiff
--- PASS: TestAccCCEClusterV3_turbo_basic (501.56s)
--- PASS: TestAccCCEClusterV3_importBasic (558.66s)
--- PASS: TestAccCCEClusterV3_proxyAuth (565.42s)
--- PASS: TestAccCCEClusterV3_basic (592.07s)
--- PASS: TestAccCCEClusterV3_withVersionDiff (981.02s)
--- PASS: TestAccCCEClusterV3_timeout (1133.66s)
--- PASS: TestAccCCEClusterV3NoAddons (1189.92s)
PASS

Process finished with the exit code 0
```
