### PR TITLE
[DCS] Add support for version 6.0

### DIFF
--- a/docs/resources/dcs_instance_v1.md
+++ b/docs/resources/dcs_instance_v1.md
@@ -100,7 +100,7 @@ The following arguments are supported:
 * `engine` - (Required) Indicates a cache engine. Only `Redis` is supported. Changing this
   creates a new instance.
 
-* `engine_version` - (Required) Indicates the version of a cache engine, which can be `3.0`/`4.0`/`5.0`.
+* `engine_version` - (Required) Indicates the version of a cache engine, which can be `3.0`/`4.0`/`5.0`/`6.0`.
   Changing this creates a new instance.
 
 * `capacity` - (Required) Indicates the Cache capacity. Unit: GB.
@@ -229,7 +229,7 @@ The following attributes are exported:
 * `resource_spec_code` - Resource specifications.
   * `dcs.single_node`: indicates a DCS instance in single-node mode.
   * `dcs.master_standby`: indicates a DCS instance in master/standby mode.
-  * `dcs.cluster`: indicates a DCS instance in cluster mode.
+  * `dcs.cluster`: indicates a DCS instance in cluster mode. Not available with version `6.0`.
 
 * `used_memory` - Size of the used memory. Unit: MB.
 

--- a/opentelekomcloud/acceptance/dcs/resource_opentelekomcloud_dcs_instance_v1_test.go
+++ b/opentelekomcloud/acceptance/dcs/resource_opentelekomcloud_dcs_instance_v1_test.go
@@ -123,7 +123,23 @@ func TestAccASV1Configuration_invalidEngineVersion(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccDcsV1InstanceEngineValidation(instanceName),
-				ExpectError: regexp.MustCompile(`expected engine_version to be one of \[3.0 4.0 5.0\].+`),
+				ExpectError: regexp.MustCompile(`expected engine_version to be one of \[3.0 4.0 5.0 6.0\].+`),
+			},
+		},
+	})
+}
+
+func TestAccASV1Configuration_invalidResourceSpecCode(t *testing.T) {
+	var instanceName = fmt.Sprintf("dcs_instance_%s", acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDcsV1InstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDcsV1InstanceResourceSpecCode(instanceName),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`DCS Redis 6.0 instance does not support cluster mode.+`),
 			},
 		},
 	})
@@ -406,6 +422,37 @@ resource "opentelekomcloud_dcs_instance_v1" "instance_1" {
   available_zones   = [data.opentelekomcloud_dcs_az_v1.az_1.id]
   product_id        = data.opentelekomcloud_dcs_product_v1.product_1.id
   security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
+}
+`, common.DataSourceSecGroupDefault, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, instanceName)
+}
+
+func testAccDcsV1InstanceResourceSpecCode(instanceName string) string {
+	return fmt.Sprintf(`
+%s
+
+%s
+
+data "opentelekomcloud_dcs_az_v1" "az_1" {
+  port = "8002"
+  code = "%s"
+}
+
+data "opentelekomcloud_dcs_product_v1" "product_1" {
+  spec_code = "redis.single.xu1.tiny.128"
+}
+
+resource "opentelekomcloud_dcs_instance_v1" "instance_1" {
+  name               = "%s"
+  engine_version     = "6.0"
+  password           = "Hungarian_rapsody"
+  engine             = "Redis"
+  capacity           = 0.125
+  vpc_id             = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  subnet_id          = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  available_zones    = [data.opentelekomcloud_dcs_az_v1.az_1.id]
+  product_id         = data.opentelekomcloud_dcs_product_v1.product_1.id
+  security_group_id  = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
+	resource_spec_code = "dcs.cluster"
 }
 `, common.DataSourceSecGroupDefault, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, instanceName)
 }

--- a/opentelekomcloud/acceptance/dcs/resource_opentelekomcloud_dcs_instance_v1_test.go
+++ b/opentelekomcloud/acceptance/dcs/resource_opentelekomcloud_dcs_instance_v1_test.go
@@ -139,7 +139,7 @@ func TestAccASV1Configuration_invalidResourceSpecCode(t *testing.T) {
 			{
 				Config:      testAccDcsV1InstanceResourceSpecCode(instanceName),
 				PlanOnly:    true,
-				ExpectError: regexp.MustCompile(`DCS Redis 6.0 instance does not support cluster mode.+`),
+				ExpectError: regexp.MustCompile(`DCS Redis 6.0 instance does not support cluster mode+`),
 			},
 		},
 	})
@@ -452,7 +452,7 @@ resource "opentelekomcloud_dcs_instance_v1" "instance_1" {
   available_zones    = [data.opentelekomcloud_dcs_az_v1.az_1.id]
   product_id         = data.opentelekomcloud_dcs_product_v1.product_1.id
   security_group_id  = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
-	resource_spec_code = "dcs.cluster"
+  resource_spec_code = "dcs.cluster"
 }
 `, common.DataSourceSecGroupDefault, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, instanceName)
 }

--- a/opentelekomcloud/services/dcs/resource_opentelekomcloud_dcs_instance_v1.go
+++ b/opentelekomcloud/services/dcs/resource_opentelekomcloud_dcs_instance_v1.go
@@ -61,7 +61,7 @@ func ResourceDcsInstanceV1() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
-					"3.0", "4.0", "5.0",
+					"3.0", "4.0", "5.0", "6.0",
 				}, false),
 			},
 			"capacity": {
@@ -743,6 +743,13 @@ func validateEngine(_ context.Context, d *schema.ResourceDiff, _ interface{}) er
 
 	if _, ok := d.GetOk("whitelist"); ok && engineVersion == "3.0" {
 		return fmt.Errorf("DCS Redis 3.0 instance does not support whitelisting")
+	}
+
+	resourceSpecCode, ok := d.GetOk("resource_spec_code")
+	if ok {
+		if resourceSpecCode.(string) == "dcs.cluster" && engineVersion == "6.0" {
+			return fmt.Errorf("DCS Redis 6.0 instance does not support cluster mode")
+		}
 	}
 
 	return nil


### PR DESCRIPTION
## Summary of the Pull Request

OTC added Redis version `6.0` [as announced here](https://open-telekom-cloud.com/de/support/release-notes/redis-6-fuer-dcs). This PR adds version `6.0`.

## PR Checklist

* [ ] Refers to: #xxx
* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.
* [ ] Release notes added.

## Acceptance Steps Performed

I currently do not have an account for testing available. Could somebody assist?

```
=== RUN   TestAccASV1Configuration_invalidEngineVersion
=== PAUSE TestAccASV1Configuration_invalidEngineVersion
=== CONT  TestAccASV1Configuration_invalidEngineVersion
--- PASS: TestAccASV1Configuration_invalidEngineVersion (7.87s)
PASS

Process finished with the exit code 0
```
