### PR TITLE
[WAF] new `resource/opentelekomcloud_waf_dedicated_instance_v1`

### DIFF
--- a/docs/resources/waf_dedicated_instance_v1.md
+++ b/docs/resources/waf_dedicated_instance_v1.md
@@ -1,0 +1,118 @@
+---
+subcategory: "Dedicated Web Application Firewall (WAFD)"
+---
+
+Up-to-date reference of API arguments for WAF datamasking rule you can get at
+`https://docs.otc.t-systems.com/web-application-firewall-dedicated/api-ref/apis/dedicated_instance_management/index.html`.
+
+# opentelekomcloud_waf_dedicated_instance_v1
+
+Manages a WAF dedicated instance resource within OpenTelekomCloud.
+
+## Example Usage
+
+```hcl
+data "opentelekomcloud_vpc_subnet_v1" "shared_subnet"  {
+  name = "my_subnet"
+}
+
+data "opentelekomcloud_networking_secgroup_v2" "default_secgroup" {
+  name = "default"
+}
+
+resource "opentelekomcloud_waf_dedicated_instance_v1" "wafd_1" {
+  name              = "wafd-instance-1"
+  availability_zone = "eu-de-01"
+  specification     = "waf.instance.professional"
+  flavor            = "s2.large.2"
+  architecture      = "x86"
+  vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+
+  security_group = [
+    data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
+  ]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, ForceNew) Region where a dedicated engine is to be created. If omitted, the
+  provider-level region will be used. Changing this setting will create a new instance.
+
+* `name` - (Required, String) The name of WAF dedicated instance. Duplicate names are allowed, we suggest to keeping the
+  name unique.
+
+* `availability_zone` - (Required, ForceNew) AZ where the dedicated engine is to be created. Changing this will create a new instance.
+
+* `specification` - (Required, ForceNew) Specifications of the dedicated engine version. Values are:
+  + `waf.instance.professional` - The professional edition, throughput: 100 Mbit/s; QPS: 2,000 (Reference only).
+  + `waf.instance.enterprise` - The enterprise edition, throughput: 500 Mbit/s; QPS: 10,000 (Reference only).
+
+* `flavor` - (Required, ForceNew) ID of the specifications of the ECS hosting the dedicated engine.
+  You can go to the management console and confirm supported specifications. Changing this will create a new instance.
+
+* `vpc_id` - (Required, ForceNew) ID of the VPC where the dedicated engine is located. Changing this will create a new
+  instance.
+
+* `subnet_id` - (Required, ForceNew) ID of the VPC subnet where the dedicated engine is located.
+  Subnet_id has the same value as network_id obtained by calling the OpenStack APIs. Changing this will create a
+  new instance.
+
+* `security_group` - (Required, ForceNew) ID of the security group where the dedicated engine is located.
+  Changing this will create a new instance.
+
+* `architecture` - (Optional, String, ForceNew) Dedicated engine CPU architecture. Default value is `x86`.
+  Changing this will create a new instance.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The id of the instance.
+
+* `server_id` - The id of the instance server.
+
+* `service_ip` - The ip of the instance service.
+
+* `status` - Running status of the dedicated engine.
+  The value can be:
+  + `0` - Instance is creating.
+  + `1` - Instance has created.
+  + `2` - Instance is deleting.
+  + `3` - Instance has deleted.
+  + `4` - Instance create failed.
+  + `5` - Instance is frozen.
+  + `6` - Instance in abnormal state.
+  + `7` - Instance in updating.
+  + `8` - Instance update failed.
+
+* `access_status` - The access status of the instance.
+  + `0`: inaccessible
+  + `1`: accessible.
+
+* `billing_status` - Billing status of dedicated WAF engine. The value can be `0`, `1`, or `2`.
+  + `0`: The billing is normal.
+  + `1`: The billing account is frozen. Resources and data will be retained, but the cloud services cannot be used by the account.
+  + `2`: The billing is terminated. Resources and data will be cleared.
+
+* `upgradable` - The instance is to support upgrades. `false`: Cannot be upgraded, `true`: Can be upgraded.
+
+* `created_at` - Timestamp when the dedicated WAF engine was created.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 30 minute.
+* `delete` - Default is 20 minute.
+
+## Import
+
+WAF dedicated instance can be imported using the `id`, e.g.
+
+```bash
+$ terraform import opentelekomcloud_waf_dedicated_instance_v1.wafd <id>
+```

--- a/docs/resources/waf_dedicated_instance_v1.md
+++ b/docs/resources/waf_dedicated_instance_v1.md
@@ -9,6 +9,8 @@ Up-to-date reference of API arguments for WAF datamasking rule you can get at
 
 Manages a WAF dedicated instance resource within OpenTelekomCloud.
 
+-> **Note:** For this resource region must be set in environment variable `OS_REGION_NAME` or in `clouds.yaml`
+
 ## Example Usage
 
 ```hcl

--- a/docs/resources/waf_dedicated_instance_v1.md
+++ b/docs/resources/waf_dedicated_instance_v1.md
@@ -12,7 +12,7 @@ Manages a WAF dedicated instance resource within OpenTelekomCloud.
 ## Example Usage
 
 ```hcl
-data "opentelekomcloud_vpc_subnet_v1" "shared_subnet"  {
+data "opentelekomcloud_vpc_subnet_v1" "shared_subnet" {
   name = "my_subnet"
 }
 

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/jinzhu/copier v0.3.5
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.7.1-0.20230721123824-97f24b448bd4
+	github.com/opentelekomcloud/gophertelekomcloud v0.7.1-0.20230725132213-d0e533318e11
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.1.0
 	golang.org/x/sync v0.1.0

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/jinzhu/copier v0.3.5
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.7.1-0.20230725132213-d0e533318e11
+	github.com/opentelekomcloud/gophertelekomcloud v0.7.1-0.20230726145730-825974b15ae8
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.1.0
 	golang.org/x/sync v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -154,8 +154,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k+Mg7cowZ8yv4Trqw9UsJby758=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.7.1-0.20230725132213-d0e533318e11 h1:pLxWuFHyeWTvJJ4nXn9qXoGUSbJ6PsdVkciVxC9vtW0=
-github.com/opentelekomcloud/gophertelekomcloud v0.7.1-0.20230725132213-d0e533318e11/go.mod h1:9Deb3q2gJvq5dExV+aX+iO+G+mD9Zr9uFt+YY9ONmq0=
+github.com/opentelekomcloud/gophertelekomcloud v0.7.1-0.20230726145730-825974b15ae8 h1:hdFXmfh22aPHbQRxlKYDE1lQqaJ1vEMx6CXfnAiV96g=
+github.com/opentelekomcloud/gophertelekomcloud v0.7.1-0.20230726145730-825974b15ae8/go.mod h1:9Deb3q2gJvq5dExV+aX+iO+G+mD9Zr9uFt+YY9ONmq0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/go.sum
+++ b/go.sum
@@ -154,8 +154,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k+Mg7cowZ8yv4Trqw9UsJby758=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.7.1-0.20230721123824-97f24b448bd4 h1:tXaosDbtNFjLogtnqkVIPKLVNFJ+gOPjbzEJwjcRbeM=
-github.com/opentelekomcloud/gophertelekomcloud v0.7.1-0.20230721123824-97f24b448bd4/go.mod h1:9Deb3q2gJvq5dExV+aX+iO+G+mD9Zr9uFt+YY9ONmq0=
+github.com/opentelekomcloud/gophertelekomcloud v0.7.1-0.20230725132213-d0e533318e11 h1:pLxWuFHyeWTvJJ4nXn9qXoGUSbJ6PsdVkciVxC9vtW0=
+github.com/opentelekomcloud/gophertelekomcloud v0.7.1-0.20230725132213-d0e533318e11/go.mod h1:9Deb3q2gJvq5dExV+aX+iO+G+mD9Zr9uFt+YY9ONmq0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/opentelekomcloud/acceptance/waf/resource_opentelekomcloud_waf_dedicated_instance_v1_test.go
+++ b/opentelekomcloud/acceptance/waf/resource_opentelekomcloud_waf_dedicated_instance_v1_test.go
@@ -2,6 +2,7 @@ package acceptance
 
 import (
 	"fmt"
+	"log"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -19,6 +20,7 @@ const wafdInstanceResourceName = "opentelekomcloud_waf_dedicated_instance_v1.waf
 func TestAccWafDedicatedInstanceV1_basic(t *testing.T) {
 	var inst instances.Instance
 	var instanceName = fmt.Sprintf("wafd_instance_%s", acctest.RandString(5))
+	log.Printf("[DEBUG] The opentelekomcloud Waf dedicated instance test running in '%s' region.", env.OS_REGION_NAME)
 	arch := "x86"
 	flavor := "s2.large.2"
 	if env.OS_REGION_NAME == "eu-ch2" {

--- a/opentelekomcloud/acceptance/waf/resource_opentelekomcloud_waf_dedicated_instance_v1_test.go
+++ b/opentelekomcloud/acceptance/waf/resource_opentelekomcloud_waf_dedicated_instance_v1_test.go
@@ -1,0 +1,173 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/waf-premium/v1/instances"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+)
+
+const wafdInstanceResourceName = "opentelekomcloud_waf_dedicated_instance_v1.wafd_1"
+
+func TestAccWafDedicatedInstanceV1_basic(t *testing.T) {
+	var inst instances.Instance
+	var instanceName = fmt.Sprintf("wafd_instance_%s", acctest.RandString(5))
+	arch := "x86"
+	flavor := "s2.large.2"
+	if env.OS_REGION_NAME == "eu-ch2" {
+		arch = "x86_64"
+		flavor = "s3.large.2"
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckWafDedicatedInstanceV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafDedicatedInstanceV1_basic(instanceName, arch, flavor),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafDedicatedInstanceV1Exists(
+						wafdInstanceResourceName, &inst),
+					resource.TestCheckResourceAttr(wafdInstanceResourceName, "name", instanceName),
+					resource.TestCheckResourceAttr(wafdInstanceResourceName, "specification", "waf.instance.professional"),
+					resource.TestCheckResourceAttr(wafdInstanceResourceName, "security_group.#", "1"),
+				),
+			},
+			{
+				Config: testAccWafDedicatedInstanceV1_update(instanceName, arch, flavor),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafDedicatedInstanceV1Exists(
+						wafdInstanceResourceName, &inst),
+					resource.TestCheckResourceAttr(wafdInstanceResourceName, "name", instanceName+"-updated"),
+					resource.TestCheckResourceAttr(wafdInstanceResourceName, "specification", "waf.instance.professional"),
+					resource.TestCheckResourceAttr(wafdInstanceResourceName, "security_group.#", "1"),
+				),
+			},
+			{
+				ResourceName:            wafdInstanceResourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"specification"},
+			},
+		},
+	})
+}
+
+func testAccCheckWafDedicatedInstanceV1Destroy(s *terraform.State) error {
+	var client *golangsdk.ServiceClient
+	var err error
+	config := common.TestAccProvider.Meta().(*cfg.Config)
+	if env.OS_REGION_NAME != "eu-ch2" {
+		client, err = config.WafDedicatedV1Client(env.OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("error creating OpenTelekomCloud Waf dedicated client: %s", err)
+		}
+	} else {
+		client, err = config.WafDedicatedSwissV1Client(env.OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("error creating OpenTelekomCloud Waf dedicated client: %s", err)
+		}
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "opentelekomcloud_waf_dedicated_instance_v1" {
+			continue
+		}
+		_, err = instances.Get(client, rs.Primary.ID)
+		if err == nil {
+			return fmt.Errorf("waf dedicated instance (%s) still exists", rs.Primary.ID)
+		}
+		if _, ok := err.(golangsdk.ErrDefault404); !ok {
+			return err
+		}
+	}
+	return nil
+}
+
+func testAccCheckWafDedicatedInstanceV1Exists(n string, instance *instances.Instance) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		var client *golangsdk.ServiceClient
+		var err error
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		config := common.TestAccProvider.Meta().(*cfg.Config)
+		if env.OS_REGION_NAME != "eu-ch2" {
+			client, err = config.WafDedicatedV1Client(env.OS_REGION_NAME)
+			if err != nil {
+				return fmt.Errorf("error creating OpenTelekomCloud Waf dedicated client: %s", err)
+			}
+		} else {
+			client, err = config.WafDedicatedSwissV1Client(env.OS_REGION_NAME)
+			if err != nil {
+				return fmt.Errorf("error creating OpenTelekomCloud Waf dedicated client: %s", err)
+			}
+		}
+
+		var found *instances.Instance
+		found, err = instances.Get(client, rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+		*instance = *found
+
+		return nil
+	}
+}
+
+func testAccWafDedicatedInstanceV1_basic(instanceName, arch, flavor string) string {
+	return fmt.Sprintf(`
+%s
+
+%s
+
+resource "opentelekomcloud_waf_dedicated_instance_v1" "wafd_1" {
+    name              = "%[4]s"
+    availability_zone = "%[3]s"
+    specification     = "waf.instance.professional"
+    flavor            = "%[6]s"
+    architecture      = "%[5]s"
+    vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+    subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+
+    security_group = [
+      data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
+    ]
+}
+`, common.DataSourceSecGroupDefault, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, instanceName, arch, flavor)
+}
+
+func testAccWafDedicatedInstanceV1_update(instanceName, arch, flavor string) string {
+	return fmt.Sprintf(`
+%s
+
+%s
+
+resource "opentelekomcloud_waf_dedicated_instance_v1" "wafd_1" {
+    name              = "%[4]s-updated"
+    availability_zone = "%[3]s"
+    specification     = "waf.instance.professional"
+    flavor            = "%[6]s"
+    architecture      = "%[5]s"
+    vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+    subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+
+    security_group = [
+      data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
+    ]
+}
+`, common.DataSourceSecGroupDefault, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, instanceName, arch, flavor)
+}

--- a/opentelekomcloud/acceptance/waf/resource_opentelekomcloud_waf_dedicated_instance_v1_test.go
+++ b/opentelekomcloud/acceptance/waf/resource_opentelekomcloud_waf_dedicated_instance_v1_test.go
@@ -135,17 +135,17 @@ func testAccWafDedicatedInstanceV1_basic(instanceName, arch, flavor string) stri
 %s
 
 resource "opentelekomcloud_waf_dedicated_instance_v1" "wafd_1" {
-    name              = "%[4]s"
-    availability_zone = "%[3]s"
-    specification     = "waf.instance.professional"
-    flavor            = "%[6]s"
-    architecture      = "%[5]s"
-    vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
-    subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  name              = "%[4]s"
+  availability_zone = "%[3]s"
+  specification     = "waf.instance.professional"
+  flavor            = "%[6]s"
+  architecture      = "%[5]s"
+  vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
 
-    security_group = [
-      data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
-    ]
+  security_group = [
+    data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
+  ]
 }
 `, common.DataSourceSecGroupDefault, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, instanceName, arch, flavor)
 }
@@ -157,17 +157,17 @@ func testAccWafDedicatedInstanceV1_update(instanceName, arch, flavor string) str
 %s
 
 resource "opentelekomcloud_waf_dedicated_instance_v1" "wafd_1" {
-    name              = "%[4]s-updated"
-    availability_zone = "%[3]s"
-    specification     = "waf.instance.professional"
-    flavor            = "%[6]s"
-    architecture      = "%[5]s"
-    vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
-    subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  name              = "%[4]s-updated"
+  availability_zone = "%[3]s"
+  specification     = "waf.instance.professional"
+  flavor            = "%[6]s"
+  architecture      = "%[5]s"
+  vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
 
-    security_group = [
-      data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
-    ]
+  security_group = [
+    data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
+  ]
 }
 `, common.DataSourceSecGroupDefault, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, instanceName, arch, flavor)
 }

--- a/opentelekomcloud/acceptance/waf/resource_opentelekomcloud_waf_dedicated_instance_v1_test.go
+++ b/opentelekomcloud/acceptance/waf/resource_opentelekomcloud_waf_dedicated_instance_v1_test.go
@@ -61,10 +61,8 @@ func TestAccWafDedicatedInstanceV1_basic(t *testing.T) {
 }
 
 func testAccCheckWafDedicatedInstanceV1Destroy(s *terraform.State) error {
-	var client *golangsdk.ServiceClient
-	var err error
 	config := common.TestAccProvider.Meta().(*cfg.Config)
-	client, err = getAccWafdClient(client, err, config)
+	client, err := getAccWafdClient(config)
 	if err != nil {
 		return err
 	}
@@ -86,8 +84,6 @@ func testAccCheckWafDedicatedInstanceV1Destroy(s *terraform.State) error {
 
 func testAccCheckWafDedicatedInstanceV1Exists(n string, instance *instances.Instance) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		var client *golangsdk.ServiceClient
-		var err error
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("not found: %s", n)
@@ -98,7 +94,7 @@ func testAccCheckWafDedicatedInstanceV1Exists(n string, instance *instances.Inst
 		}
 
 		config := common.TestAccProvider.Meta().(*cfg.Config)
-		client, err = getAccWafdClient(client, err, config)
+		client, err := getAccWafdClient(config)
 		if err != nil {
 			return err
 		}

--- a/opentelekomcloud/acceptance/waf/resource_opentelekomcloud_waf_dedicated_instance_v1_test.go
+++ b/opentelekomcloud/acceptance/waf/resource_opentelekomcloud_waf_dedicated_instance_v1_test.go
@@ -64,16 +64,9 @@ func testAccCheckWafDedicatedInstanceV1Destroy(s *terraform.State) error {
 	var client *golangsdk.ServiceClient
 	var err error
 	config := common.TestAccProvider.Meta().(*cfg.Config)
-	if env.OS_REGION_NAME != "eu-ch2" {
-		client, err = config.WafDedicatedV1Client(env.OS_REGION_NAME)
-		if err != nil {
-			return fmt.Errorf("error creating OpenTelekomCloud Waf dedicated client: %s", err)
-		}
-	} else {
-		client, err = config.WafDedicatedSwissV1Client(env.OS_REGION_NAME)
-		if err != nil {
-			return fmt.Errorf("error creating OpenTelekomCloud Waf dedicated client: %s", err)
-		}
+	client, err = getAccWafdClient(client, err, config)
+	if err != nil {
+		return err
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -105,16 +98,9 @@ func testAccCheckWafDedicatedInstanceV1Exists(n string, instance *instances.Inst
 		}
 
 		config := common.TestAccProvider.Meta().(*cfg.Config)
-		if env.OS_REGION_NAME != "eu-ch2" {
-			client, err = config.WafDedicatedV1Client(env.OS_REGION_NAME)
-			if err != nil {
-				return fmt.Errorf("error creating OpenTelekomCloud Waf dedicated client: %s", err)
-			}
-		} else {
-			client, err = config.WafDedicatedSwissV1Client(env.OS_REGION_NAME)
-			if err != nil {
-				return fmt.Errorf("error creating OpenTelekomCloud Waf dedicated client: %s", err)
-			}
+		client, err = getAccWafdClient(client, err, config)
+		if err != nil {
+			return err
 		}
 
 		var found *instances.Instance

--- a/opentelekomcloud/acceptance/waf/utils.go
+++ b/opentelekomcloud/acceptance/waf/utils.go
@@ -8,7 +8,9 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 )
 
-func getAccWafdClient(client *golangsdk.ServiceClient, err error, config *cfg.Config) (*golangsdk.ServiceClient, error) {
+func getAccWafdClient(config *cfg.Config) (*golangsdk.ServiceClient, error) {
+	var client *golangsdk.ServiceClient
+	var err error
 	if env.OS_REGION_NAME != "eu-ch2" {
 		client, err = config.WafDedicatedV1Client(env.OS_REGION_NAME)
 		if err != nil {

--- a/opentelekomcloud/acceptance/waf/utils.go
+++ b/opentelekomcloud/acceptance/waf/utils.go
@@ -1,0 +1,24 @@
+package acceptance
+
+import (
+	"fmt"
+
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+)
+
+func getAccWafdClient(client *golangsdk.ServiceClient, err error, config *cfg.Config) (*golangsdk.ServiceClient, error) {
+	if env.OS_REGION_NAME != "eu-ch2" {
+		client, err = config.WafDedicatedV1Client(env.OS_REGION_NAME)
+		if err != nil {
+			return nil, fmt.Errorf("error creating OpenTelekomCloud Waf dedicated client: %s", err)
+		}
+	} else {
+		client, err = config.WafDedicatedSwissV1Client(env.OS_REGION_NAME)
+		if err != nil {
+			return nil, fmt.Errorf("error creating OpenTelekomCloud Waf dedicated client: %s", err)
+		}
+	}
+	return client, err
+}

--- a/opentelekomcloud/common/cfg/config.go
+++ b/opentelekomcloud/common/cfg/config.go
@@ -1019,6 +1019,20 @@ func (c *Config) WafV1Client(region string) (*golangsdk.ServiceClient, error) {
 	})
 }
 
+func (c *Config) WafDedicatedV1Client(region string) (*golangsdk.ServiceClient, error) {
+	return openstack.NewWAFDV1(c.HwClient, golangsdk.EndpointOpts{
+		Region:       region,
+		Availability: c.getEndpointType(),
+	})
+}
+
+func (c *Config) WafDedicatedSwissV1Client(region string) (*golangsdk.ServiceClient, error) {
+	return openstack.NewWAFDSwissV1(c.HwClient, golangsdk.EndpointOpts{
+		Region:       region,
+		Availability: c.getEndpointType(),
+	})
+}
+
 func (c *Config) RdsV3Client(region string) (*golangsdk.ServiceClient, error) {
 	return openstack.NewRDSV3(c.HwClient, golangsdk.EndpointOpts{
 		Region:       region,

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -484,6 +484,7 @@ func Provider() *schema.Provider {
 			"opentelekomcloud_waf_ccattackprotection_rule_v1":     waf.ResourceWafCcAttackProtectionRuleV1(),
 			"opentelekomcloud_waf_preciseprotection_rule_v1":      waf.ResourceWafPreciseProtectionRuleV1(),
 			"opentelekomcloud_waf_webtamperprotection_rule_v1":    waf.ResourceWafWebTamperProtectionRuleV1(),
+			"opentelekomcloud_waf_dedicated_instance_v1":          waf.ResourceWafDedicatedInstance(),
 		},
 	}
 

--- a/opentelekomcloud/services/waf/common.go
+++ b/opentelekomcloud/services/waf/common.go
@@ -6,7 +6,21 @@ import (
 )
 
 const (
-	ClientError = "error creating OpenTelekomCloud WAF client: %w"
+	ClientError                  = "error creating OpenTelekomCloud WAF client: %w"
+	errCreationV1DedicatedClient = "error creating OpenTelekomCloud WAF dedicated client: %w"
+	keyClientV1                  = "wafd-v1-client"
+	// runStatusCreating the instance is creating.
+	runStatusCreating = 0
+	// runStatusRunning the instance has been created.
+	runStatusRunning = 1
+	// runStatusDeleting the instance deleting.
+	runStatusDeleting = 2
+	// runStatusDeleting the instance has be deleted.
+	runStatusDeleted = 3
+	// defaultCount the number of instances created.
+	defaultCount = 1
+	// Billing mode, payPerUseMode: pay pre use mode
+	payPerUseMode = 30
 )
 
 func wafRuleImporter() *schema.ResourceImporter {

--- a/opentelekomcloud/services/waf/resource_opentelekomcloud_waf_dedicated_instance.go
+++ b/opentelekomcloud/services/waf/resource_opentelekomcloud_waf_dedicated_instance.go
@@ -1,0 +1,369 @@
+package waf
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
+
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/waf-premium/v1/instances"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
+)
+
+func ResourceWafDedicatedInstance() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceWafDedicatedInstanceCreate,
+		ReadContext:   resourceWafDedicatedInstanceRead,
+		UpdateContext: resourceWafDedicatedInstanceUpdate,
+		DeleteContext: resourceWafDedicatedInstanceDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(20 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"availability_zone": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"specification": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"architecture": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "x86",
+				ForceNew: true,
+			},
+			"flavor": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"subnet_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"security_group": {
+				Type:     schema.TypeList,
+				Required: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"server_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"service_ip": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"access_status": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"billing_status": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"upgradable": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"hosts": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+							Optional: true,
+						},
+						"hostname": {
+							Type:     schema.TypeString,
+							Computed: true,
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceWafDedicatedInstanceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	region := config.GetRegion(d)
+	client, err := common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
+		return config.WafDedicatedV1Client(region)
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV1DedicatedClient, err)
+	}
+	if region == "eu-ch2" {
+		client, err = common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
+			return config.WafDedicatedSwissV1Client(region)
+		})
+		if err != nil {
+			return fmterr.Errorf(errCreationV1DedicatedClient, err)
+		}
+	}
+
+	sg := d.Get("security_group").([]interface{})
+	groups := make([]string, 0, len(sg))
+	for _, v := range sg {
+		groups = append(groups, v.(string))
+	}
+	log.Printf("[DEBUG] The security_group parameters: %+v.", groups)
+
+	opts := instances.CreateOpts{
+		Region:           region,
+		ChargeMode:       payPerUseMode,
+		AvailabilityZone: d.Get("availability_zone").(string),
+		Architecture:     d.Get("architecture").(string),
+		InstanceName:     d.Get("name").(string),
+		Specification:    d.Get("specification_code").(string),
+		Flavor:           d.Get("flavor").(string),
+		VpcId:            d.Get("vpc_id").(string),
+		SubnetId:         d.Get("subnet_id").(string),
+		SecurityGroupsId: groups,
+		Count:            defaultCount,
+	}
+
+	r, err := instances.Create(client, opts)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(r.Instances[0].Id)
+
+	log.Printf("[DEBUG] Waiting for opentelekomcloud WAF dedicated instance (%s) to become available", r.Instances[0].Id)
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"Creating"},
+		Target:       []string{"Created"},
+		Refresh:      waitForInstanceCreated(client, r.Instances[0].Id),
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		Delay:        5 * time.Second,
+		PollInterval: 15 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return fmterr.Errorf("error creating OpenTelekomCloud WAF dedicated instance: %s", err)
+	}
+
+	clientCtx := common.CtxWithClient(ctx, client, keyClientV1)
+	return resourceWafDedicatedInstanceRead(clientCtx, d, meta)
+}
+
+func resourceWafDedicatedInstanceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	region := config.GetRegion(d)
+	client, err := common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
+		return config.WafDedicatedV1Client(region)
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV1DedicatedClient, err)
+	}
+	if region == "eu-ch2" {
+		client, err = common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
+			return config.WafDedicatedSwissV1Client(region)
+		})
+		if err != nil {
+			return fmterr.Errorf(errCreationV1DedicatedClient, err)
+		}
+	}
+	instance, err := instances.Get(client, d.Id())
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving opentelekomcloud WAF dedicated instance.")
+	}
+	upgradable := false
+	if instance.Upgradable == 1 {
+		upgradable = true
+	}
+	mErr := multierror.Append(nil,
+		d.Set("region", instance.Region),
+		d.Set("name", instance.Name),
+		d.Set("availability_zone", instance.AvailabilityZone),
+		d.Set("architecture", instance.Architecture),
+		d.Set("flavor", instance.Flavor),
+		d.Set("vpc_id", instance.VpcID),
+		d.Set("subnet_id", instance.SubnetId),
+		d.Set("security_group", instance.SecurityGroups),
+		d.Set("server_id", instance.ServerId),
+		d.Set("service_ip", instance.ServiceIp),
+		d.Set("status", instance.Status),
+		d.Set("access_status", instance.AccessStatus),
+		d.Set("upgradable", upgradable),
+		d.Set("specification", instance.Specification),
+		d.Set("created_at", instance.CreatedAt),
+		d.Set("billing_status", instance.BillingStatus),
+	)
+
+	hosts := make([]map[string]interface{}, len(instance.Hosts))
+	for i, host := range instance.Hosts {
+		hosts[i] = make(map[string]interface{})
+		hosts[i]["id"] = host.ID
+		hosts[i]["hostname"] = host.Hostname
+	}
+	if err := d.Set("hosts", hosts); err != nil {
+		return diag.FromErr(err)
+	}
+
+	if mErr.ErrorOrNil() != nil {
+		return fmterr.Errorf("error setting opentelekomcloud WAF dedicated instance fields: %w", err)
+	}
+	return nil
+}
+
+func resourceWafDedicatedInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	region := config.GetRegion(d)
+	client, err := common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
+		return config.WafDedicatedV1Client(region)
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV1DedicatedClient, err)
+	}
+	if region == "eu-ch2" {
+		client, err = common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
+			return config.WafDedicatedSwissV1Client(region)
+		})
+		if err != nil {
+			return fmterr.Errorf(errCreationV1DedicatedClient, err)
+		}
+	}
+
+	if d.HasChanges("name") {
+		_, err = instances.Update(client, d.Id(), instances.UpdateOpts{
+			Name: d.Get("name").(string),
+		})
+		if err != nil {
+			return fmterr.Errorf("error updating opentelekomcloud WAF dedicated instance: %w", err)
+		}
+	}
+
+	clientCtx := common.CtxWithClient(ctx, client, keyClientV1)
+	return resourceWafDedicatedInstanceRead(clientCtx, d, meta)
+}
+
+func waitForInstanceCreated(client *golangsdk.ServiceClient, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		r, err := instances.Get(client, id)
+		if err != nil {
+			return nil, "Error", err
+		}
+		switch r.Status {
+		case runStatusCreating:
+			return r, "Creating", nil
+		case runStatusRunning:
+			return r, "Created", nil
+		default:
+			err = fmt.Errorf("error while creating opentelekomcloud WAF dedicated instance %s. "+
+				"Unexpected status: %v", r.ID, r.Status)
+			return r, "Error", err
+		}
+	}
+}
+
+func waitForInstanceDeleted(client *golangsdk.ServiceClient, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		r, err := instances.Get(client, id)
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				log.Printf("[DEBUG] The opentelekomcloud Waf dedicated instance has been deleted (ID:%s).", id)
+				return r, "Deleted", nil
+			}
+			return nil, "Error", err
+		}
+		switch r.Status {
+		case runStatusDeleting:
+			return r, "Deleting", nil
+		case runStatusDeleted:
+			return r, "Deleted", nil
+		default:
+			err = fmt.Errorf("error in delete WAF opentelekomcloud dedicated instance[%s]. "+
+				"Unexpected status: %v", r.ID, r.Status)
+			return r, "Error", err
+		}
+	}
+}
+
+func resourceWafDedicatedInstanceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	region := config.GetRegion(d)
+	client, err := common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
+		return config.WafDedicatedV1Client(region)
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV1DedicatedClient, err)
+	}
+	if region == "eu-ch2" {
+		client, err = common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
+			return config.WafDedicatedSwissV1Client(region)
+		})
+		if err != nil {
+			return fmterr.Errorf(errCreationV1DedicatedClient, err)
+		}
+	}
+
+	err = instances.Delete(client, d.Id())
+	if err != nil {
+		return fmterr.Errorf("error deleting opentelekomcloud WAF dedicated instance : %w", err)
+	}
+
+	log.Printf("[DEBUG] Waiting for opentelekomcloud WAF dedicated instance to be deleted (ID:%s).", d.Id())
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"Deleting"},
+		Target:       []string{"Deleted"},
+		Refresh:      waitForInstanceDeleted(client, d.Id()),
+		Timeout:      d.Timeout(schema.TimeoutDelete),
+		Delay:        5 * time.Second,
+		PollInterval: 15 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		log.Printf("[DEBUG] Error while waiting to delete opentelekomcloud WAF dedicated instance. \n%s : %#v", d.Id(), err)
+		return diag.FromErr(err)
+	}
+	d.SetId("")
+	return nil
+}

--- a/releasenotes/notes/wafd-instance-2c14a408cc05247b.yaml
+++ b/releasenotes/notes/wafd-instance-2c14a408cc05247b.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  |
+  **[WAF]** Add new resource ``resource/opentelekomcloud_waf_dedicated_instance_v1`` (`#2241 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2241>`_)


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [x] Refers to: #2231
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccWafDedicatedInstanceV1_basic
2023/07/27 11:00:54 [DEBUG] The opentelekomcloud Waf dedicated instance test running in 'eu-ch2' region.
--- PASS: TestAccWafDedicatedInstanceV1_basic (402.10s)
PASS

Process finished with the exit code 0

=== RUN   TestAccWafDedicatedInstanceV1_basic
2023/07/27 11:34:15 [DEBUG] The opentelekomcloud Waf dedicated instance test running in 'eu-de' region.
--- PASS: TestAccWafDedicatedInstanceV1_basic (532.35s)
PASS

Process finished with the exit code 0
```
