### PR TITLE
[IAM]: fix `opentelekomcloud_identity_user_v3` attribute output

### DIFF
--- a/docs/resources/identity_user_v3.md
+++ b/docs/resources/identity_user_v3.md
@@ -69,6 +69,8 @@ In addition to all arguments above, the following attributes are exported:
 
 * `last_login` - The time when the IAM user last login.
 
+* `domain_id` - The domain user belongs to.
+
 ## Import
 
 Users can be imported using the `id`, e.g.

--- a/opentelekomcloud/acceptance/iam/resource_opentelekomcloud_identity_user_v3_test.go
+++ b/opentelekomcloud/acceptance/iam/resource_opentelekomcloud_identity_user_v3_test.go
@@ -37,6 +37,7 @@ func TestAccIdentityV3User_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPtr(resourceName, "name", &user.Name),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "email", "test@acme.org"),
+					resource.TestCheckResourceAttrSet(resourceName, "domain_id"),
 				),
 			},
 			{
@@ -46,6 +47,7 @@ func TestAccIdentityV3User_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPtr(resourceName, "name", &user.Name),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "email", "test2@acme.org"),
+					resource.TestCheckResourceAttrSet(resourceName, "domain_id"),
 				),
 			},
 		},

--- a/opentelekomcloud/services/iam/resource_opentelekomcloud_identity_user_v3.go
+++ b/opentelekomcloud/services/iam/resource_opentelekomcloud_identity_user_v3.go
@@ -98,6 +98,10 @@ func ResourceIdentityUserV3() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"domain_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -178,6 +182,7 @@ func resourceIdentityUserV3Read(ctx context.Context, d *schema.ResourceData, met
 		d.Set("pwd_reset", user.PasswordStatus),
 		d.Set("create_time", user.CreateAt),
 		d.Set("last_login", user.LastLogin),
+		d.Set("domain_id", user.DomainID),
 	)
 
 	if err = mErr.ErrorOrNil(); err != nil {

--- a/releasenotes/notes/users_domain-a63c7989c9e87ce9.yaml
+++ b/releasenotes/notes/users_domain-a63c7989c9e87ce9.yaml
@@ -1,5 +1,5 @@
 ---
 fixes:
   - |
-    **[IAM]** Fix ``resource/opentelekomcloud_identity_user_v3`` to return `domain_id` attribute (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[IAM]** Fix ``resource/opentelekomcloud_identity_user_v3`` to return `domain_id` attribute (`#2283 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2283>`_)
 

--- a/releasenotes/notes/users_domain-a63c7989c9e87ce9.yaml
+++ b/releasenotes/notes/users_domain-a63c7989c9e87ce9.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    **[IAM]** Fix ``resource/opentelekomcloud_identity_user_v3`` to return `domain_id` attribute (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+


### PR DESCRIPTION
## Summary of the Pull Request
Fix `domain_id` attribute output for `opentelekomcloud_identity_user_v3`.

## PR Checklist

* [x] Refers to: #2281
* [x] Tests passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccIdentityV3User_basic
--- PASS: TestAccIdentityV3User_basic (43.67s)
=== RUN   TestAccIdentityV3User_importBasic
--- PASS: TestAccIdentityV3User_importBasic (31.44s)
=== RUN   TestAccCheckIAMV3EmailValidation
--- PASS: TestAccCheckIAMV3EmailValidation (4.84s)
=== RUN   TestAccCheckIAMV3SendEmailValidation
--- PASS: TestAccCheckIAMV3SendEmailValidation (3.70s)
PASS

Process finished with the exit code 0
```
