### PR TITLE
[CCE] export max_pods and subnet_id in `resource/opentelekomcloud_cce_node_pool_v3`

### DIFF
--- a/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_node_pool_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_node_pool_v3_test.go
@@ -42,7 +42,7 @@ func TestAccCCENodePoolsV3_basic(t *testing.T) {
 					testAccCheckCCENodePoolV3Exists(nodePoolResourceName, shared.DataSourceClusterName, &nodePool),
 					resource.TestCheckResourceAttr(nodePoolResourceName, "name", "opentelekomcloud-cce-node-pool"),
 					resource.TestCheckResourceAttr(nodePoolResourceName, "flavor", "s2.large.2"),
-					resource.TestCheckResourceAttr(nodePoolResourceName, "os", "EulerOS 2.5"),
+					resource.TestCheckResourceAttr(nodePoolResourceName, "os", "EulerOS 2.9"),
 					resource.TestCheckResourceAttr(nodePoolResourceName, "k8s_tags.kubelet.kubernetes.io/namespace", "muh"),
 					resource.TestCheckResourceAttr(nodePoolResourceName, "data_volumes.0.extend_params.useType", "docker"),
 				),
@@ -77,7 +77,9 @@ func TestAccCCENodePoolV3ImportBasic(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateIdFunc: testAccCCENodePoolV3ImportStateIdFunc(),
 				ImportStateVerifyIgnore: []string{
-					"max_node_count", "min_node_count", "priority", "scale_down_cooldown_time", "initial_node_count",
+					"max_node_count", "min_node_count", "priority",
+					"scale_down_cooldown_time", "initial_node_count",
+					"root_volume",
 				},
 			},
 		},
@@ -312,7 +314,7 @@ resource "opentelekomcloud_cce_node_pool_v3" "node_pool" {
   cluster_id         = data.opentelekomcloud_cce_cluster_v3.cluster.id
   name               = "opentelekomcloud-cce-node-pool"
   os                 = "EulerOS 2.5"
-  flavor             = "s3.medium.1"
+  flavor             = "s2.large.2"
   initial_node_count = 1
   key_pair           = "%s"
   availability_zone  = "random"
@@ -340,7 +342,7 @@ resource "opentelekomcloud_cce_node_pool_v3" "node_pool" {
   cluster_id         = data.opentelekomcloud_cce_cluster_v3.cluster.id
   name               = "opentelekomcloud-cce-node-pool"
   os                 = "EulerOS 2.5"
-  flavor             = "s3.medium.1"
+  flavor             = "s2.large.2"
   initial_node_count = 1
   key_pair           = "%s"
   availability_zone  = "random"
@@ -370,7 +372,7 @@ resource "opentelekomcloud_cce_node_pool_v3" "node_pool" {
   cluster_id         = data.opentelekomcloud_cce_cluster_v3.cluster.id
   name               = "opentelekomcloud-cce-node-pool"
   os                 = "EulerOS 2.5"
-  flavor             = "s3.medium.1"
+  flavor             = "s2.large.2"
   initial_node_count = 1
   key_pair           = "%s"
   availability_zone  = "random"

--- a/opentelekomcloud/acceptance/cce/shared/cluster.go
+++ b/opentelekomcloud/acceptance/cce/shared/cluster.go
@@ -55,7 +55,7 @@ func createSharedCluster(t *testing.T) string {
 			},
 			Spec: clusters.Spec{
 				Type:        "VirtualMachine",
-				Flavor:      "cce.s1.small",
+				Flavor:      "cce.s1.medium",
 				Description: "Shared cluster for CCE acceptance tests",
 				ContainerNetwork: clusters.ContainerNetworkSpec{
 					Mode: "overlay_l2",

--- a/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_pool_v3.go
+++ b/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_pool_v3.go
@@ -16,7 +16,6 @@ import (
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/cce/v3/nodepools"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/cce/v3/nodes"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/tags"
-
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
@@ -232,6 +231,7 @@ func ResourceCCENodePoolV3() *schema.Resource {
 			"subnet_id": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 			"preinstall": {
@@ -249,6 +249,7 @@ func ResourceCCENodePoolV3() *schema.Resource {
 			"max_pods": {
 				Type:     schema.TypeInt,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 			"docker_base_size": {
@@ -461,6 +462,8 @@ func resourceCCENodePoolV3Read(ctx context.Context, d *schema.ResourceData, meta
 		d.Set("os", s.Spec.NodeTemplate.Os),
 		d.Set("key_pair", s.Spec.NodeTemplate.Login.SshKey),
 		d.Set("scale_enable", s.Spec.Autoscaling.Enable),
+		d.Set("max_pods", s.Spec.NodeTemplate.ExtendParam.MaxPods),
+		d.Set("subnet_id", s.Spec.NodeTemplate.NodeNicSpec.PrimaryNic.SubnetId),
 		d.Set("root_volume", rootVolume),
 		d.Set("status", s.Status.Phase),
 	)

--- a/releasenotes/notes/cce-np-max-pods-subnet-out-793f6c8dbbeb7ad5.yaml
+++ b/releasenotes/notes/cce-np-max-pods-subnet-out-793f6c8dbbeb7ad5.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    **[CCE]** Set ``subnet_id`` and ``max_pods`` attributes in ``resource/opentelekomcloud_cce_node_pool_v3`` (`#2284 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2284>`_)


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [x] Refers to: #2279
* [x] Tests added/passed.
* [ ] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccCCENodePoolsV3_basic
=== PAUSE TestAccCCENodePoolsV3_basic
=== CONT  TestAccCCENodePoolsV3_basic
    resource_opentelekomcloud_cce_node_pool_v3_test.go:32: Cluster is required by the test. 1 test(s) are using cluster.
=== RUN   TestAccCCENodePoolV3ImportBasic
=== PAUSE TestAccCCENodePoolV3ImportBasic
=== CONT  TestAccCCENodePoolV3ImportBasic
    resource_opentelekomcloud_cce_node_pool_v3_test.go:64: Cluster is required by the test. 4 test(s) are using cluster.
    cluster.go:137: Cluster is released by the test. 1 test(s) are still using cluster.
--- PASS: TestAccCCENodePoolV3ImportBasic (695.52s)
=== RUN   TestAccCCENodePoolsV3_randomAZ
=== PAUSE TestAccCCENodePoolsV3_randomAZ
=== CONT  TestAccCCENodePoolsV3_randomAZ
    resource_opentelekomcloud_cce_node_pool_v3_test.go:111: Cluster is required by the test. 3 test(s) are using cluster.
    cluster.go:137: Cluster is released by the test. 2 test(s) are still using cluster.
--- PASS: TestAccCCENodePoolsV3_randomAZ (681.91s)
=== RUN   TestAccCCENodePoolsV3EncryptedVolume
=== PAUSE TestAccCCENodePoolsV3EncryptedVolume
=== CONT  TestAccCCENodePoolsV3EncryptedVolume
    resource_opentelekomcloud_cce_node_pool_v3_test.go:133: Cluster is required by the test. 5 test(s) are using cluster.
    cluster.go:137: Cluster is released by the test. 4 test(s) are still using cluster.
--- PASS: TestAccCCENodePoolsV3EncryptedVolume (663.63s)
=== RUN   TestAccCCENodePoolsV3ExtendParams
=== PAUSE TestAccCCENodePoolsV3ExtendParams
=== CONT  TestAccCCENodePoolsV3ExtendParams
    resource_opentelekomcloud_cce_node_pool_v3_test.go:156: Cluster is required by the test. 2 test(s) are using cluster.
    cluster.go:49: starting creating shared cluster
2023/08/24 14:42:19 [DEBUG] Waiting for state to become: [Available]
2023/08/24 14:42:24 [TRACE] Waiting 3s before next try
...
2023/08/24 14:47:46 [TRACE] Waiting 10s before next try
    cluster.go:137: Cluster is released by the test. 3 test(s) are still using cluster.
--- PASS: TestAccCCENodePoolsV3ExtendParams (664.45s)
    cluster.go:137: Cluster usage is 0 now, ready to delete the cluster
    cluster.go:100: starting deleting shared cluster
--- PASS: TestAccCCENodePoolsV3_basic (1107.60s)
PASS

Process finished with the exit code 0

```
