### PR TITLE
[DDS]: add `rocksDB` storage engine support

### DIFF
--- a/docs/resources/dds_instance_v3.md
+++ b/docs/resources/dds_instance_v3.md
@@ -169,10 +169,12 @@ The `datastore` block supports:
 * `type` - (Required) Specifies the database type. DDS Community Edition is supported.
   The value is `DDS-Community`.
 
-* `version` - (Required) Specifies the database version. The value is `3.2` or `3.4`.
+* `version` - (Required) Specifies the database version.
+The values are `3.2`, `3.4`, `4.0`, `4.2`, `4.4`.
 
-* `storage_engine` - (Optional) Specifies the storage engine. Currently, DDS supports the WiredTiger
-   storage engine. The value is `wiredTiger`.
+* `storage_engine` - (Optional) Specifies the storage engine. Currently, DDS supports the WiredTiger and RocksDB
+   storage engine. The values are `wiredTiger`, `rocksDB`.
+WiredTiger engine supports versions `3.2`, `3.4`, `4.0` while RocksDB supports versions `4.2`, `4.4`
 
 The `flavor` block supports:
 

--- a/opentelekomcloud/acceptance/dds/resource_opentelekomcloud_dds_instance_v3_test.go
+++ b/opentelekomcloud/acceptance/dds/resource_opentelekomcloud_dds_instance_v3_test.go
@@ -123,6 +123,29 @@ func TestAccDDSV3Instance_single(t *testing.T) {
 	})
 }
 
+func TestAccDDSV3InstanceRocksDB_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDDSV3InstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: TestAccDDSInstanceRocksDBV3ConfigBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDDSV3InstanceExists(resourceInstanceName),
+					resource.TestCheckResourceAttr(resourceInstanceName, "name", "dds-instance"),
+					resource.TestCheckResourceAttr(resourceInstanceName, "mode", "ReplicaSet"),
+					resource.TestCheckResourceAttr(resourceInstanceName, "datastore.0.storage_engine", "rocksDB"),
+					resource.TestCheckResourceAttr(resourceInstanceName, "ssl", "true"),
+					resource.TestCheckResourceAttr(resourceInstanceName, "flavor.0.size", "20"),
+					resource.TestCheckResourceAttr(resourceInstanceName, "flavor.0.num", "1"),
+					resource.TestCheckResourceAttr(resourceInstanceName, "flavor.0.spec_code", "dds.mongodb.s2.medium.4.repset"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDDSInstanceV3_importBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -410,5 +433,36 @@ resource "opentelekomcloud_dds_instance_v3" "instance" {
   backup_strategy {
     start_time = "08:00-09:00"
     keep_days  = "8"
+  }
+}`, common.DataSourceSecGroupDefault, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE)
+
+var TestAccDDSInstanceRocksDBV3ConfigBasic = fmt.Sprintf(`
+%s
+
+%s
+
+resource "opentelekomcloud_dds_instance_v3" "instance" {
+  name              = "dds-instance"
+  availability_zone = "%s"
+  datastore {
+    type           = "DDS-Community"
+    version        = "4.2"
+    storage_engine = "rocksDB"
+  }
+  vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
+  password          = "5ecuredPa55w0rd@"
+  mode              = "ReplicaSet"
+  flavor {
+    type      = "replica"
+    num       = 1
+    storage   = "ULTRAHIGH"
+    size      = 20
+    spec_code = "dds.mongodb.s2.medium.4.repset"
+  }
+  backup_strategy {
+    start_time = "08:00-09:00"
+    keep_days  = "1"
   }
 }`, common.DataSourceSecGroupDefault, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE)

--- a/opentelekomcloud/services/dds/resource_opentelekomcloud_dds_instance_v3.go
+++ b/opentelekomcloud/services/dds/resource_opentelekomcloud_dds_instance_v3.go
@@ -71,7 +71,7 @@ func ResourceDdsInstanceV3() *schema.Resource {
 							Optional: true,
 							ForceNew: true,
 							ValidateFunc: validation.StringInSlice([]string{
-								"wiredTiger",
+								"wiredTiger", "rocksDB",
 							}, true),
 						},
 					},

--- a/releasenotes/notes/dds_engine_update-a8676232ef87553e.yaml
+++ b/releasenotes/notes/dds_engine_update-a8676232ef87553e.yaml
@@ -1,4 +1,4 @@
 ---
 enhancements:
   - |
-    **[DDS]** Add new engine support for ``resource/opentelekomcloud_dds_instance_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[DDS]** Add new engine support for ``resource/opentelekomcloud_dds_instance_v3`` (`#2312 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2312>`_)

--- a/releasenotes/notes/dds_engine_update-a8676232ef87553e.yaml
+++ b/releasenotes/notes/dds_engine_update-a8676232ef87553e.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[DDS]** Add new engine support for ``resource/opentelekomcloud_dds_instance_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Added support for `rocksDB` storage engine, documentation updated.

## PR Checklist

* [x] Refers to: #2311
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccDDSV3InstanceRocksDB_basic
--- PASS: TestAccDDSV3InstanceRocksDB_basic (427.51s)
PASS

Process finished with the exit code 0
```
