### PR TITLE
[VPC] port_security_enabled now can set to false in `resource/opentelekomcloud_networking_port_v2`

### DIFF
--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_port_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_port_v2_test.go
@@ -161,6 +161,31 @@ func TestAccNetworkingV2Port_portSecurity_enabled(t *testing.T) {
 	})
 }
 
+func TestAccNetworkingV2Port_noPortSecurityNoSecurityGroups(t *testing.T) {
+	var port testPortWithExtensions
+	resourceName := "opentelekomcloud_networking_port_v2.port_1"
+	t.Parallel()
+	qts := subnetQuotas()
+	quotas.BookMany(t, qts)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckNetworkingV2PortDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkingV2PortSecurityDisabled,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingV2PortWithExtensionsExists(resourceName, &port),
+					resource.TestCheckResourceAttr(resourceName, "port_security_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "security_group_ids.#", "0"),
+					testAccCheckNetworkingV2PortPortSecurity(&port, false),
+				),
+			},
+		},
+	})
+}
+
 func TestAccNetworkingV2Port_timeout(t *testing.T) {
 	var network networks.Network
 	var port ports.Port

--- a/releasenotes/notes/networking-port-security-fix-1fe6f73f7e108eb3.yaml
+++ b/releasenotes/notes/networking-port-security-fix-1fe6f73f7e108eb3.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[VPC]** Fix `port_security_enabled` false value handling in case of `no_security_groups` enabled for ``resource/opentelekomcloud_networking_port_v2`` (`#2228 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2228>`_)


### PR DESCRIPTION
## Summary of the Pull Request
There was error in setting False value for `port_security_enabled`

## PR Checklist

* [x] Refers to: #2227
* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccNetworkingV2Port_basic
=== PAUSE TestAccNetworkingV2Port_basic
=== CONT  TestAccNetworkingV2Port_basic
--- PASS: TestAccNetworkingV2Port_basic (86.88s)
=== RUN   TestAccNetworkingV2Port_importBasic
=== PAUSE TestAccNetworkingV2Port_importBasic
=== CONT  TestAccNetworkingV2Port_importBasic
--- PASS: TestAccNetworkingV2Port_importBasic (94.58s)
=== RUN   TestAccNetworkingV2Port_noip
=== PAUSE TestAccNetworkingV2Port_noip
=== CONT  TestAccNetworkingV2Port_noip
--- PASS: TestAccNetworkingV2Port_noip (87.13s)
=== RUN   TestAccNetworkingV2Port_allowedAddressPairs
=== PAUSE TestAccNetworkingV2Port_allowedAddressPairs
=== CONT  TestAccNetworkingV2Port_allowedAddressPairs
--- PASS: TestAccNetworkingV2Port_allowedAddressPairs (105.86s)
=== RUN   TestAccNetworkingV2Port_portSecurity_enabled
=== PAUSE TestAccNetworkingV2Port_portSecurity_enabled
=== CONT  TestAccNetworkingV2Port_portSecurity_enabled
--- PASS: TestAccNetworkingV2Port_portSecurity_enabled (115.65s)
=== RUN   TestAccNetworkingV2Port_noPortSecurityNoSecurityGroups
=== PAUSE TestAccNetworkingV2Port_noPortSecurityNoSecurityGroups
=== CONT  TestAccNetworkingV2Port_noPortSecurityNoSecurityGroups
--- PASS: TestAccNetworkingV2Port_noPortSecurityNoSecurityGroups (86.94s)
=== RUN   TestAccNetworkingV2Port_timeout
=== PAUSE TestAccNetworkingV2Port_timeout
=== CONT  TestAccNetworkingV2Port_timeout
--- PASS: TestAccNetworkingV2Port_timeout (87.05s)
PASS


Process finished with the exit code 0

```
