### PR TITLE
[ELB]: documentation fix for `ip_list` in `lb_ipgroup_v3`

### DIFF
--- a/docs/resources/lb_ipgroup_v3.md
+++ b/docs/resources/lb_ipgroup_v3.md
@@ -50,7 +50,8 @@ The following arguments are supported:
 
 * `project_id` - (Optional, String) Specifies the project ID of the IP address group.
 
-* `ip_list` - (Optional, List) Specifies the IP addresses or CIDR blocks in the IP address group. [] indicates any IP address.
+* `ip_list` - (Optional, List) Specifies the IP addresses or CIDR blocks in the IP address group.
+    Any IP address can be used if this block isn't specified.
   * `ip` - (Required, String) Specifies the IP addresses in the IP address group.
     IPv6 is unsupported. The value cannot be an IPv6 address.
   * `description` - (Optional, String) Provides remarks about the IP address group.

--- a/releasenotes/notes/lb_ipgroup_doc-d41d1fba8d5b5f81.yaml
+++ b/releasenotes/notes/lb_ipgroup_doc-d41d1fba8d5b5f81.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[ELB]** Fix documentation for `ip_list` block in ``resource/opentelekomcloud_lb_ipgroup_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)

--- a/releasenotes/notes/lb_ipgroup_doc-d41d1fba8d5b5f81.yaml
+++ b/releasenotes/notes/lb_ipgroup_doc-d41d1fba8d5b5f81.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    **[ELB]** Fix documentation for `ip_list` block in ``resource/opentelekomcloud_lb_ipgroup_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[ELB]** Fix documentation for `ip_list` block in ``resource/opentelekomcloud_lb_ipgroup_v3`` (`#2300 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2300>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Small documentation changes for `ip_list` block in `opentelekomcloud_lb_ipgroup_v3`

## PR Checklist

* [x] Refers to: #2299
* [x] Documentation updated.
* [x] Release notes added.