### PR TITLE
[CTS]: `opentelekomcloud_cts_tracker_v3` resource for SWISSCLOUD

### DIFF
--- a/docs/resources/cts_tracker_v3.md
+++ b/docs/resources/cts_tracker_v3.md
@@ -1,0 +1,71 @@
+---
+subcategory: "Cloud Trace Service (CTS)"
+---
+
+Up-to-date reference of API arguments for CTS tracker you can get at
+`https://docs.sc.otc.t-systems.com/api/cts/cts_api_0201.html`.
+
+# opentelekomcloud_cts_tracker_v3
+
+Allows you to collect, store, and query cloud resource operation records.
+
+~> **Warning** `opentelekomcloud_cts_tracker_v3` is only available for `SWISSCLOUD` region.
+
+-> A single tracker can be created for current CTS version.
+
+## Example Usage
+
+```hcl
+variable "bucket_name" {}
+
+resource "opentelekomcloud_cts_tracker_v3" "tracker_v3" {
+  bucket_name      = var.bucket_name
+  file_prefix_name = "prefix"
+  is_lts_enabled   = true
+  status           = enabled
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `status` - (Required) Specifies whether tracker is `enabled` or `disabled`.
+
+* `is_lts_enabled` - (Optional) Specifies whether to enable trace analysis.
+
+* `bucket_name` - (Optional) The OBS bucket name for a tracker.
+
+* `file_prefix_name` - (Optional) The prefix of a log that needs to be stored in an OBS bucket.
+
+* `is_obs_created` - (Optional) Specifies whether the OBS bucket is automatically created by the tracker.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `tracker_name` - The tracker name. Currently, only tracker `system` is available.
+
+* `tracker_type` - The tracker type. Currently, only tracker `system` is available.
+
+* `id` - Specifies the tracker id.
+
+* `domain_id` - Specifies domain id of the tracker.
+
+* `project_id` - Specifies project id of the tracker.
+
+* `log_group_name` - Specifies LTS log group name.
+
+* `log_topic_name` - Specifies LTS log stream.
+
+* `detail` - Specifies the cause of the abnormal status, and its value in case of errors.
+
+* `bucket_lifecycle` - Specifies the duration that traces are stored in the OBS bucket.
+
+## Import
+
+CTS tracker can be imported using `tracker_name`, e.g.
+
+```shell
+$ terraform import opentelekomcloud_cts_tracker_v3.tracker system
+```

--- a/opentelekomcloud/acceptance/cts/resource_opentelekomcloud_cts_tracker_v3_test.go
+++ b/opentelekomcloud/acceptance/cts/resource_opentelekomcloud_cts_tracker_v3_test.go
@@ -170,7 +170,7 @@ resource "opentelekomcloud_cts_tracker_v3" "tracker_v3" {
   bucket_name      = opentelekomcloud_obs_bucket.bucket.bucket
   file_prefix_name = "yO8Q1"
   is_lts_enabled   = false
-  status = "enabled"
+  status           = "enabled"
 }
 `, bucketName)
 }

--- a/opentelekomcloud/acceptance/cts/resource_opentelekomcloud_cts_tracker_v3_test.go
+++ b/opentelekomcloud/acceptance/cts/resource_opentelekomcloud_cts_tracker_v3_test.go
@@ -1,0 +1,176 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/cts/v3/tracker"
+
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+)
+
+const trackerV3Resource = "opentelekomcloud_cts_tracker_v3.tracker_v3"
+
+func TestAccCTSTrackerV3_basic(t *testing.T) {
+	var ctsTracker tracker.Tracker
+	var bucketName = fmt.Sprintf("terra-test-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckCTSTrackerV3Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCTSTrackerV3Basic(bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCTSTrackerV3Exists(trackerV3Resource, &ctsTracker, env.OS_TENANT_NAME),
+					resource.TestCheckResourceAttr(trackerV3Resource, "bucket_name", bucketName),
+					resource.TestCheckResourceAttr(trackerV3Resource, "file_prefix_name", "yO8Q"),
+					resource.TestCheckResourceAttr(trackerV3Resource, "is_lts_enabled", "false"),
+					resource.TestCheckResourceAttr(trackerV3Resource, "status", "disabled"),
+				),
+			},
+			{
+				Config: testAccCTSTrackerV3Update(bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCTSTrackerV3Exists(trackerV3Resource, &ctsTracker, env.OS_TENANT_NAME),
+					resource.TestCheckResourceAttr(trackerV3Resource, "file_prefix_name", "yO8Q1"),
+					resource.TestCheckResourceAttr(trackerV3Resource, "is_lts_enabled", "true"),
+					resource.TestCheckResourceAttr(trackerV3Resource, "status", "enabled"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCTSTrackerV3_importBasic(t *testing.T) {
+	var bucketName = fmt.Sprintf("terra-test-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckCTSTrackerV3Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCTSTrackerV3ImportBasic(bucketName),
+			},
+
+			{
+				ResourceName:      trackerV3Resource,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckCTSTrackerV3Destroy(s *terraform.State) error {
+	config := common.TestAccProvider.Meta().(*cfg.Config)
+	ctsClient, err := config.CtsV3Client(env.OS_TENANT_NAME)
+	if err != nil {
+		return fmt.Errorf("error creating cts client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "opentelekomcloud_cts_tracker_v3" {
+			continue
+		}
+
+		ctsTracker, err := tracker.List(ctsClient, "system")
+		if err != nil {
+			return fmt.Errorf("failed to retrieve CTS list: %s", err)
+		}
+
+		if len(ctsTracker) != 0 {
+			return fmt.Errorf("failed to delete CTS tracker")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckCTSTrackerV3Exists(n string, trackers *tracker.Tracker, projectName cfg.ProjectName) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		config := common.TestAccProvider.Meta().(*cfg.Config)
+		client, err := config.CtsV3Client(projectName)
+		if err != nil {
+			return fmt.Errorf("error creating cts client: %s", err)
+		}
+
+		ctsTracker, err := tracker.List(client, "system")
+		if err != nil {
+			return err
+		}
+
+		if ctsTracker[0].TrackerName != rs.Primary.ID {
+			return fmt.Errorf("CTS tracker not found")
+		}
+
+		trackers = &ctsTracker[0]
+
+		return nil
+	}
+}
+
+func testAccCTSTrackerV3Basic(bucketName string) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_obs_bucket" "bucket" {
+  bucket = "%s"
+  acl    = "public-read"
+}
+
+resource "opentelekomcloud_cts_tracker_v3" "tracker_v3" {
+  bucket_name      = opentelekomcloud_obs_bucket.bucket.bucket
+  file_prefix_name = "yO8Q"
+  status           = "disabled"
+}
+`, bucketName)
+}
+
+func testAccCTSTrackerV3Update(bucketName string) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_obs_bucket" "bucket" {
+  bucket        = "%s"
+  acl           = "public-read"
+  force_destroy = true
+}
+
+resource "opentelekomcloud_cts_tracker_v3" "tracker_v3" {
+  bucket_name      = opentelekomcloud_obs_bucket.bucket.bucket
+  file_prefix_name = "yO8Q1"
+  is_lts_enabled   = true
+  status           = "enabled"
+}
+`, bucketName)
+}
+
+func testAccCTSTrackerV3ImportBasic(bucketName string) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_obs_bucket" "bucket" {
+  bucket        = "%s"
+  acl           = "public-read"
+  force_destroy = true
+}
+
+resource "opentelekomcloud_cts_tracker_v3" "tracker_v3" {
+  bucket_name      = opentelekomcloud_obs_bucket.bucket.bucket
+  file_prefix_name = "yO8Q1"
+  is_lts_enabled   = false
+  status = "enabled"
+}
+`, bucketName)
+}

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -345,6 +345,7 @@ func Provider() *schema.Provider {
 			"opentelekomcloud_csbs_backup_policy_v1":              csbs.ResourceCSBSBackupPolicyV1(),
 			"opentelekomcloud_cts_event_notification_v3":          cts.ResourceCTSEventNotificationV3(),
 			"opentelekomcloud_cts_tracker_v1":                     cts.ResourceCTSTrackerV1(),
+			"opentelekomcloud_cts_tracker_v3":                     cts.ResourceCTSTrackerV3(),
 			"opentelekomcloud_css_cluster_v1":                     css.ResourceCssClusterV1(),
 			"opentelekomcloud_css_snapshot_configuration_v1":      css.ResourceCssSnapshotConfigurationV1(),
 			"opentelekomcloud_dcs_instance_v1":                    dcs.ResourceDcsInstanceV1(),

--- a/opentelekomcloud/services/cts/resource_opentelekomcloud_cts_tracker_v3.go
+++ b/opentelekomcloud/services/cts/resource_opentelekomcloud_cts_tracker_v3.go
@@ -1,0 +1,178 @@
+package cts
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/cts/v3/tracker"
+
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
+)
+
+func ResourceCTSTrackerV3() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceCTSTrackerV3Create,
+		ReadContext:   resourceCTSTrackerV3Read,
+		UpdateContext: resourceCTSTrackerV3Update,
+		DeleteContext: resourceCTSTrackerV3Delete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"is_lts_enabled": {
+				Type:     schema.Bool,
+				ForceNew: true,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"bucket_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"file_prefix_name": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: common.ValidateName,
+			},
+			"is_lts_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"log_group_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"log_topic_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tracker_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tracker_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceCTSTrackerV3Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := config.CtsV1Client(config.GetProjectName(d))
+	if err != nil {
+		return fmterr.Errorf(clientError, err)
+	}
+
+	ltsEnabled := d.Get("is_lts_enabled").(bool)
+
+	createOpts := tracker.CreateOpts{
+		BucketName:     d.Get("bucket_name").(string),
+		FilePrefixName: d.Get("file_prefix_name").(string),
+		Lts: tracker.CreateLts{
+			IsLtsEnabled: &ltsEnabled,
+		},
+	}
+
+	ctsTracker, err := tracker.Create(client, createOpts)
+	if err != nil {
+		return fmterr.Errorf("error creating CTS tracker: %w", err)
+	}
+
+	d.SetId(ctsTracker.TrackerName)
+
+	return resourceCTSTrackerRead(ctx, d, meta)
+}
+
+func resourceCTSTrackerV3Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := config.CtsV1Client(config.GetProjectName(d))
+	if err != nil {
+		return fmterr.Errorf(clientError, err)
+	}
+
+	ctsTracker, err := tracker.Get(client, trackerName)
+	if err != nil {
+		return fmterr.Errorf("error retrieving cts tracker: %w", err)
+	}
+
+	mErr := multierror.Append(
+		d.Set("tracker_name", ctsTracker.TrackerName),
+		d.Set("bucket_name", ctsTracker.BucketName),
+		d.Set("status", ctsTracker.Status),
+		d.Set("file_prefix_name", ctsTracker.FilePrefixName),
+		d.Set("is_lts_enabled", ctsTracker.Lts.IsLtsEnabled),
+		d.Set("log_group_name", ctsTracker.Lts.LogGroupName),
+		d.Set("log_topic_name", ctsTracker.Lts.LogTopicName),
+		d.Set("region", config.GetRegion(d)),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return fmterr.Errorf("error setting CTS tracker fields: %w", err)
+	}
+
+	return nil
+}
+
+func resourceCTSTrackerV3Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := config.CtsV1Client(config.GetProjectName(d))
+	if err != nil {
+		return fmterr.Errorf(clientError, err)
+	}
+	ltsEnabled := d.Get("is_lts_enabled").(bool)
+	updateOpts := tracker.UpdateOpts{
+		BucketName:     d.Get("bucket_name").(string),
+		FilePrefixName: d.Get("file_prefix_name").(string),
+		Lts: tracker.CreateLts{
+			IsLtsEnabled: &ltsEnabled,
+		},
+	}
+
+	if d.HasChange("file_prefix_name") {
+		updateOpts.FilePrefixName = d.Get("file_prefix_name").(string)
+	}
+	if d.HasChange("status") {
+		updateOpts.Status = d.Get("status").(string)
+	}
+
+	_, err = tracker.Update(client, updateOpts, trackerName)
+	if err != nil {
+		return fmterr.Errorf("error updating CTS tracker: %w", err)
+	}
+	return resourceCTSTrackerRead(ctx, d, meta)
+}
+
+func resourceCTSTrackerV3Delete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := config.CtsV1Client(config.GetProjectName(d))
+	if err != nil {
+		return fmterr.Errorf(clientError, err)
+	}
+
+	if err := tracker.Delete(client, trackerName); err != nil {
+		return diag.FromErr(err)
+	}
+	log.Printf("[DEBUG] Successfully deleted cts tracker %s", d.Id())
+
+	d.SetId("")
+
+	return nil
+}

--- a/opentelekomcloud/services/cts/resource_opentelekomcloud_cts_tracker_v3.go
+++ b/opentelekomcloud/services/cts/resource_opentelekomcloud_cts_tracker_v3.go
@@ -8,6 +8,8 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/pointerto"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/cts/v3/tracker"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
@@ -32,17 +34,21 @@ func ResourceCTSTrackerV3() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"is_lts_enabled": {
-				Type:     schema.Bool,
-				ForceNew: true,
-				Computed: true,
-			},
-			"status": {
-				Type:     schema.TypeString,
+				Type:     schema.TypeBool,
+				Optional: true,
 				Computed: true,
 			},
 			"bucket_name": {
 				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
 				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"enabled", "disabled",
+				}, false),
 			},
 			"file_prefix_name": {
 				Type:         schema.TypeString,
@@ -50,17 +56,9 @@ func ResourceCTSTrackerV3() *schema.Resource {
 				Computed:     true,
 				ValidateFunc: common.ValidateName,
 			},
-			"is_lts_enabled": {
+			"is_obs_created": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Computed: true,
-			},
-			"log_group_name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"log_topic_name": {
-				Type:     schema.TypeString,
 				Computed: true,
 			},
 			"tracker_type": {
@@ -71,24 +69,53 @@ func ResourceCTSTrackerV3() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"domain_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"project_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"log_group_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"log_topic_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"detail": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"bucket_lifecycle": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
 		},
 	}
 }
 
 func resourceCTSTrackerV3Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	client, err := config.CtsV1Client(config.GetProjectName(d))
+	client, err := config.CtsV3Client(config.GetProjectName(d))
 	if err != nil {
 		return fmterr.Errorf(clientError, err)
 	}
 
-	ltsEnabled := d.Get("is_lts_enabled").(bool)
-
 	createOpts := tracker.CreateOpts{
-		BucketName:     d.Get("bucket_name").(string),
-		FilePrefixName: d.Get("file_prefix_name").(string),
-		Lts: tracker.CreateLts{
-			IsLtsEnabled: &ltsEnabled,
+		IsLtsEnabled: d.Get("is_lts_enabled").(bool),
+		TrackerName:  trackerName,
+		TrackerType:  trackerName,
+		ObsInfo: tracker.ObsInfo{
+			BucketName:     d.Get("bucket_name").(string),
+			FilePrefixName: d.Get("file_prefix_name").(string),
+			IsObsCreated:   pointerto.Bool(d.Get("is_obs_created").(bool)),
 		},
 	}
 
@@ -99,30 +126,51 @@ func resourceCTSTrackerV3Create(ctx context.Context, d *schema.ResourceData, met
 
 	d.SetId(ctsTracker.TrackerName)
 
-	return resourceCTSTrackerRead(ctx, d, meta)
+	if d.Get("status").(string) == "disabled" {
+		_, err = tracker.Update(client, tracker.UpdateOpts{
+			TrackerType: trackerName,
+			TrackerName: trackerName,
+			Status:      "disabled",
+		})
+		if err != nil {
+			return fmterr.Errorf("error setting CTS tracker status: %w", err)
+		}
+	}
+
+	return resourceCTSTrackerV3Read(ctx, d, meta)
 }
 
 func resourceCTSTrackerV3Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	client, err := config.CtsV1Client(config.GetProjectName(d))
+	client, err := config.CtsV3Client(config.GetProjectName(d))
 	if err != nil {
 		return fmterr.Errorf(clientError, err)
 	}
 
-	ctsTracker, err := tracker.Get(client, trackerName)
+	ctsTracker, err := tracker.List(client, trackerName)
 	if err != nil {
 		return fmterr.Errorf("error retrieving cts tracker: %w", err)
 	}
 
+	if len(ctsTracker) > 1 {
+		return fmterr.Errorf("tracker query returned 2 or more results")
+	}
+
 	mErr := multierror.Append(
-		d.Set("tracker_name", ctsTracker.TrackerName),
-		d.Set("bucket_name", ctsTracker.BucketName),
-		d.Set("status", ctsTracker.Status),
-		d.Set("file_prefix_name", ctsTracker.FilePrefixName),
-		d.Set("is_lts_enabled", ctsTracker.Lts.IsLtsEnabled),
-		d.Set("log_group_name", ctsTracker.Lts.LogGroupName),
-		d.Set("log_topic_name", ctsTracker.Lts.LogTopicName),
-		d.Set("region", config.GetRegion(d)),
+		d.Set("id", ctsTracker[0].Id),
+		d.Set("tracker_name", ctsTracker[0].TrackerName),
+		d.Set("tracker_type", ctsTracker[0].TrackerType),
+		d.Set("domain_id", ctsTracker[0].DomainId),
+		d.Set("project_id", ctsTracker[0].ProjectId),
+		d.Set("status", ctsTracker[0].Status),
+		d.Set("detail", ctsTracker[0].Detail),
+		d.Set("log_group_name", ctsTracker[0].Lts.LogGroupName),
+		d.Set("log_topic_name", ctsTracker[0].Lts.LogTopicName),
+		d.Set("is_lts_enabled", ctsTracker[0].Lts.IsLtsEnabled),
+		d.Set("bucket_name", ctsTracker[0].ObsInfo.BucketName),
+		d.Set("file_prefix_name", ctsTracker[0].ObsInfo.FilePrefixName),
+		d.Set("is_obs_created", ctsTracker[0].ObsInfo.IsObsCreated),
+		d.Set("bucket_lifecycle", ctsTracker[0].ObsInfo.BucketLifecycle),
 	)
 	if err := mErr.ErrorOrNil(); err != nil {
 		return fmterr.Errorf("error setting CTS tracker fields: %w", err)
@@ -133,36 +181,54 @@ func resourceCTSTrackerV3Read(_ context.Context, d *schema.ResourceData, meta in
 
 func resourceCTSTrackerV3Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	client, err := config.CtsV1Client(config.GetProjectName(d))
+	client, err := config.CtsV3Client(config.GetProjectName(d))
 	if err != nil {
 		return fmterr.Errorf(clientError, err)
 	}
-	ltsEnabled := d.Get("is_lts_enabled").(bool)
 	updateOpts := tracker.UpdateOpts{
-		BucketName:     d.Get("bucket_name").(string),
-		FilePrefixName: d.Get("file_prefix_name").(string),
-		Lts: tracker.CreateLts{
-			IsLtsEnabled: &ltsEnabled,
-		},
+		TrackerType: trackerName,
+		TrackerName: trackerName,
+	}
+
+	if d.HasChange("status") {
+		updateOpts.Status = d.Get("status").(string)
+		if updateOpts.Status == "enabled" {
+			// tracker needs to be enabled for other parameters to be applied
+			_, err = tracker.Update(client, updateOpts)
+			if err != nil {
+				return fmterr.Errorf("error updating CTS tracker: %w", err)
+			}
+		}
+	}
+
+	if d.HasChange("is_lts_enabled") {
+		updateOpts.IsLtsEnabled = pointerto.Bool(d.Get("is_lts_enabled").(bool))
+	}
+
+	if d.HasChange("bucket_name") {
+		updateOpts.ObsInfo.BucketName = d.Get("bucket_name").(string)
 	}
 
 	if d.HasChange("file_prefix_name") {
-		updateOpts.FilePrefixName = d.Get("file_prefix_name").(string)
-	}
-	if d.HasChange("status") {
-		updateOpts.Status = d.Get("status").(string)
+		updateOpts.ObsInfo.FilePrefixName = d.Get("file_prefix_name").(string)
+		updateOpts.ObsInfo.BucketName = d.Get("bucket_name").(string)
 	}
 
-	_, err = tracker.Update(client, updateOpts, trackerName)
+	if d.HasChange("is_obs_created") {
+		updateOpts.ObsInfo.IsObsCreated = pointerto.Bool(d.Get("is_obs_created").(bool))
+	}
+
+	_, err = tracker.Update(client, updateOpts)
 	if err != nil {
 		return fmterr.Errorf("error updating CTS tracker: %w", err)
 	}
-	return resourceCTSTrackerRead(ctx, d, meta)
+
+	return resourceCTSTrackerV3Read(ctx, d, meta)
 }
 
 func resourceCTSTrackerV3Delete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	client, err := config.CtsV1Client(config.GetProjectName(d))
+	client, err := config.CtsV3Client(config.GetProjectName(d))
 	if err != nil {
 		return fmterr.Errorf(clientError, err)
 	}

--- a/releasenotes/notes/cts_tracker_v3-dfb7a1d5272befe0.yaml
+++ b/releasenotes/notes/cts_tracker_v3-dfb7a1d5272befe0.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   - |
-    **[CTS]** New resource ``resource/opentelekomcloud_cts_tracker_v3`` for SWISSCLOUD (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[CTS]** New resource ``resource/opentelekomcloud_cts_tracker_v3`` for SWISSCLOUD (`#2203 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2203>`_)

--- a/releasenotes/notes/cts_tracker_v3-dfb7a1d5272befe0.yaml
+++ b/releasenotes/notes/cts_tracker_v3-dfb7a1d5272befe0.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    **[CTS]** New resource ``resource/opentelekomcloud_cts_tracker_v3`` for SWISSCLOUD (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Release of a new resource for system cts tracker management in SWISSCLOUD.

## PR Checklist

* [x] Refers to: #2159
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccCTSTrackerV3_basic
--- PASS: TestAccCTSTrackerV3_basic (45.79s)
PASS

Process finished with the exit code 0

=== RUN   TestAccCTSTrackerV3_importBasic
--- PASS: TestAccCTSTrackerV3_importBasic (29.63s)
PASS

Process finished with the exit code 0
```
