### PR TITLE
[AS] client from ctx in `resource/opentelekomcloud_as_*`

### DIFF
--- a/opentelekomcloud/acceptance/as/resource_opentelekomcloud_as_configuration_v1_test.go
+++ b/opentelekomcloud/acceptance/as/resource_opentelekomcloud_as_configuration_v1_test.go
@@ -171,7 +171,7 @@ var testAccASV1ConfigurationBasic = fmt.Sprintf(`
 %s
 
 resource "opentelekomcloud_as_configuration_v1" "as_config"{
-  scaling_configuration_name = "hth_as_config"
+  scaling_configuration_name = "as_config_basic"
   instance_config {
     image = data.opentelekomcloud_images_image_v2.latest_image.id
     disk {
@@ -194,7 +194,7 @@ var testAccASV1ConfigurationPublicIP = fmt.Sprintf(`
 %s
 
 resource "opentelekomcloud_as_configuration_v1" "as_config"{
-  scaling_configuration_name = "as_config"
+  scaling_configuration_name = "as_config_eip"
   instance_config {
     image = data.opentelekomcloud_images_image_v2.latest_image.id
     disk {
@@ -231,7 +231,7 @@ var testAccASV1ConfigurationInvalidDiskSize = fmt.Sprintf(`
 %s
 
 resource "opentelekomcloud_as_configuration_v1" "as_config"{
-  scaling_configuration_name = "as_config"
+  scaling_configuration_name = "as_config_invalid_ds"
   instance_config {
     image = data.opentelekomcloud_images_image_v2.latest_image.id
     disk {
@@ -268,7 +268,7 @@ resource "opentelekomcloud_compute_secgroup_v2" "secgroup_3" {
 }
 
 resource "opentelekomcloud_as_configuration_v1" "as_config" {
-  scaling_configuration_name = "as_config"
+  scaling_configuration_name = "as_config_multiple_sg"
   instance_config {
     image = data.opentelekomcloud_images_image_v2.latest_image.id
     disk {

--- a/opentelekomcloud/acceptance/as/resource_opentelekomcloud_as_policy_v1_test.go
+++ b/opentelekomcloud/acceptance/as/resource_opentelekomcloud_as_policy_v1_test.go
@@ -102,7 +102,7 @@ var testAccASV1PolicyBasic = fmt.Sprintf(`
 %s
 
 resource "opentelekomcloud_as_configuration_v1" "as_config"{
-  scaling_configuration_name = "as_config"
+  scaling_configuration_name = "as_config_pol_v1"
   instance_config {
     image = data.opentelekomcloud_images_image_v2.latest_image.id
     disk {
@@ -115,7 +115,7 @@ resource "opentelekomcloud_as_configuration_v1" "as_config"{
 }
 
 resource "opentelekomcloud_as_group_v1" "as_group"{
-  scaling_group_name       = "as_group"
+  scaling_group_name       = "as_group_pol_v1"
   scaling_configuration_id = opentelekomcloud_as_configuration_v1.as_config.id
   delete_instances         = "yes"
   delete_publicip          = true
@@ -129,7 +129,7 @@ resource "opentelekomcloud_as_group_v1" "as_group"{
 }
 
 resource "opentelekomcloud_as_policy_v1" "as_policy"{
-  scaling_policy_name = "as_policy"
+  scaling_policy_name = "as_policy_v1"
   scaling_group_id    = opentelekomcloud_as_group_v1.as_group.id
   scaling_policy_type = "SCHEDULED"
   scaling_policy_action {
@@ -137,7 +137,7 @@ resource "opentelekomcloud_as_policy_v1" "as_policy"{
     instance_number = 1
   }
   scheduled_policy {
-    launch_time = "2022-12-22T12:00Z"
+    launch_time = "2023-12-22T12:00Z"
   }
 }
 `, common.DataSourceSecGroupDefault, common.DataSourceImage, common.DataSourceSubnet, env.OS_KEYPAIR_NAME)

--- a/opentelekomcloud/acceptance/as/resource_opentelekomcloud_as_policy_v2_test.go
+++ b/opentelekomcloud/acceptance/as/resource_opentelekomcloud_as_policy_v2_test.go
@@ -38,7 +38,7 @@ func TestAccASPolicyV2_basic(t *testing.T) {
 					testAccCheckASV2PolicyExists(resourceName, &asPolicy),
 					resource.TestCheckResourceAttr(resourceName, "scaling_policy_action.0.operation", "ADD"),
 					resource.TestCheckResourceAttr(resourceName, "scaling_policy_action.0.percentage", "15"),
-					resource.TestCheckResourceAttr(resourceName, "scaling_policy_name", "as_policy"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_policy_name", "as_policy_pol_v2"),
 					resource.TestCheckResourceAttr(resourceName, "cool_down_time", "300"),
 				),
 			},
@@ -47,7 +47,7 @@ func TestAccASPolicyV2_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckASV2PolicyExists(resourceName, &asPolicy),
 					resource.TestCheckResourceAttr(resourceName, "scaling_policy_action.0.percentage", "30"),
-					resource.TestCheckResourceAttr(resourceName, "scaling_policy_name", "as_policy_update"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_policy_name", "as_policy_pol_v2_update"),
 					resource.TestCheckResourceAttr(resourceName, "cool_down_time", "100"),
 				),
 			},
@@ -80,7 +80,7 @@ func TestAccASPolicyV2_withSize(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "scaling_policy_action.0.operation", "ADD"),
 					resource.TestCheckResourceAttr(resourceName, "scaling_policy_action.0.percentage", "0"),
 					resource.TestCheckResourceAttr(resourceName, "scaling_policy_action.0.size", "1"),
-					resource.TestCheckResourceAttr(resourceName, "scaling_policy_name", "as_policy"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_policy_name", "as_policy_pol_v2_size"),
 					resource.TestCheckResourceAttr(resourceName, "cool_down_time", "100"),
 				),
 			},
@@ -166,7 +166,7 @@ var testAccASPolicyV2Basic = fmt.Sprintf(`
 %s
 
 resource "opentelekomcloud_as_configuration_v1" "as_config"{
-  scaling_configuration_name = "as_config"
+  scaling_configuration_name = "as_config_pol_v2"
 
   instance_config {
     image = data.opentelekomcloud_images_image_v2.latest_image.id
@@ -180,7 +180,7 @@ resource "opentelekomcloud_as_configuration_v1" "as_config"{
 }
 
 resource "opentelekomcloud_as_group_v1" "as_group"{
-  scaling_group_name       = "as_group"
+  scaling_group_name       = "as_group_pol_v2"
   scaling_configuration_id = opentelekomcloud_as_configuration_v1.as_config.id
 
   networks {
@@ -196,7 +196,7 @@ resource "opentelekomcloud_as_group_v1" "as_group"{
 }
 
 resource "opentelekomcloud_as_policy_v2" "as_policy"{
-  scaling_policy_name   = "as_policy"
+  scaling_policy_name   = "as_policy_pol_v2"
   scaling_policy_type   = "RECURRENCE"
   scaling_resource_id   = opentelekomcloud_as_group_v1.as_group.id
   scaling_resource_type = "SCALING_GROUP"
@@ -225,7 +225,7 @@ var testAccASPolicyV2Update = fmt.Sprintf(`
 %s
 
 resource "opentelekomcloud_as_configuration_v1" "as_config"{
-  scaling_configuration_name = "as_config"
+  scaling_configuration_name = "as_config_pol_v2"
 
   instance_config {
     image = data.opentelekomcloud_images_image_v2.latest_image.id
@@ -239,7 +239,7 @@ resource "opentelekomcloud_as_configuration_v1" "as_config"{
 }
 
 resource "opentelekomcloud_as_group_v1" "as_group"{
-  scaling_group_name       = "as_group"
+  scaling_group_name       = "as_group_pol_v2"
   scaling_configuration_id = opentelekomcloud_as_configuration_v1.as_config.id
 
   networks {
@@ -255,7 +255,7 @@ resource "opentelekomcloud_as_group_v1" "as_group"{
 }
 
 resource "opentelekomcloud_as_policy_v2" "as_policy"{
-  scaling_policy_name   = "as_policy_update"
+  scaling_policy_name   = "as_policy_pol_v2_update"
   scaling_policy_type   = "RECURRENCE"
   scaling_resource_id   = opentelekomcloud_as_group_v1.as_group.id
   scaling_resource_type = "SCALING_GROUP"
@@ -285,7 +285,7 @@ var testAccASPolicyV2ActionWithSize = fmt.Sprintf(`
 %s
 
 resource "opentelekomcloud_as_configuration_v1" "as_config"{
-  scaling_configuration_name = "as_config"
+  scaling_configuration_name = "as_config_pol_v2_size"
 
   instance_config {
     image = data.opentelekomcloud_images_image_v2.latest_image.id
@@ -299,7 +299,7 @@ resource "opentelekomcloud_as_configuration_v1" "as_config"{
 }
 
 resource "opentelekomcloud_as_group_v1" "as_group"{
-  scaling_group_name       = "as_group"
+  scaling_group_name       = "as_group_pol_v2_size"
   scaling_configuration_id = opentelekomcloud_as_configuration_v1.as_config.id
 
   networks {
@@ -315,7 +315,7 @@ resource "opentelekomcloud_as_group_v1" "as_group"{
 }
 
 resource "opentelekomcloud_as_policy_v2" "as_policy"{
-  scaling_policy_name   = "as_policy"
+  scaling_policy_name   = "as_policy_pol_v2_size"
   scaling_policy_type   = "RECURRENCE"
   scaling_resource_id   = opentelekomcloud_as_group_v1.as_group.id
   scaling_resource_type = "SCALING_GROUP"
@@ -345,7 +345,7 @@ var testAccASPolicyV2ActionConflict = fmt.Sprintf(`
 %s
 
 resource "opentelekomcloud_as_configuration_v1" "as_config"{
-  scaling_configuration_name = "as_config"
+  scaling_configuration_name = "as_config_pol_v2_conflict"
 
   instance_config {
     image = data.opentelekomcloud_images_image_v2.latest_image.id
@@ -359,7 +359,7 @@ resource "opentelekomcloud_as_configuration_v1" "as_config"{
 }
 
 resource "opentelekomcloud_as_group_v1" "as_group"{
-  scaling_group_name       = "as_group"
+  scaling_group_name       = "as_group_pol_v2_conflict"
   scaling_configuration_id = opentelekomcloud_as_configuration_v1.as_config.id
 
   networks {
@@ -375,7 +375,7 @@ resource "opentelekomcloud_as_group_v1" "as_group"{
 }
 
 resource "opentelekomcloud_as_policy_v2" "as_policy"{
-  scaling_policy_name   = "as_policy"
+  scaling_policy_name   = "as_policy_pol_v2_conflict"
   scaling_policy_type   = "RECURRENCE"
   scaling_resource_id   = opentelekomcloud_as_group_v1.as_group.id
   scaling_resource_type = "SCALING_GROUP"

--- a/opentelekomcloud/services/as/common.go
+++ b/opentelekomcloud/services/as/common.go
@@ -3,4 +3,6 @@ package as
 const (
 	errCreationV2Client = "error creating OpenTelekomCloud AutoScalingV2 client: %w"
 	errCreationV1Client = "error creating OpenTelekomCloud AutoScalingV1 client: %w"
+	keyClientV1         = "as-v1-client"
+	keyClientV2         = "as-v2-client"
 )

--- a/opentelekomcloud/services/as/resource_opentelekomcloud_as_group_v1.go
+++ b/opentelekomcloud/services/as/resource_opentelekomcloud_as_group_v1.go
@@ -338,9 +338,11 @@ func refreshInstancesLifeStates(client *golangsdk.ServiceClient, groupID string,
 
 func resourceASGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	client, err := config.AutoscalingV1Client(config.GetRegion(d))
+	client, err := common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
+		return config.AutoscalingV1Client(config.GetRegion(d))
+	})
 	if err != nil {
-		return fmterr.Errorf("error creating OpenTelekomCloud AutoScaling client: %s", err)
+		return fmterr.Errorf(errCreationV1Client, err)
 	}
 
 	minNum := d.Get("min_instance_number").(int)
@@ -428,14 +430,17 @@ func resourceASGroupCreate(ctx context.Context, d *schema.ResourceData, meta int
 
 	d.SetId(asGroupID)
 
-	return resourceASGroupRead(ctx, d, meta)
+	clientCtx := common.CtxWithClient(ctx, client, keyClientV1)
+	return resourceASGroupRead(clientCtx, d, meta)
 }
 
-func resourceASGroupRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceASGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	client, err := config.AutoscalingV1Client(config.GetRegion(d))
+	client, err := common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
+		return config.AutoscalingV1Client(config.GetRegion(d))
+	})
 	if err != nil {
-		return fmterr.Errorf("error creating OpenTelekomCloud autoscaling client: %s", err)
+		return fmterr.Errorf(errCreationV1Client, err)
 	}
 
 	asGroup, err := groups.Get(client, d.Id())
@@ -513,9 +518,11 @@ func resourceASGroupRead(_ context.Context, d *schema.ResourceData, meta interfa
 
 func resourceASGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	client, err := config.AutoscalingV1Client(config.GetRegion(d))
+	client, err := common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
+		return config.AutoscalingV1Client(config.GetRegion(d))
+	})
 	if err != nil {
-		return fmterr.Errorf("error creating OpenTelekomCloud autoscaling client: %s", err)
+		return fmterr.Errorf(errCreationV1Client, err)
 	}
 	d.Partial(true)
 
@@ -568,14 +575,18 @@ func resourceASGroupUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	}
 
 	d.Partial(false)
-	return resourceASGroupRead(ctx, d, meta)
+
+	clientCtx := common.CtxWithClient(ctx, client, keyClientV1)
+	return resourceASGroupRead(clientCtx, d, meta)
 }
 
 func resourceASGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	client, err := config.AutoscalingV1Client(config.GetRegion(d))
+	client, err := common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
+		return config.AutoscalingV1Client(config.GetRegion(d))
+	})
 	if err != nil {
-		return fmterr.Errorf("error creating OpenTelekomCloud AutoScaling client: %s", err)
+		return fmterr.Errorf(errCreationV1Client, err)
 	}
 
 	log.Printf("[DEBUG] Begin to get instances of AutoScaling Group %q", d.Id())

--- a/opentelekomcloud/services/as/resource_opentelekomcloud_as_policy_v2.go
+++ b/opentelekomcloud/services/as/resource_opentelekomcloud_as_policy_v2.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/autoscaling/v2/policies"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
@@ -198,7 +199,9 @@ func resourceASPolicyScalingAction(d *schema.ResourceData) policies.ActionOpts {
 
 func resourceASPolicyV2Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	client, err := config.AutoscalingV2Client(config.GetRegion(d))
+	client, err := common.ClientFromCtx(ctx, keyClientV2, func() (*golangsdk.ServiceClient, error) {
+		return config.AutoscalingV2Client(config.GetRegion(d))
+	})
 	if err != nil {
 		return fmterr.Errorf(errCreationV2Client, err)
 	}
@@ -219,12 +222,15 @@ func resourceASPolicyV2Create(ctx context.Context, d *schema.ResourceData, meta 
 	}
 	d.SetId(asPolicyID)
 
-	return resourceASPolicyV2Read(ctx, d, meta)
+	clientCtx := common.CtxWithClient(ctx, client, keyClientV2)
+	return resourceASPolicyV2Read(clientCtx, d, meta)
 }
 
-func resourceASPolicyV2Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceASPolicyV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	client, err := config.AutoscalingV2Client(config.GetRegion(d))
+	client, err := common.ClientFromCtx(ctx, keyClientV2, func() (*golangsdk.ServiceClient, error) {
+		return config.AutoscalingV2Client(config.GetRegion(d))
+	})
 	if err != nil {
 		return fmterr.Errorf(errCreationV2Client, err)
 	}
@@ -284,7 +290,9 @@ func resourceASPolicyV2Read(_ context.Context, d *schema.ResourceData, meta inte
 
 func resourceASPolicyV2Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	client, err := config.AutoscalingV2Client(config.GetRegion(d))
+	client, err := common.ClientFromCtx(ctx, keyClientV2, func() (*golangsdk.ServiceClient, error) {
+		return config.AutoscalingV2Client(config.GetRegion(d))
+	})
 	if err != nil {
 		return fmterr.Errorf(errCreationV2Client, err)
 	}
@@ -305,12 +313,15 @@ func resourceASPolicyV2Update(ctx context.Context, d *schema.ResourceData, meta 
 		return fmterr.Errorf("error updating ASPolicy %q: %w", asPolicyID, err)
 	}
 
-	return resourceASPolicyV2Read(ctx, d, meta)
+	clientCtx := common.CtxWithClient(ctx, client, keyClientV2)
+	return resourceASPolicyV2Read(clientCtx, d, meta)
 }
 
-func resourceASPolicyV2Delete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceASPolicyV2Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	client, err := config.AutoscalingV1Client(config.GetRegion(d))
+	client, err := common.ClientFromCtx(ctx, keyClientV2, func() (*golangsdk.ServiceClient, error) {
+		return config.AutoscalingV1Client(config.GetRegion(d))
+	})
 	if err != nil {
 		return fmterr.Errorf(errCreationV1Client, err)
 	}

--- a/releasenotes/notes/as-client-ctx-e8280cbaa22c2fef.yaml
+++ b/releasenotes/notes/as-client-ctx-e8280cbaa22c2fef.yaml
@@ -1,0 +1,10 @@
+---
+enhancements:
+  - |
+    **[AS]** Reduce amount of init client requests in ``resource/opentelekomcloud_as_configuration_v1`` (`#2251 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2251>`_)
+  - |
+    **[AS]** Reduce amount of init client requests in ``resource/opentelekomcloud_as_group_v1`` (`#2251 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2251>`_)
+  - |
+    **[AS]** Reduce amount of init client requests in ``resource/opentelekomcloud_as_policy_v1`` (`#2251 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2251>`_)
+  - |
+    **[AS]** Reduce amount of init client requests in ``resource/opentelekomcloud_as_policy_v2`` (`#2251 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2251>`_)


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [ ] Refers to: #xxx
* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccASV1Group_basic
=== PAUSE TestAccASV1Group_basic
=== CONT  TestAccASV1Group_basic
    common.go:121: Service: asv1, Region eu-de
--- PASS: TestAccASV1Group_basic (184.92s)
=== RUN   TestAccASV1Group_RemoveWithSetMinNumber
=== PAUSE TestAccASV1Group_RemoveWithSetMinNumber
=== CONT  TestAccASV1Group_RemoveWithSetMinNumber
    common.go:121: Service: asv1, Region eu-de
--- PASS: TestAccASV1Group_RemoveWithSetMinNumber (157.41s)
=== RUN   TestAccASV1Group_WithoutSecurityGroups
=== PAUSE TestAccASV1Group_WithoutSecurityGroups
=== CONT  TestAccASV1Group_WithoutSecurityGroups
    common.go:121: Service: asv1, Region eu-de
--- PASS: TestAccASV1Group_WithoutSecurityGroups (63.12s)
PASS


Process finished with the exit code 0


=== RUN   TestAccASV1Configuration_basic
=== PAUSE TestAccASV1Configuration_basic
=== CONT  TestAccASV1Configuration_basic
    common.go:121: Service: asv1, Region eu-de
--- PASS: TestAccASV1Configuration_basic (47.99s)
=== RUN   TestAccASV1Configuration_publicIP
=== PAUSE TestAccASV1Configuration_publicIP
=== CONT  TestAccASV1Configuration_publicIP
    common.go:121: Service: asv1, Region eu-de
--- PASS: TestAccASV1Configuration_publicIP (48.16s)
=== RUN   TestAccASV1Configuration_invalidDiskSize
=== PAUSE TestAccASV1Configuration_invalidDiskSize
=== CONT  TestAccASV1Configuration_invalidDiskSize
    common.go:121: Service: asv1, Region eu-de
--- PASS: TestAccASV1Configuration_invalidDiskSize (10.99s)
=== RUN   TestAccASV1Configuration_multipleSecurityGroups
=== PAUSE TestAccASV1Configuration_multipleSecurityGroups
=== CONT  TestAccASV1Configuration_multipleSecurityGroups
    common.go:121: Service: asv1, Region eu-de
--- PASS: TestAccASV1Configuration_multipleSecurityGroups (62.38s)
PASS


Process finished with the exit code 0


=== RUN   TestAccASV1Policy_basic
=== PAUSE TestAccASV1Policy_basic
=== CONT  TestAccASV1Policy_basic
    common.go:121: Service: asv1, Region eu-de
--- PASS: TestAccASV1Policy_basic (65.02s)
PASS


Process finished with the exit code 0

=== RUN   TestAccASPolicyV2_basic
=== PAUSE TestAccASPolicyV2_basic
=== CONT  TestAccASPolicyV2_basic
    common.go:121: Service: asv1, Region eu-de
--- PASS: TestAccASPolicyV2_basic (99.82s)
=== RUN   TestAccASPolicyV2_withSize
=== PAUSE TestAccASPolicyV2_withSize
=== CONT  TestAccASPolicyV2_withSize
    common.go:121: Service: asv1, Region eu-de
--- PASS: TestAccASPolicyV2_withSize (61.00s)
=== RUN   TestAccASPolicyV2_conflictsAction
    common.go:121: Service: asv1, Region eu-de
--- PASS: TestAccASPolicyV2_conflictsAction (11.27s)
PASS


Process finished with the exit code 0

```
