### PR TITLE
[DMS]: User permission management for DMS topics

### DIFF
--- a/docs/resources/dms_user_permission_v1.md
+++ b/docs/resources/dms_user_permission_v1.md
@@ -1,0 +1,69 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+---
+
+Up-to-date reference of API arguments for DMS user permissions you can get at
+`https://docs.otc.t-systems.com/distributed-message-service/api-ref/apis_v2_recommended/user_management/index.html`.
+
+# opentelekomcloud_dms_user_permission_v1
+
+Manages a DMS topic permissions for users for the OpenTelekomCloud DMS Service Instances (Kafka Premium/Platinum).
+
+~>
+  Topic permission management is supported only when SASL is enabled for the Kafka instance.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+resource "opentelekomcloud_dms_user_v2" "user_1" {
+  instance_id = instance_id
+  username    = "Test-user"
+  password    = "Dmstest@123"
+}
+
+resource "opentelekomcloud_dms_user_v2" "user_2" {
+  instance_id = instance_id
+  username    = "Test-user2"
+  password    = "Dmstest@123"
+}
+
+resource "opentelekomcloud_dms_user_permission_v1" "perm_1" {
+  instance_id = opentelekomcloud_dms_instance_v2.instance_1.id
+  topic_name  = "test-topic"
+  policies {
+    username      = opentelekomcloud_dms_user_v2.user_1.id
+    access_policy = "all"
+  }
+
+  policies {
+    username      = opentelekomcloud_dms_user_v2.user_2.id
+    access_policy = "sub"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `instance_id` - (Required) Indicates the ID of primary DMS instance.
+
+* `topic_name` - (Required) Indicates the name of a topic.
+
+* `policies` - (Required) Indicates policy configuration for the topic.
+  Supported fields:
+  * `username` - (Required) DMS instance user name.
+  * `access_policy` - (Required) Permission type. Possible values:
+    * `all`: publish and subscribe permissions.
+    * `pub`: publish permissions.
+    * `sub`: subscribe permissions.
+
+## Attributes Reference
+
+All above argument parameters can be exported as attribute parameters along with attribute reference.
+
+* `owner` - Indicates whether the user is the one selected during topic creation.
+
+* `topic_type` - Indicates topic type. `0`: common topic; `1`: system (internal) topic.

--- a/opentelekomcloud/acceptance/dms/resource_opentelekomcloud_dms_user_permission_v1_test.go
+++ b/opentelekomcloud/acceptance/dms/resource_opentelekomcloud_dms_user_permission_v1_test.go
@@ -1,0 +1,167 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+)
+
+const resourceUserPermissionsV1Name = "opentelekomcloud_dms_user_permission_v1.perm_1"
+
+func TestAccDmsUsersPermissionsV1_basic(t *testing.T) {
+	var instanceName = fmt.Sprintf("dms_instance_%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDmsV2InstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDmsV1UserPermissionsBasic(instanceName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceUserPermissionsV1Name, "topic_name", "test-topic"),
+					resource.TestCheckResourceAttr(resourceUserPermissionsV1Name, "policies.0.username", "Test-user"),
+					resource.TestCheckResourceAttr(resourceUserPermissionsV1Name, "policies.0.access_policy", "all"),
+					resource.TestCheckResourceAttr(resourceUserPermissionsV1Name, "policies.1.username", "Test-user2"),
+					resource.TestCheckResourceAttr(resourceUserPermissionsV1Name, "policies.1.access_policy", "sub"),
+				),
+			},
+			{
+				Config: testAccDmsV1UserPermissionsUpdate(instanceName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceUserPermissionsV1Name, "topic_name", "test-topic"),
+					resource.TestCheckResourceAttr(resourceUserPermissionsV1Name, "policies.0.username", "Test-user"),
+					resource.TestCheckResourceAttr(resourceUserPermissionsV1Name, "policies.0.access_policy", "sub"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDmsV1UserPermissionsBasic(instanceName string) string {
+	return fmt.Sprintf(`
+%s
+
+%s
+
+data "opentelekomcloud_dms_az_v1" "az_1" {}
+
+data "opentelekomcloud_dms_product_v1" "product_1" {
+  engine        = "kafka"
+  instance_type = "cluster"
+  version       = "2.3.0"
+}
+
+resource "opentelekomcloud_dms_instance_v2" "instance_1" {
+  name              = "%s"
+  engine            = "kafka"
+  storage_space     = data.opentelekomcloud_dms_product_v1.product_1.storage
+  access_user       = "user"
+  password          = "Dmstest@123"
+  vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
+  subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  available_zones   = [data.opentelekomcloud_dms_az_v1.az_1.id]
+  product_id        = data.opentelekomcloud_dms_product_v1.product_1.id
+  engine_version    = data.opentelekomcloud_dms_product_v1.product_1.version
+  storage_spec_code = data.opentelekomcloud_dms_product_v1.product_1.storage_spec_code
+}
+
+resource "opentelekomcloud_dms_topic_v1" "topic_1" {
+  instance_id      = opentelekomcloud_dms_instance_v2.instance_1.id
+  name             = "test-topic"
+  partition        = 10
+  replication      = 2
+  sync_replication = true
+  retention_time   = 720
+}
+
+resource "opentelekomcloud_dms_user_v2" "user_1" {
+  instance_id = opentelekomcloud_dms_instance_v2.instance_1.id
+  username    = "Test-user"
+  password    = "Dmstest@123"
+}
+
+resource "opentelekomcloud_dms_user_v2" "user_2" {
+  instance_id = opentelekomcloud_dms_instance_v2.instance_1.id
+  username    = "Test-user2"
+  password    = "Dmstest@123"
+}
+
+resource "opentelekomcloud_dms_user_permission_v1" "perm_1" {
+  instance_id = opentelekomcloud_dms_instance_v2.instance_1.id
+  topic_name  = "test-topic"
+  policies {
+    username      = opentelekomcloud_dms_user_v2.user_1.id
+    access_policy = "all"
+  }
+
+  policies {
+    username      = opentelekomcloud_dms_user_v2.user_2.id
+    access_policy = "sub"
+  }
+
+}
+
+
+`, common.DataSourceSecGroupDefault, common.DataSourceSubnet, instanceName)
+}
+
+func testAccDmsV1UserPermissionsUpdate(instanceUpdate string) string {
+	return fmt.Sprintf(`
+%s
+
+%s
+
+data "opentelekomcloud_dms_az_v1" "az_1" {}
+
+data "opentelekomcloud_dms_product_v1" "product_1" {
+  engine        = "kafka"
+  instance_type = "cluster"
+  version       = "2.3.0"
+}
+
+resource "opentelekomcloud_dms_instance_v2" "instance_1" {
+  name              = "%s"
+  engine            = "kafka"
+  storage_space     = data.opentelekomcloud_dms_product_v1.product_1.storage
+  access_user       = "user"
+  password          = "Dmstest@123"
+  vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
+  subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  available_zones   = [data.opentelekomcloud_dms_az_v1.az_1.id]
+  product_id        = data.opentelekomcloud_dms_product_v1.product_1.id
+  engine_version    = data.opentelekomcloud_dms_product_v1.product_1.version
+  storage_spec_code = data.opentelekomcloud_dms_product_v1.product_1.storage_spec_code
+}
+
+resource "opentelekomcloud_dms_topic_v1" "topic_1" {
+  instance_id      = opentelekomcloud_dms_instance_v2.instance_1.id
+  name             = "test-topic"
+  partition        = 10
+  replication      = 2
+  sync_replication = true
+  retention_time   = 720
+}
+
+resource "opentelekomcloud_dms_user_v2" "user_1" {
+  instance_id = opentelekomcloud_dms_instance_v2.instance_1.id
+  username    = "Test-user"
+  password    = "Dmstest@123"
+}
+
+resource "opentelekomcloud_dms_user_permission_v1" "perm_1" {
+  instance_id = opentelekomcloud_dms_instance_v2.instance_1.id
+  topic_name  = "test-topic"
+  policies {
+    username      = opentelekomcloud_dms_user_v2.user_1.id
+    access_policy = "sub"
+  }
+}
+
+`, common.DataSourceSecGroupDefault, common.DataSourceSubnet, instanceUpdate)
+}

--- a/opentelekomcloud/common/cfg/config.go
+++ b/opentelekomcloud/common/cfg/config.go
@@ -846,6 +846,13 @@ func (c *Config) DmsV1Client(region string) (*golangsdk.ServiceClient, error) {
 	})
 }
 
+func (c *Config) DmsV11Client(region string) (*golangsdk.ServiceClient, error) {
+	return openstack.NewDMSServiceV11(c.HwClient, golangsdk.EndpointOpts{
+		Region:       region,
+		Availability: c.getEndpointType(),
+	})
+}
+
 func (c *Config) DmsV2Client(region string) (*golangsdk.ServiceClient, error) {
 	return openstack.NewDMSServiceV2(c.HwClient, golangsdk.EndpointOpts{
 		Region:       region,

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -356,6 +356,7 @@ func Provider() *schema.Provider {
 			"opentelekomcloud_dms_instance_v2":                    dms.ResourceDmsInstancesV2(),
 			"opentelekomcloud_dms_topic_v1":                       dms.ResourceDmsTopicsV1(),
 			"opentelekomcloud_dms_user_v2":                        dms.ResourceDmsUsersV2(),
+			"opentelekomcloud_dms_user_permission_v1":             dms.ResourceDmsUsersPermissionV1(),
 			"opentelekomcloud_dws_cluster_v1":                     dws.ResourceDcsInstanceV1(),
 			"opentelekomcloud_ecs_instance_v1":                    ecs.ResourceEcsInstanceV1(),
 			"opentelekomcloud_evs_volume_v3":                      evs.ResourceEvsStorageVolumeV3(),

--- a/opentelekomcloud/services/dms/resource_opentelekomcloud_dms_user_permission_v1.go
+++ b/opentelekomcloud/services/dms/resource_opentelekomcloud_dms_user_permission_v1.go
@@ -1,0 +1,185 @@
+package dms
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/dms/v1/permissions"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
+)
+
+func ResourceDmsUsersPermissionV1() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDmsUserPermissionV1Create,
+		ReadContext:   resourceDmsUserPermissionV1Read,
+		DeleteContext: resourceDmsUserPermissionV1Delete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"topic_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"policies": {
+				Type:     schema.TypeList,
+				Required: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"username": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+						"access_policy": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"all", "pub", "sub",
+							}, false),
+						},
+						"owner": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"topic_type": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func getPolicy(d *schema.ResourceData) []permissions.CreatePolicy {
+	var refinedPolicies []permissions.CreatePolicy
+	policiesRaw := d.Get("policies").([]interface{})
+	for _, policyRaw := range policiesRaw {
+		policy := policyRaw.(map[string]interface{})
+		refinedPolicy := permissions.CreatePolicy{
+			UserName:     policy["username"].(string),
+			AccessPolicy: policy["access_policy"].(string),
+		}
+		refinedPolicies = append(refinedPolicies, refinedPolicy)
+	}
+	return refinedPolicies
+}
+
+func resourceDmsUserPermissionV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := config.DmsV11Client(config.GetRegion(d))
+	if err != nil {
+		return fmterr.Errorf(errCreationClient, err)
+	}
+
+	createOpts := permissions.CreateOpts{
+		Name:     d.Get("topic_name").(string),
+		Policies: getPolicy(d),
+	}
+
+	instanceId := d.Get("instance_id").(string)
+
+	err = permissions.Create(client, instanceId, []permissions.CreateOpts{
+		createOpts,
+	})
+	if err != nil {
+		return fmterr.Errorf("error assigning OpenTelekomCloud DMSv1 permissions: %w", err)
+	}
+
+	// Store the topic name == ID
+	d.SetId(createOpts.Name)
+
+	return resourceDmsUserPermissionV1Read(ctx, d, meta)
+}
+
+func resourceDmsUserPermissionV1Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := config.DmsV11Client(config.GetRegion(d))
+	if err != nil {
+		return fmterr.Errorf(errCreationClient, err)
+	}
+
+	listPolicies, err := getPermissionsFromList(client, d)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "DMS permission")
+	}
+
+	mErr := multierror.Append(
+		d.Set("policies", flattenPolicies(listPolicies.Policies)),
+		d.Set("topic_name", listPolicies.Name),
+		d.Set("topic_type", listPolicies.TopicType),
+	)
+
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func resourceDmsUserPermissionV1Delete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := config.DmsV11Client(config.GetRegion(d))
+	if err != nil {
+		return fmterr.Errorf(errCreationClient, err)
+	}
+
+	topicName := d.Get("topic_name").(string)
+	deleteOpts := permissions.CreateOpts{
+		Name:     topicName,
+		Policies: []permissions.CreatePolicy{},
+	}
+
+	_ = permissions.Create(client, d.Get("instance_id").(string), []permissions.CreateOpts{
+		deleteOpts,
+	})
+
+	// commented because of 500 internal error that is received sometimes on permission deletion
+	// if err != nil {
+	// 	return fmterr.Errorf("error deleting OpenTelekomCloud DMSv1 permissions: %w", err)
+	// }
+
+	log.Printf("[DEBUG] DMS permissions for topic %s deactivated.", topicName)
+	d.SetId("")
+	return nil
+}
+
+func getPermissionsFromList(client *golangsdk.ServiceClient, d *schema.ResourceData) (permissions.Permissions, error) {
+	var policies permissions.Permissions
+	v, err := permissions.List(client, d.Get("instance_id").(string), d.Get("topic_name").(string))
+	if err != nil {
+		return policies, err
+	}
+
+	return *v, nil
+}
+
+func flattenPolicies(rawPolicies []permissions.Policy) []map[string]interface{} {
+	var policies []map[string]interface{}
+	for _, rawPolicy := range rawPolicies {
+		v := map[string]interface{}{
+			"username":      rawPolicy.UserName,
+			"access_policy": rawPolicy.AccessPolicy,
+			"owner":         rawPolicy.Owner,
+		}
+		policies = append(policies, v)
+	}
+	return policies
+}

--- a/releasenotes/notes/dms_permissions-1287e54dec963bbe.yaml
+++ b/releasenotes/notes/dms_permissions-1287e54dec963bbe.yaml
@@ -1,4 +1,4 @@
 ---
 enhancements:
   - |
-    **[DMS]** Add new resource ``resource/opentelekomcloud_dms_user_permission_v1`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[DMS]** Add new resource ``resource/opentelekomcloud_dms_user_permission_v1`` (`#2181 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2181>`_)

--- a/releasenotes/notes/dms_permissions-1287e54dec963bbe.yaml
+++ b/releasenotes/notes/dms_permissions-1287e54dec963bbe.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[DMS]** Add new resource ``resource/opentelekomcloud_dms_user_permission_v1`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Introduce new `resource/opentelekomcloud_dms_user_permission_v1` to manage DMS user permissions.

## PR Checklist

* [x] Refers to: #2166
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccDmsUsersPermissionsV1_basic
--- PASS: TestAccDmsUsersPermissionsV1_basic (559.45s)
PASS

Process finished with the exit code 0
```
