### PR TITLE
[DMS]: Enable encryption for `resource/opentelekomcloud_dms_instance_v2`

### DIFF
--- a/docs/resources/dms_instance_v2.md
+++ b/docs/resources/dms_instance_v2.md
@@ -195,6 +195,10 @@ The following arguments are supported:
   * Provided ip amount should be same as amount of DMS cluster nodes.
   * Example: `["0f2a51dc-93ce-42af","d967d49b-6659-4052","002872f4-82a4-4f6e-9a4e"]`.
 
+* `disk_encrypted_enable` - (Optional) - Indicates whether disk encryption is enabled.
+
+* `disk_encrypted_key` - (Optional) - Disk encryption key. If disk encryption is not enabled, this parameter is left blank.
+
 * `tags` - (Optional) Tags key/value pairs to associate with the instance.
 
 ## Attributes Reference

--- a/opentelekomcloud/services/dms/resource_opentelekomcloud_dms_instance_v2.go
+++ b/opentelekomcloud/services/dms/resource_opentelekomcloud_dms_instance_v2.go
@@ -486,9 +486,8 @@ func resourceDmsInstancesV2Delete(ctx context.Context, d *schema.ResourceData, m
 	log.Printf("[DEBUG] Waiting for instance (%s) to delete", d.Id())
 
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{"RUNNING"},
-		// Taking too long to delete instance when KMS is enabled
-		Target:     []string{"DELETED", "DELETING"},
+		Pending:    []string{"DELETING", "RUNNING"},
+		Target:     []string{"DELETED"},
 		Refresh:    instancesV2StateRefreshFunc(client, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
 		Delay:      10 * time.Second,

--- a/opentelekomcloud/services/dms/resource_opentelekomcloud_dms_instance_v2.go
+++ b/opentelekomcloud/services/dms/resource_opentelekomcloud_dms_instance_v2.go
@@ -159,20 +159,19 @@ func ResourceDmsInstancesV2() *schema.Resource {
 					"produce_reject", "time_base",
 				}, false),
 			},
-			// Not supported on current version
-			// "disk_encrypted_enable": {
-			// 	Type:     schema.TypeBool,
-			// 	Optional: true,
-			// 	Computed: true,
-			// 	ForceNew: true,
-			// },
-			// "disk_encrypted_key": {
-			// 	Type:         schema.TypeString,
-			// 	Optional:     true,
-			// 	Computed:     true,
-			// 	ForceNew:     true,
-			// 	RequiredWith: []string{"disk_encrypted_enable"},
-			// },
+			"disk_encrypted_enable": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"disk_encrypted_key": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				RequiredWith: []string{"disk_encrypted_enable"},
+			},
 			"specification": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -310,11 +309,11 @@ func resourceDmsInstancesV2Create(ctx context.Context, d *schema.ResourceData, m
 		createOpts.PublicIpID = strings.Join(ipList, ",")
 	}
 
-	// if d.Get("disk_encrypted_enable").(bool) {
-	// 	diskEncryptedEnable := true
-	// 	createOpts.DiskEncryptedEnable = &diskEncryptedEnable
-	// 	createOpts.DiskEncryptedKey = d.Get("disk_encrypted_key").(string)
-	// }
+	if d.Get("disk_encrypted_enable").(bool) {
+		diskEncryptedEnable := true
+		createOpts.DiskEncryptedEnable = &diskEncryptedEnable
+		createOpts.DiskEncryptedKey = d.Get("disk_encrypted_key").(string)
+	}
 
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)
 	v, err := instances.Create(client, createOpts)
@@ -396,8 +395,8 @@ func resourceDmsInstancesV2Read(_ context.Context, d *schema.ResourceData, meta 
 		d.Set("public_connect_address", flattenPublicIps(v.PublicConnectionAddress)),
 		d.Set("public_bandwidth", v.PublicBandWidth),
 		d.Set("ssl_enable", v.SslEnable),
-		// d.Set("disk_encrypted_enable", v.DiskEncrypted),
-		// d.Set("disk_encrypted_key", v.DiskEncryptedKey),
+		d.Set("disk_encrypted_enable", v.DiskEncrypted),
+		d.Set("disk_encrypted_key", v.DiskEncryptedKey),
 		d.Set("subnet_cidr", v.SubnetCIDR),
 		d.Set("total_storage_space", v.TotalStorageSpace),
 		d.Set("storage_resource_id", v.StorageResourceID),
@@ -487,8 +486,9 @@ func resourceDmsInstancesV2Delete(ctx context.Context, d *schema.ResourceData, m
 	log.Printf("[DEBUG] Waiting for instance (%s) to delete", d.Id())
 
 	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"DELETING", "RUNNING"},
-		Target:     []string{"DELETED"},
+		Pending: []string{"RUNNING"},
+		// Taking too long to delete instance when KMS is enabled
+		Target:     []string{"DELETED", "DELETING"},
 		Refresh:    instancesV2StateRefreshFunc(client, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
 		Delay:      10 * time.Second,

--- a/releasenotes/notes/dms_encrypted-e04c3be9a2bd3474.yaml
+++ b/releasenotes/notes/dms_encrypted-e04c3be9a2bd3474.yaml
@@ -1,4 +1,4 @@
 ---
 enhancements:
   - |
-    **[DMS]** Add encryption for ``resource/opentelekomcloud_dms_instance_v2`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[DMS]** Add encryption for ``resource/opentelekomcloud_dms_instance_v2`` (`#2280 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2280>`_)

--- a/releasenotes/notes/dms_encrypted-e04c3be9a2bd3474.yaml
+++ b/releasenotes/notes/dms_encrypted-e04c3be9a2bd3474.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[DMS]** Add encryption for ``resource/opentelekomcloud_dms_instance_v2`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Encryption has been fixed on API level, implemented in this PR.

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccDmsInstancesV2_basic
--- PASS: TestAccDmsInstancesV2_basic (1133.67s)
=== RUN   TestAccDmsInstancesV2_Encrypted
--- PASS: TestAccDmsInstancesV2_Encrypted (1048.51s)
=== RUN   TestAccDmsInstancesV2_EIP
--- PASS: TestAccDmsInstancesV2_EIP (1046.84s)
PASS

Process finished with the exit code 0
```
