### PR TITLE
[VPC]: Fix security group assignment for `opentelekomcloud_networking_port_v2`

### DIFF
--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_port_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_port_v2_test.go
@@ -330,6 +330,10 @@ resource "opentelekomcloud_networking_subnet_v2" "subnet_1" {
   network_id = opentelekomcloud_networking_network_v2.network_1.id
 }
 
+resource "opentelekomcloud_networking_secgroup_v2" "group_1" {
+  name        = "terraform-sg-1"
+}
+
 resource "opentelekomcloud_networking_port_v2" "port_1" {
   name           = "port_1"
   admin_state_up = "true"
@@ -339,6 +343,9 @@ resource "opentelekomcloud_networking_port_v2" "port_1" {
     subnet_id  = opentelekomcloud_networking_subnet_v2.subnet_1.id
     ip_address = "192.168.199.23"
   }
+  security_group_ids = [
+    opentelekomcloud_networking_secgroup_v2.group_1.id
+  ]
 }
 `
 

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_port_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_port_v2_test.go
@@ -331,7 +331,7 @@ resource "opentelekomcloud_networking_subnet_v2" "subnet_1" {
 }
 
 resource "opentelekomcloud_networking_secgroup_v2" "group_1" {
-  name        = "terraform-sg-1"
+  name = "terraform-sg-1"
 }
 
 resource "opentelekomcloud_networking_port_v2" "port_1" {

--- a/opentelekomcloud/services/vpc/resource_opentelekomcloud_networking_port_v2.go
+++ b/opentelekomcloud/services/vpc/resource_opentelekomcloud_networking_port_v2.go
@@ -148,7 +148,7 @@ func ResourceNetworkingPortV2() *schema.Resource {
 			"port_security_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Computed: true,
+				Default:  true,
 			},
 		},
 	}
@@ -193,6 +193,10 @@ func resourceNetworkingPortV2Create(ctx context.Context, d *schema.ResourceData,
 		common.MapValueSpecs(d),
 	}
 
+	if len(securityGroups) > 0 {
+		createOpts.SecurityGroups = &securityGroups
+	}
+
 	// Declare a extendedCreateOpts interface to hold either the
 	// base create options.
 	var extendedCreateOpts ports.CreateOptsBuilder
@@ -203,13 +207,6 @@ func resourceNetworkingPortV2Create(ctx context.Context, d *schema.ResourceData,
 	extendedCreateOpts = portsecurity.PortCreateOptsExt{
 		CreateOptsBuilder:   extendedCreateOpts,
 		PortSecurityEnabled: &portSecurityEnabled,
-	}
-
-	if noSecurityGroups {
-		if portSecurityEnabled {
-			securityGroups = []string{}
-			createOpts.SecurityGroups = &securityGroups
-		}
 	}
 
 	log.Printf("[DEBUG] Create Options: %#v", extendedCreateOpts)

--- a/opentelekomcloud/services/vpc/resource_opentelekomcloud_networking_port_v2.go
+++ b/opentelekomcloud/services/vpc/resource_opentelekomcloud_networking_port_v2.go
@@ -169,8 +169,7 @@ func resourceNetworkingPortV2Create(ctx context.Context, d *schema.ResourceData,
 		pAsu = &asu
 	}
 
-	var securityGroups []string
-	securityGroups = ResourcePortSecurityGroupsV2(d)
+	securityGroups := ResourcePortSecurityGroupsV2(d)
 	noSecurityGroups := d.Get("no_security_groups").(bool)
 
 	// Check and make sure an invalid security group configuration wasn't given.

--- a/releasenotes/notes/networking_port_fix-bb5e9d5cba801f72.yaml
+++ b/releasenotes/notes/networking_port_fix-bb5e9d5cba801f72.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[VPC]** Fix security group assignment for ``resource/opentelekomcloud_networking_port_v2`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)

--- a/releasenotes/notes/networking_port_fix-bb5e9d5cba801f72.yaml
+++ b/releasenotes/notes/networking_port_fix-bb5e9d5cba801f72.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    **[VPC]** Fix security group assignment for ``resource/opentelekomcloud_networking_port_v2`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[VPC]** Fix security group assignment for ``resource/opentelekomcloud_networking_port_v2`` (`#2310 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2310>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Security group assignment fixed in cases when it's provided

## PR Checklist

* [x] Refers to: #[OTC Community](https://community.open-telekom-cloud.com/community?id=community_question&sys_id=bd9fc1cd13646dd0d15ac969a6744115&anchor=answer_4f97b00d13993918d15ac969a6744198)
* [x] Tests added/passed.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccNetworkingV2Port_basic
=== PAUSE TestAccNetworkingV2Port_basic
=== CONT  TestAccNetworkingV2Port_basic
--- PASS: TestAccNetworkingV2Port_basic (70.19s)
=== RUN   TestAccNetworkingV2Port_importBasic
=== PAUSE TestAccNetworkingV2Port_importBasic
=== CONT  TestAccNetworkingV2Port_importBasic
--- PASS: TestAccNetworkingV2Port_importBasic (76.19s)
=== RUN   TestAccNetworkingV2Port_noip
=== PAUSE TestAccNetworkingV2Port_noip
=== CONT  TestAccNetworkingV2Port_noip
--- PASS: TestAccNetworkingV2Port_noip (69.66s)
=== RUN   TestAccNetworkingV2Port_allowedAddressPairs
=== PAUSE TestAccNetworkingV2Port_allowedAddressPairs
=== CONT  TestAccNetworkingV2Port_allowedAddressPairs
--- PASS: TestAccNetworkingV2Port_allowedAddressPairs (87.75s)
=== RUN   TestAccNetworkingV2Port_portSecurity_enabled
=== PAUSE TestAccNetworkingV2Port_portSecurity_enabled
=== CONT  TestAccNetworkingV2Port_portSecurity_enabled
--- PASS: TestAccNetworkingV2Port_portSecurity_enabled (88.15s)
=== RUN   TestAccNetworkingV2Port_noPortSecurityNoSecurityGroups
=== PAUSE TestAccNetworkingV2Port_noPortSecurityNoSecurityGroups
=== CONT  TestAccNetworkingV2Port_noPortSecurityNoSecurityGroups
--- PASS: TestAccNetworkingV2Port_noPortSecurityNoSecurityGroups (68.98s)
=== RUN   TestAccNetworkingV2Port_timeout
=== PAUSE TestAccNetworkingV2Port_timeout
=== CONT  TestAccNetworkingV2Port_timeout
--- PASS: TestAccNetworkingV2Port_timeout (70.31s)
PASS

Process finished with the exit code 0
```
