### PR TITLE
[FW]: fix resource update from `tcp`/`udp` to `icmp`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/jinzhu/copier v0.3.5
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.7.1-0.20230703122253-28970dde6aba
+	github.com/opentelekomcloud/gophertelekomcloud v0.7.1-0.20230704091355-65a7d0a1b0c8
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.1.0
 	golang.org/x/sync v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -171,8 +171,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k+Mg7cowZ8yv4Trqw9UsJby758=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.7.1-0.20230703122253-28970dde6aba h1:JMKwEs5fFItVW97NE+lzggY41gAXZFyHMWnHhJeOkjI=
-github.com/opentelekomcloud/gophertelekomcloud v0.7.1-0.20230703122253-28970dde6aba/go.mod h1:9Deb3q2gJvq5dExV+aX+iO+G+mD9Zr9uFt+YY9ONmq0=
+github.com/opentelekomcloud/gophertelekomcloud v0.7.1-0.20230704091355-65a7d0a1b0c8 h1:tz2SFXmjpLtK6RjYICcs/+FX2/2bIqjF0oxHhjcJsik=
+github.com/opentelekomcloud/gophertelekomcloud v0.7.1-0.20230704091355-65a7d0a1b0c8/go.mod h1:9Deb3q2gJvq5dExV+aX+iO+G+mD9Zr9uFt+YY9ONmq0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/opentelekomcloud/acceptance/fw/resource_opentelekomcloud_fw_rule_v2_test.go
+++ b/opentelekomcloud/acceptance/fw/resource_opentelekomcloud_fw_rule_v2_test.go
@@ -104,6 +104,31 @@ func TestAccFWRuleV2_anyProtocol(t *testing.T) {
 	})
 }
 
+func TestAccFWRuleV2_TCPtoICMP(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckFWRuleV2Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFWRuleV2_TCP,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("opentelekomcloud_fw_rule_v2.rule_1", "protocol", "tcp"),
+					resource.TestCheckResourceAttr("opentelekomcloud_fw_rule_v2.rule_1", "destination_port", "23"),
+				),
+			},
+			{
+				Config: testAccFWRuleV2_ICMP,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("opentelekomcloud_fw_rule_v2.rule_1", "protocol", "icmp"),
+					resource.TestCheckResourceAttr("opentelekomcloud_fw_rule_v2.rule_1", "destination_port", ""),
+					resource.TestCheckResourceAttr("opentelekomcloud_fw_rule_v2.rule_1", "source_port", ""),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckFWRuleV2Destroy(s *terraform.State) error {
 	config := common.TestAccProvider.Meta().(*cfg.Config)
 	networkingClient, err := config.NetworkingV2Client(env.OS_REGION_NAME)
@@ -218,5 +243,28 @@ resource "opentelekomcloud_fw_rule_v2" "rule_1" {
   ip_version        = 4
   source_ip_address = "192.168.199.0/24"
   enabled           = true
+}
+`
+
+const testAccFWRuleV2_TCP = `
+resource "opentelekomcloud_fw_rule_v2" "rule_1" {
+  name             = "rule_1"
+  description      = "Tcp protocol"
+  protocol         = "tcp"
+  ip_version       = 4
+  enabled          = true
+  action           = "deny"
+  destination_port = "23"
+}
+`
+
+const testAccFWRuleV2_ICMP = `
+resource "opentelekomcloud_fw_rule_v2" "rule_1" {
+  name        = "rule_1"
+  description = "ICMP protocol"
+  protocol    = "icmp"
+  ip_version  = 4
+  enabled     = true
+  action      = "allow"
 }
 `

--- a/opentelekomcloud/services/fw/resource_opentelekomcloud_fw_rule_v2.go
+++ b/opentelekomcloud/services/fw/resource_opentelekomcloud_fw_rule_v2.go
@@ -213,15 +213,6 @@ func resourceFWRuleV2Update(ctx context.Context, d *schema.ResourceData, meta in
 		if protocol == "icmp" {
 			updateOpts.DestinationPort = nil
 			updateOpts.SourcePort = nil
-		} else {
-			sourcePort := d.Get("source_port").(string)
-			destPort := d.Get("destination_port").(string)
-			if sourcePort != "" {
-				updateOpts.SourcePort = &sourcePort
-			}
-			if destPort != "" {
-				updateOpts.DestinationPort = &destPort
-			}
 		}
 	}
 	if d.HasChange("action") {

--- a/opentelekomcloud/services/fw/resource_opentelekomcloud_fw_rule_v2.go
+++ b/opentelekomcloud/services/fw/resource_opentelekomcloud_fw_rule_v2.go
@@ -193,9 +193,36 @@ func resourceFWRuleV2Update(ctx context.Context, d *schema.ResourceData, meta in
 		description := d.Get("description").(string)
 		updateOpts.Description = &description
 	}
+	if d.HasChange("destination_port") {
+		destinationPort := d.Get("destination_port").(string)
+		updateOpts.DestinationPort = &destinationPort
+		if *updateOpts.DestinationPort == "" {
+			updateOpts.DestinationPort = nil
+		}
+	}
+	if d.HasChange("source_port") {
+		sourcePort := d.Get("source_port").(string)
+		updateOpts.SourcePort = &sourcePort
+		if *updateOpts.SourcePort == "" {
+			updateOpts.SourcePort = nil
+		}
+	}
 	if d.HasChange("protocol") {
 		protocol := d.Get("protocol").(string)
 		updateOpts.Protocol = &protocol
+		if protocol == "icmp" {
+			updateOpts.DestinationPort = nil
+			updateOpts.SourcePort = nil
+		} else {
+			sourcePort := d.Get("source_port").(string)
+			destPort := d.Get("destination_port").(string)
+			if sourcePort != "" {
+				updateOpts.SourcePort = &sourcePort
+			}
+			if destPort != "" {
+				updateOpts.DestinationPort = &destPort
+			}
+		}
 	}
 	if d.HasChange("action") {
 		action := d.Get("action").(string)
@@ -209,23 +236,14 @@ func resourceFWRuleV2Update(ctx context.Context, d *schema.ResourceData, meta in
 		sourceIPAddress := d.Get("source_ip_address").(string)
 		updateOpts.SourceIPAddress = &sourceIPAddress
 	}
-	if d.HasChange("source_port") {
-		sourcePort := d.Get("source_port").(string)
-		updateOpts.SourcePort = &sourcePort
-	}
 	if d.HasChange("destination_ip_address") {
 		destinationIPAddress := d.Get("destination_ip_address").(string)
 		updateOpts.DestinationIPAddress = &destinationIPAddress
-	}
-	if d.HasChange("destination_port") {
-		destinationPort := d.Get("destination_port").(string)
-		updateOpts.DestinationPort = &destinationPort
 	}
 	if d.HasChange("enabled") {
 		enabled := d.Get("enabled").(bool)
 		updateOpts.Enabled = &enabled
 	}
-
 	log.Printf("[DEBUG] Updating firewall rules: %#v", updateOpts)
 	err = rules.Update(networkingClient, d.Id(), updateOpts).Err
 	if err != nil {

--- a/releasenotes/notes/fix-waf-logic-1eda21dce588c3d4.yaml
+++ b/releasenotes/notes/fix-waf-logic-1eda21dce588c3d4.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    **[FW]** Fix resource update from `tcp` tp `icmp` protocol for ``resource/opentelekomcloud_fw_rule_v2`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[WAF]** Fix use of ``logic`` field in ``resource/opentelekomcloud_waf_preciseprotection_rule_v1`` (`#1193 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1193>`_)

--- a/releasenotes/notes/fix-waf-logic-1eda21dce588c3d4.yaml
+++ b/releasenotes/notes/fix-waf-logic-1eda21dce588c3d4.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    **[WAF]** Fix use of ``logic`` field in ``resource/opentelekomcloud_waf_preciseprotection_rule_v1`` (`#1193 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/1193>`_)
+    **[FW]** Fix resource update from `tcp` tp `icmp` protocol for ``resource/opentelekomcloud_fw_rule_v2`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)

--- a/releasenotes/notes/fw_rule_v2_fix-6af380c3cd98b3f0.yaml
+++ b/releasenotes/notes/fw_rule_v2_fix-6af380c3cd98b3f0.yaml
@@ -1,8 +1,4 @@
 ---
 fixes:
   - |
-    Add normal bug fixes here, or remove this section.  All of the list items
-    in this section are combined when the release notes are rendered, so the
-    text needs to be worded so that it does not depend on any information only
-    available in another section, such as the prelude. This may mean repeating
-    some details.
+    **[FW]** Fix resource update from `tcp` tp `icmp` protocol for ``resource/opentelekomcloud_fw_rule_v2`` (`#2212 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2212>`_)

--- a/releasenotes/notes/fw_rule_v2_fix-6af380c3cd98b3f0.yaml
+++ b/releasenotes/notes/fw_rule_v2_fix-6af380c3cd98b3f0.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    **[FW]** Fix resource update from `tcp` tp `icmp` protocol for ``resource/opentelekomcloud_fw_rule_v2`` (`#2212 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2212>`_)
+    **[FW]** Fix resource update from `tcp`/`udp` to `icmp` protocol for ``resource/opentelekomcloud_fw_rule_v2`` (`#2212 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2212>`_)

--- a/releasenotes/notes/fw_rule_v2_fix-6af380c3cd98b3f0.yaml
+++ b/releasenotes/notes/fw_rule_v2_fix-6af380c3cd98b3f0.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Add normal bug fixes here, or remove this section.  All of the list items
+    in this section are combined when the release notes are rendered, so the
+    text needs to be worded so that it does not depend on any information only
+    available in another section, such as the prelude. This may mean repeating
+    some details.


### PR DESCRIPTION
## Summary of the Pull Request
Fix resource update for protocols (from `tcp`/`udp` to `icmp`).

## PR Checklist

* [x] Refers to: #1915
* [x] Tests added/passed.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccFWRuleV2_basic
--- PASS: TestAccFWRuleV2_basic (58.62s)
=== RUN   TestAccFWRuleV2_anyProtocol
--- PASS: TestAccFWRuleV2_anyProtocol (22.73s)
=== RUN   TestAccFWRuleV2_TCPtoICMP
--- PASS: TestAccFWRuleV2_TCPtoICMP (38.63s)
PASS

Process finished with the exit code 0
```
