### PR TITLE
[WAF] new resource/opentelekomcloud_waf_dedicated_certificate_v1

### DIFF
--- a/docs/resources/waf_dedicated_certificate_v1.md
+++ b/docs/resources/waf_dedicated_certificate_v1.md
@@ -1,0 +1,73 @@
+---
+subcategory: "Dedicated Web Application Firewall (WAFD)"
+---
+
+Up-to-date reference of API arguments for WAF dedicated certificate you can get at
+`https://docs.otc.t-systems.com/web-application-firewall-dedicated/api-ref/apis/certificate_management/index.html`.
+
+# opentelekomcloud_waf_dedicated_certificate_v1
+
+Manages a WAF dedicated certificate resource within OpenTelekomCloud.
+
+-> **Note:** For this resource region must be set in environment variable `OS_REGION_NAME` or in `clouds.yaml`
+
+## Example Usage
+
+```hcl
+resource "opentelekomcloud_waf_dedicated_certificate_v1" "certificate_1" {
+  name    = "certificate_1"
+  content = <<EOT
+-----BEGIN CERTIFICATE-----
+MIIFazCCA1OgAwIBAgIUN3w1KX8/T/HWVxZIOdHXPhUOnsAwDQYJKoZIhvcNAQEL
+BQAwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM
+...
+dKvZbPEsygYRIjwyhHHUh/YXH8KDI/uu6u6AxDckQ3rP1BkkKXr5NPBGjVgM3ZI=
+-----END CERTIFICATE-----
+EOT
+  key     = <<EOT
+-----BEGIN PRIVATE KEY-----
+MIIJQQIBADANBgkqhkiG9w0BAQEFAASCCSswggknAgEAAoICAQC+9uwFVenCdPD9
+5LWSWMuy4riZW718wxBpYV5Y9N8nM7N0qZLLdpImZrzBbaBldTI+AZGI3Nupuurw
+...
+s9urs/Kk/tbQhsEvu0X8FyGwo0zH6rG8apTFTlac+v4mJ4vlpxSvT5+FW2lgLISE
++4sM7kp0qO3/p+45HykwBY5iHq3H
+-----END PRIVATE KEY-----
+EOT
+
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The certificate name. The value can contain a maximum of 64 characters.
+  Only digits, letters, underscores(`_`), and hyphens(`-`) are allowed. Changing this creates a new certificate.
+
+* `content` - (Optional) The certificate content. Changing this creates a new certificate.
+
+* `key` - (Optional) The private key. Changing this creates a new certificate.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - ID of the certificate.
+
+* `name` - See Argument Reference above.
+
+* `content` - See Argument Reference above.
+
+* `key` - See Argument Reference above.
+
+* `expires` - Date when the certificate expires.
+
+* `created_at` - Date when the certificate is uploaded.
+
+## Import
+
+WAF dedicated certificates can be imported using the `id`, e.g.
+
+```shell
+terraform import opentelekomcloud_waf_certificate_v1.cert_1 7117d38e-4c8f-4624-a505-bd96b97d024c
+```

--- a/docs/resources/waf_dedicated_domain_v1.md
+++ b/docs/resources/waf_dedicated_domain_v1.md
@@ -13,6 +13,7 @@ Manages a WAF dedicated domain resource within OpenTelekomCloud.
 
 ## Example Usage
 
+### Basic
 ```hcl
 data "opentelekomcloud_vpc_subnet_v1" "shared_subnet" {
   name = "my_subnet"
@@ -31,6 +32,57 @@ resource "opentelekomcloud_waf_dedicated_domain_v1" "domain_1" {
     type            = "ipv4"
     vpc_id          = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
   }
+}
+```
+
+### With certificate
+```hcl
+data "opentelekomcloud_vpc_subnet_v1" "shared_subnet" {
+  name = "my_subnet"
+}
+
+resource "opentelekomcloud_waf_dedicated_certificate_v1" "certificate_1" {
+  name    = "certificate_1"
+  content = <<EOT
+-----BEGIN CERTIFICATE-----
+MIIFazCCA1OgAwIBAgIUN3w1KX8/T/HWVxZIOdHXPhUOnsAwDQYJKoZIhvcNAQEL
+BQAwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM
+...
+dKvZbPEsygYRIjwyhHHUh/YXH8KDI/uu6u6AxDckQ3rP1BkkKXr5NPBGjVgM3ZI=
+-----END CERTIFICATE-----
+EOT
+  key     = <<EOT
+-----BEGIN PRIVATE KEY-----
+MIIJQQIBADANBgkqhkiG9w0BAQEFAASCCSswggknAgEAAoICAQC+9uwFVenCdPD9
+5LWSWMuy4riZW718wxBpYV5Y9N8nM7N0qZLLdpImZrzBbaBldTI+AZGI3Nupuurw
+...
+s9urs/Kk/tbQhsEvu0X8FyGwo0zH6rG8apTFTlac+v4mJ4vlpxSvT5+FW2lgLISE
++4sM7kp0qO3/p+45HykwBY5iHq3H
+-----END PRIVATE KEY-----
+EOT
+
+}
+
+resource "opentelekomcloud_waf_dedicated_domain_v1" "domain_1" {
+  domain         = "www.mydom.com"
+  certificate_id = opentelekomcloud_waf_dedicated_certificate_v1.certificate_1.id
+  keep_policy    = false
+  proxy          = false
+  tls            = "TLS v1.1"
+  cipher         = "cipher_1"
+
+  server {
+    client_protocol = "HTTPS"
+    server_protocol = "HTTP"
+    address         = "192.168.0.20"
+    port            = 8443
+    type            = "ipv4"
+    vpc_id          = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  }
+
+  depends_on = [
+    opentelekomcloud_waf_dedicated_certificate_v1.certificate_1
+  ]
 }
 ```
 

--- a/opentelekomcloud/acceptance/waf/resource_opentelekomcloud_dedicated_certificate_v1_test.go
+++ b/opentelekomcloud/acceptance/waf/resource_opentelekomcloud_dedicated_certificate_v1_test.go
@@ -1,0 +1,219 @@
+package acceptance
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/waf-premium/v1/certificates"
+
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+)
+
+const (
+	wafdCertificateResourceName = "opentelekomcloud_waf_dedicated_certificate_v1.cert_1"
+	certificate                 = `<<EOT
+-----BEGIN CERTIFICATE-----
+MIIFRzCCAy8CFBKwjdhuzVswxRC4CExG3q6kRXZoMA0GCSqGSIb3DQEBCwUAMGAx
+CzAJBgNVBAYTAkVTMRAwDgYDVQQIDAdHUkFOQURBMRAwDgYDVQQHDAdHUkFOQURB
+MRAwDgYDVQQKDAdERUZBVUxUMQwwCgYDVQQLDANFQ08xDTALBgNVBAMMBEhPU1Qw
+HhcNMjMwNzI4MTExNTEyWhcNMjQwNzI3MTExNTEyWjBgMQswCQYDVQQGEwJFUzEQ
+MA4GA1UECAwHR1JBTkFEQTEQMA4GA1UEBwwHR1JBTkFEQTEQMA4GA1UECgwHREVG
+QVVMVDEMMAoGA1UECwwDRUNPMQ0wCwYDVQQDDARIT1NUMIICIjANBgkqhkiG9w0B
+AQEFAAOCAg8AMIICCgKCAgEA4Lqz8JUbPJITjuigx0HXsRv6YWG2li1LZH8qxVTR
+bdioAc8pZ7ZMogAE1hQP/uAmcMGustqjZYMJIBCrGPr1VN+AKho823leJrGh6Ibk
+Nj/OFju1HoFKYUCT4GM9LtkmT1139jKAsp8n0Ayl3K//DuoMOfZFqogdcqF+kVmg
+Q6iplqAqpgbmFUm9R73nMFJhOiI9K7d3p3JiEVeuRTc9mqwqKjVutP3fdKfIdrEt
+TnoPfp9GfNMMQTMCTZ8Aowm5pLeL1bnZuKsloYU47hWJD9XdeDjonzsJH13xh8kc
+4mTLpr+DhYNnVtvUCpBDA3WPhYrFQBubR/cfVvDRhsFsVOo7QMDYWfwt+mSD5ad+
+PQCkd1PpLghMqz+plz+h1OiSPIpWD6TGBly5SR79agUFWlOUh0n8zoqfoOJAohgn
+SJvERv/i06U/eyFaMrwlum2m9qv4vhIrYGpJAtCRFQlrfW+yniYfGY1Cs5Bw4UnR
+r2WZqtkLl3BR71135G5mie2K82EigV3118VHj8NCblhLocDV0jiWc9gnyefppCP6
+IocGMi+Gy++bmHIPQP2yI4NvXx1atZEB8wH1YTIsDagDfX3ef9WkKftctgn8T2L8
+re8phURGjCPMNeq4ybslXY4EfldOOFIUWshkZUViV0KycJIb6J4IuBpHT1tQATcM
+25kCAwEAATANBgkqhkiG9w0BAQsFAAOCAgEApAJOscxakTRp7ET7AY0CwaLbvgUO
+2NZWbg/Pr+jrt55Sxo9exMtOAexxUSRCVcAMfz2DPfdv8TzW/eIMV84BN1RZivTO
+g3LgbrbgwVe8q200GNoji8lQWePyBvUqMXaZ5ESN8K7aWiEphCoSp7W+2OvwNd1o
+yY/ovKGEmpioqla64qxIRMO4JHJJXv3lTLh1jBrPFET6AyhQbv/urZwkm9rWNTG+
+fJ11/k8W1cHCdid72YL94TqQ3AIq5swSizERDXHck0jONkA88bBYExdQoqfE+X8n
+rFSrpW4HGPDnE8/FBvir4JWOlEymifgAqmfCQZfkr/XTOircNwMLiAwUwqn7cMYc
+kWCq8JgJXVpAegCPy/rzB1+M4FxVL4HMFLAiTVvkdK52e3bJ4HRCX5k48fKSj8RX
+wWiWnK6YSShkplerCZ50ng+SvSiWzcqsJRqgupwFJKM3+iZ6zsyIpOLqZ/XgSiRg
+F1NrTkx+2qdNqp/F0PUEJMJQA0ZukviDqvHefr07ZjFL7qBJb19cEV0sgvnA93b4
+KirQdAKxHYWrZl+rTTmlHPsfvylMFXDef5X66USvRdcK3xDpeAiXwJRg+HeDGk8w
+9DAfnoBiV1K/gi4dWW9GqIzzqk7HdyzmjRyJJRoYV3nRssOGlcjUeu5GJgrKHv/0
+nGCTZwjrFytcgdo=
+-----END CERTIFICATE-----
+EOT
+`
+
+	privateKey = `<<EOT
+-----BEGIN PRIVATE KEY-----
+MIIJQwIBADANBgkqhkiG9w0BAQEFAASCCS0wggkpAgEAAoICAQDgurPwlRs8khOO
+6KDHQdexG/phYbaWLUtkfyrFVNFt2KgBzylntkyiAATWFA/+4CZwwa6y2qNlgwkg
+EKsY+vVU34AqGjzbeV4msaHohuQ2P84WO7UegUphQJPgYz0u2SZPXXf2MoCynyfQ
+DKXcr/8O6gw59kWqiB1yoX6RWaBDqKmWoCqmBuYVSb1HvecwUmE6Ij0rt3encmIR
+V65FNz2arCoqNW60/d90p8h2sS1Oeg9+n0Z80wxBMwJNnwCjCbmkt4vVudm4qyWh
+hTjuFYkP1d14OOifOwkfXfGHyRziZMumv4OFg2dW29QKkEMDdY+FisVAG5tH9x9W
+8NGGwWxU6jtAwNhZ/C36ZIPlp349AKR3U+kuCEyrP6mXP6HU6JI8ilYPpMYGXLlJ
+Hv1qBQVaU5SHSfzOip+g4kCiGCdIm8RG/+LTpT97IVoyvCW6bab2q/i+EitgakkC
+0JEVCWt9b7KeJh8ZjUKzkHDhSdGvZZmq2QuXcFHvXXfkbmaJ7YrzYSKBXfXXxUeP
+w0JuWEuhwNXSOJZz2CfJ5+mkI/oihwYyL4bL75uYcg9A/bIjg29fHVq1kQHzAfVh
+MiwNqAN9fd5/1aQp+1y2CfxPYvyt7ymFREaMI8w16rjJuyVdjgR+V044UhRayGRl
+RWJXQrJwkhvongi4GkdPW1ABNwzbmQIDAQABAoICAEdw0vcuT4RH49PQfBwcAFeb
+T1NZ3tOK/qaqDozA0/sZnv9EPiNsPpxZaTAtHJCn7VB3IfRVsQ/6QhJheiLs1MTw
+cCvyP1p+EMI4QgJLr4zXZ8qFnKRf8adNAjWZFsAn5Bfi3Nn1YBhopB1th+TKRkkV
+emGKusblkob4c+X9GgeoPJFXxXcWRlqKIJQH+NDRv3rdm5ikMHOY1zgwKYRzdTAQ
+fy7/4XvEIR9Sn1WsKX0DLJ3SQHQ6G3E2qArI+0jZNJz6hIejF2Wvcr0QPvLhAbt4
+/3jSjpDgEZxZHwlNk9Mcu+j8hPESvu1L4PKivcsBumh3nxEsNYcBNoNK9zDhmHAl
+qAVConp4jD0V0ZadKGWHzzIEFX5ga4eKNvWGWoK6IJr0botKgT0tEtpVwWSxdWnc
+vgzLQ9BQcKVH26gLTM7mNyumexF024sV3J7s3wEEgjbAHGljFAdTCuQn6oAM07ZS
+IsDSOcghiIKHZ2m8m9itlzzrI4SHy0Y10ZDFB716PVsUpjvqQ9ooAZJzWHNBI2le
+20vRAu62flueeS1I8erb66eMkQTd/5H/7HYzBbUBYSvhMMlEDrQY8K2UGZ8bXUx4
+fiYW2ZzZxtx27Zg9Iw3eJCZJqi/0I1uqIrKPXLOC4YX/WeW1uzOv/OCaU5CFYg9b
+BX53Q1NQnGZkwrd4M/sBAoIBAQD0GUJLEdHCWRohMSxXTgdxUdAgWgOh6rPkI+n+
+UrYi+upLFwVsxGlZXXyokuWnPy6xwVs3tuWsEwHsZjmGcetCtVdYmHyILlss73Ol
+Rij+1q+THBfrL5hVnBMBm+DN/XnzLguFBQVJRcbE+wOavppBk2NIrbpCQgpiFPTT
+no4goehZYqKpr2t6kLuLoJn4/RfMUkiV2nsl3klQnurGn+CS0PaBuZAhmOy5fVb+
+wV8nvUNLXWAVM5hGOTMgWrtIVoEVRYi7lXoA2OISXAhPG3AXYRej99lXxl1HlNuj
+Jd6IPKo2h/nHW29iGaWNfLNSn3CQ0kIuLtFqoFo/XjL7LkTxAoIBAQDrr67zgWm9
+cpqwmdCNXkE0us4Wl1GlybLemajdVi9BBBo6Nuivb3GiT4r8mZ9KTyk4yqAsULpY
+Z+7+4qRyfMpArcq+7ERjXUJw6yq14DVbA/GlJcQ2yuWCOqv+2Mul91myt7O4V7Wc
+Os36f4KPCJkEqucTtz+DiX4YwbDVCvHfTpJXYbDXOVG6UEVf+Tx6Wx16Emjfhi4B
+0uzu0atniVidQSibF81AvymmjPkRGkx91Br0qDMkRQBsfrxNJu1O712bKms1GAFO
+MnTdIh5ljU4MQDPaJtFKcjmw5eTHbMvGruxS6LwgM8DrQvOIXdPMdSTz7tOSgToF
+fzT9jlKCzOEpAoIBAQClJgHIMIIub4JSOqa5Wr2GWcfqW3xhrB2RmQrTWrqH6CNk
+MmslL63nHG0e0GQ4R3McKKnChCfXx/RhMLhy0dhOBcrW0jRPHq3pNQiVJWbPJAke
+Cr/UCxuRsErbp87tDzXW5aw9jywIawEUfI/vvk03WLSvk3qVIYFM4sjR9FBMm75L
+24QaMekRv6Jj0YDbCMF1J6acXHk9IauQtDQ7tieGrYJaOmXdlU10Ie0d506t4EsL
+Tl2XepTnzgNdPIXBZ2VmMulToMoukI5DxaiJfRLVfoc0FJgj3r11lK0VMKXinsi6
+pDzGOIKfaKKtm1Tn7Z+HG/pSrLJa5aqpfN4ZOzDBAoIBACVt+TLi0pArqzVwuBY7
+ac+d+yzLS0QxDB8d+BtunIKOzDuCjOGPqVRFnaUQIKQEfl9ujpF7IJz5pJMGG2ez
+Ocubzh8UFqhRH0QflODdgpu5vJ6lqMuq3VgZSUdn1q+84JnpYrlb9JOjIyMtLOba
+TrLXEWuoJoYVR9lWqWasHk2AhO0rrpH/oGMebGYZhulHnx7L3avh+1x+yvICil4f
+CduvhWtcFFS8BzlUGhoFOzCghsdkDvsrmi2g0vbNv9JRYWRLEEuWTF7G1Jhp2rn1
+/vcjGxkCISrZiR/24qZpONOM5CsmmvniPjkeoN5/SCuoTv4OZ7tUmopU8W1zNNdh
+AkECggEBANvWUz3Vd4xttKAOYGWpMG1btteQoFjTRIal2arW5pbs/oYkHboufxpH
+o+R4J/QRAsZ+juRmao4D/JtyCamKKQpNRU+lXOduHIPa+BynCsRGnV/IjyeQaXKa
+rgB6c1gENB3sKCEl9KRjSqkQVjLuiO2T9Ugvn0h2qYcvkbqsaAseOXj5E4FbWSQE
+Sy4cUIi/4Rf7EVlJFDH4L4k1388uh7lqYB4wzMHEmPTD8uhOgaokF9pO3pYwSTM7
+v2FKjteSuRcJ+oGbMoLvKHFnAGsGC0vYbrVQhw5krFjSPEjHdSj+P0cSGKOVax26
+6Ty0X9L6AsYiuWgPiTkurNI9qz7lYwg=
+-----END PRIVATE KEY-----
+EOT
+`
+)
+
+func TestAccWafDedicatedCertificateV1_basic(t *testing.T) {
+	var cert certificates.Certificate
+	log.Printf("[DEBUG] The opentelekomcloud Waf dedicated certificate test running in '%s' region.", env.OS_REGION_NAME)
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckWafDedicatedCertificateV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafDedicatedCertificateV1Basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafDedicatedCertificateV1Exists(wafdCertificateResourceName, &cert),
+					resource.TestCheckResourceAttr(wafdCertificateResourceName, "name", "cert_1"),
+					resource.TestCheckResourceAttr(wafdCertificateResourceName, "expires", "2024-07-27 11:15:12 UTC"),
+				),
+			},
+			{
+				ResourceName:            wafdCertificateResourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"content", "key"},
+			},
+		},
+	})
+}
+
+func TestAccWafDedicatedCertificateV1_validation(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccWafDedicatedCertificateV1InvalidName,
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`Invalid certificate name.+`),
+			},
+		},
+	})
+}
+
+func testAccCheckWafDedicatedCertificateV1Destroy(s *terraform.State) error {
+	config := common.TestAccProvider.Meta().(*cfg.Config)
+	client, err := config.WafDedicatedV1Client(env.OS_REGION_NAME)
+	if err != nil {
+		return err
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "opentelekomcloud_waf_dedicated_certificate_v1" {
+			continue
+		}
+
+		_, err := certificates.Get(client, rs.Primary.ID)
+		if err == nil {
+			return fmt.Errorf("waf dedicated certificate (%s) still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckWafDedicatedCertificateV1Exists(n string, certificate *certificates.Certificate) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		config := common.TestAccProvider.Meta().(*cfg.Config)
+		client, err := config.WafDedicatedV1Client(env.OS_REGION_NAME)
+		if err != nil {
+			return err
+		}
+
+		found, err := certificates.Get(client, rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if found.ID != rs.Primary.ID {
+			return fmt.Errorf("waf dedicated certificate not found")
+		}
+		*certificate = *found
+
+		return nil
+	}
+}
+
+var testAccWafDedicatedCertificateV1Basic = fmt.Sprintf(`
+resource "opentelekomcloud_waf_dedicated_certificate_v1" "cert_1" {
+  name    = "cert_1"
+  key     = %s
+  content = %s
+}
+`, privateKey, certificate)
+
+var testAccWafDedicatedCertificateV1InvalidName = fmt.Sprintf(`
+resource "opentelekomcloud_waf_dedicated_certificate_v1" "cert_1" {
+  name    = "cert_1!&?"
+  key     = %s
+  content = %s
+}
+`, privateKey, certificate)

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -488,6 +488,7 @@ func Provider() *schema.Provider {
 			"opentelekomcloud_waf_dedicated_instance_v1":          waf.ResourceWafDedicatedInstance(),
 			"opentelekomcloud_waf_dedicated_domain_v1":            waf.ResourceWafDedicatedDomain(),
 			"opentelekomcloud_waf_dedicated_policy_v1":            waf.ResourceWafDedicatedPolicy(),
+			"opentelekomcloud_waf_dedicated_certificate_v1":       waf.ResourceWafDedicatedCertificateV1(),
 		},
 	}
 

--- a/opentelekomcloud/services/waf/resource_opentelekomcloud_waf_dedicated_certificate_v1.go
+++ b/opentelekomcloud/services/waf/resource_opentelekomcloud_waf_dedicated_certificate_v1.go
@@ -1,0 +1,150 @@
+package waf
+
+import (
+	"context"
+	"log"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/waf-premium/v1/certificates"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
+)
+
+func ResourceWafDedicatedCertificateV1() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceWafDedicatedCertificateV1Create,
+		ReadContext:   resourceWafDedicatedCertificateV1Read,
+		DeleteContext: resourceWafDedicatedCertificateV1Delete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[\w-_.]{1,64}$`), "Invalid certificate name. "+
+					"Certificate name. The value can contain a maximum of 64 characters. Only digits, "+
+					"letters, hyphens (-), underscores (_), and periods (.) are allowed."),
+			},
+			"content": {
+				Type:      schema.TypeString,
+				Required:  true,
+				ForceNew:  true,
+				StateFunc: common.GetHashOrEmpty,
+			},
+			"key": {
+				Type:      schema.TypeString,
+				Required:  true,
+				ForceNew:  true,
+				StateFunc: common.GetHashOrEmpty,
+			},
+			"expires": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceWafDedicatedCertificateV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
+		return config.WafDedicatedV1Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV1DedicatedClient, err)
+	}
+
+	opts := certificates.CreateOpts{
+		Name:    d.Get("name").(string),
+		Content: strings.TrimSpace(d.Get("content").(string)),
+		Key:     strings.TrimSpace(d.Get("key").(string)),
+	}
+
+	certificate, err := certificates.Create(client, opts)
+	if err != nil {
+		return fmterr.Errorf("error creating OpenTelekomCloud WAF Dedicated Certificate: %w", err)
+	}
+
+	log.Printf("[DEBUG] Waf Dedicated Certificate created: %#v", certificate.ID)
+	d.SetId(certificate.ID)
+
+	clientCtx := common.CtxWithClient(ctx, client, keyClientV1)
+	return resourceWafDedicatedCertificateV1Read(clientCtx, d, meta)
+}
+
+func resourceWafDedicatedCertificateV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
+		return config.WafDedicatedV1Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV1DedicatedClient, err)
+	}
+
+	n, err := certificates.Get(client, d.Id())
+
+	if err != nil {
+		if _, ok := err.(golangsdk.ErrDefault404); ok {
+			d.SetId("")
+			return nil
+		}
+
+		return fmterr.Errorf("error retrieving OpenTelekomCloud Waf Dedicated Certificate: %w", err)
+	}
+	layout := "2006-01-02 15:04:05 MST"
+	mErr := multierror.Append(
+		d.Set("name", n.Name),
+		d.Set("expires", time.Unix(n.ExpireAt/1000, 0).UTC().Format(layout)),
+		d.Set("created_at", time.Unix(n.CreatedAt/1000, 0).UTC().Format(layout)),
+	)
+	if mErr.ErrorOrNil() != nil {
+		return diag.FromErr(mErr)
+	}
+
+	return nil
+}
+
+func resourceWafDedicatedCertificateV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
+		return config.WafDedicatedV1Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV1DedicatedClient, err)
+	}
+
+	err = certificates.Delete(client, d.Id())
+	if err != nil {
+		return fmterr.Errorf("error deleting OpenTelekomCloud WAF Dedicated Certificate: %s", err)
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/releasenotes/notes/wafd-certificate-a850ebfea702734f.yaml
+++ b/releasenotes/notes/wafd-certificate-a850ebfea702734f.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  |
+  **[WAF]** Add new resource ``resource/opentelekomcloud_waf_dedicated_certificate_v1`` (`#2267 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2267>`_)


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [x] Refers to: #2231
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccWafDedicatedDomainV1_basic
2023/08/17 12:46:51 [DEBUG] The opentelekomcloud Waf dedicated instance test running in 'eu-de' region.
--- PASS: TestAccWafDedicatedDomainV1_basic (149.12s)

=== RUN   TestAccWafDedicatedCertificateV1_basic
2023/08/17 12:55:32 [DEBUG] The opentelekomcloud Waf dedicated certificate test running in 'eu-de' region.
--- PASS: TestAccWafDedicatedCertificateV1_basic (45.74s)
=== RUN   TestAccWafDedicatedCertificateV1_validation
--- PASS: TestAccWafDedicatedCertificateV1_validation (5.24s)
PASS


Process finished with the exit code 0

=== RUN   TestAccWafDedicatedCertificateV1_basic
2023/08/17 12:57:00 [DEBUG] The opentelekomcloud Waf dedicated certificate test running in 'eu-ch2' region.
--- PASS: TestAccWafDedicatedCertificateV1_basic (47.01s)
=== RUN   TestAccWafDedicatedCertificateV1_validation
--- PASS: TestAccWafDedicatedCertificateV1_validation (5.23s)
PASS


Process finished with the exit code 0
```
