### PR TITLE
[OBS] proxy support in `NewObjectStorageClient`

### DIFF
--- a/docs/resources/obs_bucket.md
+++ b/docs/resources/obs_bucket.md
@@ -8,6 +8,7 @@ Up-to-date reference of API arguments for OBS bucket you can get at
 # opentelekomcloud_obs_bucket
 
 Provides an OBS bucket resource within OpenTelekomCloud.
+Now respects HTTP_PROXY, HTTPS_PROXY environment variables.
 
 ## Example Usage
 

--- a/docs/resources/obs_bucket_object.md
+++ b/docs/resources/obs_bucket_object.md
@@ -8,6 +8,7 @@ Up-to-date reference of API arguments for OBS bucket object you can get at
 # opentelekomcloud_obs_bucket_object
 
 Provides an OBS bucket object resource within OpenTelekomCloud.
+Now respects HTTP_PROXY, HTTPS_PROXY environment variables.
 
 ## Example Usage
 

--- a/docs/resources/obs_bucket_policy.md
+++ b/docs/resources/obs_bucket_policy.md
@@ -8,6 +8,7 @@ Up-to-date reference of API arguments for OBS bucket policy you can get at
 # opentelekomcloud_obs_bucket_policy
 
 Attaches a policy to an OBS bucket resource within OpenTelekomCloud.
+Now respects HTTP_PROXY, HTTPS_PROXY environment variables.
 
 ## Example Usage
 

--- a/opentelekomcloud/common/cfg/config.go
+++ b/opentelekomcloud/common/cfg/config.go
@@ -656,25 +656,18 @@ func obsProxyConf() (obs.Configurer, error) {
 	httpProxy := os.Getenv("HTTP_PROXY")
 	httpsProxy := os.Getenv("HTTPS_PROXY")
 
-	if httpProxy != "" {
-		if httpsProxy != "" {
-			_, err := url.ParseRequestURI(httpsProxy)
-			if err != nil {
-				return proxyConfigure, err
-			}
-			return obs.WithProxyUrl(httpsProxy), nil
-		}
-		_, err := url.ParseRequestURI(httpProxy)
-		if err != nil {
-			return proxyConfigure, err
-		}
-		return obs.WithProxyUrl(httpProxy), nil
-	} else if httpsProxy != "" {
+	if httpsProxy != "" {
 		_, err := url.ParseRequestURI(httpsProxy)
 		if err != nil {
 			return proxyConfigure, err
 		}
 		return obs.WithProxyUrl(httpsProxy), nil
+	} else if httpProxy != "" {
+		_, err := url.ParseRequestURI(httpProxy)
+		if err != nil {
+			return proxyConfigure, err
+		}
+		return obs.WithProxyUrl(httpProxy), nil
 	}
 	return proxyConfigure, nil
 }

--- a/releasenotes/notes/obs-client-proxy-conf-e6386e6abaea9800.yaml
+++ b/releasenotes/notes/obs-client-proxy-conf-e6386e6abaea9800.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[OBS]** client respects `HTTP_PROXY` and `HTTPS_PROXY` environment variables while creation (`#2225 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2225>`_)


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [x] Refers to: #2220
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccObsBucket_basic
=== PAUSE TestAccObsBucket_basic
=== CONT  TestAccObsBucket_basic
--- PASS: TestAccObsBucket_basic (105.78s)
=== RUN   TestAccObsBucket_tags
=== PAUSE TestAccObsBucket_tags
=== CONT  TestAccObsBucket_tags
--- PASS: TestAccObsBucket_tags (35.87s)
=== RUN   TestAccObsBucket_versioning
=== PAUSE TestAccObsBucket_versioning
=== CONT  TestAccObsBucket_versioning
--- PASS: TestAccObsBucket_versioning (74.71s)
=== RUN   TestAccObsBucket_logging
=== PAUSE TestAccObsBucket_logging
=== CONT  TestAccObsBucket_logging
--- PASS: TestAccObsBucket_logging (51.28s)
=== RUN   TestAccObsBucket_lifecycle
=== PAUSE TestAccObsBucket_lifecycle
=== CONT  TestAccObsBucket_lifecycle
--- PASS: TestAccObsBucket_lifecycle (43.70s)
=== RUN   TestAccObsBucket_website
=== PAUSE TestAccObsBucket_website
=== CONT  TestAccObsBucket_website
--- PASS: TestAccObsBucket_website (44.38s)
=== RUN   TestAccObsBucket_cors
=== PAUSE TestAccObsBucket_cors
=== CONT  TestAccObsBucket_cors
--- PASS: TestAccObsBucket_cors (43.72s)
=== RUN   TestAccObsBucket_notifications
=== PAUSE TestAccObsBucket_notifications
=== CONT  TestAccObsBucket_notifications
--- PASS: TestAccObsBucket_notifications (53.63s)
=== RUN   TestAccObsBucket_pfs
=== PAUSE TestAccObsBucket_pfs
=== CONT  TestAccObsBucket_pfs
--- PASS: TestAccObsBucket_pfs (44.70s)
PASS


Process finished with the exit code 0
```
