### PR TITLE
[DCS] no password access in `resource/opentelekomcloud_dcs_instance_v1`

### DIFF
--- a/docs/resources/dcs_instance_v1.md
+++ b/docs/resources/dcs_instance_v1.md
@@ -109,7 +109,7 @@ The following arguments are supported:
   For a DCS Redis instance in cluster mode, the cache capacity can be `64`, `128`, `256`, `512` GB.
   Changing this creates a new instance.
 
-* `password` - (Required) Indicates the password of an instance. An instance password
+* `password` - (Optional) Indicates the password of an instance. An instance password
   must meet the following complexity requirements: Must be 8 to 32 characters long.
   Must contain at least 3 of the following character types: lowercase letters, uppercase
   letters, digits, and special characters (`~!@#$%^&*()-_=+\|[{}]:'",<.>/?).
@@ -249,3 +249,13 @@ The following attributes are exported:
   `RESTARTING`, `EXTENDING`, `RESTORING`
 
 * `created_at` - Time at which the DCS instance is created. For example, `2017-03-31T12:24:46.297Z`.
+
+* `no_password_access` - An indicator of whether a DCS instance can be accessed in password-free mode.
+  `true` when password not set.
+
+## Import
+
+DCS instance can be imported using  `instance_name`, e.g.
+```shell
+$ terraform import opentelekomcloud_dcs_instance_v1.instance instance_name
+```

--- a/opentelekomcloud/acceptance/dcs/resource_opentelekomcloud_dcs_instance_v1_test.go
+++ b/opentelekomcloud/acceptance/dcs/resource_opentelekomcloud_dcs_instance_v1_test.go
@@ -62,6 +62,30 @@ func TestAccDcsInstancesV1_basicSingleInstance(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceInstanceName, "name", instanceName),
 					resource.TestCheckResourceAttr(resourceInstanceName, "engine", "Redis"),
 					resource.TestCheckResourceAttr(resourceInstanceName, "resource_spec_code", "redis.single.xu1.tiny.128"),
+					resource.TestCheckResourceAttr(resourceInstanceName, "no_password_access", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDcsInstancesV1_basicNoPasswordAccess(t *testing.T) {
+	var instance lifecycle.Instance
+	var instanceName = fmt.Sprintf("dcs_instance_%s", acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDcsV1InstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDcsV1InstanceNoPassword(instanceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDcsV1InstanceExists(resourceInstanceName, instance),
+					resource.TestCheckResourceAttr(resourceInstanceName, "name", instanceName),
+					resource.TestCheckResourceAttr(resourceInstanceName, "engine", "Redis"),
+					resource.TestCheckResourceAttr(resourceInstanceName, "resource_spec_code", "redis.single.xu1.tiny.128"),
+					resource.TestCheckResourceAttr(resourceInstanceName, "no_password_access", "true"),
 				),
 			},
 		},
@@ -637,6 +661,34 @@ resource "opentelekomcloud_dcs_instance_v1" "instance_1" {
     group_name = "test-group-name-2"
     ip_list    = ["10.10.10.11", "10.10.10.3", "10.10.10.4"]
   }
+}
+`, common.DataSourceSecGroupDefault, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, instanceName)
+}
+
+func testAccDcsV1InstanceNoPassword(instanceName string) string {
+	return fmt.Sprintf(`
+%s
+
+%s
+
+data "opentelekomcloud_dcs_az_v1" "az_1" {
+  port = "8002"
+  code = "%s"
+}
+
+data "opentelekomcloud_dcs_product_v1" "product_1" {
+  spec_code = "redis.single.xu1.tiny.128"
+}
+
+resource "opentelekomcloud_dcs_instance_v1" "instance_1" {
+  name            = "%s"
+  engine_version  = "4.0"
+  engine          = "Redis"
+  capacity        = 0.125
+  vpc_id          = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  subnet_id       = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  available_zones = [data.opentelekomcloud_dcs_az_v1.az_1.id]
+  product_id      = data.opentelekomcloud_dcs_product_v1.product_1.id
 }
 `, common.DataSourceSecGroupDefault, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, instanceName)
 }

--- a/opentelekomcloud/services/dcs/resource_opentelekomcloud_dcs_instance_v1.go
+++ b/opentelekomcloud/services/dcs/resource_opentelekomcloud_dcs_instance_v1.go
@@ -72,7 +72,7 @@ func ResourceDcsInstanceV1() *schema.Resource {
 			"password": {
 				Type:      schema.TypeString,
 				Sensitive: true,
-				Required:  true,
+				Optional:  true,
 				ForceNew:  true,
 			},
 			"vpc_id": {
@@ -198,6 +198,10 @@ func ResourceDcsInstanceV1() *schema.Resource {
 						},
 					},
 				},
+			},
+			"no_password_access": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"order_id": {
 				Type:     schema.TypeString,
@@ -531,6 +535,7 @@ func resourceDcsInstancesV1Read(_ context.Context, d *schema.ResourceData, meta 
 		d.Set("maintain_begin", v.MaintainBegin),
 		d.Set("maintain_end", v.MaintainEnd),
 		d.Set("ip", v.IP),
+		d.Set("no_password_access", v.NoPasswordAccess),
 	)
 
 	if v.EngineVersion == "3.0" {

--- a/releasenotes/notes/dcs-no-password-access-27c2c8c71cbc94fd.yaml
+++ b/releasenotes/notes/dcs-no-password-access-27c2c8c71cbc94fd.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[DCS]** `password` optional now and `no_password_access` is true when password not set ``resource/opentelekomcloud_dcs_instance_v1`` (`#2174 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2174>`_)


### PR DESCRIPTION
## Summary of the Pull Request
password now optional and if not set then no_password_access = true

## PR Checklist

* [x] Refers to: #2173
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccDcsInstancesV1_basic
=== PAUSE TestAccDcsInstancesV1_basic
=== CONT  TestAccDcsInstancesV1_basic
--- PASS: TestAccDcsInstancesV1_basic (141.56s)
=== RUN   TestAccDcsInstancesV1_basicSingleInstance
=== PAUSE TestAccDcsInstancesV1_basicSingleInstance
=== CONT  TestAccDcsInstancesV1_basicSingleInstance
--- PASS: TestAccDcsInstancesV1_basicSingleInstance (99.67s)
=== RUN   TestAccDcsInstancesV1_basicNoPasswordAccess
=== PAUSE TestAccDcsInstancesV1_basicNoPasswordAccess

=== CONT  TestAccDcsInstancesV1_basicNoPasswordAccess
--- PASS: TestAccDcsInstancesV1_basicNoPasswordAccess (99.03s)
=== RUN   TestAccDcsInstancesV1_basicEngineV3Instance
=== PAUSE TestAccDcsInstancesV1_basicEngineV3Instance
=== CONT  TestAccDcsInstancesV1_basicEngineV3Instance
--- PASS: TestAccDcsInstancesV1_basicEngineV3Instance (419.47s)
=== RUN   TestAccASV1Configuration_invalidEngineVersion
=== PAUSE TestAccASV1Configuration_invalidEngineVersion
=== CONT  TestAccASV1Configuration_invalidEngineVersion
--- PASS: TestAccASV1Configuration_invalidEngineVersion (7.83s)
=== RUN   TestAccASV1Configuration_WhitelistValidation
=== PAUSE TestAccASV1Configuration_WhitelistValidation
=== CONT  TestAccASV1Configuration_WhitelistValidation
--- PASS: TestAccASV1Configuration_WhitelistValidation (9.38s)
=== RUN   TestAccDcsInstancesV1_Whitelist
=== PAUSE TestAccDcsInstancesV1_Whitelist
=== CONT  TestAccDcsInstancesV1_Whitelist

--- PASS: TestAccDcsInstancesV1_Whitelist (248.45s)
=== RUN   TestAccDCSInstanceV1_importBasic
--- PASS: TestAccDCSInstanceV1_importBasic (127.78s)
PASS


Process finished with the exit code 0

```
