### PR TITLE
[VPC]: `opentelekomcloud_networking_router_route_v2` refactor & deprecation message

### DIFF
--- a/opentelekomcloud/services/vpc/resource_opentelekomcloud_networking_router_route_v2.go
+++ b/opentelekomcloud/services/vpc/resource_opentelekomcloud_networking_router_route_v2.go
@@ -8,8 +8,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
-
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/layer3/routers"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
@@ -18,9 +16,10 @@ import (
 
 func ResourceNetworkingRouterRouteV2() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceNetworkingRouterRouteV2Create,
-		ReadContext:   resourceNetworkingRouterRouteV2Read,
-		DeleteContext: resourceNetworkingRouterRouteV2Delete,
+		CreateContext:      resourceNetworkingRouterRouteV2Create,
+		ReadContext:        resourceNetworkingRouterRouteV2Read,
+		DeleteContext:      resourceNetworkingRouterRouteV2Delete,
+		DeprecationMessage: "use opentelekomcloud_vpc_route_v2 resource instead",
 
 		Schema: map[string]*schema.Schema{
 			"region": {
@@ -49,33 +48,26 @@ func ResourceNetworkingRouterRouteV2() *schema.Resource {
 }
 
 func resourceNetworkingRouterRouteV2Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	routerId := d.Get("router_id").(string)
-	osMutexKV.Lock(routerId)
-	defer osMutexKV.Unlock(routerId)
-
-	var destCidr string = d.Get("destination_cidr").(string)
-	var nextHop string = d.Get("next_hop").(string)
-
 	config := meta.(*cfg.Config)
 	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
 	if err != nil {
 		return fmterr.Errorf("error creating OpenTelekomCloud networking client: %s", err)
 	}
 
+	updateOpts := routers.UpdateOpts{}
+
+	routerId := d.Get("router_id").(string)
+	destCidr := d.Get("destination_cidr").(string)
+	nextHop := d.Get("next_hop").(string)
+
 	n, err := routers.Get(networkingClient, routerId).Extract()
 	if err != nil {
-		if _, ok := err.(golangsdk.ErrDefault404); ok {
-			d.SetId("")
-			return nil
-		}
-
 		return fmterr.Errorf("error retrieving OpenTelekomCloud Neutron Router: %s", err)
 	}
 
-	var updateOpts routers.UpdateOpts
-	var routeExists bool = false
+	routeExists := false
 
-	var rts []routers.Route = n.Routes
+	rts := n.Routes
 	for _, r := range rts {
 		if r.DestinationCIDR == destCidr && r.NextHop == nextHop {
 			routeExists = true
@@ -101,35 +93,30 @@ func resourceNetworkingRouterRouteV2Create(ctx context.Context, d *schema.Resour
 		}
 		d.SetId(fmt.Sprintf("%s-route-%s-%s", routerId, destCidr, nextHop))
 	} else {
-		log.Printf("[DEBUG] Router %s has route already", routerId)
+		fmterr.Errorf("[DEBUG] Router %s has route already", routerId)
 	}
 
 	return resourceNetworkingRouterRouteV2Read(ctx, d, meta)
 }
 
 func resourceNetworkingRouterRouteV2Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	routerId := d.Get("router_id").(string)
-
 	config := meta.(*cfg.Config)
 	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
 	if err != nil {
 		return fmterr.Errorf("error creating OpenTelekomCloud networking client: %s", err)
 	}
 
+	routerId := d.Get("router_id").(string)
+
 	n, err := routers.Get(networkingClient, routerId).Extract()
 	if err != nil {
-		if _, ok := err.(golangsdk.ErrDefault404); ok {
-			d.SetId("")
-			return nil
-		}
-
 		return fmterr.Errorf("error retrieving OpenTelekomCloud Neutron Router: %s", err)
 	}
 
 	log.Printf("[DEBUG] Retrieved Router %s: %+v", routerId, n)
 
-	var destCidr string = d.Get("destination_cidr").(string)
-	var nextHop string = d.Get("next_hop").(string)
+	destCidr := d.Get("destination_cidr").(string)
+	nextHop := d.Get("next_hop").(string)
 
 	mErr := multierror.Append(
 		d.Set("next_hop", ""),
@@ -155,10 +142,6 @@ func resourceNetworkingRouterRouteV2Read(_ context.Context, d *schema.ResourceDa
 }
 
 func resourceNetworkingRouterRouteV2Delete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	routerId := d.Get("router_id").(string)
-	osMutexKV.Lock(routerId)
-	defer osMutexKV.Unlock(routerId)
-
 	config := meta.(*cfg.Config)
 
 	networkingClient, err := config.NetworkingV2Client(config.GetRegion(d))
@@ -166,21 +149,19 @@ func resourceNetworkingRouterRouteV2Delete(_ context.Context, d *schema.Resource
 		return fmterr.Errorf("error creating OpenTelekomCloud networking client: %s", err)
 	}
 
+	routerId := d.Get("router_id").(string)
+
 	n, err := routers.Get(networkingClient, routerId).Extract()
 	if err != nil {
-		if _, ok := err.(golangsdk.ErrDefault404); ok {
-			return nil
-		}
-
 		return fmterr.Errorf("error retrieving OpenTelekomCloud Neutron Router: %s", err)
 	}
 
 	var updateOpts routers.UpdateOpts
 
-	var destCidr string = d.Get("destination_cidr").(string)
-	var nextHop string = d.Get("next_hop").(string)
+	destCidr := d.Get("destination_cidr").(string)
+	nextHop := d.Get("next_hop").(string)
 
-	var oldRts []routers.Route = n.Routes
+	oldRts := n.Routes
 	var newRts []routers.Route
 
 	for _, r := range oldRts {

--- a/opentelekomcloud/services/vpc/utils.go
+++ b/opentelekomcloud/services/vpc/utils.go
@@ -1,3 +1,8 @@
 package vpc
 
+import "github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/helper/mutexkv"
+
+// This is a global MutexKV for use within this plugin.
+var osMutexKV = mutexkv.NewMutexKV()
+
 var defaultDNS = []string{"100.125.4.25", "100.125.129.199"}

--- a/opentelekomcloud/services/vpc/utils.go
+++ b/opentelekomcloud/services/vpc/utils.go
@@ -1,8 +1,3 @@
 package vpc
 
-import "github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/helper/mutexkv"
-
-// This is a global MutexKV for use within this plugin.
-var osMutexKV = mutexkv.NewMutexKV()
-
 var defaultDNS = []string{"100.125.4.25", "100.125.129.199"}

--- a/releasenotes/notes/router_route-803566ca6c2e8565.yaml
+++ b/releasenotes/notes/router_route-803566ca6c2e8565.yaml
@@ -2,8 +2,8 @@
 deprecations:
   - |
     **[VPC]** Added deprecation warning for ``resource/opentelekomcloud_networking_router_route_v2``
-    (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    (`#2328 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2328>`_)
 other:
   - |
     **[VPC]** Refactoring of ``resource/opentelekomcloud_networking_router_route_v2``
-    (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    (`#2328 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2328>`_)

--- a/releasenotes/notes/router_route-803566ca6c2e8565.yaml
+++ b/releasenotes/notes/router_route-803566ca6c2e8565.yaml
@@ -1,0 +1,9 @@
+---
+deprecations:
+  - |
+    **[VPC]** Added deprecation warning for ``resource/opentelekomcloud_networking_router_route_v2``
+    (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+other:
+  - |
+    **[VPC]** Refactoring of ``resource/opentelekomcloud_networking_router_route_v2``
+    (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Small refactoring for `opentelekomcloud_networking_router_route_v2` and deprecation message added.

## PR Checklist

* [x] Refers to: #2322
* [x] Tests added/passed.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccNetworkingV2RouterRoute_basic
=== PAUSE TestAccNetworkingV2RouterRoute_basic
=== CONT  TestAccNetworkingV2RouterRoute_basic
--- PASS: TestAccNetworkingV2RouterRoute_basic (131.32s)
PASS

Process finished with the exit code 0

```
