### PR TITLE
[VPC]: fix `networking_port_v2` `fixed_ip` available in resource

### DIFF
--- a/docs/resources/networking_port_v2.md
+++ b/docs/resources/networking_port_v2.md
@@ -12,15 +12,27 @@ Manages a V2 port resource within OpenTelekomCloud.
 ## Example Usage
 
 ```hcl
+resource "opentelekomcloud_networking_port_v2" "port_1" {
+  name           = "port_1"
+  admin_state_up = "true"
+  network_id     = opentelekomcloud_networking_network_v2.network_1.id
+
+  fixed_ip {
+    subnet_id  = opentelekomcloud_networking_subnet_v2.subnet_1.id
+    ip_address = "192.168.199.23"
+  }
+}
+
 resource "opentelekomcloud_networking_network_v2" "network_1" {
   name           = "network_1"
   admin_state_up = "true"
 }
 
-resource "opentelekomcloud_networking_port_v2" "port_1" {
-  name           = "port_1"
-  network_id     = opentelekomcloud_networking_network_v2.network_1.id
-  admin_state_up = "true"
+resource "opentelekomcloud_networking_subnet_v2" "subnet_1" {
+  name       = "subnet_1"
+  cidr       = "192.168.199.0/24"
+  ip_version = 4
+  network_id = opentelekomcloud_networking_network_v2.network_1.id
 }
 ```
 
@@ -67,7 +79,7 @@ The following arguments are supported:
   creates a new port.
 
 * `fixed_ip` - (Optional) An array of desired IPs for this port. The structure is
-  described below.
+  described below. A single `fixed_ip` entry is allowed for a port.
 
 * `allowed_address_pairs` - (Optional) An IP/MAC Address pair of additional IP
   addresses that can be active on this port. The structure is described below.

--- a/opentelekomcloud/services/vpc/resource_opentelekomcloud_networking_port_v2.go
+++ b/opentelekomcloud/services/vpc/resource_opentelekomcloud_networking_port_v2.go
@@ -101,6 +101,7 @@ func ResourceNetworkingPortV2() *schema.Resource {
 				Type:     schema.TypeList,
 				Optional: true,
 				ForceNew: false,
+				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"subnet_id": {

--- a/releasenotes/notes/networking_port_fix-c6c2420c3055152b.yaml
+++ b/releasenotes/notes/networking_port_fix-c6c2420c3055152b.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    **[VPC]** Fix amount of `fixed_ip` available for ``resource/opentelekomcloud_networking_port_v2`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[VPC]** Fix amount of `fixed_ip` available for ``resource/opentelekomcloud_networking_port_v2`` (`#2365 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2365>`_)

--- a/releasenotes/notes/networking_port_fix-c6c2420c3055152b.yaml
+++ b/releasenotes/notes/networking_port_fix-c6c2420c3055152b.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[VPC]** Fix amount of `fixed_ip` available for ``resource/opentelekomcloud_networking_port_v2`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)


### PR DESCRIPTION
## Summary of the Pull Request
`opentelekomcloud_networking_port_v2` can map only one `fixed_ip` for one resource as stated in #1780.

## PR Checklist

* [x] Closes: #1780
* [x] Tests passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccNetworkingV2Port_basic
=== PAUSE TestAccNetworkingV2Port_basic
=== CONT  TestAccNetworkingV2Port_basic
=== RUN   TestAccNetworkingV2Port_importBasic
=== PAUSE TestAccNetworkingV2Port_importBasic
=== CONT  TestAccNetworkingV2Port_importBasic
=== RUN   TestAccNetworkingV2Port_noip
=== PAUSE TestAccNetworkingV2Port_noip
=== CONT  TestAccNetworkingV2Port_noip
=== RUN   TestAccNetworkingV2Port_allowedAddressPairs
=== PAUSE TestAccNetworkingV2Port_allowedAddressPairs
=== CONT  TestAccNetworkingV2Port_allowedAddressPairs
=== RUN   TestAccNetworkingV2Port_portSecurity_enabled
=== PAUSE TestAccNetworkingV2Port_portSecurity_enabled
=== CONT  TestAccNetworkingV2Port_portSecurity_enabled
=== RUN   TestAccNetworkingV2Port_noPortSecurityNoSecurityGroups
=== PAUSE TestAccNetworkingV2Port_noPortSecurityNoSecurityGroups
=== CONT  TestAccNetworkingV2Port_noPortSecurityNoSecurityGroups
=== RUN   TestAccNetworkingV2Port_timeout
=== PAUSE TestAccNetworkingV2Port_timeout
=== CONT  TestAccNetworkingV2Port_timeout
--- PASS: TestAccNetworkingV2Port_basic (78.42s)
--- PASS: TestAccNetworkingV2Port_noPortSecurityNoSecurityGroups (78.62s)
--- PASS: TestAccNetworkingV2Port_noip (78.65s)
--- PASS: TestAccNetworkingV2Port_timeout (78.71s)
--- PASS: TestAccNetworkingV2Port_importBasic (84.57s)
--- PASS: TestAccNetworkingV2Port_allowedAddressPairs (99.78s)
--- PASS: TestAccNetworkingV2Port_portSecurity_enabled (102.45s)
PASS

Process finished with the exit code 0
```
