### PR TITLE
OBS: filesystems implementation

### DIFF
--- a/docs/resources/cts_tracker_v3.md
+++ b/docs/resources/cts_tracker_v3.md
@@ -22,7 +22,7 @@ resource "opentelekomcloud_cts_tracker_v3" "tracker_v3" {
   bucket_name      = var.bucket_name
   file_prefix_name = "prefix"
   is_lts_enabled   = true
-  status           = enabled
+  status           = "enabled"
 }
 ```
 

--- a/docs/resources/obs_bucket.md
+++ b/docs/resources/obs_bucket.md
@@ -29,7 +29,7 @@ resource "opentelekomcloud_obs_bucket" "b" {
 
 ```hcl
 resource "opentelekomcloud_obs_bucket" "b" {
-  bucket = "my-tf-test-bucket"
+  bucket      = "my-tf-test-bucket"
   parallel_fs = true
 }
 ```

--- a/docs/resources/obs_bucket.md
+++ b/docs/resources/obs_bucket.md
@@ -25,6 +25,15 @@ resource "opentelekomcloud_obs_bucket" "b" {
 }
 ```
 
+### Parallel file system bucket
+
+```hcl
+resource "opentelekomcloud_obs_bucket" "b" {
+  bucket = "my-tf-test-bucket"
+  parallel_fs = true
+}
+```
+
 ### Enable versioning
 
 ```hcl
@@ -245,6 +254,8 @@ The following arguments are supported:
 * `storage_class` - (Optional) Specifies the storage class of the bucket. OBS provides three storage classes:
   `STANDARD`, `WARM` (Infrequent Access) and `COLD` (Archive). Defaults to `STANDARD`.
 
+* `parallel_fs` - (Optional) Whether enable a bucket as a parallel file system.
+
 * `acl` - (Optional) Specifies the ACL policy for a bucket. The predefined common policies are as follows:
   `private`, `public-read`, `public-read-write` and `log-delivery-write`. Defaults to `private`.
 
@@ -399,13 +410,15 @@ The `filter_rule` object supports the following
 
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to all arguments above, the following attributes are exported:
 
 * `id` - The name of the bucket.
 
 * `bucket_domain_name` - The bucket domain name. Will be of format `bucketname.obs.region.otc.t-systems.com`.
 
 * `region` - The region this bucket resides in.
+
+* `bucket_version` - The OBS version of the bucket.
 
 ## Import
 

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/jinzhu/copier v0.3.5
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.7.1-0.20230630095411-cba8b4db3d3b
+	github.com/opentelekomcloud/gophertelekomcloud v0.7.1-0.20230703122253-28970dde6aba
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.1.0
 	golang.org/x/sync v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -171,8 +171,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k+Mg7cowZ8yv4Trqw9UsJby758=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.7.1-0.20230630095411-cba8b4db3d3b h1:G3u2MN9uQjh1MEuYlGIqBHgoyDUCm2OdVXM6g6ki50o=
-github.com/opentelekomcloud/gophertelekomcloud v0.7.1-0.20230630095411-cba8b4db3d3b/go.mod h1:9Deb3q2gJvq5dExV+aX+iO+G+mD9Zr9uFt+YY9ONmq0=
+github.com/opentelekomcloud/gophertelekomcloud v0.7.1-0.20230703122253-28970dde6aba h1:JMKwEs5fFItVW97NE+lzggY41gAXZFyHMWnHhJeOkjI=
+github.com/opentelekomcloud/gophertelekomcloud v0.7.1-0.20230703122253-28970dde6aba/go.mod h1:9Deb3q2gJvq5dExV+aX+iO+G+mD9Zr9uFt+YY9ONmq0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/opentelekomcloud/acceptance/obs/resource_opentelekomcloud_obs_bucket_test.go
+++ b/opentelekomcloud/acceptance/obs/resource_opentelekomcloud_obs_bucket_test.go
@@ -631,8 +631,8 @@ resource "opentelekomcloud_obs_bucket" "bucket" {
 func testAccObsBucketPfs(randInt int) string {
 	return fmt.Sprintf(`
 resource "opentelekomcloud_obs_bucket" "bucket" {
-  bucket        = "tf-test-bucket-%d"
-  parallel_fs   = true
+  bucket      = "tf-test-bucket-%d"
+  parallel_fs = true
 }
 `, randInt)
 }

--- a/opentelekomcloud/acceptance/obs/resource_opentelekomcloud_obs_bucket_test.go
+++ b/opentelekomcloud/acceptance/obs/resource_opentelekomcloud_obs_bucket_test.go
@@ -217,6 +217,26 @@ func TestAccObsBucket_notifications(t *testing.T) {
 	})
 }
 
+func TestAccObsBucket_pfs(t *testing.T) {
+	rInt := acctest.RandInt()
+	resourceName := "opentelekomcloud_obs_bucket.bucket"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckObsBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccObsBucketPfs(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "parallel_fs", "true"),
+					resource.TestCheckResourceAttr(resourceName, "bucket_version", "3.0"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckObsBucketDestroy(s *terraform.State) error {
 	config := common.TestAccProvider.Meta().(*cfg.Config)
 	client, err := config.NewObjectStorageClient(env.OS_REGION_NAME)
@@ -604,6 +624,15 @@ resource "opentelekomcloud_obs_bucket" "bucket" {
   }
 
   depends_on = [opentelekomcloud_smn_topic_attribute_v2.policy]
+}
+`, randInt)
+}
+
+func testAccObsBucketPfs(randInt int) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_obs_bucket" "bucket" {
+  bucket        = "tf-test-bucket-%d"
+  parallel_fs   = true
 }
 `, randInt)
 }

--- a/releasenotes/notes/obs_fs-c5499dfd6df3febc.yaml
+++ b/releasenotes/notes/obs_fs-c5499dfd6df3febc.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[OBS]** Added file system creation for ``resource/opentelekomcloud_obs_bucket`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)

--- a/releasenotes/notes/obs_fs-c5499dfd6df3febc.yaml
+++ b/releasenotes/notes/obs_fs-c5499dfd6df3febc.yaml
@@ -1,4 +1,4 @@
 ---
 enhancements:
   - |
-    **[OBS]** Added file system creation for ``resource/opentelekomcloud_obs_bucket`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[OBS]** Added file system creation for ``resource/opentelekomcloud_obs_bucket`` (`#2210 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2210>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Added ability to create filesystem OBS buckets.

## PR Checklist

* [x] Refers to: #2209
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccObsBucket_basic
=== PAUSE TestAccObsBucket_basic
=== CONT  TestAccObsBucket_basic
--- PASS: TestAccObsBucket_basic (68.60s)
=== RUN   TestAccObsBucket_tags
=== PAUSE TestAccObsBucket_tags
=== CONT  TestAccObsBucket_tags
--- PASS: TestAccObsBucket_tags (25.28s)
=== RUN   TestAccObsBucket_versioning
=== PAUSE TestAccObsBucket_versioning
=== CONT  TestAccObsBucket_versioning
--- PASS: TestAccObsBucket_versioning (46.03s)
=== RUN   TestAccObsBucket_logging
=== PAUSE TestAccObsBucket_logging
=== CONT  TestAccObsBucket_logging
--- PASS: TestAccObsBucket_logging (30.85s)
=== RUN   TestAccObsBucket_lifecycle
=== PAUSE TestAccObsBucket_lifecycle
=== CONT  TestAccObsBucket_lifecycle
--- PASS: TestAccObsBucket_lifecycle (26.01s)
=== RUN   TestAccObsBucket_website
=== PAUSE TestAccObsBucket_website
=== CONT  TestAccObsBucket_website
--- PASS: TestAccObsBucket_website (25.94s)
=== RUN   TestAccObsBucket_cors
=== PAUSE TestAccObsBucket_cors
=== CONT  TestAccObsBucket_cors
--- PASS: TestAccObsBucket_cors (26.12s)
=== RUN   TestAccObsBucket_notifications
=== PAUSE TestAccObsBucket_notifications
=== CONT  TestAccObsBucket_notifications
--- PASS: TestAccObsBucket_notifications (33.60s)
=== RUN   TestAccObsBucket_pfs
=== PAUSE TestAccObsBucket_pfs
=== CONT  TestAccObsBucket_pfs
--- PASS: TestAccObsBucket_pfs (25.85s)
PASS

Process finished with the exit code 0
```
