### PR TITLE
[WAF] new `resource/opentelekomcloud_waf_dedicated_anti_leakage_rule_v1`

### DIFF
--- a/docs/resources/waf_dedicated_anti_leakage_rule_v1.md
+++ b/docs/resources/waf_dedicated_anti_leakage_rule_v1.md
@@ -1,0 +1,66 @@
+---
+subcategory: "Dedicated Web Application Firewall (WAFD)"
+---
+
+Up-to-date reference of API arguments for WAF dedicated Information Leakage Protection rule you can get at
+`https://docs.otc.t-systems.com/web-application-firewall-dedicated/api-ref/apis/rule_management/creating_an_information_leakage_protection_rule.html`.
+
+# opentelekomcloud_waf_dedicated_anti_leakage_rule_v1
+
+Manages a WAF Dedicated Information Leakage Protection Rule resource within OpenTelekomCloud.
+
+## Example Usage
+
+```hcl
+resource "opentelekomcloud_waf_dedicated_policy_v1" "policy_1" {
+  name = "policy_al"
+}
+
+resource "opentelekomcloud_waf_dedicated_anti_leakage_rule_v1" "rule_1" {
+  policy_id   = opentelekomcloud_waf_dedicated_policy_v1.policy_1.id
+  url         = "/attack"
+  category    = "sensitive"
+  contents    = ["id_card"]
+  description = "test description"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `policy_id` - (Required, ForceNew, String) The WAF policy ID. Changing this creates a new rule.
+
+* `category` - (Required, String) Sensitive information type in the information leakage prevention rule.
+  Values:
+  + `sensitive`: The rule masks sensitive user information, such as ID code, phone numbers, and email addresses.
+  + `code`: The rule blocks response pages of specified HTTP response code.
+
+* `url` - (Required, String) URL to which the rule applies, for example, `/admin`
+
+* `description` - (Optional, String) Rule description.
+
+* `contents` - (Optional, List) Content corresponding to the sensitive information type.
+  Multiple options can be set.
+  + When category is set to `code`, the pages that contain the following HTTP response codes will be blocked: `400`, `401`, `402`, `403`, `404`, `405`, `500`, `501`, `502`, `503`, `504` and `507`.
+  + When category is set to `sensitive`, parameters `phone`, `id_card`, and `email` can be set.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` -  ID of the rule.
+
+* `status` - Rule status. The value can be:
+  + `0`: The rule is disabled.
+  + `1`: The rule is enabled.
+
+* `created_at` - Timestamp the rule is created.
+
+## Import
+
+Dedicated WAF Web Information Leakage Protection rules can be imported using `policy_id/id`, e.g.
+
+```sh
+terraform import opentelekomcloud_waf_dedicated_anti_leakage_rule_v1.rule_1 ff95e71c8ae74eba9887193ab22c5757/b39f3a5a1b4f447a8030f0b0703f47f5
+```

--- a/opentelekomcloud/acceptance/waf/resource_opentelekomcloud_waf_dedicated_anti_leakage_rule_v1_test.go
+++ b/opentelekomcloud/acceptance/waf/resource_opentelekomcloud_waf_dedicated_anti_leakage_rule_v1_test.go
@@ -1,0 +1,137 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/waf-premium/v1/rules"
+
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+)
+
+const wafdAntiLeakageRuleName = "opentelekomcloud_waf_dedicated_anti_leakage_rule_v1.rule_1"
+
+func TestAccWafDedicatedAntiLeakageRuleV1_basic(t *testing.T) {
+	var rule rules.AntiLeakageRule
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckWafDedicatedAntiLeakageRuleV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafDedicatedAntiLeakageRuleV1Basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafDedicatedAntiLeakageRuleV1Exists(wafdAntiLeakageRuleName, &rule),
+					resource.TestCheckResourceAttr(wafdAntiLeakageRuleName, "url", "/attack"),
+					resource.TestCheckResourceAttr(wafdAntiLeakageRuleName, "contents.#", "1"),
+					resource.TestCheckResourceAttr(wafdAntiLeakageRuleName, "contents.0", "id_card"),
+					resource.TestCheckResourceAttr(wafdAntiLeakageRuleName, "category", "sensitive"),
+					resource.TestCheckResourceAttr(wafdAntiLeakageRuleName, "description", "test description"),
+				),
+			},
+			{
+				Config: testAccWafDedicatedAntiLeakageRuleV1Update,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafDedicatedAntiLeakageRuleV1Exists(wafdAntiLeakageRuleName, &rule),
+					resource.TestCheckResourceAttr(wafdAntiLeakageRuleName, "url", "/pass"),
+					resource.TestCheckResourceAttr(wafdAntiLeakageRuleName, "contents.#", "1"),
+					resource.TestCheckResourceAttr(wafdAntiLeakageRuleName, "contents.0", "id_card"),
+					resource.TestCheckResourceAttr(wafdAntiLeakageRuleName, "category", "sensitive"),
+					resource.TestCheckResourceAttr(wafdAntiLeakageRuleName, "description", "test description updated"),
+				),
+			},
+			{
+				ResourceName:      wafdAntiLeakageRuleName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: dedicatedRuleImportStateIDFunc(wafdAntiLeakageRuleName, wafdPolicyResourceName),
+			},
+		},
+	})
+}
+
+func testAccCheckWafDedicatedAntiLeakageRuleV1Destroy(s *terraform.State) error {
+	config := common.TestAccProvider.Meta().(*cfg.Config)
+	client, err := config.WafDedicatedV1Client(env.OS_REGION_NAME)
+	if err != nil {
+		return err
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "opentelekomcloud_waf_dedicated_anti_leakage_rule_v1" {
+			continue
+		}
+
+		_, err := rules.GetAntiLeakage(client, rs.Primary.Attributes["policy_id"], rs.Primary.ID)
+		if err == nil {
+			return fmt.Errorf("waf dedicated rule still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckWafDedicatedAntiLeakageRuleV1Exists(n string, rule *rules.AntiLeakageRule) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		config := common.TestAccProvider.Meta().(*cfg.Config)
+		client, err := config.WafDedicatedV1Client(env.OS_REGION_NAME)
+		if err != nil {
+			return err
+		}
+
+		found, err := rules.GetAntiLeakage(client, rs.Primary.Attributes["policy_id"], rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if found.ID != rs.Primary.ID {
+			return fmt.Errorf("waf dedicated rule not found")
+		}
+
+		*rule = *found
+
+		return nil
+	}
+}
+
+const testAccWafDedicatedAntiLeakageRuleV1Basic = `
+resource "opentelekomcloud_waf_dedicated_policy_v1" "policy_1" {
+  name = "policy_al"
+}
+
+resource "opentelekomcloud_waf_dedicated_anti_leakage_rule_v1" "rule_1" {
+  policy_id   = opentelekomcloud_waf_dedicated_policy_v1.policy_1.id
+  url         = "/attack"
+  category    = "sensitive"
+  contents    = ["id_card"]
+  description = "test description"
+}
+`
+
+const testAccWafDedicatedAntiLeakageRuleV1Update = `
+resource "opentelekomcloud_waf_dedicated_policy_v1" "policy_1" {
+  name = "policy_al"
+}
+
+resource "opentelekomcloud_waf_dedicated_anti_leakage_rule_v1" "rule_1" {
+  policy_id   = opentelekomcloud_waf_dedicated_policy_v1.policy_1.id
+  url         = "/pass"
+  category    = "sensitive"
+  contents    = ["id_card"]
+  description = "test description updated"
+}
+`

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -513,6 +513,7 @@ func Provider() *schema.Provider {
 			"opentelekomcloud_waf_dedicated_data_masking_rule_v1":        waf.ResourceWafDedicatedDataMaskingRuleV1(),
 			"opentelekomcloud_waf_dedicated_known_attack_source_rule_v1": waf.ResourceWafDedicatedKnownAttackSourceRuleV1(),
 			"opentelekomcloud_waf_dedicated_web_tamper_rule_v1":          waf.ResourceWafDedicatedWebTamperRuleV1(),
+			"opentelekomcloud_waf_dedicated_anti_leakage_rule_v1":        waf.ResourceWafDedicatedAntiLeakageRuleV1(),
 		},
 	}
 

--- a/opentelekomcloud/services/waf/resource_opentelekomcloud_waf_dedicated_anti_leakage_rule_v1.go
+++ b/opentelekomcloud/services/waf/resource_opentelekomcloud_waf_dedicated_anti_leakage_rule_v1.go
@@ -1,0 +1,193 @@
+package waf
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/waf-premium/v1/rules"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
+)
+
+func ResourceWafDedicatedAntiLeakageRuleV1() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceWafDedicatedAntiLeakageRuleV1Create,
+		ReadContext:   resourceWafDedicatedAntiLeakageRuleV1Read,
+		UpdateContext: resourceWafDedicatedAntiLeakageRuleV1Update,
+		DeleteContext: resourceWafDedicatedAntiLeakageRuleV1Delete,
+		Importer: &schema.ResourceImporter{
+			StateContext: common.ImportByPath("policy_id", "id"),
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"policy_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"url": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"category": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice(
+					[]string{"sensitive", "code"},
+					false),
+			},
+			"contents": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"created_at": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceWafDedicatedAntiLeakageRuleV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
+		return config.WafDedicatedV1Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV1DedicatedClient, err)
+	}
+
+	createOpts := rules.CreateAntiLeakageOpts{
+		Url:         d.Get("url").(string),
+		Category:    d.Get("category").(string),
+		Contents:    getContents(d),
+		Description: d.Get("description").(string),
+	}
+
+	policyID := d.Get("policy_id").(string)
+	rule, err := rules.CreateAntiLeakage(client, policyID, createOpts)
+	if err != nil {
+		return fmterr.Errorf("error creating OpenTelekomCloud WAF Dedicated Information Leakage Protection Rule: %s", err)
+	}
+
+	log.Printf("[DEBUG] Waf dedicated information leakage protection rule created: %#v", rule)
+	d.SetId(rule.ID)
+
+	clientCtx := common.CtxWithClient(ctx, client, keyClientV1)
+	return resourceWafDedicatedAntiLeakageRuleV1Read(clientCtx, d, meta)
+}
+
+func resourceWafDedicatedAntiLeakageRuleV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
+		return config.WafDedicatedV1Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV1DedicatedClient, err)
+	}
+	policyID := d.Get("policy_id").(string)
+
+	rule, err := rules.GetAntiLeakage(client, policyID, d.Id())
+
+	if err != nil {
+		if _, ok := err.(golangsdk.ErrDefault404); ok {
+			d.SetId("")
+			return nil
+		}
+
+		return fmterr.Errorf("error retrieving OpenTelekomCloud Waf Dedicated Information Leakage Protection Rule: %s", err)
+	}
+
+	mErr := multierror.Append(
+		d.Set("policy_id", rule.PolicyId),
+		d.Set("category", rule.Category),
+		d.Set("contents", rule.Contents),
+		d.Set("url", rule.Url),
+		d.Set("description", rule.Description),
+		d.Set("status", rule.Status),
+		d.Set("created_at", rule.CreatedAt),
+	)
+
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func resourceWafDedicatedAntiLeakageRuleV1Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
+		return config.WafDedicatedV1Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV1DedicatedClient, err)
+	}
+	policyId := d.Get("policy_id").(string)
+	var updateOpts rules.UpdateAntiLeakageOpts
+
+	if d.HasChanges("url", "category", "contents", "description") {
+		updateOpts.Url = d.Get("url").(string)
+		updateOpts.Category = d.Get("category").(string)
+		updateOpts.Contents = getContents(d)
+		updateOpts.Description = d.Get("description").(string)
+	}
+
+	_, err = rules.UpdateAntiLeakage(client, policyId, d.Id(), updateOpts)
+	if err != nil {
+		return fmterr.Errorf("error updating OpenTelekomCloud WAF Dedicated Information Leakage Protection Rule: %s", err)
+	}
+
+	clientCtx := common.CtxWithClient(ctx, client, keyClientV1)
+	return resourceWafDedicatedAntiLeakageRuleV1Read(clientCtx, d, meta)
+}
+
+func getContents(d *schema.ResourceData) []string {
+	contents := d.Get("contents").([]interface{})
+	cont := make([]string, len(contents))
+	for i, content := range contents {
+		cont[i] = content.(string)
+	}
+	return cont
+}
+
+func resourceWafDedicatedAntiLeakageRuleV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
+		return config.WafDedicatedV1Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV1DedicatedClient, err)
+	}
+
+	policyID := d.Get("policy_id").(string)
+	err = rules.DeleteAntiLeakageRule(client, policyID, d.Id())
+	if err != nil {
+		return fmterr.Errorf("error deleting OpenTelekomCloud WAF Dedicated Information Leakage Protection Rule: %s", err)
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/releasenotes/notes/wafd-anti-leakage-f199e3add641d149.yaml
+++ b/releasenotes/notes/wafd-anti-leakage-f199e3add641d149.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  |
+  **[WAF]** Add new resource ``resource/opentelekomcloud_waf_dedicated_anti_leakage_rule_v1`` (`#2308 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2308>`_)


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [x] Refers to: #2231
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccWafDedicatedAntiLeakageRuleV1_basic
--- PASS: TestAccWafDedicatedAntiLeakageRuleV1_basic (75.66s)
PASS

Process finished with the exit code 0
```
