### PR TITLE
[RDS]: Remove backup_strategy workaround for PostgreSql after fix

### DIFF
--- a/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_instance_v3.go
+++ b/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_instance_v3.go
@@ -524,22 +524,6 @@ func resourceRdsInstanceV3Create(ctx context.Context, d *schema.ResourceData, me
 		}
 	}
 
-	var backupOpts backups.UpdateOpts
-
-	// workaround for https://jira.tsi-dev.otc-service.com/browse/BM-2388
-	if strings.ToLower(datastore.Type) == "postgresql" && common.HasFilledOpt(d, "backup_strategy") {
-		backupRaw := resourceRDSBackupStrategy(d)
-		backupOpts.KeepDays = &backupRaw.KeepDays
-		backupOpts.StartTime = backupRaw.StartTime
-		backupOpts.Period = "1,2,3,4,5,6,7"
-		backupOpts.InstanceId = d.Id()
-		log.Printf("[DEBUG] Backup Strategy Opts: %#v", backupOpts)
-
-		if err = backups.Update(client, backupOpts); err != nil {
-			return fmterr.Errorf("error updating OpenTelekomCloud RDSv3 Backup Strategy: %s", err)
-		}
-	}
-
 	clientCtx := common.CtxWithClient(ctx, client, keyClientV3)
 
 	ip := getPublicIP(d)

--- a/releasenotes/notes/rds_remove_workaround-bd1d5b1538be8617.yaml
+++ b/releasenotes/notes/rds_remove_workaround-bd1d5b1538be8617.yaml
@@ -1,4 +1,4 @@
 ---
 other:
   - |
-    **[RDS]** PostgreSQL 13/14 `parameters` remove workaround for ``resource/opentelekomcloud_rds_instance_v3`` after fix (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[RDS]** PostgreSQL 13/14 `parameters` remove workaround for ``resource/opentelekomcloud_rds_instance_v3`` after fix (`#2353 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2353>`_)

--- a/releasenotes/notes/rds_remove_workaround-bd1d5b1538be8617.yaml
+++ b/releasenotes/notes/rds_remove_workaround-bd1d5b1538be8617.yaml
@@ -1,0 +1,4 @@
+---
+other:
+  - |
+    **[RDS]** PostgreSQL 13/14 `parameters` remove workaround for ``resource/opentelekomcloud_rds_instance_v3`` after fix (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Backup strategy was fixed for PostgreSql and workaround can be removed

## PR Checklist

* [x] Tests added/passed.
* [x] Release notes added.
