### PR TITLE
 [VPC]: fix port ranges for `opentelekomcloud_networking_secgroup_rule_v2`

### DIFF
--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_secgroup_rule_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_secgroup_rule_v2_test.go
@@ -2,6 +2,7 @@ package acceptance
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -115,6 +116,68 @@ func TestAccNetworkingV2SecGroupRule_numericProtocol(t *testing.T) {
 					testAccCheckNetworkingV2SecGroupRuleExists(resourceNwSGRuleName, &secgroupRule1),
 					resource.TestCheckResourceAttr(resourceNwSGRuleName, "protocol", "115"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccNetworkingV2SecGroupRule_noPorts(t *testing.T) {
+	var secgroup1 groups.SecGroup
+	var secgroupRule1 rules.SecGroupRule
+	t.Parallel()
+	quotas.BookOne(t, quotas.SecurityGroup)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckNetworkingV2SecGroupRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkingV2SecGroupRuleNoPorts,
+				Check: resource.ComposeTestCheckFunc(
+					TestAccCheckNetworkingV2SecGroupExists(resourceNwSecGroupName, &secgroup1),
+					testAccCheckNetworkingV2SecGroupRuleExists(resourceNwSGRuleName, &secgroupRule1),
+					resource.TestCheckResourceAttr(resourceNwSGRuleName, "direction", "egress"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetworkingV2SecGroupRule_ICMP(t *testing.T) {
+	var secgroup1 groups.SecGroup
+	var secgroupRule1 rules.SecGroupRule
+	t.Parallel()
+	quotas.BookOne(t, quotas.SecurityGroup)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckNetworkingV2SecGroupRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkingV2SecGroupRuleICMP,
+				Check: resource.ComposeTestCheckFunc(
+					TestAccCheckNetworkingV2SecGroupExists(resourceNwSecGroupName, &secgroup1),
+					testAccCheckNetworkingV2SecGroupRuleExists(resourceNwSGRuleName, &secgroupRule1),
+					resource.TestCheckResourceAttr(resourceNwSGRuleName, "direction", "ingress"),
+					resource.TestCheckResourceAttr(resourceNwSGRuleName, "port_range_min", "8"),
+					resource.TestCheckResourceAttr(resourceNwSGRuleName, "port_range_max", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetworkingV2SecGroupRule_noProtocolError(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckNetworkingV2SecGroupRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccNetworkingV2SecGroupRuleError,
+				ExpectError: regexp.MustCompile(`"port_range_min": all of .+`),
 			},
 		},
 	})
@@ -259,6 +322,53 @@ resource "opentelekomcloud_networking_secgroup_rule_v2" "secgroup_rule_1" {
   port_range_min    = 22
   protocol          = "115"
   remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = opentelekomcloud_networking_secgroup_v2.secgroup_1.id
+}
+`
+
+const testAccNetworkingV2SecGroupRuleNoPorts = `
+resource "opentelekomcloud_networking_secgroup_v2" "secgroup_1" {
+  name        = "secgroup_1"
+  description = "terraform security group rule acceptance test"
+}
+
+resource "opentelekomcloud_networking_secgroup_rule_v2" "secgroup_rule_1" {
+  direction         = "egress"
+  ethertype         = "IPv4"
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = opentelekomcloud_networking_secgroup_v2.secgroup_1.id
+}
+`
+
+const testAccNetworkingV2SecGroupRuleICMP = `
+resource "opentelekomcloud_networking_secgroup_v2" "secgroup_1" {
+  name        = "secgroup_1"
+  description = "terraform security group rule acceptance test"
+}
+
+resource "opentelekomcloud_networking_secgroup_rule_v2" "secgroup_rule_1" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "icmp"
+  port_range_min    = 8
+  port_range_max    = 0
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = opentelekomcloud_networking_secgroup_v2.secgroup_1.id
+}
+`
+
+const testAccNetworkingV2SecGroupRuleError = `
+resource "opentelekomcloud_networking_secgroup_v2" "secgroup_1" {
+  name        = "secgroup_1"
+  description = "terraform security group rule acceptance test"
+}
+
+resource "opentelekomcloud_networking_secgroup_rule_v2" "secgroup_rule_1" {
+  direction         = "egress"
+  ethertype         = "IPv4"
+  remote_ip_prefix  = "0.0.0.0/0"
+  port_range_min    = 0
+  port_range_max    = 22
   security_group_id = opentelekomcloud_networking_secgroup_v2.secgroup_1.id
 }
 `

--- a/releasenotes/notes/vpc_sg_fix-21d0ecfcbc4a3948.yaml
+++ b/releasenotes/notes/vpc_sg_fix-21d0ecfcbc4a3948.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[VPC]** Fix secgroup rule creation ``resource/opentelekomcloud_networking_secgroup_rule_v2`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)

--- a/releasenotes/notes/vpc_sg_fix-21d0ecfcbc4a3948.yaml
+++ b/releasenotes/notes/vpc_sg_fix-21d0ecfcbc4a3948.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    **[VPC]** Fix secgroup rule creation ``resource/opentelekomcloud_networking_secgroup_rule_v2`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[VPC]** Fix secgroup rule creation ``resource/opentelekomcloud_networking_secgroup_rule_v2`` (`#2175 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2175>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Port ranges were set every time even if they weren't provided by the user. This happened due to terraform being unable to differentiate empty parameter from zero value provided in config.

## PR Checklist

* [x] Refers to: #2162
* [x] Tests added/passed.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccNetworkingV2SecGroupRule_basic
=== PAUSE TestAccNetworkingV2SecGroupRule_basic
=== CONT  TestAccNetworkingV2SecGroupRule_basic
--- PASS: TestAccNetworkingV2SecGroupRule_basic (42.93s)
=== RUN   TestAccNetworkingV2SecGroupRule_importBasic
=== PAUSE TestAccNetworkingV2SecGroupRule_importBasic
=== CONT  TestAccNetworkingV2SecGroupRule_importBasic
--- PASS: TestAccNetworkingV2SecGroupRule_importBasic (47.87s)
=== RUN   TestAccNetworkingV2SecGroupRule_timeout
=== PAUSE TestAccNetworkingV2SecGroupRule_timeout
=== CONT  TestAccNetworkingV2SecGroupRule_timeout
--- PASS: TestAccNetworkingV2SecGroupRule_timeout (42.56s)
=== RUN   TestAccNetworkingV2SecGroupRule_numericProtocol
=== PAUSE TestAccNetworkingV2SecGroupRule_numericProtocol
=== CONT  TestAccNetworkingV2SecGroupRule_numericProtocol
--- PASS: TestAccNetworkingV2SecGroupRule_numericProtocol (42.87s)
=== RUN   TestAccNetworkingV2SecGroupRule_noPorts
=== PAUSE TestAccNetworkingV2SecGroupRule_noPorts
=== CONT  TestAccNetworkingV2SecGroupRule_noPorts
--- PASS: TestAccNetworkingV2SecGroupRule_noPorts (42.17s)
=== RUN   TestAccNetworkingV2SecGroupRule_ICMP
=== PAUSE TestAccNetworkingV2SecGroupRule_ICMP
=== CONT  TestAccNetworkingV2SecGroupRule_ICMP
--- PASS: TestAccNetworkingV2SecGroupRule_ICMP (42.92s)
=== RUN   TestAccNetworkingV2SecGroupRule_noProtocolError
--- PASS: TestAccNetworkingV2SecGroupRule_noProtocolError (3.65s)
PASS

Process finished with the exit code 0
```
