### PR TITLE
[DCS]: fix `opentelekomcloud_dcs_instance_v1` password requirements

### DIFF
--- a/docs/resources/dcs_instance_v1.md
+++ b/docs/resources/dcs_instance_v1.md
@@ -114,7 +114,7 @@ The following arguments are supported:
 * `password` - (Optional, ForceNew, String) Indicates the password of an instance. An instance password
   must meet the following complexity requirements: Must be 8 to 32 characters long.
   Must contain at least 3 of the following character types: lowercase letters, uppercase
-  letters, digits, and special characters (`~!@#$%^&*()-_=+\|[{}]:'",<.>/?).
+  letters, digits, and special characters: `~!@#$^&*()-_=+|{}:,<>./?
   Changing this creates a new instance.
 
 * `vpc_id` - (Required, ForceNew, String) Specifies the VPC ID. Changing this creates a new instance.

--- a/releasenotes/notes/dcs_instance_pwd_doc-6a81f81028e5b8cc.yaml
+++ b/releasenotes/notes/dcs_instance_pwd_doc-6a81f81028e5b8cc.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    **[DCS]** Fixed documentation password requirements for ``resource/opentelekomcloud_dcs_instance_v1`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[DCS]** Fixed documentation password requirements for ``resource/opentelekomcloud_dcs_instance_v1`` (`#2367 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2367>`_)

--- a/releasenotes/notes/dcs_instance_pwd_doc-6a81f81028e5b8cc.yaml
+++ b/releasenotes/notes/dcs_instance_pwd_doc-6a81f81028e5b8cc.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[DCS]** Fixed documentation password requirements for ``resource/opentelekomcloud_dcs_instance_v1`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Accoridng to #2335 password complexity for DCS instance v1 should be changed.

## PR Checklist

* [x] Refers to: #2366, 2365
* [ ] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.
* [x] Release notes added.