### PR TITLE
[CCE] skip predefined taints for `resource/opentelekomcloud_cce_node_v3`

### DIFF
--- a/releasenotes/notes/cce-node-skip-predefined-taints-8e20749c7ee52536.yaml
+++ b/releasenotes/notes/cce-node-skip-predefined-taints-8e20749c7ee52536.yaml
@@ -1,3 +1,4 @@
 ---
 fixes:
-  - **[CCE]** skip predefined taints for ``resource/opentelekomcloud_cce_node_v3`` (`#2380 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2380>`_)
+  - |
+    **[CCE]** skip predefined taints for ``resource/opentelekomcloud_cce_node_v3`` (`#2380 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2380>`_)

--- a/releasenotes/notes/cce-node-skip-predefined-taints-8e20749c7ee52536.yaml
+++ b/releasenotes/notes/cce-node-skip-predefined-taints-8e20749c7ee52536.yaml
@@ -1,0 +1,3 @@
+---
+fixes:
+  - **[CCE]** skip predefined taints for ``resource_opentelekomcloud_cce_node_v3`` (`#2380 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2380>`_)

--- a/releasenotes/notes/cce-node-skip-predefined-taints-8e20749c7ee52536.yaml
+++ b/releasenotes/notes/cce-node-skip-predefined-taints-8e20749c7ee52536.yaml
@@ -1,3 +1,3 @@
 ---
 fixes:
-  - **[CCE]** skip predefined taints for ``resource_opentelekomcloud_cce_node_v3`` (`#2380 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2380>`_)
+  - **[CCE]** skip predefined taints for ``resource/opentelekomcloud_cce_node_v3`` (`#2380 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2380>`_)

--- a/releasenotes/notes/skip-predefined-taints-8e20749c7ee52536.yaml
+++ b/releasenotes/notes/skip-predefined-taints-8e20749c7ee52536.yaml
@@ -1,3 +1,0 @@
----
-fixes:
-  - **[CCE]** skip predefined taints for nodes (`#2380 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2380>`_)

--- a/releasenotes/notes/skip-predefined-taints-8e20749c7ee52536.yaml
+++ b/releasenotes/notes/skip-predefined-taints-8e20749c7ee52536.yaml
@@ -1,0 +1,3 @@
+---
+fixes:
+  - **[CCE]** skip predefined taints for nodes (`#2380 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2380>`_)


### PR DESCRIPTION
## Summary of the Pull Request

If CCE nodes are stopped and you're running `terraform apply/plan`, two taints will give you a "force replacement".

```tf
  # opentelekomcloud_cce_node_v3.node-1 must be replaced
-/+ resource "opentelekomcloud_cce_node_v3" "node-1" {

...

      - taints { # forces replacement
          - effect = "NoSchedule" -> null
          - key    = "node.kubernetes.io/unreachable" -> null
        }
      - taints { # forces replacement
          - effect = "NoSchedule" -> null
          - key    = "node.cloudprovider.kubernetes.io/shutdown" -> null
        }
    }
```

## PR Checklist

* [ ] Refers to: #xxx
* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccCCENodesV3Basic
=== PAUSE TestAccCCENodesV3Basic
=== CONT  TestAccCCENodesV3Basic
--- PASS: TestAccCCENodesV3Basic (4276.41s)
=== RUN   TestAccCCENodesV3Agency
=== PAUSE TestAccCCENodesV3Agency
=== CONT  TestAccCCENodesV3Agency
--- PASS: TestAccCCENodesV3Agency (1307.36s)
=== RUN   TestAccCCENodesV3Multiple
=== PAUSE TestAccCCENodesV3Multiple
=== CONT  TestAccCCENodesV3Multiple
--- PASS: TestAccCCENodesV3Multiple (5339.57s)
=== RUN   TestAccCCENodesV3Timeout
=== PAUSE TestAccCCENodesV3Timeout
=== CONT  TestAccCCENodesV3Timeout
--- PASS: TestAccCCENodesV3Timeout (1387.04s)
=== RUN   TestAccCCENodesV3BandWidthResize
=== PAUSE TestAccCCENodesV3BandWidthResize
=== CONT  TestAccCCENodesV3BandWidthResize
--- PASS: TestAccCCENodesV3BandWidthResize (1483.01s)
=== RUN   TestAccCCENodesV3_eipIds
=== PAUSE TestAccCCENodesV3_eipIds
=== CONT  TestAccCCENodesV3_eipIds
--- PASS: TestAccCCENodesV3_eipIds (2329.20s)
=== RUN   TestAccCCENodesV3IpSetNull
=== PAUSE TestAccCCENodesV3IpSetNull
=== CONT  TestAccCCENodesV3IpSetNull
--- PASS: TestAccCCENodesV3IpSetNull (1899.44s)
=== RUN   TestAccCCENodesV3IpCreate
=== PAUSE TestAccCCENodesV3IpCreate
=== CONT  TestAccCCENodesV3IpCreate
--- PASS: TestAccCCENodesV3IpCreate (1695.46s)
=== RUN   TestAccCCENodesV3IpNulls
=== PAUSE TestAccCCENodesV3IpNulls
=== CONT  TestAccCCENodesV3IpNulls
--- PASS: TestAccCCENodesV3IpNulls (1022.68s)
=== RUN   TestAccCCENodesV3EncryptedVolume
=== PAUSE TestAccCCENodesV3EncryptedVolume
=== CONT  TestAccCCENodesV3EncryptedVolume
--- PASS: TestAccCCENodesV3EncryptedVolume (1336.78s)
=== RUN   TestAccCCENodesV3TaintsK8sTags
=== PAUSE TestAccCCENodesV3TaintsK8sTags
=== CONT  TestAccCCENodesV3TaintsK8sTags
--- PASS: TestAccCCENodesV3TaintsK8sTags (1341.82s)
=== RUN   TestAccCCENodesV3_extendParams
=== PAUSE TestAccCCENodesV3_extendParams
=== CONT  TestAccCCENodesV3_extendParams
--- PASS: TestAccCCENodesV3_extendParams (1349.84s)
PASS

Process finished with exit code 0
```
