### PR TITLE
RDS: Enable compute property for `ssl_enable` parameter in ReadContext

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/jinzhu/copier v0.3.5
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.7.1-0.20230807120835-a3bd0d237c63
+	github.com/opentelekomcloud/gophertelekomcloud v0.7.1-0.20230809112707-614c893fc590
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.1.0
 	golang.org/x/sync v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -154,8 +154,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k+Mg7cowZ8yv4Trqw9UsJby758=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.7.1-0.20230807120835-a3bd0d237c63 h1:4oaBLP3Lcm9An+GCpwqG4Hryx9gyawC6JsFHR4JAoAc=
-github.com/opentelekomcloud/gophertelekomcloud v0.7.1-0.20230807120835-a3bd0d237c63/go.mod h1:9Deb3q2gJvq5dExV+aX+iO+G+mD9Zr9uFt+YY9ONmq0=
+github.com/opentelekomcloud/gophertelekomcloud v0.7.1-0.20230809112707-614c893fc590 h1:w8sHvnfAGDfSrnk1yLQNaqqvcwsaqPBL7eRfjP/uecY=
+github.com/opentelekomcloud/gophertelekomcloud v0.7.1-0.20230809112707-614c893fc590/go.mod h1:9Deb3q2gJvq5dExV+aX+iO+G+mD9Zr9uFt+YY9ONmq0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
+++ b/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
@@ -41,6 +41,7 @@ func TestAccRdsInstanceV3Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(instanceV3ResourceName, "tags.muh", "value-create"),
 					resource.TestCheckResourceAttr(instanceV3ResourceName, "tags.kuh", "value-create"),
 					resource.TestCheckResourceAttr(instanceV3ResourceName, "lower_case_table_names", "0"),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "ssl_enable", "true"),
 				),
 			},
 			{
@@ -183,6 +184,7 @@ func TestAccRdsInstanceV3HA(t *testing.T) {
 					resource.TestCheckResourceAttr(instanceV3ResourceName, "volume.0.type", "ULTRAHIGH"),
 					resource.TestCheckResourceAttr(instanceV3ResourceName, "db.0.type", "MySQL"),
 					resource.TestCheckResourceAttr(instanceV3ResourceName, "availability_zones.#", "2"),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "ssl_enable", "false"),
 				),
 			},
 		},

--- a/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_instance_v3.go
+++ b/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_instance_v3.go
@@ -277,6 +277,7 @@ func ResourceRdsInstanceV3() *schema.Resource {
 			},
 			"ssl_enable": {
 				Type:     schema.TypeBool,
+				Computed: true,
 				Optional: true,
 			},
 			"availability_zones": {
@@ -566,8 +567,6 @@ func resourceRdsInstanceV3Create(ctx context.Context, d *schema.ResourceData, me
 			if err != nil {
 				return fmterr.Errorf("error updating instance SSL configuration: %s ", err)
 			}
-		} else {
-			return diag.Errorf("only MySQL database support SSL enable and disable")
 		}
 	}
 
@@ -1076,6 +1075,7 @@ func resourceRdsInstanceV3Read(ctx context.Context, d *schema.ResourceData, meta
 		d.Set("created", rdsInstance.Created),
 		d.Set("ha_replication_mode", rdsInstance.Ha.ReplicationMode),
 		d.Set("lower_case_table_names", d.Get("lower_case_table_names").(string)),
+		d.Set("ssl_enable", *rdsInstance.EnableSSL),
 	)
 
 	if me.ErrorOrNil() != nil {

--- a/releasenotes/notes/rds_ssl_compute-7b04f85e295f2164.yaml
+++ b/releasenotes/notes/rds_ssl_compute-7b04f85e295f2164.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[RDS]** Enable ``resource/opentelekomcloud_rds_instance_v3`` SSL parameter read (`#2258 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2258>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Update `ssl_enable` parameter with `computed` property.

## PR Checklist

* [x] Refers to: #2246
* [x] Tests passed.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccRdsInstanceV3Basic
--- PASS: TestAccRdsInstanceV3Basic (783.37s)
=== RUN   TestAccRdsPostgre13V3ParamsBasic
--- PASS: TestAccRdsPostgre13V3ParamsBasic (457.79s)
=== RUN   TestAccRdsInstanceV3RestoreBackup
--- PASS: TestAccRdsInstanceV3RestoreBackup (1026.19s)
=== RUN   TestAccRdsInstanceV3HA
    resource_opentelekomcloud_rds_instance_v3_test.go:170: OS_AVAILABILITY_ZONE_2 is empty
--- SKIP: TestAccRdsInstanceV3HA (0.00s)
Test ignored.
=== RUN   TestAccRdsInstanceV3OptionalParams
--- PASS: TestAccRdsInstanceV3OptionalParams (370.04s)
=== RUN   TestAccRdsInstanceV3Backup
--- PASS: TestAccRdsInstanceV3Backup (392.90s)
=== RUN   TestAccRdsInstanceV3TemplateConfig
--- PASS: TestAccRdsInstanceV3TemplateConfig (427.86s)
=== RUN   TestAccRdsInstanceV3InvalidDBVersion
--- PASS: TestAccRdsInstanceV3InvalidDBVersion (6.32s)
=== RUN   TestAccRdsInstanceV3InvalidFlavor
--- PASS: TestAccRdsInstanceV3InvalidFlavor (6.52s)
=== RUN   TestAccRdsInstanceV3_configurationParameters
--- PASS: TestAccRdsInstanceV3_configurationParameters (414.59s)
=== RUN   TestAccRdsInstanceV3ElasticIP
--- PASS: TestAccRdsInstanceV3ElasticIP (772.17s)
PASS

Process finished with the exit code 0
```
