### PR TITLE
[RDS] AZ switchover and backup strategy fix in `resource/opentelekomcloud_rds_instance_v3`

### DIFF
--- a/docs/resources/rds_instance_v3.md
+++ b/docs/resources/rds_instance_v3.md
@@ -434,6 +434,8 @@ The `restore_point` block supports:
 
 In addition to the arguments listed above, the following computed attributes are exported:
 
+* `availability_zones` - Indicates the instance AZs.
+
 * `created` - Indicates the creation time.
 
 * `nodes` - Indicates the instance nodes information. Structure is documented below.

--- a/opentelekomcloud/acceptance/rds/import_opentelekomcloud_rds_instance_v3_test.go
+++ b/opentelekomcloud/acceptance/rds/import_opentelekomcloud_rds_instance_v3_test.go
@@ -28,6 +28,7 @@ func TestAccRdsInstanceV3_importBasic(t *testing.T) {
 				ImportStateVerifyIgnore: []string{
 					"db",
 					"availability_zone",
+					"tags",
 				},
 			},
 		},

--- a/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
+++ b/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
@@ -181,17 +181,6 @@ func TestAccRdsInstanceV3HA(t *testing.T) {
 					resource.TestCheckResourceAttr(instanceV3ResourceName, "availability_zones.#", "2"),
 				),
 			},
-			{
-				Config: testAccRdsInstanceV3HAUpdate(postfix, availabilityZone2),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRdsInstanceV3Exists(instanceV3ResourceName, &rdsInstance),
-					resource.TestCheckResourceAttr(instanceV3ResourceName, "name", "tf_rds_instance_"+postfix),
-					resource.TestCheckResourceAttr(instanceV3ResourceName, "ha_replication_mode", "semisync"),
-					resource.TestCheckResourceAttr(instanceV3ResourceName, "volume.0.type", "ULTRAHIGH"),
-					resource.TestCheckResourceAttr(instanceV3ResourceName, "db.0.type", "MySQL"),
-					resource.TestCheckResourceAttr(instanceV3ResourceName, "availability_zones.#", "2"),
-				),
-			},
 		},
 	})
 }
@@ -523,37 +512,6 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
   backup_strategy {
     start_time = "08:00-09:00"
     keep_days  = 1
-  }
-  ha_replication_mode = "semisync"
-}
-`, common.DataSourceSecGroupDefault, common.DataSourceSubnet, postfix, env.OS_AVAILABILITY_ZONE, az2)
-}
-
-func testAccRdsInstanceV3HAUpdate(postfix string, az2 string) string {
-	return fmt.Sprintf(`
-%s
-%s
-
-resource "opentelekomcloud_rds_instance_v3" "instance" {
-  name              = "tf_rds_instance_%s"
-  availability_zone = ["%s", "%s"]
-  db {
-    password = "MySql!120521"
-    type     = "MySQL"
-    version  = "5.6"
-    port     = "8635"
-  }
-  security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
-  subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
-  vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
-  volume {
-    type = "ULTRAHIGH"
-    size = 100
-  }
-  flavor = "rds.mysql.s1.large.ha"
-  backup_strategy {
-    start_time = "18:00-19:00"
-    keep_days  = 2
   }
   ha_replication_mode = "semisync"
 }

--- a/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
+++ b/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
@@ -178,6 +178,18 @@ func TestAccRdsInstanceV3HA(t *testing.T) {
 					resource.TestCheckResourceAttr(instanceV3ResourceName, "ha_replication_mode", "semisync"),
 					resource.TestCheckResourceAttr(instanceV3ResourceName, "volume.0.type", "ULTRAHIGH"),
 					resource.TestCheckResourceAttr(instanceV3ResourceName, "db.0.type", "MySQL"),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "availability_zones.#", "2"),
+				),
+			},
+			{
+				Config: testAccRdsInstanceV3HAUpdate(postfix, availabilityZone2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRdsInstanceV3Exists(instanceV3ResourceName, &rdsInstance),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "name", "tf_rds_instance_"+postfix),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "ha_replication_mode", "semisync"),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "volume.0.type", "ULTRAHIGH"),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "db.0.type", "MySQL"),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "availability_zones.#", "2"),
 				),
 			},
 		},
@@ -511,6 +523,37 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
   backup_strategy {
     start_time = "08:00-09:00"
     keep_days  = 1
+  }
+  ha_replication_mode = "semisync"
+}
+`, common.DataSourceSecGroupDefault, common.DataSourceSubnet, postfix, env.OS_AVAILABILITY_ZONE, az2)
+}
+
+func testAccRdsInstanceV3HAUpdate(postfix string, az2 string) string {
+	return fmt.Sprintf(`
+%s
+%s
+
+resource "opentelekomcloud_rds_instance_v3" "instance" {
+  name              = "tf_rds_instance_%s"
+  availability_zone = ["%s", "%s"]
+  db {
+    password = "MySql!120521"
+    type     = "MySQL"
+    version  = "5.6"
+    port     = "8635"
+  }
+  security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
+  subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  volume {
+    type = "ULTRAHIGH"
+    size = 100
+  }
+  flavor = "rds.mysql.s1.large.ha"
+  backup_strategy {
+    start_time = "18:00-19:00"
+    keep_days  = 2
   }
   ha_replication_mode = "semisync"
 }

--- a/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_instance_v3.go
+++ b/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_instance_v3.go
@@ -182,20 +182,17 @@ func ResourceRdsInstanceV3() *schema.Resource {
 				Type:     schema.TypeList,
 				Computed: true,
 				Optional: true,
-				ForceNew: false,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"start_time": {
 							Type:     schema.TypeString,
 							Required: true,
-							ForceNew: false,
 						},
 						"keep_days": {
 							Type:     schema.TypeInt,
 							Computed: true,
 							Optional: true,
-							ForceNew: false,
 						},
 					},
 				},
@@ -281,6 +278,13 @@ func ResourceRdsInstanceV3() *schema.Resource {
 			"ssl_enable": {
 				Type:     schema.TypeBool,
 				Optional: true,
+			},
+			"availability_zones": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
 			},
 		},
 	}
@@ -370,6 +374,7 @@ func resourceRdsInstanceV3Create(ctx context.Context, d *schema.ResourceData, me
 		dbPortString = ""
 	}
 
+	datastore := resourceRDSDataStore(d)
 	var r *instances.CreateRds
 	if _, ok := d.GetOk("restore_point"); ok {
 		restoreOpts := backups.RestoreToNewOpts{
@@ -396,7 +401,7 @@ func resourceRdsInstanceV3Create(ctx context.Context, d *schema.ResourceData, me
 	} else {
 		createOpts := instances.CreateRdsOpts{
 			Name:             d.Get("name").(string),
-			Datastore:        resourceRDSDataStore(d),
+			Datastore:        datastore,
 			Ha:               resourceRDSHa(d),
 			ConfigurationId:  d.Get("param_group_id").(string),
 			Port:             dbPortString,
@@ -462,6 +467,22 @@ func resourceRdsInstanceV3Create(ctx context.Context, d *schema.ResourceData, me
 			if err := tags.Create(client, "instances", r.Instance.Id, tagList).ExtractErr(); err != nil {
 				return fmterr.Errorf("error setting tags of RDSv3 instance: %w", err)
 			}
+		}
+	}
+
+	var backupOpts backups.UpdateOpts
+
+	// workaround for https://jira.tsi-dev.otc-service.com/browse/BM-2388
+	if strings.ToLower(datastore.Type) == "postgresql" && common.HasFilledOpt(d, "backup_strategy") {
+		backupRaw := resourceRDSBackupStrategy(d)
+		backupOpts.KeepDays = backupRaw.KeepDays
+		backupOpts.StartTime = backupRaw.StartTime
+		backupOpts.Period = "1,2,3,4,5,6,7"
+		backupOpts.InstanceId = d.Id()
+		log.Printf("[DEBUG] Backup Strategy Opts: %#v", backupOpts)
+
+		if err = backups.Update(client, backupOpts); err != nil {
+			return fmterr.Errorf("error updating OpenTelekomCloud RDSv3 Backup Strategy: %s", err)
 		}
 	}
 
@@ -1080,7 +1101,7 @@ func resourceRdsInstanceV3Read(ctx context.Context, d *schema.ResourceData, meta
 		fmterr.Errorf("RDSv3 instance expects 1 or 2 nodes, but got %d", n)
 	}
 
-	if err := d.Set("availability_zone", availabilityZones); err != nil {
+	if err := d.Set("availability_zones", availabilityZones); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/releasenotes/notes/rdsv3-switchover-fix-3cf96ef10cb26c1d.yaml
+++ b/releasenotes/notes/rdsv3-switchover-fix-3cf96ef10cb26c1d.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    **[RDS]** Fix forcing update after switchover by storing `azs` in computed attribute `availability_zones` in ``resource/opentelekomcloud_rds_instance_v3`` (`#2194 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2194>`_)
+  - |
+    **[RDS]** Temporary fix for PostrgeSQL failed `backup_strategy` setting of `start_time` in ``resource/opentelekomcloud_rds_instance_v3`` (`#2194 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2194>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Now storing azs info in availability_zones param instead of availability_zone which is with forceNew flag.

Also added workaround for https://jira.tsi-dev.otc-service.com/browse/BM-2388.

## PR Checklist

* [x] Refers to: #2191
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccRdsInstanceV3Basic
--- PASS: TestAccRdsInstanceV3Basic (813.42s)
=== RUN   TestAccRdsPostgre13V3ParamsBasic
--- PASS: TestAccRdsPostgre13V3ParamsBasic (575.98s)
=== RUN   TestAccRdsInstanceV3RestoreBackup
--- PASS: TestAccRdsInstanceV3RestoreBackup (1015.33s)
=== RUN   TestAccRdsInstanceV3ElasticIP
--- PASS: TestAccRdsInstanceV3ElasticIP (472.32s)
=== RUN   TestAccRdsInstanceV3HA
--- PASS: TestAccRdsInstanceV3HA (383.51s)
=== RUN   TestAccRdsInstanceV3OptionalParams
--- PASS: TestAccRdsInstanceV3OptionalParams (385.60s)
=== RUN   TestAccRdsInstanceV3Backup
--- PASS: TestAccRdsInstanceV3Backup (393.61s)
=== RUN   TestAccRdsInstanceV3TemplateConfig
--- PASS: TestAccRdsInstanceV3TemplateConfig (541.17s)
=== RUN   TestAccRdsInstanceV3InvalidDBVersion
--- PASS: TestAccRdsInstanceV3InvalidDBVersion (9.30s)
=== RUN   TestAccRdsInstanceV3InvalidFlavor
--- PASS: TestAccRdsInstanceV3InvalidFlavor (9.80s)
=== RUN   TestAccRdsInstanceV3_configurationParameters
--- PASS: TestAccRdsInstanceV3_configurationParameters (513.40s)
```
