### PR TITLE
[CCE] add keys for skip sensitive data in `resource/opentelekomcloud_cce_cluster_v3`

### DIFF
--- a/docs/resources/cce_cluster_v3.md
+++ b/docs/resources/cce_cluster_v3.md
@@ -201,6 +201,10 @@ The following arguments are supported:
 
 * `ignore_addons` - (Optional) Skip all cluster addons operations.
 
+* `ignore_certificate_users_data` - (Optional) Skip sensitive user data.
+
+* `ignore_certificate_clusters_data` - (Optional) Skip sensitive cluster data.
+
 * `kube_proxy_mode` - Service forwarding mode. Two modes are available:
   * `iptables`: Traditional kube-proxy uses iptables rules to implement service load balancing.
     In this mode, too many iptables rules will be generated when many services are deployed.

--- a/releasenotes/notes/cce-cluster-skip-cert-data-b8f4bda1b959c43a.yaml
+++ b/releasenotes/notes/cce-cluster-skip-cert-data-b8f4bda1b959c43a.yaml
@@ -1,0 +1,8 @@
+---
+enhancements:
+  - |
+    **[CCE]** Allow skipping user certificate operations with ``ignore_certificate_users_data`` argument for ``resource/opentelekomcloud_cce_cluster_v3``
+    (`#2217 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2217>`_)
+  - |
+    **[CCE]** Allow skipping cluster certificate operations with ``ignore_certificate_clusters_data`` argument for ``resource/opentelekomcloud_cce_cluster_v3``
+    (`#2217 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2217>`_)


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [x] Refers to: #2208
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccCCEClusterV3_basic
=== PAUSE TestAccCCEClusterV3_basic
=== CONT  TestAccCCEClusterV3_basic
--- PASS: TestAccCCEClusterV3_basic (1169.56s)
=== RUN   TestAccCCEClusterV3_turbo_basic
=== PAUSE TestAccCCEClusterV3_turbo_basic
=== CONT  TestAccCCEClusterV3_turbo_basic
--- PASS: TestAccCCEClusterV3_turbo_basic (1084.51s)
=== RUN   TestAccCCEClusterV3_importBasic
=== PAUSE TestAccCCEClusterV3_importBasic
=== CONT  TestAccCCEClusterV3_importBasic
--- PASS: TestAccCCEClusterV3_importBasic (603.80s)
=== RUN   TestAccCCEClusterV3_invalidNetwork
=== PAUSE TestAccCCEClusterV3_invalidNetwork
=== CONT  TestAccCCEClusterV3_invalidNetwork
--- PASS: TestAccCCEClusterV3_invalidNetwork (589.35s)
=== RUN   TestAccCCEClusterV3_proxyAuth
=== PAUSE TestAccCCEClusterV3_proxyAuth
=== CONT  TestAccCCEClusterV3_proxyAuth
--- PASS: TestAccCCEClusterV3_proxyAuth (1020.73s)
=== RUN   TestAccCCEClusterV3_timeout
=== PAUSE TestAccCCEClusterV3_timeout
=== CONT  TestAccCCEClusterV3_timeout
--- PASS: TestAccCCEClusterV3_timeout (593.59s)
=== RUN   TestAccCCEClusterV3NoAddons
=== PAUSE TestAccCCEClusterV3NoAddons
=== CONT  TestAccCCEClusterV3NoAddons
--- PASS: TestAccCCEClusterV3NoAddons (1169.61s)
=== RUN   TestAccCCEClusterV3NoUserClusterDataSet
=== PAUSE TestAccCCEClusterV3NoUserClusterDataSet
=== CONT  TestAccCCEClusterV3NoUserClusterDataSet
--- PASS: TestAccCCEClusterV3NoUserClusterDataSet (562.30s)
=== RUN   TestAccCCEClusterV3_withVersionDiff
=== PAUSE TestAccCCEClusterV3_withVersionDiff
=== CONT  TestAccCCEClusterV3_withVersionDiff
--- PASS: TestAccCCEClusterV3_withVersionDiff (480.67s)
PASS

Process finished with the exit code 0
```
