### PR TITLE
[WAF] new `resource/opentelekomcloud_waf_dedicated_anti_crawler_rule_v1`

### DIFF
--- a/docs/resources/waf_dedicated_anti_crawler_rule_v1.md
+++ b/docs/resources/waf_dedicated_anti_crawler_rule_v1.md
@@ -1,0 +1,73 @@
+---
+subcategory: "Dedicated Web Application Firewall (WAFD)"
+---
+
+Up-to-date reference of API arguments for WAF dedicated Anti Crawler rule you can get at
+`https://docs.otc.t-systems.com/web-application-firewall-dedicated/api-ref/apis/rule_management/creating_a_javascript_anti-crawler_rule.html`.
+
+# opentelekomcloud_waf_dedicated_anti_crawler_rule_v1
+
+Manages a WAF Dedicated Anti Crawler Rule resource within OpenTelekomCloud.
+
+## Example Usage
+
+```hcl
+resource "opentelekomcloud_waf_dedicated_policy_v1" "policy_1" {
+  name = "policy_cc"
+}
+
+resource "opentelekomcloud_waf_dedicated_anti_crawler_rule_v1" "rule_1" {
+  policy_id       = opentelekomcloud_waf_dedicated_policy_v1.policy_1.id
+  name            = "anticrawler_1"
+  url             = "/patent/id"
+  logic           = 3
+  protection_mode = "anticrawler_except_url"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `policy_id` - (Required, ForceNew, String) The WAF policy ID. Changing this creates a new rule.
+
+* `url` - (Required, String) URL to which the rule applies.
+
+* `logic` - (Required, Int) Rule matching logic.
+  Values are:
+  + 1: Include
+  + 2: Not include
+  + 3: Equal
+  + 4: Not equal
+  + 5: Prefix is
+  + 6: Prefix is not
+  + 7: Suffix is
+  + 8: Suffix is not
+
+* `name` - (Required, String) Rule name.
+
+* `protection_mode` - (Required, ForceNew, String) JavaScript anti-crawler rule type.
+  Values are:
+  + `anticrawler_specific_url`: used to protect a specific path specified by the rule.
+  + `anticrawler_except_url`: used to protect all paths except the one specified by the rule
+  Changing this creates a new rule.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` -  ID of the rule.
+
+* `status` - Rule status. The value can be `0` or `1`.
+  + `0`: The rule is disabled.
+  + `1`: The rule is enabled.
+
+* `created_at` - Timestamp the rule is created.
+
+## Import
+
+Dedicated WAF Anti Crawler Rules can be imported using `policy_id/id`, e.g.
+
+```sh
+terraform import opentelekomcloud_waf_dedicated_anti_crawler_rule_v1.rule_1 ff95e71c8ae74eba9887193ab22c5757/b39f3a5a1b4f447a8030f0b0703f47f5
+```

--- a/opentelekomcloud/acceptance/waf/resource_opentelekomcloud_waf_dedicated_anti_crawler_rule_v1_test.go
+++ b/opentelekomcloud/acceptance/waf/resource_opentelekomcloud_waf_dedicated_anti_crawler_rule_v1_test.go
@@ -1,0 +1,134 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/waf-premium/v1/rules"
+
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+)
+
+const wafdAntiCrawlerRuleName = "opentelekomcloud_waf_dedicated_anti_crawler_rule_v1.rule_1"
+
+func TestAccWafDedicatedAntiCrawlerRuleV1_basic(t *testing.T) {
+	var rule rules.AntiCrawlerRule
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckWafDedicatedAntiCrawlerRuleV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafDedicatedAntiCrawlerRuleV1Basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafDedicatedAntiCrawlerRuleV1Exists(wafdAntiCrawlerRuleName, &rule),
+					resource.TestCheckResourceAttr(wafdAntiCrawlerRuleName, "url", "/patent/id"),
+					resource.TestCheckResourceAttr(wafdAntiCrawlerRuleName, "logic", "3"),
+					resource.TestCheckResourceAttr(wafdAntiCrawlerRuleName, "protection_mode", "anticrawler_except_url"),
+					resource.TestCheckResourceAttr(wafdAntiCrawlerRuleName, "name", "anticrawler_1"),
+				),
+			},
+			{
+				Config: testAccWafDedicatedAntiCrawlerRuleV1Update,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafDedicatedAntiCrawlerRuleV1Exists(wafdAntiCrawlerRuleName, &rule),
+					resource.TestCheckResourceAttr(wafdAntiCrawlerRuleName, "url", "/patent/id/update"),
+					resource.TestCheckResourceAttr(wafdAntiCrawlerRuleName, "logic", "4"),
+					resource.TestCheckResourceAttr(wafdAntiCrawlerRuleName, "name", "anticrawler_1_update"),
+				),
+			},
+			{
+				ResourceName:      wafdAntiCrawlerRuleName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: dedicatedRuleImportStateIDFunc(wafdAntiCrawlerRuleName, wafdPolicyResourceName),
+			},
+		},
+	})
+}
+
+func testAccCheckWafDedicatedAntiCrawlerRuleV1Destroy(s *terraform.State) error {
+	config := common.TestAccProvider.Meta().(*cfg.Config)
+	client, err := config.WafDedicatedV1Client(env.OS_REGION_NAME)
+	if err != nil {
+		return err
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "opentelekomcloud_waf_dedicated_anti_crawler_rule_v1" {
+			continue
+		}
+
+		_, err := rules.GetAntiCrawler(client, rs.Primary.Attributes["policy_id"], rs.Primary.ID)
+		if err == nil {
+			return fmt.Errorf("waf dedicated rule still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckWafDedicatedAntiCrawlerRuleV1Exists(n string, rule *rules.AntiCrawlerRule) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		config := common.TestAccProvider.Meta().(*cfg.Config)
+		client, err := config.WafDedicatedV1Client(env.OS_REGION_NAME)
+		if err != nil {
+			return err
+		}
+
+		found, err := rules.GetAntiCrawler(client, rs.Primary.Attributes["policy_id"], rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if found.ID != rs.Primary.ID {
+			return fmt.Errorf("waf dedicated rule not found")
+		}
+
+		*rule = *found
+
+		return nil
+	}
+}
+
+const testAccWafDedicatedAntiCrawlerRuleV1Basic = `
+resource "opentelekomcloud_waf_dedicated_policy_v1" "policy_1" {
+  name = "policy_anticrawler"
+}
+
+resource "opentelekomcloud_waf_dedicated_anti_crawler_rule_v1" "rule_1" {
+  policy_id       = opentelekomcloud_waf_dedicated_policy_v1.policy_1.id
+  name            = "anticrawler_1"
+  url             = "/patent/id"
+  logic           = 3
+  protection_mode = "anticrawler_except_url"
+}
+`
+
+const testAccWafDedicatedAntiCrawlerRuleV1Update = `
+resource "opentelekomcloud_waf_dedicated_policy_v1" "policy_1" {
+  name = "policy_anticrawler"
+}
+
+resource "opentelekomcloud_waf_dedicated_anti_crawler_rule_v1" "rule_1" {
+  policy_id       = opentelekomcloud_waf_dedicated_policy_v1.policy_1.id
+  name            = "anticrawler_1_update"
+  url             = "/patent/id/update"
+  logic           = 4
+  protection_mode = "anticrawler_except_url"
+}
+`

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -490,6 +490,7 @@ func Provider() *schema.Provider {
 			"opentelekomcloud_waf_dedicated_policy_v1":            waf.ResourceWafDedicatedPolicy(),
 			"opentelekomcloud_waf_dedicated_certificate_v1":       waf.ResourceWafDedicatedCertificateV1(),
 			"opentelekomcloud_waf_dedicated_cc_rule_v1":           waf.ResourceWafDedicatedCcRuleV1(),
+			"opentelekomcloud_waf_dedicated_anti_crawler_rule_v1": waf.ResourceWafDedicatedAntiCrawlerRuleV1(),
 		},
 	}
 

--- a/opentelekomcloud/services/waf/resource_opentelekomcloud_waf_dedicated_anti_crawler_rule_v1.go
+++ b/opentelekomcloud/services/waf/resource_opentelekomcloud_waf_dedicated_anti_crawler_rule_v1.go
@@ -1,0 +1,190 @@
+package waf
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/waf-premium/v1/rules"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
+)
+
+func ResourceWafDedicatedAntiCrawlerRuleV1() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceWafDedicatedAntiCrawlerRuleV1Create,
+		ReadContext:   resourceWafDedicatedAntiCrawlerRuleV1Read,
+		UpdateContext: resourceWafDedicatedAntiCrawlerRuleV1Update,
+		DeleteContext: resourceWafDedicatedAntiCrawlerRuleV1Delete,
+		Importer: &schema.ResourceImporter{
+			StateContext: common.ImportByPath("policy_id", "id"),
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"policy_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"url": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"logic": {
+				Type:         schema.TypeInt,
+				Required:     true,
+				ValidateFunc: validation.IntBetween(1, 8),
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"protection_mode": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice(
+					[]string{"anticrawler_specific_url", "anticrawler_except_url"},
+					false),
+			},
+			"status": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceWafDedicatedAntiCrawlerRuleV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
+		return config.WafDedicatedV1Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV1DedicatedClient, err)
+	}
+
+	createOpts := rules.CreateAntiCrawlerOpts{
+		Url:   d.Get("url").(string),
+		Logic: d.Get("logic").(int),
+		Name:  d.Get("name").(string),
+		Type:  d.Get("protection_mode").(string),
+	}
+
+	policyID := d.Get("policy_id").(string)
+	rule, err := rules.CreateAntiCrawler(client, policyID, createOpts)
+	if err != nil {
+		return fmterr.Errorf("error creating OpenTelekomCloud WAF Dedicated Anti Crawler Rule: %s", err)
+	}
+
+	log.Printf("[DEBUG] Waf dedicated anti crawler rule created: %#v", rule)
+	d.SetId(rule.ID)
+
+	clientCtx := common.CtxWithClient(ctx, client, keyClientV1)
+	return resourceWafDedicatedAntiCrawlerRuleV1Read(clientCtx, d, meta)
+}
+
+func resourceWafDedicatedAntiCrawlerRuleV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
+		return config.WafDedicatedV1Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV1DedicatedClient, err)
+	}
+
+	policyID := d.Get("policy_id").(string)
+	rule, err := rules.GetAntiCrawler(client, policyID, d.Id())
+
+	if err != nil {
+		if _, ok := err.(golangsdk.ErrDefault404); ok {
+			d.SetId("")
+			return nil
+		}
+
+		return fmterr.Errorf("error retrieving OpenTelekomCloud Waf Dedicated Anti Crawler Rule: %s", err)
+	}
+
+	mErr := multierror.Append(
+		d.Set("policy_id", rule.PolicyId),
+		d.Set("name", rule.Name),
+		d.Set("url", rule.Url),
+		d.Set("protection_mode", rule.Type),
+		d.Set("logic", rule.Logic),
+		d.Set("status", rule.Status),
+		d.Set("created_at", rule.CreatedAt),
+	)
+
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func resourceWafDedicatedAntiCrawlerRuleV1Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
+		return config.WafDedicatedV1Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV1DedicatedClient, err)
+	}
+	policyId := d.Get("policy_id").(string)
+	var updateOpts rules.UpdateAntiCrawlerOpts
+
+	if d.HasChange("name") {
+		updateOpts.Name = d.Get("name").(string)
+	}
+
+	if d.HasChange("url") {
+		updateOpts.Url = d.Get("url").(string)
+	}
+
+	if d.HasChange("logic") {
+		updateOpts.Logic = d.Get("logic").(int)
+	}
+
+	_, err = rules.UpdateAntiCrawler(client, policyId, d.Id(), updateOpts)
+	if err != nil {
+		return fmterr.Errorf("error updating OpenTelekomCloud WAF Anti Crawler Rule: %s", err)
+	}
+
+	clientCtx := common.CtxWithClient(ctx, client, keyClientV1)
+	return resourceWafDedicatedAntiCrawlerRuleV1Read(clientCtx, d, meta)
+}
+
+func resourceWafDedicatedAntiCrawlerRuleV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
+		return config.WafDedicatedV1Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV1DedicatedClient, err)
+	}
+
+	policyID := d.Get("policy_id").(string)
+	err = rules.DeleteAntiCrawlerRule(client, policyID, d.Id())
+	if err != nil {
+		return fmterr.Errorf("error deleting OpenTelekomCloud WAF Dedicated Anti Crawler Rule: %s", err)
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/releasenotes/notes/wafd-anti-crawler-rule-6868abf7ece84c97.yaml
+++ b/releasenotes/notes/wafd-anti-crawler-rule-6868abf7ece84c97.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  |
+  **[WAF]** Add new resource ``resource/opentelekomcloud_waf_dedicated_anti_crawler_rule_v1`` (`#2295 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2295>`_)


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [x] Refers to: #2231 
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccWafDedicatedAntiCrawlerRuleV1_basic
--- PASS: TestAccWafDedicatedAntiCrawlerRuleV1_basic (121.09s)
PASS


Debugger finished with the exit code 0
```
