### PR TITLE
Update cce_addon_v3.md

### DIFF
--- a/docs/resources/cce_addon_v3.md
+++ b/docs/resources/cce_addon_v3.md
@@ -31,14 +31,14 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
 
 resource "opentelekomcloud_cce_addon_v3" "addon" {
   template_name    = "metrics-server"
-  template_version = "1.0.6"
+  template_version = "1.3.6"
   cluster_id       = opentelekomcloud_cce_cluster_v3.cluster_1.id
 
   values {
     basic = {
-      "image_version" : "v0.3.7",
+      "image_version" : "v0.6.2",
       "swr_addr" : "100.125.7.25:20202",
-      "swr_user" : "hwofficial"
+      "swr_user" : "cce-addons"
     }
     custom = {}
   }


### PR DESCRIPTION
## Summary of the Pull Request
CCE addons are no longer hosted from `hwofficial` org/repo. They have been moved to `cce-addons` org. Also updated the example with latest `metrics-server` versions.

```hcl
resource "opentelekomcloud_cce_addon_v3" "metrics" {
  template_name    = "metrics-server"
  template_version = "1.3.6"
  cluster_id       = opentelekomcloud_cce_cluster_v3.this.id

  values {
    basic = {
      "image_version" : "v0.6.2"
      "swr_addr" : "100.125.7.25:20202",
      "swr_user" : "cce-addons"
    }
    custom = {}
  }
}

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.cce.opentelekomcloud_cce_addon_v3.metrics will be created
  + resource "opentelekomcloud_cce_addon_v3" "metrics" {
      + cluster_id       = "1cbd6eb5-7719-11ee-b5ca-02550a100043"
      + description      = (known after apply)
      + id               = (known after apply)
      + name             = (known after apply)
      + template_name    = "metrics-server"
      + template_version = "1.3.6"

      + values {
          + basic = {
              + "image_version" = "v0.6.2"
              + "swr_addr"      = "100.125.7.25:20202"
              + "swr_user"      = "cce-addons"
            }
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

module.cce.opentelekomcloud_cce_addon_v3.metrics: Creating...
module.cce.opentelekomcloud_cce_addon_v3.metrics: Still creating... [10s elapsed]
module.cce.opentelekomcloud_cce_addon_v3.metrics: Still creating... [20s elapsed]
module.cce.opentelekomcloud_cce_addon_v3.metrics: Creation complete after 23s [id=6fdefb62-77f0-11ee-8a71-02550a10004a]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

```
$ kubectl get deploy metrics-server -nkube-system -o jsonpath="{..image}"                                                                                                                                                                                                                                                                    
100.125.7.25:20202/cce-addons/metrics-server:v0.6.2
```

## PR Checklist

* [ ] Refers to: #xxx
* [ ] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.
* [ ] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (101.71s)
=== RUN   TestAccSomethingV0_timeout
--- PASS: TestAccSomethingV0_timeout (128.67s)
PASS

Process finished with exit code 0
```
