### PR TITLE
[WAF] new `resource/opentelekomcloud_waf_dedicated_policy_v1`

### DIFF
--- a/docs/resources/waf_dedicated_domain_v1.md
+++ b/docs/resources/waf_dedicated_domain_v1.md
@@ -2,7 +2,7 @@
 subcategory: "Dedicated Web Application Firewall (WAFD)"
 ---
 
-Up-to-date reference of API arguments for WAF datamasking rule you can get at
+Up-to-date reference of API arguments for WAF dedicated domain you can get at
 `https://docs.otc.t-systems.com/web-application-firewall-dedicated/api-ref/apis/managing_websites_protected_in_dedicated_mode/index.html`.
 
 # opentelekomcloud_waf_dedicated_domain_v1

--- a/docs/resources/waf_dedicated_instance_v1.md
+++ b/docs/resources/waf_dedicated_instance_v1.md
@@ -2,7 +2,7 @@
 subcategory: "Dedicated Web Application Firewall (WAFD)"
 ---
 
-Up-to-date reference of API arguments for WAF datamasking rule you can get at
+Up-to-date reference of API arguments for WAF dedicated instance you can get at
 `https://docs.otc.t-systems.com/web-application-firewall-dedicated/api-ref/apis/dedicated_instance_management/index.html`.
 
 # opentelekomcloud_waf_dedicated_instance_v1

--- a/docs/resources/waf_dedicated_policy_v1.md
+++ b/docs/resources/waf_dedicated_policy_v1.md
@@ -1,0 +1,92 @@
+---
+subcategory: "Dedicated Web Application Firewall (WAFD)"
+---
+
+Up-to-date reference of API arguments for WAF policy you can get at
+https://docs.otc.t-systems.com/web-application-firewall-dedicated/api-ref/apis/policy_management/index.html.
+
+# opentelekomcloud_waf_dedicated_policy_v1
+
+Manages a WAF dedicated policy resource within OpenTelekomCloud.
+
+-> **Note:** For this resource region must be set in environment variable `OS_REGION_NAME` or in `clouds.yaml`
+
+
+## Example Usage
+
+```hcl
+resource "opentelekomcloud_waf_dedicated_policy_v1" "policy_1" {
+  name            = "policy_1"
+  level           = 3
+  protection_mode = "block"
+  full_detection  = true
+
+  options {
+    crawler    = false
+    web_attack = false
+    cc         = true
+    web_shell  = true
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The policy name.
+
+* `protection_mode` - (Optional) Specifies the protective action after a rule is matched.
+  Values are:
+  + `block`: WAF blocks and logs detected attacks.
+  + `log`: WAF logs detected attacks only.
+
+* `level` - (Optional) Specifies the protection level.
+  Values are:
+  + `1`: low
+  + `2`: medium
+  + `3`: high
+
+* `options` - (Optional) Specifies the protection switches.
+  The `options` block supports:
+  + `web_attack` - (Optional) Specifies whether Basic Web Protection is enabled.
+  + `common` - (Optional) Specifies whether General Check in Basic Web Protection is enabled.
+  + `crawler` - (Optional) Specifies whether the master crawler detection switch in Basic Web Protection is enabled.
+  + `anti_crawler` - (Optional) JavaScript anti-crawler function.
+  + `crawler_engine` - (Optional) Specifies whether the Search Engine switch in Basic Web Protection is enabled.
+  + `crawler_scanner` - (Optional) Specifies whether the Scanner switch in Basic Web Protection is enabled.
+  + `crawler_script` - (Optional) Specifies whether the Script Tool switch in Basic Web Protection is enabled.
+  + `crawler_other` - (Optional) Specifies whether detection of other crawlers in Basic Web Protection is enabled.
+  + `web_shell` - (Optional) Specifies whether webshell detection in Basic Web Protection is enabled.
+  + `cc` - (Optional) Specifies whether CC Attack Protection is enabled.
+  + `custom` - (Optional) Specifies whether Precise Protection is enabled.
+  + `blacklist` - (Optional) Specifies whether Blacklist and Whitelist is enabled.
+  + `geolocation_access_control` - (Optional) Whether geolocation access control is enabled.
+  + `ignore` - (Optional) Whether false alarm masking is enabled.
+  + `privacy` - (Optional) Specifies whether Data Masking is enabled.
+  + `ignore` - (Optional) Specifies whether False Alarm Masking is enabled.
+  + `anti_tamper` - (Optional) Specifies whether Web Tamper Protection is enabled.
+  + `anti_leakage` - (Optional) Whether the information leakage prevention is enabled.
+  + `followed_action` - (Optional) Whether the Known Attack Source protection is enabled.
+
+* `full_detection` - (Optional) Specifies the detection mode in Precise Protection.
+  * `true`: full detection, Full detection finishes all threat detections before blocking requests that meet Precise Protection specified conditions.
+  * `false`: instant detection. Instant detection immediately ends threat detection after blocking a request that meets Precise Protection specified conditions.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` -  ID of the policy.
+
+* `domains` - Specifies the domain IDs.
+
+* `created_at` - Time the policy is created. The value is a 13-digit timestamp, in ms.
+
+## Import
+
+WAF dedicated policies can be imported using the `id`, e.g.
+
+```sh
+terraform import opentelekomcloud_waf_dedicated_policy_v1.policy_1 7117d38e-4c8f-4624-a505-bd96b97d024c
+```

--- a/opentelekomcloud/acceptance/waf/resource_opentelekomcloud_waf_dedicated_domain_v1_test.go
+++ b/opentelekomcloud/acceptance/waf/resource_opentelekomcloud_waf_dedicated_domain_v1_test.go
@@ -125,10 +125,24 @@ func testAccWafDedicatedDomainV1_basic(name string) string {
 	return fmt.Sprintf(`
 %s
 
+resource "opentelekomcloud_waf_dedicated_policy_v1" "policy_1" {
+  name            = "domain_policy_1"
+  protection_mode = "log"
+  full_detection  = false
+  level           = 2
+
+  options {
+    crawler    = true
+    web_attack = true
+  }
+}
+
 resource "opentelekomcloud_waf_dedicated_domain_v1" "domain_1" {
   domain      = "www.%s.com"
-  keep_policy = false
+  keep_policy = true
   proxy       = true
+
+  policy_id = opentelekomcloud_waf_dedicated_policy_v1.policy_1.id
 
   server {
     client_protocol = "HTTP"
@@ -145,6 +159,18 @@ resource "opentelekomcloud_waf_dedicated_domain_v1" "domain_1" {
 func testAccWafDedicatedDomainV1_basicUpdate(name string) string {
 	return fmt.Sprintf(`
 %s
+
+resource "opentelekomcloud_waf_dedicated_policy_v1" "policy_1" {
+  name            = "domain_policy_1"
+  protection_mode = "log"
+  full_detection  = false
+  level           = 2
+
+  options {
+    crawler    = true
+    web_attack = true
+  }
+}
 
 resource "opentelekomcloud_waf_dedicated_domain_v1" "domain_1" {
   domain      = "www.%s.com"

--- a/opentelekomcloud/acceptance/waf/resource_opentelekomcloud_waf_dedicated_policy_v1_test.go
+++ b/opentelekomcloud/acceptance/waf/resource_opentelekomcloud_waf_dedicated_policy_v1_test.go
@@ -1,0 +1,146 @@
+package acceptance
+
+import (
+	"fmt"
+	"log"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/waf-premium/v1/policies"
+
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+)
+
+const wafdPolicyResourceName = "opentelekomcloud_waf_dedicated_policy_v1.policy_1"
+
+func TestAccWafDedicatedPolicyV1_basic(t *testing.T) {
+	var policy policies.Policy
+	var policyName = fmt.Sprintf("wafd_policy_%s", acctest.RandString(5))
+	log.Printf("[DEBUG] The opentelekomcloud Waf dedicated instance test running in '%s' region.", env.OS_REGION_NAME)
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckWafDedicatedPolicyV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafDedicatedPolicyV1_basic(policyName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafDedicatedPolicyV1Exists(wafdPolicyResourceName, &policy),
+					resource.TestCheckResourceAttr(wafdPolicyResourceName, "name", policyName),
+					resource.TestCheckResourceAttr(wafdPolicyResourceName, "level", "2"),
+					resource.TestCheckResourceAttr(wafdPolicyResourceName, "full_detection", "false"),
+					resource.TestCheckResourceAttr(wafdPolicyResourceName, "protection_mode", "log"),
+					resource.TestCheckResourceAttr(wafdPolicyResourceName, "options.0.web_attack", "true"),
+				),
+			},
+			{
+				Config: testAccWafDedicatedPolicyV1_update(policyName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafDedicatedPolicyV1Exists(wafdPolicyResourceName, &policy),
+					resource.TestCheckResourceAttr(wafdPolicyResourceName, "name", policyName+"-updated"),
+					resource.TestCheckResourceAttr(wafdPolicyResourceName, "level", "3"),
+					resource.TestCheckResourceAttr(wafdPolicyResourceName, "full_detection", "true"),
+					resource.TestCheckResourceAttr(wafdPolicyResourceName, "protection_mode", "block"),
+					resource.TestCheckResourceAttr(wafdPolicyResourceName, "options.0.web_attack", "false"),
+					resource.TestCheckResourceAttr(wafdPolicyResourceName, "options.0.cc", "true"),
+					resource.TestCheckResourceAttr(wafdPolicyResourceName, "options.0.web_shell", "true"),
+				),
+			},
+			{
+				ResourceName:      wafdPolicyResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckWafDedicatedPolicyV1Destroy(s *terraform.State) error {
+	config := common.TestAccProvider.Meta().(*cfg.Config)
+	client, err := config.WafDedicatedV1Client(env.OS_REGION_NAME)
+	if err != nil {
+		return err
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "opentelekomcloud_waf_dedicated_policy_v1" {
+			continue
+		}
+
+		_, err := policies.Get(client, rs.Primary.ID)
+		if err == nil {
+			return fmt.Errorf("waf dedicated policy (%s) still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckWafDedicatedPolicyV1Exists(n string, policy *policies.Policy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		config := common.TestAccProvider.Meta().(*cfg.Config)
+		client, err := config.WafDedicatedV1Client(env.OS_REGION_NAME)
+		if err != nil {
+			return err
+		}
+
+		found, err := policies.Get(client, rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if found.ID != rs.Primary.ID {
+			return err
+		}
+		*policy = *found
+
+		return nil
+	}
+}
+
+func testAccWafDedicatedPolicyV1_basic(policyName string) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_waf_dedicated_policy_v1" "policy_1" {
+  name            = "%s"
+  protection_mode = "log"
+  full_detection  = false
+  level           = 2
+
+  options {
+    crawler    = true
+    web_attack = true
+  }
+}
+`, policyName)
+}
+
+func testAccWafDedicatedPolicyV1_update(policyName string) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_waf_dedicated_policy_v1" "policy_1" {
+  name            = "%s-updated"
+  level           = 3
+  protection_mode = "block"
+  full_detection  = true
+
+  options {
+    crawler    = false
+    web_attack = false
+    cc         = true
+    web_shell  = true
+  }
+}
+`, policyName)
+}

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -486,6 +486,7 @@ func Provider() *schema.Provider {
 			"opentelekomcloud_waf_webtamperprotection_rule_v1":    waf.ResourceWafWebTamperProtectionRuleV1(),
 			"opentelekomcloud_waf_dedicated_instance_v1":          waf.ResourceWafDedicatedInstance(),
 			"opentelekomcloud_waf_dedicated_domain_v1":            waf.ResourceWafDedicatedDomain(),
+			"opentelekomcloud_waf_dedicated_policy_v1":            waf.ResourceWafDedicatedPolicy(),
 		},
 	}
 

--- a/opentelekomcloud/services/waf/resource_opentelekomcloud_waf_dedicated_policy_v1.go
+++ b/opentelekomcloud/services/waf/resource_opentelekomcloud_waf_dedicated_policy_v1.go
@@ -1,0 +1,378 @@
+package waf
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/pointerto"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
+
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/waf-premium/v1/policies"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
+)
+
+func ResourceWafDedicatedPolicy() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceWafDedicatedPolicyV1Create,
+		ReadContext:   resourceWafDedicatedPolicyV1Read,
+		UpdateContext: resourceWafDedicatedPolicyV1Update,
+		DeleteContext: resourceWafDedicatedPolicyV1Delete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"protection_mode": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"log", "block",
+				}, false),
+			},
+			"level": {
+				Type:         schema.TypeInt,
+				Computed:     true,
+				Optional:     true,
+				ValidateFunc: validation.IntBetween(0, 3),
+			},
+			"options": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"web_attack": {
+							Type:     schema.TypeBool,
+							Computed: true,
+							Optional: true,
+						},
+						"common": {
+							Type:     schema.TypeBool,
+							Computed: true,
+							Optional: true,
+						},
+						"crawler": {
+							Type:     schema.TypeBool,
+							Computed: true,
+							Optional: true,
+						},
+						"anti_crawler": {
+							Type:     schema.TypeBool,
+							Computed: true,
+							Optional: true,
+						},
+						"crawler_engine": {
+							Type:     schema.TypeBool,
+							Computed: true,
+							Optional: true,
+						},
+						"crawler_script": {
+							Type:     schema.TypeBool,
+							Computed: true,
+							Optional: true,
+						},
+						"crawler_scanner": {
+							Type:     schema.TypeBool,
+							Computed: true,
+							Optional: true,
+						},
+						"crawler_other": {
+							Type:     schema.TypeBool,
+							Computed: true,
+							Optional: true,
+						},
+						"web_shell": {
+							Type:     schema.TypeBool,
+							Computed: true,
+							Optional: true,
+						},
+						"cc": {
+							Type:     schema.TypeBool,
+							Computed: true,
+							Optional: true,
+						},
+						"custom": {
+							Type:     schema.TypeBool,
+							Computed: true,
+							Optional: true,
+						},
+						"blacklist": {
+							Type:     schema.TypeBool,
+							Computed: true,
+							Optional: true,
+						},
+						"geolocation_access_control": {
+							Type:     schema.TypeBool,
+							Computed: true,
+							Optional: true,
+						},
+						"ignore": {
+							Type:     schema.TypeBool,
+							Computed: true,
+							Optional: true,
+						},
+						"privacy": {
+							Type:     schema.TypeBool,
+							Computed: true,
+							Optional: true,
+						},
+						"anti_tamper": {
+							Type:     schema.TypeBool,
+							Computed: true,
+							Optional: true,
+						},
+						"anti_leakage": {
+							Type:     schema.TypeBool,
+							Computed: true,
+							Optional: true,
+						},
+						"followed_action": {
+							Type:     schema.TypeBool,
+							Computed: true,
+							Optional: true,
+						},
+						"bot_enable": {
+							Type:     schema.TypeBool,
+							Computed: true,
+							// Optional: true,
+						},
+						"precise": {
+							Type:     schema.TypeBool,
+							Computed: true,
+							// Optional: true,
+						},
+					},
+				},
+			},
+			"full_detection": {
+				Type:     schema.TypeBool,
+				Computed: true,
+				Optional: true,
+			},
+			"domains": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"created_at": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceWafDedicatedPolicyV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
+		return config.WafDedicatedV1Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV1DedicatedClient, err)
+	}
+
+	r, err := policies.Create(client, policies.CreateOpts{
+		Name: d.Get("name").(string),
+	})
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(r.ID)
+
+	if d.HasChanges("protection_mode", "level", "options", "full_detection") {
+		if err := updateWafPolicy(ctx, d, meta); err != nil {
+			return fmterr.Errorf("error creating OpenTelekomCloud WAF dedicated policy: %s", err)
+		}
+	}
+
+	clientCtx := common.CtxWithClient(ctx, client, keyClientV1)
+	return resourceWafDedicatedPolicyV1Read(clientCtx, d, meta)
+}
+
+func resourceWafDedicatedPolicyV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
+		return config.WafDedicatedV1Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV1DedicatedClient, err)
+	}
+
+	policy, err := policies.Get(client, d.Id())
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving OpenTelekomCloud WAF dedicated policy.")
+	}
+
+	options := []map[string]interface{}{
+		{
+			"web_attack":                 policy.Options.WebAttack,
+			"common":                     policy.Options.Common,
+			"crawler":                    policy.Options.Crawler,
+			"anti_crawler":               policy.Options.AntiCrawler,
+			"crawler_engine":             policy.Options.CrawlerEngine,
+			"crawler_scanner":            policy.Options.CrawlerScanner,
+			"crawler_script":             policy.Options.CrawlerScript,
+			"crawler_other":              policy.Options.CrawlerOther,
+			"web_shell":                  policy.Options.WebShell,
+			"cc":                         policy.Options.Cc,
+			"custom":                     policy.Options.Custom,
+			"blacklist":                  policy.Options.WhiteblackIp,
+			"geolocation_access_control": policy.Options.GeoIp,
+			"ignore":                     policy.Options.Ignore,
+			"privacy":                    policy.Options.Privacy,
+			"anti_tamper":                policy.Options.AntiTamper,
+			"anti_leakage":               policy.Options.AntiLeakage,
+			"followed_action":            policy.Options.FollowedAction,
+			"bot_enable":                 policy.Options.BotEnable,
+			"precise":                    policy.Options.Precise,
+		},
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", config.GetRegion(d)),
+		d.Set("name", policy.Name),
+		d.Set("level", policy.Level),
+		d.Set("protection_mode", policy.Action.Category),
+		d.Set("full_detection", policy.FullDetection),
+		d.Set("options", options),
+		d.Set("domains", policy.Hosts),
+		d.Set("created_at", policy.CreatedAt),
+	)
+
+	if mErr.ErrorOrNil() != nil {
+		return fmterr.Errorf("error setting opentelekomcloud WAF dedicated instance fields: %w", err)
+	}
+	return nil
+}
+
+func resourceWafDedicatedPolicyV1Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
+		return config.WafDedicatedV1Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV1DedicatedClient, err)
+	}
+
+	if d.HasChanges("name", "protection_mode", "level", "options", "full_detection") {
+		if err := updateWafPolicy(ctx, d, meta); err != nil {
+			return fmterr.Errorf("error updating OpenTelekomCloud WAF dedicated policy: %s", err)
+		}
+	}
+
+	clientCtx := common.CtxWithClient(ctx, client, keyClientV1)
+	return resourceWafDedicatedPolicyV1Read(clientCtx, d, meta)
+}
+
+func resourceWafDedicatedPolicyV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
+		return config.WafDedicatedV1Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV1DedicatedClient, err)
+	}
+
+	err = policies.Delete(client, d.Id())
+	if err != nil {
+		return fmterr.Errorf("error deleting opentelekomcloud WAF dedicated policy : %w", err)
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func updateWafPolicy(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
+		return config.WafDedicatedV1Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV1DedicatedClient, err)
+	}
+
+	var updateOpts policies.UpdateOpts
+
+	if d.HasChange("name") {
+		updateOpts.Name = d.Get("name").(string)
+	}
+
+	if d.HasChange("level") {
+		updateOpts.Level = d.Get("level").(int)
+	}
+
+	if d.HasChange("full_detection") {
+		updateOpts.FullDetection = pointerto.Bool(d.Get("full_detection").(bool))
+	}
+
+	if d.HasChange("options") {
+		updateOpts.Options = buildOptions(d)
+	}
+
+	if d.HasChange("protection_mode") {
+		updateOpts.Action = &policies.PolicyAction{
+			Category: d.Get("protection_mode").(string),
+		}
+	}
+
+	_, err = policies.Update(client, d.Id(), updateOpts)
+	if err != nil {
+		return fmterr.Errorf("error updating OpenTelekomCloud WAF Policy: %s", err)
+	}
+	return nil
+}
+
+func buildOptions(d *schema.ResourceData) *policies.PolicyOption {
+	optionsRaw := d.Get("options").([]interface{})
+	rawMap := optionsRaw[0].(map[string]interface{})
+
+	options := &policies.PolicyOption{
+		WebAttack:      pointerto.Bool(rawMap["web_attack"].(bool)),
+		Common:         pointerto.Bool(rawMap["common"].(bool)),
+		Crawler:        pointerto.Bool(rawMap["crawler"].(bool)),
+		AntiCrawler:    pointerto.Bool(rawMap["anti_crawler"].(bool)),
+		CrawlerEngine:  pointerto.Bool(rawMap["crawler_engine"].(bool)),
+		CrawlerScanner: pointerto.Bool(rawMap["crawler_scanner"].(bool)),
+		CrawlerScript:  pointerto.Bool(rawMap["crawler_script"].(bool)),
+		CrawlerOther:   pointerto.Bool(rawMap["crawler_other"].(bool)),
+		WebShell:       pointerto.Bool(rawMap["web_shell"].(bool)),
+		Cc:             pointerto.Bool(rawMap["cc"].(bool)),
+		Custom:         pointerto.Bool(rawMap["custom"].(bool)),
+		WhiteblackIp:   pointerto.Bool(rawMap["blacklist"].(bool)),
+		GeoIp:          pointerto.Bool(rawMap["geolocation_access_control"].(bool)),
+		Ignore:         pointerto.Bool(rawMap["ignore"].(bool)),
+		Privacy:        pointerto.Bool(rawMap["privacy"].(bool)),
+		AntiTamper:     pointerto.Bool(rawMap["anti_tamper"].(bool)),
+		AntiLeakage:    pointerto.Bool(rawMap["anti_leakage"].(bool)),
+		FollowedAction: pointerto.Bool(rawMap["followed_action"].(bool)),
+		// not works in swiss
+		// BotEnable:      pointerto.Bool(rawMap["bot_enable"].(bool)),
+		// lead to 500 in eu-de and swiss
+		// Precise:        pointerto.Bool(rawMap["precise"].(bool)),
+	}
+
+	log.Printf("[DEBUG] Options for OpenTelekomCloud WAF Policy: %#v", options)
+	return options
+}

--- a/opentelekomcloud/services/waf/resource_opentelekomcloud_waf_dedicated_policy_v1.go
+++ b/opentelekomcloud/services/waf/resource_opentelekomcloud_waf_dedicated_policy_v1.go
@@ -203,7 +203,7 @@ func resourceWafDedicatedPolicyV1Create(ctx context.Context, d *schema.ResourceD
 
 	if d.HasChanges("protection_mode", "level", "options", "full_detection") {
 		if err := updateWafPolicy(ctx, d, meta); err != nil {
-			return fmterr.Errorf("error creating OpenTelekomCloud WAF dedicated policy: %s", err)
+			return err
 		}
 	}
 
@@ -278,7 +278,7 @@ func resourceWafDedicatedPolicyV1Update(ctx context.Context, d *schema.ResourceD
 
 	if d.HasChanges("name", "protection_mode", "level", "options", "full_detection") {
 		if err := updateWafPolicy(ctx, d, meta); err != nil {
-			return fmterr.Errorf("error updating OpenTelekomCloud WAF dedicated policy: %s", err)
+			return err
 		}
 	}
 

--- a/releasenotes/notes/wafd-policy-75133b3ea48dd8dc.yaml
+++ b/releasenotes/notes/wafd-policy-75133b3ea48dd8dc.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  |
+  **[WAF]** Add new resource ``resource/opentelekomcloud_waf_dedicated_policy_v1`` (`#2252 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2252>`_)


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [x] Refers to: #2231
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccWafDedicatedPolicyV1_basic
2023/08/04 14:51:07 [DEBUG] The opentelekomcloud Waf dedicated instance test running in 'eu-de' region.
--- PASS: TestAccWafDedicatedPolicyV1_basic (93.87s)
PASS

=== RUN   TestAccWafDedicatedPolicyV1_basic
2023/08/04 16:27:05 [DEBUG] The opentelekomcloud Waf dedicated instance test running in 'eu-ch2' region.
--- PASS: TestAccWafDedicatedPolicyV1_basic (82.94s)
PASS

=== RUN   TestAccWafDedicatedDomainV1_basic
2023/08/04 14:51:07 [DEBUG] The opentelekomcloud Waf dedicated instance test running in 'eu-de' region.
--- PASS: TestAccWafDedicatedDomainV1_basic (98.94s)
PASS

=== RUN   TestAccWafDedicatedDomainV1_basic
2023/08/04 14:59:52 [DEBUG] The opentelekomcloud Waf dedicated instance test running in 'eu-ch2' region.
--- PASS: TestAccWafDedicatedDomainV1_basic (109.95s)
PASS


Process finished with the exit code 0
```
