### PR TITLE
[RDS]: Implement case-sensitive state of table names parameter

### DIFF
--- a/docs/resources/rds_instance_v3.md
+++ b/docs/resources/rds_instance_v3.md
@@ -350,6 +350,11 @@ The following arguments are supported:
 * `parameters` - (Optional) Map of additional configuration parameters. Values should be strings. Parameters set here
   overrides values from configuration template (parameter group).
 
+* `lower_case_table_names` - Specifies the case-sensitive state of the database table name,
+  the default value is "1". Changing this parameter will create a new resource.
+  + 0: Table names are stored as fixed and table names are case-sensitive.
+  + 1: Table names will be stored in lower case and table names are not case-sensitive.
+
 * `public_ips` - (Optional) Specifies floating IP to be assigned to the instance.
   This should be a list with single element only.
 

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/jinzhu/copier v0.3.5
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.7.1-0.20230704091355-65a7d0a1b0c8
+	github.com/opentelekomcloud/gophertelekomcloud v0.7.1-0.20230707114449-73da2e88df88
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.1.0
 	golang.org/x/sync v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -154,8 +154,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k+Mg7cowZ8yv4Trqw9UsJby758=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.7.1-0.20230704091355-65a7d0a1b0c8 h1:tz2SFXmjpLtK6RjYICcs/+FX2/2bIqjF0oxHhjcJsik=
-github.com/opentelekomcloud/gophertelekomcloud v0.7.1-0.20230704091355-65a7d0a1b0c8/go.mod h1:9Deb3q2gJvq5dExV+aX+iO+G+mD9Zr9uFt+YY9ONmq0=
+github.com/opentelekomcloud/gophertelekomcloud v0.7.1-0.20230707114449-73da2e88df88 h1:B8GT9dvLWl7M/AdbPGfFX4d5FGt7xHW2BtulbViqLfY=
+github.com/opentelekomcloud/gophertelekomcloud v0.7.1-0.20230707114449-73da2e88df88/go.mod h1:9Deb3q2gJvq5dExV+aX+iO+G+mD9Zr9uFt+YY9ONmq0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
+++ b/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
@@ -40,6 +40,7 @@ func TestAccRdsInstanceV3Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(instanceV3ResourceName, "backup_strategy.0.keep_days", "1"),
 					resource.TestCheckResourceAttr(instanceV3ResourceName, "tags.muh", "value-create"),
 					resource.TestCheckResourceAttr(instanceV3ResourceName, "tags.kuh", "value-create"),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "lower_case_table_names", "0"),
 				),
 			},
 			{
@@ -49,6 +50,7 @@ func TestAccRdsInstanceV3Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(instanceV3ResourceName, "volume.0.size", "100"),
 					resource.TestCheckResourceAttr(instanceV3ResourceName, "tags.muh", "value-update"),
 					resource.TestCheckResourceAttr(instanceV3ResourceName, "db.0.port", "8636"),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "lower_case_table_names", "0"),
 				),
 			},
 		},
@@ -108,6 +110,7 @@ func TestAccRdsInstanceV3RestoreBackup(t *testing.T) {
 				Config: testAccRdsInstanceV3Basic(postfix),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRdsInstanceV3Exists(instanceV3ResourceName, &rdsInstance),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "lower_case_table_names", "0"),
 				),
 			},
 			{
@@ -121,6 +124,7 @@ func TestAccRdsInstanceV3RestoreBackup(t *testing.T) {
 					resource.TestCheckResourceAttr(restoredResourceName, "flavor", "rds.pg.c2.large"),
 					resource.TestCheckResourceAttr(restoredResourceName, "volume.0.size", "40"),
 					resource.TestCheckResourceAttr(restoredResourceName, "tags.muh", "value-create"),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "lower_case_table_names", "0"),
 				),
 			},
 		},
@@ -412,6 +416,7 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
     muh = "value-create"
     kuh = "value-create"
   }
+  lower_case_table_names = "0"
 }
 `, common.DataSourceSecGroupDefault, common.DataSourceSubnet, postfix, env.OS_AVAILABILITY_ZONE)
 }
@@ -449,6 +454,7 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
   tags = {
     muh = "value-update"
   }
+  lower_case_table_names = "0"
 }
 `, common.DataSourceSubnet, postfix, env.OS_AVAILABILITY_ZONE)
 }
@@ -796,6 +802,7 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
     muh = "value-create"
     kuh = "value-create"
   }
+  lower_case_table_names = "0"
 }
 
 data "opentelekomcloud_rds_backup_v3" "backup" {
@@ -834,6 +841,7 @@ resource "opentelekomcloud_rds_instance_v3" "from_backup" {
     muh = "value-create"
     kuh = "value-create"
   }
+  lower_case_table_names = "0"
 }
 `, common.DataSourceSecGroupDefault, common.DataSourceSubnet, postfix, env.OS_AVAILABILITY_ZONE)
 }

--- a/releasenotes/notes/rds_lowercase_tables-390fa1f47a97a6c0.yaml
+++ b/releasenotes/notes/rds_lowercase_tables-390fa1f47a97a6c0.yaml
@@ -1,4 +1,4 @@
 ---
 enhancements:
   - |
-    **[RDS]** Implement parameter to manage case-sensitive state of the database table name ``resource/opentelekomcloud_rds_instance_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[RDS]** Implement parameter to manage case-sensitive state of the database table name ``resource/opentelekomcloud_rds_instance_v3`` (`#2218 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2218>`_)

--- a/releasenotes/notes/rds_lowercase_tables-390fa1f47a97a6c0.yaml
+++ b/releasenotes/notes/rds_lowercase_tables-390fa1f47a97a6c0.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[RDS]** Implement parameter to manage case-sensitive state of the database table name ``resource/opentelekomcloud_rds_instance_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Implementation of `lower_case_table_names` parameter to manage case-sensitive state of the database tables name for ``resource/opentelekomcloud_rds_instance_v3``

## PR Checklist

* [x] Refers to: #2207
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccRdsInstanceV3_importBasic
--- PASS: TestAccRdsInstanceV3_importBasic (385.81s)
PASS

Process finished with the exit code 0

=== RUN   TestAccRdsReadReplicaV3ImportBasic
--- PASS: TestAccRdsReadReplicaV3ImportBasic (744.41s)
PASS

Process finished with the exit code 0

=== RUN   TestAccRdsReadReplicaV3Basic
--- PASS: TestAccRdsReadReplicaV3Basic (801.60s)
PASS

Process finished with the exit code 0

=== RUN   TestAccRdsInstanceV3Basic
--- PASS: TestAccRdsInstanceV3Basic (775.08s)
PASS

Process finished with the exit code 0

=== RUN   TestAccRdsInstanceV3RestoreBackup
--- PASS: TestAccRdsInstanceV3RestoreBackup (1161.53s)
PASS

Process finished with the exit code 0
```
