### PR TITLE
[VPC] icmp any in `resource/opentelekomcloud_networking_secgroup_rule_v2`

### DIFF
--- a/docs/resources/networking_secgroup_rule_v2.md
+++ b/docs/resources/networking_secgroup_rule_v2.md
@@ -30,6 +30,50 @@ resource "opentelekomcloud_networking_secgroup_rule_v2" "secgroup_rule_1" {
 }
 ```
 
+## Example ICMP
+ICMP port codes you can get at:
+`https://docs.otc.t-systems.com/virtual-private-cloud/api-ref/appendix/icmp-port_range_relationship_table.html`.
+
+But for `Any` values must be:
+* `port_range_min` = 0
+* `port_range_max` = 255
+
+#### Echo
+```hcl
+resource "opentelekomcloud_networking_secgroup_v2" "secgroup_1" {
+  name        = "secgroup_1"
+  description = "My neutron security group"
+}
+
+resource "opentelekomcloud_networking_secgroup_rule_v2" "secgroup_rule_icmp_echo_reply" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "icmp"
+  port_range_min    = 0
+  port_range_max    = 0
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = opentelekomcloud_networking_secgroup_v2.secgroup_1.id
+}
+```
+
+#### Any
+```hcl
+resource "opentelekomcloud_networking_secgroup_v2" "secgroup_1" {
+  name        = "secgroup_1"
+  description = "My neutron security group"
+}
+
+resource "opentelekomcloud_networking_secgroup_rule_v2" "secgroup_rule_icmp_any" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "icmp"
+  port_range_min    = 0
+  port_range_max    = 255
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = opentelekomcloud_networking_secgroup_v2.secgroup_1.id
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -50,11 +94,13 @@ The following arguments are supported:
 
 * `port_range_min` - (Optional) The lower part of the allowed port range, valid
   integer value needs to be between 1 and 65535. Changing this creates a new
-  security group rule.
+  security group rule. When ICMP is used, the value is the ICMP code
+  (The value ranges from 0 to 255 when it indicates the code).
 
 * `port_range_max` - (Optional) The higher part of the allowed port range, valid
   integer value needs to be between 1 and 65535. Changing this creates a new
-  security group rule.
+  security group rule. When ICMP is used, the value is the ICMP code
+  (The value ranges from 0 to 255 when it indicates the code).
 
 * `remote_ip_prefix` - (Optional) The remote CIDR, the value needs to be a valid
   CIDR (i.e. 192.168.0.0/16). Changing this creates a new security group rule.

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/jinzhu/copier v0.3.5
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.6.3-0.20230616113628-6cd56e3a5442
+	github.com/opentelekomcloud/gophertelekomcloud v0.6.3-0.20230621145858-35930a8cab9c
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.1.0
 	golang.org/x/sync v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -209,8 +209,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.6.3-0.20230616113628-6cd56e3a5442 h1:b5BSiwnpXx9orP3zhHB1Sq3ypIjn/WnKGErwmvButXY=
-github.com/opentelekomcloud/gophertelekomcloud v0.6.3-0.20230616113628-6cd56e3a5442/go.mod h1:9Deb3q2gJvq5dExV+aX+iO+G+mD9Zr9uFt+YY9ONmq0=
+github.com/opentelekomcloud/gophertelekomcloud v0.6.3-0.20230621145858-35930a8cab9c h1:B7oerzOG5p6oi3YtgJvuFUda5eXBUtx2X5Dj3O3VzCA=
+github.com/opentelekomcloud/gophertelekomcloud v0.6.3-0.20230621145858-35930a8cab9c/go.mod h1:9Deb3q2gJvq5dExV+aX+iO+G+mD9Zr9uFt+YY9ONmq0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_secgroup_rule_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_secgroup_rule_v2_test.go
@@ -156,7 +156,27 @@ func TestAccNetworkingV2SecGroupRule_ICMP(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkingV2SecGroupRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkingV2SecGroupRuleICMP,
+				Config: testAccNetworkingV2SecGroupRuleICMPEchoReply,
+				Check: resource.ComposeTestCheckFunc(
+					TestAccCheckNetworkingV2SecGroupExists(resourceNwSecGroupName, &secgroup1),
+					testAccCheckNetworkingV2SecGroupRuleExists(resourceNwSGRuleName, &secgroupRule1),
+					resource.TestCheckResourceAttr(resourceNwSGRuleName, "direction", "ingress"),
+					resource.TestCheckResourceAttr(resourceNwSGRuleName, "port_range_min", "0"),
+					resource.TestCheckResourceAttr(resourceNwSGRuleName, "port_range_max", "0"),
+				),
+			},
+			{
+				Config: testAccNetworkingV2SecGroupRuleICMPAll,
+				Check: resource.ComposeTestCheckFunc(
+					TestAccCheckNetworkingV2SecGroupExists(resourceNwSecGroupName, &secgroup1),
+					testAccCheckNetworkingV2SecGroupRuleExists(resourceNwSGRuleName, &secgroupRule1),
+					resource.TestCheckResourceAttr(resourceNwSGRuleName, "direction", "ingress"),
+					resource.TestCheckResourceAttr(resourceNwSGRuleName, "port_range_min", "0"),
+					resource.TestCheckResourceAttr(resourceNwSGRuleName, "port_range_max", "255"),
+				),
+			},
+			{
+				Config: testAccNetworkingV2SecGroupRuleICMPEcho,
 				Check: resource.ComposeTestCheckFunc(
 					TestAccCheckNetworkingV2SecGroupExists(resourceNwSecGroupName, &secgroup1),
 					testAccCheckNetworkingV2SecGroupRuleExists(resourceNwSGRuleName, &secgroupRule1),
@@ -340,7 +360,23 @@ resource "opentelekomcloud_networking_secgroup_rule_v2" "secgroup_rule_1" {
 }
 `
 
-const testAccNetworkingV2SecGroupRuleICMP = `
+const testAccNetworkingV2SecGroupRuleError = `
+resource "opentelekomcloud_networking_secgroup_v2" "secgroup_1" {
+  name        = "secgroup_1"
+  description = "terraform security group rule acceptance test"
+}
+
+resource "opentelekomcloud_networking_secgroup_rule_v2" "secgroup_rule_1" {
+  direction         = "egress"
+  ethertype         = "IPv4"
+  remote_ip_prefix  = "0.0.0.0/0"
+  port_range_min    = 0
+  port_range_max    = 22
+  security_group_id = opentelekomcloud_networking_secgroup_v2.secgroup_1.id
+}
+`
+
+const testAccNetworkingV2SecGroupRuleICMPEcho = `
 resource "opentelekomcloud_networking_secgroup_v2" "secgroup_1" {
   name        = "secgroup_1"
   description = "terraform security group rule acceptance test"
@@ -357,18 +393,38 @@ resource "opentelekomcloud_networking_secgroup_rule_v2" "secgroup_rule_1" {
 }
 `
 
-const testAccNetworkingV2SecGroupRuleError = `
+const testAccNetworkingV2SecGroupRuleICMPAll = `
 resource "opentelekomcloud_networking_secgroup_v2" "secgroup_1" {
   name        = "secgroup_1"
   description = "terraform security group rule acceptance test"
 }
 
 resource "opentelekomcloud_networking_secgroup_rule_v2" "secgroup_rule_1" {
-  direction         = "egress"
+  description       = "all ICMP ports"
+  direction         = "ingress"
   ethertype         = "IPv4"
+  protocol          = "icmp"
+  port_range_min    = null
+  port_range_max    = null
   remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = opentelekomcloud_networking_secgroup_v2.secgroup_1.id
+}
+`
+
+const testAccNetworkingV2SecGroupRuleICMPEchoReply = `
+resource "opentelekomcloud_networking_secgroup_v2" "secgroup_1" {
+  name        = "secgroup_1"
+  description = "terraform security group rule acceptance test"
+}
+
+resource "opentelekomcloud_networking_secgroup_rule_v2" "secgroup_rule_1" {
+  description       = "echo ICMP"
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "icmp"
   port_range_min    = 0
-  port_range_max    = 22
+  port_range_max    = 0
+  remote_ip_prefix  = "0.0.0.0/0"
   security_group_id = opentelekomcloud_networking_secgroup_v2.secgroup_1.id
 }
 `

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_secgroup_rule_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_secgroup_rule_v2_test.go
@@ -404,8 +404,8 @@ resource "opentelekomcloud_networking_secgroup_rule_v2" "secgroup_rule_1" {
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "icmp"
-  port_range_min    = null
-  port_range_max    = null
+  port_range_min    = 0
+  port_range_max    = 255
   remote_ip_prefix  = "0.0.0.0/0"
   security_group_id = opentelekomcloud_networking_secgroup_v2.secgroup_1.id
 }

--- a/opentelekomcloud/services/vpc/resource_opentelekomcloud_networking_secgroup_rule_v2.go
+++ b/opentelekomcloud/services/vpc/resource_opentelekomcloud_networking_secgroup_rule_v2.go
@@ -143,9 +143,9 @@ func resourceNetworkingSecGroupRuleV2Create(ctx context.Context, d *schema.Resou
 		opts.PortRangeMax = &portRangeMax
 		opts.Protocol = protocol
 		if opts.Protocol == rules.ProtocolICMP {
-			if checkNull(d, "port_range_min") && checkNull(d, "port_range_max") {
-				opts.PortRangeMin = pointerto.Int(0)
-				opts.PortRangeMax = pointerto.Int(255)
+			if portRangeMin == 0 && portRangeMax == 255 {
+				opts.PortRangeMin = nil
+				opts.PortRangeMax = nil
 			}
 		}
 	}
@@ -343,9 +343,4 @@ func waitForSecGroupRuleDelete(client *golangsdk.ServiceClient, secGroupRuleId s
 		log.Printf("[DEBUG] OpenTelekomCloud Neutron Security Group Rule %s still active.\n", secGroupRuleId)
 		return r, "ACTIVE", nil
 	}
-}
-
-func checkNull(d *schema.ResourceData, value string) bool {
-	raw := d.GetRawConfig()
-	return raw.GetAttr(value).IsNull()
 }

--- a/releasenotes/notes/vpc-networking-sg-icmp-any-fix-fb07369d039f188f.yaml
+++ b/releasenotes/notes/vpc-networking-sg-icmp-any-fix-fb07369d039f188f.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[VPC]** Fix ICMP `any` secgroup rule creation ``resource/opentelekomcloud_networking_secgroup_rule_v2`` (`#2197 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2197>`_)


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [x] Refers to: #2195
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccNetworkingV2SecGroupRule_basic
=== PAUSE TestAccNetworkingV2SecGroupRule_basic
=== CONT  TestAccNetworkingV2SecGroupRule_basic
--- PASS: TestAccNetworkingV2SecGroupRule_basic (54.77s)
=== RUN   TestAccNetworkingV2SecGroupRule_importBasic
=== PAUSE TestAccNetworkingV2SecGroupRule_importBasic
=== CONT  TestAccNetworkingV2SecGroupRule_importBasic
--- PASS: TestAccNetworkingV2SecGroupRule_importBasic (61.23s)
=== RUN   TestAccNetworkingV2SecGroupRule_timeout
=== PAUSE TestAccNetworkingV2SecGroupRule_timeout
=== CONT  TestAccNetworkingV2SecGroupRule_timeout
--- PASS: TestAccNetworkingV2SecGroupRule_timeout (54.78s)
=== RUN   TestAccNetworkingV2SecGroupRule_numericProtocol
=== PAUSE TestAccNetworkingV2SecGroupRule_numericProtocol
=== CONT  TestAccNetworkingV2SecGroupRule_numericProtocol
--- PASS: TestAccNetworkingV2SecGroupRule_numericProtocol (54.46s)
=== RUN   TestAccNetworkingV2SecGroupRule_noPorts
=== PAUSE TestAccNetworkingV2SecGroupRule_noPorts
=== CONT  TestAccNetworkingV2SecGroupRule_noPorts
--- PASS: TestAccNetworkingV2SecGroupRule_noPorts (54.33s)
=== RUN   TestAccNetworkingV2SecGroupRule_ICMP
=== PAUSE TestAccNetworkingV2SecGroupRule_ICMP
=== CONT  TestAccNetworkingV2SecGroupRule_ICMP
--- PASS: TestAccNetworkingV2SecGroupRule_ICMP (132.69s)
=== RUN   TestAccNetworkingV2SecGroupRule_noProtocolError
--- PASS: TestAccNetworkingV2SecGroupRule_noProtocolError (9.26s)
PASS


Process finished with the exit code 0
```
