### PR TITLE
S3 tests fix

### DIFF
--- a/opentelekomcloud/acceptance/s3/resource_opentelekomcloud_s3_bucket_object_test.go
+++ b/opentelekomcloud/acceptance/s3/resource_opentelekomcloud_s3_bucket_object_test.go
@@ -389,10 +389,11 @@ func TestResourceS3BucketObjectAcl_validation(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.Value, func(t *testing.T) {
+			tx := tc
 			t.Parallel()
-			_, errors := s3s.ValidateS3BucketObjectAclType(tc.Value, "acl")
-			if len(errors) != tc.ErrCount {
-				t.Fatalf("Expected to trigger %d validation errors, but got %d", tc.ErrCount, len(errors))
+			_, errors := s3s.ValidateS3BucketObjectAclType(tx.Value, "acl")
+			if len(errors) != tx.ErrCount {
+				t.Fatalf("Expected to trigger %d validation errors, but got %d", tx.ErrCount, len(errors))
 			}
 		})
 	}
@@ -421,9 +422,10 @@ func TestResourceS3BucketObjectStorageClass_validation(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.Value, func(t *testing.T) {
+			tx := tc
 			t.Parallel()
-			_, errors := validateS3BucketObjectStorageClassType(tc.Value, "storage_class")
-			if len(errors) != tc.ErrCount {
+			_, errors := validateS3BucketObjectStorageClassType(tx.Value, "storage_class")
+			if len(errors) != tx.ErrCount {
 				t.Fatalf("Expected not to trigger a validation error")
 			}
 		})


### PR DESCRIPTION
## Summary of the Pull Request
Fix S3 tests for linters.

## Acceptance Steps Performed

```
=== RUN   TestResourceS3BucketObjectStorageClass_validation
=== PAUSE TestResourceS3BucketObjectStorageClass_validation
=== CONT  TestResourceS3BucketObjectStorageClass_validation
--- PASS: TestResourceS3BucketObjectStorageClass_validation (0.00s)
=== RUN   TestResourceS3BucketObjectStorageClass_validation/incorrect
=== PAUSE TestResourceS3BucketObjectStorageClass_validation/incorrect
=== CONT  TestResourceS3BucketObjectStorageClass_validation/incorrect
    --- PASS: TestResourceS3BucketObjectStorageClass_validation/incorrect (0.00s)
=== RUN   TestResourceS3BucketObjectStorageClass_validation/STANDARD
=== PAUSE TestResourceS3BucketObjectStorageClass_validation/STANDARD
=== CONT  TestResourceS3BucketObjectStorageClass_validation/STANDARD
    --- PASS: TestResourceS3BucketObjectStorageClass_validation/STANDARD (0.00s)
=== RUN   TestResourceS3BucketObjectStorageClass_validation/REDUCED_REDUNDANCY
=== PAUSE TestResourceS3BucketObjectStorageClass_validation/REDUCED_REDUNDANCY
=== CONT  TestResourceS3BucketObjectStorageClass_validation/REDUCED_REDUNDANCY
    --- PASS: TestResourceS3BucketObjectStorageClass_validation/REDUCED_REDUNDANCY (0.00s)
PASS

Process finished with the exit code 0

```
