### PR TITLE
[WAF]: alarm page enhancement

### DIFF
--- a/docs/resources/waf_domain_v1.md
+++ b/docs/resources/waf_domain_v1.md
@@ -12,6 +12,8 @@ Manages a WAF domain resource within OpenTelekomCloud.
 ## Example Usage
 
 ```hcl
+variable "content" {}
+
 resource "opentelekomcloud_waf_certificate_v1" "certificate_1" {
   name    = "cert_1"
   content = "-----BEGIN CERTIFICATE-----MIIDIjCCAougAwIBAgIJALV96mEtVF4EMA0GCSqGSIb3DQEBBQUAMGoxCzAJBgNVBAYTAnh4MQswCQYDVQQIEwJ4eDELMAkGA1UEBxMCeHgxCzAJBgNVBAoTAnh4MQswCQYDVQQLEwJ-----END CERTIFICATE-----"
@@ -30,6 +32,12 @@ resource "opentelekomcloud_waf_domain_v1" "domain_1" {
   proxy           = true
   sip_header_name = "default"
   sip_header_list = ["X-Forwarded-For"]
+  block_page {
+    template     = "custom"
+    status_code  = "200"
+    content_type = "application/json"
+    content      = var.content
+  }
 }
 ```
 
@@ -44,6 +52,14 @@ The following arguments are supported:
   `front_protocol`/`client_protocol` is set to `HTTPS`.
 
 * `server` - (Required) Array of server object. The server object structure is documented below.
+  The `server` block supports:
+  * `client_protocol` - (Optional) Protocol type of the client. The options are HTTP and HTTPS.
+    Required if `front_protocol` is not set
+  * `server_protocol` - (Optional) Protocol used by WAF to forward client requests to the server.
+    The options are HTTP and HTTPS. Required if `back_protocol` is not set.
+  * `address` - (Required) IP address or domain name of the web server that the client accesses.
+    For example, `192.168.1.1` or `www.bla-bla.com`.
+  * `port` - (Required) Port number used by the web server. The value ranges from `0` to `65535`, for example, `8080`.
 
 * `proxy` - (Required) Specifies whether a proxy is configured.
 
@@ -73,22 +89,18 @@ The following arguments are supported:
 * `tls` - (Optional) Minimum TLS version for accessing the protected domain name  if `client_protocol` is set to `HTTPS`.
   Possible values are: `TLS v1.1` and `TLS v1.2`.
 
-The `server` block supports:
+* `block_page` - (Optional) Alarm page configuration
+  The `block_page` block supports:
+  * `template` - (Required) Template name which can be `default`, `custom` or `redirect`.
 
-* `client_protocol` - (Optional) Protocol type of the client. The options are HTTP and HTTPS.
-  Required if `front_protocol` is not set
+  -> Redirection arguments (`redirect` template):
+  * `redirect_url` - (Optional) URL of the redirected page.
 
-* `front_protocol` **DEPRECATED** - (Optional)  Same as `client_protocol`. Required if `client_protocol` is not set.
-
-* `server_protocol` - (Optional) Protocol used by WAF to forward client requests to the server.
-  The options are HTTP and HTTPS. Required if `back_protocol` is not set.
-
-* `back_protocol` **DEPRECATED** - (Optional) Same as `server_protocol`. Required if `server_protocol` is not set.
-
-* `address` - (Required) IP address or domain name of the web server that the client accesses.
-  For example, `192.168.1.1` or `www.bla-bla.com`.
-
-* `port` - (Required) Port number used by the web server. The value ranges from `0` to `65535`, for example, `8080`.
+  -> Custom alarm page arguments (`custom` template):
+  * `status_code` - (Optional) Status Codes for custom.
+  * `content_type` - (Optional) The content type of the custom alarm page.
+    The value can be `text/html`, `text/xml`, or `application/json`.
+  * `content` - (Optional) The page content based on the selected page type.
 
 ## Attributes Reference
 

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/jinzhu/copier v0.3.5
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.6.3-0.20230607083507-d883fedc6681
+	github.com/opentelekomcloud/gophertelekomcloud v0.6.3-0.20230616113628-6cd56e3a5442
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.1.0
 	golang.org/x/sync v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -209,8 +209,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.6.3-0.20230607083507-d883fedc6681 h1:VPaetUAAJL6+8pRZjDUeS5koxIV4RoZjh6oxHscNiUg=
-github.com/opentelekomcloud/gophertelekomcloud v0.6.3-0.20230607083507-d883fedc6681/go.mod h1:9Deb3q2gJvq5dExV+aX+iO+G+mD9Zr9uFt+YY9ONmq0=
+github.com/opentelekomcloud/gophertelekomcloud v0.6.3-0.20230616113628-6cd56e3a5442 h1:b5BSiwnpXx9orP3zhHB1Sq3ypIjn/WnKGErwmvButXY=
+github.com/opentelekomcloud/gophertelekomcloud v0.6.3-0.20230616113628-6cd56e3a5442/go.mod h1:9Deb3q2gJvq5dExV+aX+iO+G+mD9Zr9uFt+YY9ONmq0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/opentelekomcloud/acceptance/waf/resource_domain_v1_test.go
+++ b/opentelekomcloud/acceptance/waf/resource_domain_v1_test.go
@@ -33,6 +33,7 @@ func TestAccWafDomainV1Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceDomainName, "server.0.server_protocol", "HTTP"),
 					resource.TestCheckResourceAttr(resourceDomainName, "server.0.client_protocol", "HTTPS"),
 					resource.TestCheckResourceAttr(resourceDomainName, "cipher", "cipher_1"),
+					resource.TestCheckResourceAttr(resourceDomainName, "block_page.0.template", "default"),
 				),
 			},
 			{
@@ -42,6 +43,9 @@ func TestAccWafDomainV1Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceDomainName, "hostname", "www.b.com"),
 					resource.TestCheckResourceAttr(resourceDomainName, "sip_header_name", ""),
 					resource.TestCheckResourceAttr(resourceDomainName, "cipher", "cipher_default"),
+					resource.TestCheckResourceAttr(resourceDomainName, "block_page.0.template", "custom"),
+					resource.TestCheckResourceAttr(resourceDomainName, "block_page.0.status_code", "200"),
+					resource.TestCheckResourceAttr(resourceDomainName, "block_page.0.content_type", "application/json"),
 				),
 			},
 			{
@@ -162,10 +166,6 @@ func testAccCheckWafDomainV1CertificateChanged(n string, domain *domains.Domain)
 }
 
 const testAccWafDomainV1Basic = `
-variable "content" {
-	default = "<h1>Hello world</h1>"
-}
-
 resource "opentelekomcloud_networking_floatingip_v2" "fip_1" {}
 
 resource "opentelekomcloud_waf_certificate_v1" "certificate_1" {
@@ -198,17 +198,17 @@ resource "opentelekomcloud_waf_domain_v1" "domain_1" {
   proxy           = true
   sip_header_name = "default"
   sip_header_list = ["X-Forwarded-For"]
-
   block_page {
-  	template = "custom"
-	status_code = "200"
-    content_type = "application/json"
-    content = var.content
+    template = "default"
   }
 }
 `
 
 const testAccWafDomainV1Update = `
+variable "content" {
+  default = "<h1>Hello world</h1>"
+}
+
 resource "opentelekomcloud_networking_floatingip_v2" "fip_1" {}
 
 resource "opentelekomcloud_waf_certificate_v1" "certificate_1" {
@@ -243,8 +243,12 @@ resource "opentelekomcloud_waf_domain_v1" "domain_1" {
   certificate_id = opentelekomcloud_waf_certificate_v1.certificate_1.id
   policy_id      = opentelekomcloud_waf_policy_v1.policy_2.id
   proxy          = false
+
   block_page {
-  	template = "default"
+    template     = "custom"
+    status_code  = "200"
+    content_type = "application/json"
+    content      = var.content
   }
 }
 `
@@ -281,5 +285,8 @@ resource "opentelekomcloud_waf_domain_v1" "domain_1" {
   certificate_id = opentelekomcloud_waf_certificate_v1.certificate_2.id
   policy_id      = opentelekomcloud_waf_policy_v1.policy_2.id
   proxy          = false
+  block_page {
+    template = "default"
+  }
 }
 `

--- a/opentelekomcloud/acceptance/waf/resource_domain_v1_test.go
+++ b/opentelekomcloud/acceptance/waf/resource_domain_v1_test.go
@@ -162,6 +162,10 @@ func testAccCheckWafDomainV1CertificateChanged(n string, domain *domains.Domain)
 }
 
 const testAccWafDomainV1Basic = `
+variable "content" {
+	default = "<h1>Hello world</h1>"
+}
+
 resource "opentelekomcloud_networking_floatingip_v2" "fip_1" {}
 
 resource "opentelekomcloud_waf_certificate_v1" "certificate_1" {
@@ -194,6 +198,13 @@ resource "opentelekomcloud_waf_domain_v1" "domain_1" {
   proxy           = true
   sip_header_name = "default"
   sip_header_list = ["X-Forwarded-For"]
+
+  block_page {
+  	template = "custom"
+	status_code = "200"
+    content_type = "application/json"
+    content = var.content
+  }
 }
 `
 
@@ -232,6 +243,9 @@ resource "opentelekomcloud_waf_domain_v1" "domain_1" {
   certificate_id = opentelekomcloud_waf_certificate_v1.certificate_1.id
   policy_id      = opentelekomcloud_waf_policy_v1.policy_2.id
   proxy          = false
+  block_page {
+  	template = "default"
+  }
 }
 `
 

--- a/opentelekomcloud/services/waf/resource_domain_v1.go
+++ b/opentelekomcloud/services/waf/resource_domain_v1.go
@@ -83,6 +83,39 @@ func ResourceWafDomainV1() *schema.Resource {
 					},
 				},
 			},
+			"block_page": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"template": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"redirect_url": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"status_code": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"content_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"content": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+			},
 			"tls": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -229,6 +262,24 @@ func resourceWafDomainV1Create(ctx context.Context, d *schema.ResourceData, meta
 		}
 	}
 
+	if blockPage, ok := d.GetOk("block_page"); ok {
+		blockItem := blockPage.(*schema.Set).List()[0].(map[string]interface{})
+		updateOpts := domains.UpdateOpts{
+			BlockPage: &domains.BlockPage{
+				Template:    blockItem["template"].(string),
+				RedirectUrl: blockItem["redirect_url"].(string),
+				CustomPage: &domains.CustomPage{
+					Content:     blockItem["content"].(string),
+					ContentType: blockItem["content_type"].(string),
+					StatusCode:  blockItem["status_code"].(string),
+				},
+			},
+		}
+		if _, err := domains.Update(client, d.Id(), updateOpts).Extract(); err != nil {
+			return fmterr.Errorf("error updating alarm page configuration: %w", err)
+		}
+	}
+
 	return resourceWafDomainV1Read(ctx, d, meta)
 }
 
@@ -272,8 +323,22 @@ func resourceWafDomainV1Read(_ context.Context, d *schema.ResourceData, meta int
 		servers[i]["address"] = server.Address
 		servers[i]["port"] = strconv.Itoa(server.Port)
 	}
+
+	blockPage := []map[string]interface{}{
+		{
+			"template":     n.BlockPage.Template,
+			"redirect_url": n.BlockPage.RedirectUrl,
+		},
+	}
+
+	if n.BlockPage.CustomPage != nil {
+		blockPage[0]["status_code"] = n.BlockPage.CustomPage.StatusCode
+		blockPage[0]["content_type"] = n.BlockPage.CustomPage.ContentType
+		blockPage[0]["content"] = n.BlockPage.CustomPage.Content
+	}
+
 	mErr = multierror.Append(mErr,
-		d.Set("server", servers),
+		d.Set("block_page", blockPage),
 	)
 	if err := mErr.ErrorOrNil(); err != nil {
 		return fmterr.Errorf("error setting WAF fields: %w", err)
@@ -322,6 +387,21 @@ func resourceWafDomainV1Update(ctx context.Context, d *schema.ResourceData, meta
 	if d.HasChange("tls") {
 		tls := d.Get("tls").(string)
 		updateOpts.TLS = tls
+	}
+	if d.HasChange("block_page") {
+		blockPage := d.Get("block_page")
+		blockItem := blockPage.(*schema.Set).List()[0].(map[string]interface{})
+		updateOpts.BlockPage = &domains.BlockPage{
+			Template:    blockItem["template"].(string),
+			RedirectUrl: blockItem["redirect_url"].(string),
+		}
+		if blockItem["content"].(string) != "" {
+			updateOpts.BlockPage.CustomPage = &domains.CustomPage{
+				Content:     blockItem["content"].(string),
+				ContentType: blockItem["content_type"].(string),
+				StatusCode:  blockItem["status_code"].(string),
+			}
+		}
 	}
 	log.Printf("[DEBUG] updateOpts: %#v", updateOpts)
 

--- a/releasenotes/notes/waf_alarm_page-2fcbc25932b47162.yaml
+++ b/releasenotes/notes/waf_alarm_page-2fcbc25932b47162.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    **[WAF]** Alarm page configuration added for ``resource/opentelekomcloud_waf_domain_v1``
+    (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)

--- a/releasenotes/notes/waf_alarm_page-2fcbc25932b47162.yaml
+++ b/releasenotes/notes/waf_alarm_page-2fcbc25932b47162.yaml
@@ -2,4 +2,4 @@
 enhancements:
   - |
     **[WAF]** Alarm page configuration added for ``resource/opentelekomcloud_waf_domain_v1``
-    (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    (`#2192 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2192>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Alarm page configuration added via ``resource/opentelekomcloud_waf_domain_v1``.

## PR Checklist

* [x] Refers to: #1911
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccWafDomainV1Basic
--- PASS: TestAccWafDomainV1Basic (81.46s)
PASS

Process finished with the exit code 0
```
