### PR TITLE
Update lb_loadbalancer_v3.md

### DIFF
--- a/docs/resources/lb_loadbalancer_v3.md
+++ b/docs/resources/lb_loadbalancer_v3.md
@@ -162,7 +162,7 @@ The following arguments are supported:
 * `router_id` - (Optional) ID of the router (or VPC) this LoadBalancer belongs to. Changing
   this creates a new LoadBalancer.
 
-* `subnet_id` - (Optional) The ID of the subnet to which the LoadBalancer belongs.
+* `subnet_id` - (Optional) The ID of the subnet to which the LoadBalancer belongs. Required when using `vip_address`.
 
 -> `router_id` and `subnet_id` cannot be left blank at the same time.
 


### PR DESCRIPTION
## Summary of the Pull Request

When using `vip_address` `subnet_id` becomes a mandatory argument. Updated the documentation.

```hcl
resource "opentelekomcloud_lb_loadbalancer_v3" "this" {
  name = "sdombi-dlb"

  router_id = opentelekomcloud_vpc_subnet_v1.this.vpc_id
  network_ids = [opentelekomcloud_vpc_subnet_v1.this.network_id]
  vip_address = "10.110.10.222"
  #subnet_id = opentelekomcloud_vpc_subnet_v1.this.subnet_id
  availability_zones=["eu-de-01"]

  public_ip {
    id = opentelekomcloud_vpc_eip_v1.this_lb.id
  }
}
```

Gives you the following error:
```
╷
│ Error: unable to update LoadBalancerV3 d233c8af-2264-46cc-9aaa-71ebbb237ba5: Bad request with: [PUT https://elb.eu-de.otc.t-systems.com/v3/6e0c06471f294bca80ea01c589f04a18/elb/loadbalancers/d233c8af-2264-46cc-9aaa-71ebbb237ba5], error message: {"error_msg":"'vip_subnet_cidr_id' attribute isn't allowed 'empty'","error_code":"SYS.0400","request_id":"7c4d2a548e42007c7607d102e3796fa0"}
│
│   with opentelekomcloud_lb_loadbalancer_v3.this,
│   on elb.tf line 13, in resource "opentelekomcloud_lb_loadbalancer_v3" "this":
│   13: resource "opentelekomcloud_lb_loadbalancer_v3" "this" {
│
╵
```

## PR Checklist

* [ ] Refers to: #xxx
* [ ] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.
* [ ] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (101.71s)
=== RUN   TestAccSomethingV0_timeout
--- PASS: TestAccSomethingV0_timeout (128.67s)
PASS

Process finished with exit code 0
```
