### PR TITLE
[DCS] removed dependency between enable_whitelist and whitelist in `resource/opentelekomcloud_dcs_instance_v1`

### DIFF
--- a/releasenotes/notes/dcs-waitlist-reqwith-remove-b078fc58badb042f.yaml
+++ b/releasenotes/notes/dcs-waitlist-reqwith-remove-b078fc58badb042f.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[DCS]** `whitelist` and `enable_whitelist` not depends from each other now in ``resource/opentelekomcloud_dcs_instance_v1`` (`#2170 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2170>`_)


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [x] Refers to: #2163
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccDcsInstancesV1_basic
=== PAUSE TestAccDcsInstancesV1_basic
=== CONT  TestAccDcsInstancesV1_basic
--- PASS: TestAccDcsInstancesV1_basic (147.99s)
=== RUN   TestAccDcsInstancesV1_basicSingleInstance
=== PAUSE TestAccDcsInstancesV1_basicSingleInstance
=== CONT  TestAccDcsInstancesV1_basicSingleInstance
--- PASS: TestAccDcsInstancesV1_basicSingleInstance (107.92s)
=== RUN   TestAccDcsInstancesV1_basicEngineV3Instance
=== PAUSE TestAccDcsInstancesV1_basicEngineV3Instance
=== CONT  TestAccDcsInstancesV1_basicEngineV3Instance
--- PASS: TestAccDcsInstancesV1_basicEngineV3Instance (399.24s)
=== RUN   TestAccASV1Configuration_invalidEngineVersion
=== PAUSE TestAccASV1Configuration_invalidEngineVersion

=== CONT  TestAccASV1Configuration_invalidEngineVersion
--- PASS: TestAccASV1Configuration_invalidEngineVersion (8.29s)
=== RUN   TestAccASV1Configuration_WhitelistValidation
=== PAUSE TestAccASV1Configuration_WhitelistValidation
=== CONT  TestAccASV1Configuration_WhitelistValidation
--- PASS: TestAccASV1Configuration_WhitelistValidation (10.21s)
=== RUN   TestAccDcsInstancesV1_Whitelist
=== PAUSE TestAccDcsInstancesV1_Whitelist
=== CONT  TestAccDcsInstancesV1_Whitelist

--- PASS: TestAccDcsInstancesV1_Whitelist (250.00s)
=== RUN   TestAccDCSInstanceV1_importBasic
--- PASS: TestAccDCSInstanceV1_importBasic (121.40s)
PASS


Process finished with the exit code 0
```
