### PR TITLE
[CCE] expiry_date attribute in `data-source/opentelekomcloud_cce_cluster_kubeconfig_v3`

### DIFF
--- a/docs/data-sources/cce_cluster_kubeconfig_v3.md
+++ b/docs/data-sources/cce_cluster_kubeconfig_v3.md
@@ -16,15 +16,29 @@ data "opentelekomcloud_cce_cluster_kubeconfig_v3" "this" {
 }
 ```
 
+## Example with expiration date
+
+```hcl
+variable "cluster_id" {}
+
+data "opentelekomcloud_cce_cluster_kubeconfig_v3" "this" {
+  cluster_id  = opentelekomcloud_cce_cluster_v3.cluster_1.id
+  expiry_date = "2024-02-01"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
 
-* `cluster_id` -  (Optional) The Name of the cluster resource.
+* `cluster_id` -  (Required, String) The Name of the cluster resource.
 
-* `duration` - (Optional) Period during which a cluster certificate is valid, in days. A cluster certificate can
+* `duration` - (Optional, Int) Period during which a cluster certificate is valid, in days. A cluster certificate can
   be valid for `1` to `1825` days. If this parameter is set to `-1`, the validity period is `1825` days (about 5 years).
   Default vault `-1`.
+
+* `expiry_date` - (Optional, String) Specifies the date until which the certificate will be valid, in RFC3339 format, like `2023-02-01`.
+  Conflicts with `duration` attribute.
 
 ## Attributes Reference
 

--- a/opentelekomcloud/acceptance/cce/data_source_opentelekomcloud_cce_cluster_kubeconfig_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/data_source_opentelekomcloud_cce_cluster_kubeconfig_v3_test.go
@@ -33,6 +33,13 @@ func TestAccCCEKubeConfigV3DataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(dataSourceName, "kubeconfig"),
 				),
 			},
+			{
+				Config: testAccCCEClusterKubeconfigV3DataSourceExpiryDate(cceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCCEClusterKubeconfigV3DataSourceID(dataSourceName),
+					resource.TestCheckResourceAttrSet(dataSourceName, "kubeconfig"),
+				),
+			},
 		},
 	})
 }
@@ -82,6 +89,26 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
 
 data "opentelekomcloud_cce_cluster_kubeconfig_v3" "this" {
   cluster_id = opentelekomcloud_cce_cluster_v3.cluster_1.id
+}
+`, common.DataSourceSubnet, cceName)
+}
+
+func testAccCCEClusterKubeconfigV3DataSourceExpiryDate(cceName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
+  name                   = "%s"
+  cluster_type           = "VirtualMachine"
+  flavor_id              = "cce.s1.small"
+  vpc_id                 = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  subnet_id              = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  container_network_type = "overlay_l2"
+}
+
+data "opentelekomcloud_cce_cluster_kubeconfig_v3" "this" {
+  cluster_id  = opentelekomcloud_cce_cluster_v3.cluster_1.id
+  expiry_date = "2024-02-01"
 }
 `, common.DataSourceSubnet, cceName)
 }

--- a/opentelekomcloud/common/utils.go
+++ b/opentelekomcloud/common/utils.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"time"
 
 	ver "github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -261,4 +262,15 @@ func CompareJsonTemplateAreEquivalent(tem1, tem2 string) (bool, error) {
 			canonicalJson1, canonicalJson2)
 	}
 	return equal, nil
+}
+
+func ValidateRFC3339Timestamp(v interface{}, _ string) (ws []string, errors []error) {
+	value := v.(string)
+	_, err := time.Parse(time.RFC3339, fmt.Sprintf("%sT00:00:00Z", value))
+	if err != nil {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be parsed as RFC3339 Timestamp Format", value))
+	}
+
+	return
 }

--- a/opentelekomcloud/services/cce/data_source_opentelekomcloud_cce_cluster_kubeconfig_v3.go
+++ b/opentelekomcloud/services/cce/data_source_opentelekomcloud_cce_cluster_kubeconfig_v3.go
@@ -3,12 +3,15 @@ package cce
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/cce/v3/clusters"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
 )
@@ -26,7 +29,12 @@ func DataSourceCCEClusterKubeConfigV3() *schema.Resource {
 			"duration": {
 				Type:     schema.TypeInt,
 				Optional: true,
-				Default:  -1,
+			},
+			"expiry_date": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ValidateFunc:  common.ValidateRFC3339Timestamp,
+				ConflictsWith: []string{"duration"},
 			},
 			"kubeconfig": {
 				Type:     schema.TypeString,
@@ -44,7 +52,19 @@ func dataSourceCCEClusterKubeConfigV3Read(_ context.Context, d *schema.ResourceD
 	}
 
 	clusterID := d.Get("cluster_id").(string)
-	duration := d.Get("duration").(int)
+	expiryDate := d.Get("expiry_date").(string)
+	duration := -1
+	if v, ok := d.GetOk("duration"); ok {
+		duration = v.(int)
+	}
+	if expiryDate != "" {
+		currentTime := time.Now()
+		t, err := time.Parse(time.RFC3339, fmt.Sprintf("%sT00:00:00Z", expiryDate))
+		if err != nil {
+			return fmterr.Errorf("error Parsing Expiration Date: %s", err)
+		}
+		duration = int(t.Sub(currentTime).Hours() / 24)
+	}
 	expiryOpts := clusters.ExpirationOpts{
 		Duration: duration,
 	}

--- a/opentelekomcloud/services/s3/resource_opentelekomcloud_s3_bucket.go
+++ b/opentelekomcloud/services/s3/resource_opentelekomcloud_s3_bucket.go
@@ -231,7 +231,7 @@ func ResourceS3Bucket() *schema.Resource {
 									"date": {
 										Type:         schema.TypeString,
 										Optional:     true,
-										ValidateFunc: validateS3BucketLifecycleTimestamp,
+										ValidateFunc: common.ValidateRFC3339Timestamp,
 									},
 									"days": {
 										Type:         schema.TypeInt,

--- a/opentelekomcloud/services/s3/utils.go
+++ b/opentelekomcloud/services/s3/utils.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"regexp"
-	"time"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/helper/hashcode"
 )
@@ -53,17 +52,6 @@ func RemoveNil(data map[string]interface{}) map[string]interface{} {
 
 func BucketDomainName(bucket, region string) string {
 	return fmt.Sprintf("%s.obs.%s.otc.t-systems.com", bucket, region)
-}
-
-func validateS3BucketLifecycleTimestamp(v interface{}, _ string) (ws []string, errors []error) {
-	value := v.(string)
-	_, err := time.Parse(time.RFC3339, fmt.Sprintf("%sT00:00:00Z", value))
-	if err != nil {
-		errors = append(errors, fmt.Errorf(
-			"%q cannot be parsed as RFC3339 Timestamp Format", value))
-	}
-
-	return
 }
 
 func validateS3BucketLifecycleExpirationDays(v interface{}, k string) (ws []string, errors []error) {

--- a/releasenotes/notes/cce-ds-cluster-config-expiry-3159cdd1f01af990.yaml
+++ b/releasenotes/notes/cce-ds-cluster-config-expiry-3159cdd1f01af990.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    **[CCE]** New attribute ``expiry_date`` in ``data_source/opentelekomcloud_cce_cluster_kubeconfig_v3``.
+    (`#2388 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2388>`_)


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [x] Refers to: #2381
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccCCEKubeConfigV3DataSource_basic
=== PAUSE TestAccCCEKubeConfigV3DataSource_basic
=== CONT  TestAccCCEKubeConfigV3DataSource_basic
--- PASS: TestAccCCEKubeConfigV3DataSource_basic (586.51s)
PASS

Process finished with the exit code 0

Process finished with exit code 0
```
