### PR TITLE
[WAF] new `resource/opentelekomcloud_waf_dedicated_web_tamper_rule_v1`

### DIFF
--- a/docs/resources/waf_dedicated_web_tamper_rule_v1.md
+++ b/docs/resources/waf_dedicated_web_tamper_rule_v1.md
@@ -1,0 +1,60 @@
+---
+subcategory: "Dedicated Web Application Firewall (WAFD)"
+---
+
+Up-to-date reference of API arguments for WAF dedicated Web Tamper rule you can get at
+`https://docs-beta.otc.t-systems.com/web-application-firewall-dedicated/api-ref/apis/rule_management/creating_a_web_tamper_protection_rule.html`.
+
+# opentelekomcloud_waf_dedicated_web_tamper_rule_v1
+
+Manages a WAF Dedicated Web Tamper Rule resource within OpenTelekomCloud.
+
+## Example Usage
+
+```hcl
+resource "opentelekomcloud_waf_dedicated_policy_v1" "policy_1" {
+  name = "policy_at"
+}
+
+resource "opentelekomcloud_waf_dedicated_web_tamper_rule_v1" "rule_1" {
+  policy_id   = opentelekomcloud_waf_dedicated_policy_v1.policy_1.id
+  hostname    = "www.domain.com"
+  url         = "/login"
+  description = "test description"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `policy_id` - (Required, ForceNew, String) The WAF policy ID. Changing this creates a new rule.
+
+* `hostname` - (Required, ForceNew, String) Protected website.
+
+* `url` - (Required, ForceNew, String) URL protected by the web tamper protection rule.
+  The value must be in the standard URL format, for example, `/admin`
+
+* `description` - (Optional, ForceNew, String) Rule description.
+
+* `update_cache` - (Optional, Bool) To update the cache for a web tamper protection Rule.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` -  ID of the rule.
+
+* `status` - Rule status. The value can be:
+  + `0`: The rule is disabled.
+  + `1`: The rule is enabled.
+
+* `created_at` - Timestamp the rule is created.
+
+## Import
+
+Dedicated WAF Web Tamper Rules can be imported using `policy_id/id`, e.g.
+
+```sh
+terraform import opentelekomcloud_waf_dedicated_web_tamper_rule_v1.rule_1 ff95e71c8ae74eba9887193ab22c5757/b39f3a5a1b4f447a8030f0b0703f47f5
+```

--- a/opentelekomcloud/acceptance/waf/resource_opentelekomcloud_waf_dedicated_web_tamper_rule_v1_test.go
+++ b/opentelekomcloud/acceptance/waf/resource_opentelekomcloud_waf_dedicated_web_tamper_rule_v1_test.go
@@ -1,0 +1,134 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/waf-premium/v1/rules"
+
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+)
+
+const wafdWebTamperRuleName = "opentelekomcloud_waf_dedicated_web_tamper_rule_v1.rule_1"
+
+func TestAccWafDedicatedWebTamperRuleV1_basic(t *testing.T) {
+	var rule rules.AntiTamperRule
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckWafDedicatedWebTamperRuleV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafDedicatedWebTamperRuleV1Basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafDedicatedWebTamperRuleV1Exists(wafdWebTamperRuleName, &rule),
+					resource.TestCheckResourceAttr(wafdWebTamperRuleName, "hostname", "www.domain.com"),
+					resource.TestCheckResourceAttr(wafdWebTamperRuleName, "url", "/login"),
+					resource.TestCheckResourceAttr(wafdWebTamperRuleName, "description", "test description"),
+				),
+			},
+			{
+				Config: testAccWafDedicatedWebTamperRuleV1Update,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafDedicatedWebTamperRuleV1Exists(wafdWebTamperRuleName, &rule),
+					resource.TestCheckResourceAttr(wafdWebTamperRuleName, "hostname", "www.domain.com"),
+					resource.TestCheckResourceAttr(wafdWebTamperRuleName, "url", "/login"),
+					resource.TestCheckResourceAttr(wafdWebTamperRuleName, "description", "test description"),
+				),
+			},
+			{
+				ResourceName:            wafdWebTamperRuleName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateIdFunc:       dedicatedRuleImportStateIDFunc(wafdWebTamperRuleName, wafdPolicyResourceName),
+				ImportStateVerifyIgnore: []string{"update_cache"},
+			},
+		},
+	})
+}
+
+func testAccCheckWafDedicatedWebTamperRuleV1Destroy(s *terraform.State) error {
+	config := common.TestAccProvider.Meta().(*cfg.Config)
+	client, err := config.WafDedicatedV1Client(env.OS_REGION_NAME)
+	if err != nil {
+		return err
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "opentelekomcloud_waf_dedicated_web_tamper_rule_v1" {
+			continue
+		}
+
+		_, err := rules.GetAntiTamper(client, rs.Primary.Attributes["policy_id"], rs.Primary.ID)
+		if err == nil {
+			return fmt.Errorf("waf dedicated rule still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckWafDedicatedWebTamperRuleV1Exists(n string, rule *rules.AntiTamperRule) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		config := common.TestAccProvider.Meta().(*cfg.Config)
+		client, err := config.WafDedicatedV1Client(env.OS_REGION_NAME)
+		if err != nil {
+			return err
+		}
+
+		found, err := rules.GetAntiTamper(client, rs.Primary.Attributes["policy_id"], rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if found.ID != rs.Primary.ID {
+			return fmt.Errorf("waf dedicated rule not found")
+		}
+
+		*rule = *found
+
+		return nil
+	}
+}
+
+const testAccWafDedicatedWebTamperRuleV1Basic = `
+resource "opentelekomcloud_waf_dedicated_policy_v1" "policy_1" {
+  name = "policy_at"
+}
+
+resource "opentelekomcloud_waf_dedicated_web_tamper_rule_v1" "rule_1" {
+  policy_id   = opentelekomcloud_waf_dedicated_policy_v1.policy_1.id
+  hostname    = "www.domain.com"
+  url         = "/login"
+  description = "test description"
+}
+`
+
+const testAccWafDedicatedWebTamperRuleV1Update = `
+resource "opentelekomcloud_waf_dedicated_policy_v1" "policy_1" {
+  name = "policy_at"
+}
+
+resource "opentelekomcloud_waf_dedicated_web_tamper_rule_v1" "rule_1" {
+  policy_id   = opentelekomcloud_waf_dedicated_policy_v1.policy_1.id
+  hostname    = "www.domain.com"
+  url         = "/login"
+  description = "test description"
+
+  update_cache = true
+}
+`

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -510,6 +510,7 @@ func Provider() *schema.Provider {
 			"opentelekomcloud_waf_dedicated_anti_crawler_rule_v1":        waf.ResourceWafDedicatedAntiCrawlerRuleV1(),
 			"opentelekomcloud_waf_dedicated_data_masking_rule_v1":        waf.ResourceWafDedicatedDataMaskingRuleV1(),
 			"opentelekomcloud_waf_dedicated_known_attack_source_rule_v1": waf.ResourceWafDedicatedKnownAttackSourceRuleV1(),
+			"opentelekomcloud_waf_dedicated_web_tamper_rule_v1":          waf.ResourceWafDedicatedWebTamperRuleV1(),
 		},
 	}
 

--- a/opentelekomcloud/services/waf/resource_opentelekomcloud_waf_dedicated_web_tamper_rule_v1.go
+++ b/opentelekomcloud/services/waf/resource_opentelekomcloud_waf_dedicated_web_tamper_rule_v1.go
@@ -1,0 +1,176 @@
+package waf
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/waf-premium/v1/rules"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
+)
+
+func ResourceWafDedicatedWebTamperRuleV1() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceWafDedicatedWebTamperRuleV1Create,
+		ReadContext:   resourceWafDedicatedWebTamperRuleV1Read,
+		UpdateContext: resourceWafDedicatedWebTamperRuleV1Update,
+		DeleteContext: resourceWafDedicatedWebTamperRuleV1Delete,
+		Importer: &schema.ResourceImporter{
+			StateContext: common.ImportByPath("policy_id", "id"),
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"policy_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"hostname": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"url": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"update_cache": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"created_at": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceWafDedicatedWebTamperRuleV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
+		return config.WafDedicatedV1Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV1DedicatedClient, err)
+	}
+
+	createOpts := rules.CreateAntiTamperOpts{
+		Hostname:    d.Get("hostname").(string),
+		Url:         d.Get("url").(string),
+		Description: d.Get("description").(string),
+	}
+
+	policyID := d.Get("policy_id").(string)
+	rule, err := rules.CreateAntiTamper(client, policyID, createOpts)
+	if err != nil {
+		return fmterr.Errorf("error creating OpenTelekomCloud WAF Dedicated Web Tamper Rule: %s", err)
+	}
+
+	log.Printf("[DEBUG] Waf dedicated web tamper rule created: %#v", rule)
+	d.SetId(rule.ID)
+
+	clientCtx := common.CtxWithClient(ctx, client, keyClientV1)
+	return resourceWafDedicatedWebTamperRuleV1Read(clientCtx, d, meta)
+}
+
+func resourceWafDedicatedWebTamperRuleV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
+		return config.WafDedicatedV1Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV1DedicatedClient, err)
+	}
+
+	policyID := d.Get("policy_id").(string)
+	rule, err := rules.GetAntiTamper(client, policyID, d.Id())
+
+	if err != nil {
+		if _, ok := err.(golangsdk.ErrDefault404); ok {
+			d.SetId("")
+			return nil
+		}
+
+		return fmterr.Errorf("error retrieving OpenTelekomCloud Waf Dedicated Web Tamper Rule: %s", err)
+	}
+
+	mErr := multierror.Append(
+		d.Set("policy_id", rule.PolicyId),
+		d.Set("hostname", rule.Hostname),
+		d.Set("url", rule.Url),
+		d.Set("description", rule.Description),
+		d.Set("status", rule.Status),
+		d.Set("created_at", rule.CreatedAt),
+	)
+
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func resourceWafDedicatedWebTamperRuleV1Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
+		return config.WafDedicatedV1Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV1DedicatedClient, err)
+	}
+	policyId := d.Get("policy_id").(string)
+
+	if d.HasChange("update_cache") {
+		if d.Get("update_cache").(bool) {
+			_, err = rules.UpdateAntiTamperCache(client, policyId, d.Id())
+			if err != nil {
+				return fmterr.Errorf("error updating OpenTelekomCloud WAF Dedicated Web Tamper Rule cache: %s", err)
+			}
+		}
+	}
+
+	clientCtx := common.CtxWithClient(ctx, client, keyClientV1)
+	return resourceWafDedicatedWebTamperRuleV1Read(clientCtx, d, meta)
+}
+
+func resourceWafDedicatedWebTamperRuleV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
+		return config.WafDedicatedV1Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV1DedicatedClient, err)
+	}
+
+	policyID := d.Get("policy_id").(string)
+	err = rules.DeleteAntiTamperRule(client, policyID, d.Id())
+	if err != nil {
+		return fmterr.Errorf("error deleting OpenTelekomCloud WAF Dedicated Web Tamper Rule: %s", err)
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/releasenotes/notes/wafd-web-tamper-a890ec515fb4e828.yaml
+++ b/releasenotes/notes/wafd-web-tamper-a890ec515fb4e828.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  |
+  **[WAF]** Add new resource ``resource/opentelekomcloud_waf_dedicated_web_tamper_rule_v1`` (`#2307 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2307>`_)


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [x] Refers to: #2231
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccWafDedicatedWebTamperRuleV1_basic
--- PASS: TestAccWafDedicatedWebTamperRuleV1_basic (70.37s)
PASS


Process finished with the exit code 0
```
