### PR TITLE
[ELB] rework of ip_groups in `resource/opentelekomcloud_lb_ipgroup_v3` and `resource/opentelekomcloud_lb_listener_v3`

### DIFF
--- a/docs/resources/lb_ipgroup_v3.md
+++ b/docs/resources/lb_ipgroup_v3.md
@@ -31,20 +31,29 @@ resource "opentelekomcloud_lb_ipgroup_v3" "group_1" {
 }
 ```
 
+## Example empty ip list
+
+```hcl
+resource "opentelekomcloud_lb_ipgroup_v3" "group_1" {
+  name        = "group_1"
+  description = "group description"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
 
-* `name` - (Optional) Specifies the IP address group name.
+* `name` - (Optional, String) Specifies the IP address group name.
 
-* `description` - (Optional) Provides supplementary information about the IP address group.
+* `description` - (Optional, String) Provides supplementary information about the IP address group.
 
-* `project_id` - (Optional) Specifies the project ID of the IP address group.
+* `project_id` - (Optional, String) Specifies the project ID of the IP address group.
 
-* `ip_list` - (Required) Specifies the IP addresses or CIDR blocks in the IP address group. [] indicates any IP address.
-  * `ip` - (Required) Specifies the IP addresses in the IP address group.
+* `ip_list` - (Optional, List) Specifies the IP addresses or CIDR blocks in the IP address group. [] indicates any IP address.
+  * `ip` - (Required, String) Specifies the IP addresses in the IP address group.
     IPv6 is unsupported. The value cannot be an IPv6 address.
-  * `description` - (Optional) Provides remarks about the IP address group.
+  * `description` - (Optional, String) Provides remarks about the IP address group.
 
 ## Attributes Reference
 

--- a/docs/resources/lb_listener_v3.md
+++ b/docs/resources/lb_listener_v3.md
@@ -140,6 +140,9 @@ The following arguments are supported:
 
 * `ip_group` - (Optional) Specifies the IP address group associated with the listener.
   * `id` - (Required) Specifies the ID of the IP address group associated with the listener.
+    Specifies the ID of the IP address group associated with the listener.
+    If `ip_list` in `opentelekomcloud_lb_ipgroup_v3` is set to an empty array `[]` and type to `whitelist`, no IP addresses are allowed to access the listener.
+    If `ip_list` in `opentelekomcloud_lb_ipgroup_v3` is set to an empty array `[]` and type to `blacklist`, any IP address is allowed to access the listener.
   * `enable` - (Optional) Specifies whether to enable access control.
     `true` (default): Access control will be enabled.
     `false`: Access control will be disabled.

--- a/docs/resources/lb_listener_v3.md
+++ b/docs/resources/lb_listener_v3.md
@@ -61,92 +61,92 @@ resource "opentelekomcloud_lb_listener_v3" "listener_1" {
 
 The following arguments are supported:
 
-* `name` - (Optional) Specifies the listener name.
+* `name` - (Optional, String) Specifies the listener name.
 
-* `description` - (Optional) Provides supplementary information about the listener.
+* `description` - (Optional, String) Provides supplementary information about the listener.
 
-* `client_ca_tls_container_ref` - (Optional) Specifies the ID of the CA certificate used by the listener.
+* `client_ca_tls_container_ref` - (Optional, String) Specifies the ID of the CA certificate used by the listener.
 
-* `default_pool_id` - (Optional) Specifies the ID of the default backend server group. If there is no
+* `default_pool_id` - (Optional, String) Specifies the ID of the default backend server group. If there is no
   matched forwarding policy, requests are forwarded to the default backend server for processing.
 
-* `default_tls_container_ref` - (Optional) Specifies the ID of the server certificate used by the listener.
+* `default_tls_container_ref` - (Optional, String) Specifies the ID of the server certificate used by the listener.
 
-* `http2_enable` - (Optional) Specifies whether to use HTTP/2. This parameter is available only for `HTTPS`
+* `http2_enable` - (Optional, Bool) Specifies whether to use HTTP/2. This parameter is available only for `HTTPS`
   listeners. If you configure this parameter for other types of listeners, it will not take effect. Enable
   HTTP/2 if you want the clients to use HTTP/2 to communicate with the load balancer.
   However, connections between the load balancer and backend servers use HTTP/1.x by default.
 
-* `insert_headers` - (Optional) Specifies the HTTP header fields.
-  * `forward_elb_ip` - (Optional) Specifies whether to transparently transmit the load balancer EIP
+* `insert_headers` - (Optional, List) Specifies the HTTP header fields.
+  * `forward_elb_ip` - (Optional, Bool) Specifies whether to transparently transmit the load balancer EIP
   to backend servers. If `forward_elb_ip` is set to `true`, the load balancer EIP will be stored in
   the HTTP header and passed to backend servers.
-  * `forwarded_port` - (Optional) Specifies whether to transparently transmit the listening port of
+  * `forwarded_port` - (Optional, Bool) Specifies whether to transparently transmit the listening port of
   the load balancer to backend servers. If `forwarded_port` is set to `true`, the listening port of
   the load balancer will be stored in the HTTP header and passed to backend servers.
-  * `forwarded_for_port` - (Optional) Specifies whether to transparently transmit the source port of
+  * `forwarded_for_port` - (Optional, Bool) Specifies whether to transparently transmit the source port of
   the client to backend servers. If `forwarded_for_port` is set to `true`, the source port of the
   client will be stored in the HTTP header and passed to backend servers.
-  * `forwarded_host` - (Optional) Specifies whether to rewrite the `X-Forwarded-Host` header.
+  * `forwarded_host` - (Optional, Bool) Specifies whether to rewrite the `X-Forwarded-Host` header.
   If `forwarded_host` is set to `true`, `X-Forwarded-Host` in the request header from the clients
   can be set to Host in the request header sent from the load balancer to backend servers.
 
-* `loadbalancer_id` - (Required) Specifies the ID of the load balancer that the listener is added to.
+* `loadbalancer_id` - (Required, ForceNew, String) Specifies the ID of the load balancer that the listener is added to.
 
-* `protocol` - (Required) The protocol - can either be `TCP`, `HTTP`, `HTTPS` or `UDP`.
+* `protocol` - (Required, ForceNew, String) The protocol - can either be `TCP`, `HTTP`, `HTTPS` or `UDP`.
   Changing this creates a new Listener.
 
-* `protocol_port` - (Required) Specifies the port used by the listener. Changing this creates a new Listener.
+* `protocol_port` - (Required, ForceNew, Int) Specifies the port used by the listener. Changing this creates a new Listener.
 
-* `sni_container_refs` - (Optional) Lists the IDs of SNI certificates (server certificates with domain names) used by the listener.
+* `sni_container_refs` - (Optional, List) Lists the IDs of SNI certificates (server certificates with domain names) used by the listener.
   Each SNI certificate can have up to 30 domain names, and each domain name in the SNI certificate must be unique.
   This parameter will be ignored and an empty array will be returned if the listener's protocol is not `HTTPS`.
 
-* `tls_ciphers_policy` - (Optional) Specifies the security policy that will be used by the listener.
+* `tls_ciphers_policy` - (Optional, String) Specifies the security policy that will be used by the listener.
   This parameter is available only for `HTTPS` listeners. An error will be returned if the protocol
   of the listener is not `HTTPS`. Possible values are: `tls-1-0`, `tls-1-1`, `tls-1-2`, `tls-1-2-strict`,
   `tls-1-2-fs`, `tls-1-0-with-1-3`, `tls-1-2-fs-with-1-3`.
 
-* `member_retry_enable` - (Optional) Specifies whether to enable health check retries for backend servers.
+* `member_retry_enable` - (Optional, Bool) Specifies whether to enable health check retries for backend servers.
   This parameter is available only for `HTTP` and `HTTPS` listeners. An error will be returned if you configure
   this parameter for `TCP` and `UDP` listeners.
 
-* `keep_alive_timeout` - (Optional) Specifies the idle timeout duration, in seconds.
+* `keep_alive_timeout` - (Optional, Int) Specifies the idle timeout duration, in seconds.
   * For `TCP` listeners, the value ranges from `10` to `4000`, and the default value is `300`.
   * For `HTTP` and `HTTPS` listeners, the value ranges from `0` to `4000`, and the default value is `60`.
   * For `UDP` listeners, this parameter is not available. An error will be returned if you
   configure this parameter for `UDP` listeners.
 
-* `client_timeout` - (Optional) Specifies the timeout duration for waiting for a request from a client, in seconds.
+* `client_timeout` - (Optional, Int) Specifies the timeout duration for waiting for a request from a client, in seconds.
   This parameter is available only for `HTTP` and `HTTPS` listeners. The value ranges from `1` to `300`, and
   the default value is `60`. An error will be returned if you configure this parameter for `TCP` and `UDP` listeners.
 
-* `member_timeout` - (Optional) Specifies the timeout duration for waiting for a request from a
+* `member_timeout` - (Optional, Int) Specifies the timeout duration for waiting for a request from a
   backend server, in seconds. This parameter is available only for `HTTP` and `HTTPS` listeners.
   The value ranges from `1` to `300`, and the default value is `60`. An error will be returned if
   you configure this parameter for `TCP` and `UDP` listeners.
 
-* `tags` - (Optional) Tags key/value pairs to associate with the loadbalancer listener.
+* `tags` - (Optional, ForceNew, Map) Tags key/value pairs to associate with the loadbalancer listener.
 
-* `advanced_forwarding` - (Optional) Specifies whether to enable advanced forwarding.
+* `advanced_forwarding` - (Optional, ForceNew, Bool) Specifies whether to enable advanced forwarding.
   If advanced forwarding is enabled, more flexible forwarding policies and rules are supported.
   The value can be `true` (enable advanced forwarding) or `false` (disable advanced forwarding),
   and the default value is `false`. Changing this creates a new Listener.
 
-* `sni_match_algo` - (Optional) Specifies how wildcard domain name matches with the SNI certificates
+* `sni_match_algo` - (Optional, String) Specifies how wildcard domain name matches with the SNI certificates
   used by the listener.
 
-* `security_policy_id` - (Optional) Specifies the ID of the custom security policy.
+* `security_policy_id` - (Optional, String) Specifies the ID of the custom security policy.
 
-* `ip_group` - (Optional) Specifies the IP address group associated with the listener.
-  * `id` - (Required) Specifies the ID of the IP address group associated with the listener.
+* `ip_group` - (Optional, List) Specifies the IP address group associated with the listener.
+  * `id` - (Required, String) Specifies the ID of the IP address group associated with the listener.
     Specifies the ID of the IP address group associated with the listener.
     If `ip_list` in `opentelekomcloud_lb_ipgroup_v3` is set to an empty array `[]` and type to `whitelist`, no IP addresses are allowed to access the listener.
     If `ip_list` in `opentelekomcloud_lb_ipgroup_v3` is set to an empty array `[]` and type to `blacklist`, any IP address is allowed to access the listener.
-  * `enable` - (Optional) Specifies whether to enable access control.
+  * `enable` - (Optional, Bool) Specifies whether to enable access control.
     `true` (default): Access control will be enabled.
     `false`: Access control will be disabled.
-  * `type` - (Optional) Specifies how access to the listener is controlled.
+  * `type` - (Optional, String) Specifies how access to the listener is controlled.
     `white` (default): A whitelist will be configured. Only IP addresses in the whitelist can access the listener.
     `black`: A blacklist will be configured. IP addresses in the blacklist are not allowed to access the listener.
 

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/jinzhu/copier v0.3.5
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.7.1-0.20230823124741-e936ed960943
+	github.com/opentelekomcloud/gophertelekomcloud v0.7.1-0.20230825122025-b55cf09f8039
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.1.0
 	golang.org/x/sync v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -154,8 +154,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k+Mg7cowZ8yv4Trqw9UsJby758=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.7.1-0.20230823124741-e936ed960943 h1:BWJEc/zZRb9jHusIAO5VKlyqjxstiUB1nG0lAfKn3to=
-github.com/opentelekomcloud/gophertelekomcloud v0.7.1-0.20230823124741-e936ed960943/go.mod h1:9Deb3q2gJvq5dExV+aX+iO+G+mD9Zr9uFt+YY9ONmq0=
+github.com/opentelekomcloud/gophertelekomcloud v0.7.1-0.20230825122025-b55cf09f8039 h1:HOwuJ4shWM57149uRrE5l0NbV9M5mmbsJUybtReM8JU=
+github.com/opentelekomcloud/gophertelekomcloud v0.7.1-0.20230825122025-b55cf09f8039/go.mod h1:9Deb3q2gJvq5dExV+aX+iO+G+mD9Zr9uFt+YY9ONmq0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/opentelekomcloud/acceptance/elb/v3/resource_opentelekomcloud_lb_ipgroup_v3_test.go
+++ b/opentelekomcloud/acceptance/elb/v3/resource_opentelekomcloud_lb_ipgroup_v3_test.go
@@ -45,6 +45,14 @@ func TestAccLBV3IpGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceIpGroupName, "ip_list.#", "3"),
 				),
 			},
+			{
+				Config: testAccLBV3IpGroupConfigEmptyIp,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLBV3IpGroupExists(resourceIpGroupName, &ipgroup),
+					resource.TestCheckResourceAttr(resourceIpGroupName, "name", "group_1"),
+					resource.TestCheckResourceAttr(resourceIpGroupName, "description", "description update"),
+				),
+			},
 		},
 	})
 }
@@ -153,5 +161,12 @@ resource "opentelekomcloud_lb_ipgroup_v3" "group_1" {
     ip          = "192.168.150.10"
     description = "three"
   }
+}
+`
+
+const testAccLBV3IpGroupConfigEmptyIp = `
+resource "opentelekomcloud_lb_ipgroup_v3" "group_1" {
+  name        = "group_1"
+  description = "description update"
 }
 `

--- a/opentelekomcloud/acceptance/elb/v3/resource_opentelekomcloud_lb_ipgroup_v3_test.go
+++ b/opentelekomcloud/acceptance/elb/v3/resource_opentelekomcloud_lb_ipgroup_v3_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 const resourceIpGroupName = "opentelekomcloud_lb_ipgroup_v3.group_1"
+const resourceIpGroupName2 = "opentelekomcloud_lb_ipgroup_v3.group_2"
 
 func TestAccLBV3IpGroup_basic(t *testing.T) {
 	var ipgroup ipgroups.IpGroup
@@ -46,11 +47,21 @@ func TestAccLBV3IpGroup_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccLBV3IpGroupConfigEmptyIp,
+				Config: testAccLBV3IpGroupConfigUpdateEmptyIp,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLBV3IpGroupExists(resourceIpGroupName, &ipgroup),
 					resource.TestCheckResourceAttr(resourceIpGroupName, "name", "group_1"),
 					resource.TestCheckResourceAttr(resourceIpGroupName, "description", "description update"),
+					resource.TestCheckResourceAttr(resourceIpGroupName, "ip_list.#", "0"),
+				),
+			},
+			{
+				Config: testAccLBV3IpGroupConfigCreateEmptyIp,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLBV3IpGroupExists(resourceIpGroupName2, &ipgroup),
+					resource.TestCheckResourceAttr(resourceIpGroupName2, "name", "group_2"),
+					resource.TestCheckResourceAttr(resourceIpGroupName2, "description", "empty group"),
+					resource.TestCheckResourceAttr(resourceIpGroupName2, "ip_list.#", "0"),
 				),
 			},
 		},
@@ -164,9 +175,16 @@ resource "opentelekomcloud_lb_ipgroup_v3" "group_1" {
 }
 `
 
-const testAccLBV3IpGroupConfigEmptyIp = `
+const testAccLBV3IpGroupConfigUpdateEmptyIp = `
 resource "opentelekomcloud_lb_ipgroup_v3" "group_1" {
   name        = "group_1"
   description = "description update"
+}
+`
+
+const testAccLBV3IpGroupConfigCreateEmptyIp = `
+resource "opentelekomcloud_lb_ipgroup_v3" "group_2" {
+  name        = "group_2"
+  description = "empty group"
 }
 `

--- a/opentelekomcloud/acceptance/elb/v3/resource_opentelekomcloud_lb_listener_v3_test.go
+++ b/opentelekomcloud/acceptance/elb/v3/resource_opentelekomcloud_lb_listener_v3_test.go
@@ -175,9 +175,7 @@ func TestAccLBV3Listener_ipGroup(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLBV3ListenerExists(resourceListenerName, &listener),
 					resource.TestCheckResourceAttr(resourceListenerName, "name", "listener_1_updated"),
-					resource.TestCheckResourceAttr(resourceListenerName, "ip_group.#", "1"),
-					resource.TestCheckResourceAttr(resourceListenerName, "ip_group.0.enable", "false"),
-					resource.TestCheckResourceAttr(resourceListenerName, "ip_group.0.type", "black"),
+					resource.TestCheckResourceAttr(resourceListenerName, "ip_group.#", "0"),
 				),
 			},
 		},
@@ -499,11 +497,5 @@ resource "opentelekomcloud_lb_listener_v3" "listener_1" {
   protocol_port   = 8080
 
   sni_match_algo = "longest_suffix"
-
-  ip_group {
-    id     = opentelekomcloud_lb_ipgroup_v3.group_2.id
-    enable = false
-    type   = "black"
-  }
 }
 `, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE)

--- a/opentelekomcloud/acceptance/elb/v3/resource_opentelekomcloud_lb_listener_v3_test.go
+++ b/opentelekomcloud/acceptance/elb/v3/resource_opentelekomcloud_lb_listener_v3_test.go
@@ -171,7 +171,7 @@ func TestAccLBV3Listener_ipGroup(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccLBV3ListenerConfigIpGroupAllIpAddresses,
+				Config: testAccLBV3ListenerConfigIpGroupRemoveAllIpAddresses,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLBV3ListenerExists(resourceListenerName, &listener),
 					resource.TestCheckResourceAttr(resourceListenerName, "name", "listener_1_updated"),
@@ -466,7 +466,7 @@ resource "opentelekomcloud_lb_listener_v3" "listener_1" {
 }
 `, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE)
 
-var testAccLBV3ListenerConfigIpGroupAllIpAddresses = fmt.Sprintf(`
+var testAccLBV3ListenerConfigIpGroupRemoveAllIpAddresses = fmt.Sprintf(`
 %s
 
 resource "opentelekomcloud_lb_loadbalancer_v3" "loadbalancer_1" {

--- a/releasenotes/notes/elb-ipgroup-empty-iplist-31be5ee0105772f2.yaml
+++ b/releasenotes/notes/elb-ipgroup-empty-iplist-31be5ee0105772f2.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    **[ELB]** Now can create ``ip_group`` with empty ``ip_list`` in ``resource/opentelekomcloud_lb_ipgroup_v3`` (`#2285 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2285>`_)
+    **[ELB]** Now can create or update ``ip_group`` with empty ``ip_list`` in ``resource/opentelekomcloud_lb_ipgroup_v3`` (`#2285 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2285>`_)

--- a/releasenotes/notes/elb-ipgroup-empty-iplist-31be5ee0105772f2.yaml
+++ b/releasenotes/notes/elb-ipgroup-empty-iplist-31be5ee0105772f2.yaml
@@ -2,3 +2,5 @@
 fixes:
   - |
     **[ELB]** Now can create or update ``ip_group`` with empty ``ip_list`` in ``resource/opentelekomcloud_lb_ipgroup_v3`` (`#2285 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2285>`_)
+  - |
+    **[ELB]** Now can remove ``ip_group`` from ``resource/opentelekomcloud_lb_listener_v3`` (`#2285 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2285>`_)

--- a/releasenotes/notes/elb-ipgroup-empty-iplist-31be5ee0105772f2.yaml
+++ b/releasenotes/notes/elb-ipgroup-empty-iplist-31be5ee0105772f2.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[ELB]** Now can create ``ip_group`` with empty ``ip_list`` in ``resource/opentelekomcloud_lb_ipgroup_v3`` (`#2285 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2285>`_)


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [x] Refers to: #2277 
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccLBV3Listener_basic
=== PAUSE TestAccLBV3Listener_basic
=== RUN   TestAccLBV3Listener_TCP
=== PAUSE TestAccLBV3Listener_TCP
=== RUN   TestAccLBV3Listener_HTTP_to_TCP
=== PAUSE TestAccLBV3Listener_HTTP_to_TCP
=== RUN   TestAccLBV3Listener_ipGroup
=== PAUSE TestAccLBV3Listener_ipGroup
=== RUN   TestAccLBV3Listener_import
=== PAUSE TestAccLBV3Listener_import
=== CONT  TestAccLBV3Listener_basic
=== CONT  TestAccLBV3Listener_import
=== CONT  TestAccLBV3Listener_TCP
=== CONT  TestAccLBV3Listener_ipGroup
=== CONT  TestAccLBV3Listener_HTTP_to_TCP
--- PASS: TestAccLBV3Listener_import (50.34s)
--- PASS: TestAccLBV3Listener_TCP (81.81s)
--- PASS: TestAccLBV3Listener_HTTP_to_TCP (81.99s)
--- PASS: TestAccLBV3Listener_basic (82.27s)
--- PASS: TestAccLBV3Listener_ipGroup (117.79s)

PASS


Process finished with the exit code 0



=== RUN   TestAccLBV3IpGroup_basic
--- PASS: TestAccLBV3IpGroup_basic (86.50s)
=== RUN   TestAccLBV3IpGroup_import
--- PASS: TestAccLBV3IpGroup_import (41.28s)
PASS


Process finished with the exit code 0
```
