### PR TITLE
[ECS] sg ids instead of names in `data-source/opentelekomcloud_compute_instances_v2`

### DIFF
--- a/docs/data-sources/compute_instances_v2.md
+++ b/docs/data-sources/compute_instances_v2.md
@@ -72,7 +72,7 @@ The `instances` block supports:
 
 * `key_pair` - The key pair that is used to authenticate the instance.
 
-* `security_groups` - An array of one or more security group Names to associate with the instance.
+* `security_groups_ids` - An array of one or more security group Ids to associate with the instance.
 
 * `availability_zone` - The availability zone of this server.
 

--- a/releasenotes/notes/ecs-instances-ds-sg-ids-0ae598316d5747d9.yaml
+++ b/releasenotes/notes/ecs-instances-ds-sg-ids-0ae598316d5747d9.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[ECS]** Storing security groups ids in ``data-source/opentelekomcloud_compute_instances_v2`` (`#2178 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2178>`_)


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [x] Refers to: #2155
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccComputeV2InstancesDataSource_basic
--- PASS: TestAccComputeV2InstancesDataSource_basic (232.61s)
PASS


Debugger finished with the exit code 0
```
