### PR TITLE
[DCS] removed obsolete parameter access_user in `docs/resource/dcs_instance_v1`

### DIFF
--- a/docs/resources/dcs_instance_v1.md
+++ b/docs/resources/dcs_instance_v1.md
@@ -187,8 +187,6 @@ The following attributes are exported:
 
 * `capacity` - See Argument Reference above.
 
-* `access_user` - See Argument Reference above.
-
 * `password` - See Argument Reference above.
 
 * `vpc_id` - See Argument Reference above.

--- a/releasenotes/notes/dcs-doc-access-user-rm-5816222fbe942e86.yaml
+++ b/releasenotes/notes/dcs-doc-access-user-rm-5816222fbe942e86.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    **[DCS]** Removed `access_user` from documentation for ``resource/opentelekomcloud_dcs_instance_v1`` (`#2172 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2172>`_)
+


### PR DESCRIPTION
## Summary of the Pull Request
Update for documentation

## PR Checklist

* [x] Refers to: #2160
* [ ] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.
* [ ] Release notes added.

