### PR TITLE
[VPC]: `opentelekomcloud_networking_secgroup_rule_v2` fix port & protocol update

### DIFF
--- a/opentelekomcloud/services/vpc/resource_opentelekomcloud_networking_secgroup_rule_v2.go
+++ b/opentelekomcloud/services/vpc/resource_opentelekomcloud_networking_secgroup_rule_v2.go
@@ -61,21 +61,18 @@ func ResourceNetworkingSecGroupRuleV2() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				ForceNew:     true,
-				Computed:     true,
 				RequiredWith: []string{"protocol"},
 			},
 			"port_range_max": {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				ForceNew:     true,
-				Computed:     true,
 				RequiredWith: []string{"port_range_min"},
 			},
 			"protocol": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
-				Computed: true,
 			},
 			"remote_group_id": {
 				Type:     schema.TypeString,

--- a/releasenotes/notes/sg_rules_forcenew_fix-3ea960d558cf824c.yaml
+++ b/releasenotes/notes/sg_rules_forcenew_fix-3ea960d558cf824c.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    **[VPC]** Fix issue with port & protocol update for ``resource/opentelekomcloud_networking_secgroup_rule_v2`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+

--- a/releasenotes/notes/sg_rules_forcenew_fix-3ea960d558cf824c.yaml
+++ b/releasenotes/notes/sg_rules_forcenew_fix-3ea960d558cf824c.yaml
@@ -1,5 +1,5 @@
 ---
 fixes:
   - |
-    **[VPC]** Fix issue with port & protocol update for ``resource/opentelekomcloud_networking_secgroup_rule_v2`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[VPC]** Fix issue with port & protocol update for ``resource/opentelekomcloud_networking_secgroup_rule_v2`` (`#2341 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2341>`_)
 


### PR DESCRIPTION
## Summary of the Pull Request
Fix protocol and ports update for `opentelekomcloud_networking_secgroup_rule_v2`.

## PR Checklist

* [x] Refers to: #2338
* [x] Tests added/passed.
* [ ] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccNetworkingV2SecGroupRule_basic
=== PAUSE TestAccNetworkingV2SecGroupRule_basic
=== CONT  TestAccNetworkingV2SecGroupRule_basic
--- PASS: TestAccNetworkingV2SecGroupRule_basic (44.50s)
=== RUN   TestAccNetworkingV2SecGroupRule_importBasic
=== PAUSE TestAccNetworkingV2SecGroupRule_importBasic
=== CONT  TestAccNetworkingV2SecGroupRule_importBasic
--- PASS: TestAccNetworkingV2SecGroupRule_importBasic (49.10s)
=== RUN   TestAccNetworkingV2SecGroupRule_timeout
=== PAUSE TestAccNetworkingV2SecGroupRule_timeout
=== CONT  TestAccNetworkingV2SecGroupRule_timeout
--- PASS: TestAccNetworkingV2SecGroupRule_timeout (44.27s)
=== RUN   TestAccNetworkingV2SecGroupRule_numericProtocol
=== PAUSE TestAccNetworkingV2SecGroupRule_numericProtocol
=== CONT  TestAccNetworkingV2SecGroupRule_numericProtocol
--- PASS: TestAccNetworkingV2SecGroupRule_numericProtocol (43.59s)
=== RUN   TestAccNetworkingV2SecGroupRule_noPorts
=== PAUSE TestAccNetworkingV2SecGroupRule_noPorts
=== CONT  TestAccNetworkingV2SecGroupRule_noPorts
--- PASS: TestAccNetworkingV2SecGroupRule_noPorts (43.52s)
=== RUN   TestAccNetworkingV2SecGroupRule_ICMP
=== PAUSE TestAccNetworkingV2SecGroupRule_ICMP
=== CONT  TestAccNetworkingV2SecGroupRule_ICMP
--- PASS: TestAccNetworkingV2SecGroupRule_ICMP (102.21s)
=== RUN   TestAccNetworkingV2SecGroupRule_noProtocolError
--- PASS: TestAccNetworkingV2SecGroupRule_noProtocolError (4.05s)
PASS

Process finished with the exit code 0
```
