### PR TITLE
[DCAAS] refactoring `opentelekomcloud_dc_virtual_gateway_v2`, deprecation `opentelekomcloud_dc_endpoint_group_v2`

### DIFF
--- a/docs/resources/dс_endpoint_group_v2.md
+++ b/docs/resources/dс_endpoint_group_v2.md
@@ -6,6 +6,10 @@ subcategory: "Direct Connect (DCaaS)"
 Up-to-date reference of API arguments for Direct Connect Endpoint Group you can get at
 [Official Docs Portal](https://docs.otc.t-systems.com/direct-connect/api-ref/apis/direct_connect_endpoint_group/index.html).
 
+~>
+opentelekomcloud_dc_endpoint_group_v2 is no longer provided. Impossible to update assigned endpoint group.
+Please use `opentelekomcloud_dc_virtual_gateway_v2` with `local_ep_group` block instead.
+
 ## Example Usage
 
 ```hcl

--- a/docs/resources/dс_virtual_gateway_v2.md
+++ b/docs/resources/dс_virtual_gateway_v2.md
@@ -9,23 +9,15 @@ Up-to-date reference of API arguments for Direct Connect Virtual Gateway you can
 ## Example Usage
 
 ```hcl
-data "opentelekomcloud_identity_project_v3" "project" {
-  name = "eu-de_project_1"
-}
-
-resource "opentelekomcloud_dc_endpoint_group_v2" "dc_endpoint_group" {
-  name        = "tf_acc_eg_1"
-  type        = "cidr"
-  endpoints   = ["10.2.0.0/24", "10.3.0.0/24"]
-  description = "first"
-  project_id  = data.opentelekomcloud_identity_project_v3.project.id
-}
-
 resource "opentelekomcloud_dc_virtual_gateway_v2" "vgw_1" {
   vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
-  name              = "my_virtual_gateway"
+  name              = "%s"
   description       = "acc test"
-  local_ep_group_id = opentelekomcloud_dc_endpoint_group_v2.dc_endpoint_group.id
+  local_ep_group {
+    name        = "tf_eg_1"
+    endpoints   = ["10.2.0.0/24", "10.3.0.0/24"]
+    description = "first"
+  }
 }
 ```
 
@@ -34,7 +26,12 @@ resource "opentelekomcloud_dc_virtual_gateway_v2" "vgw_1" {
 The following arguments are supported:
 
 * `vpc_id` (String, Required, ForceNew) - Specifies the ID of the VPC to be accessed.
-* `local_ep_group_id` (String, Required) - Specifies the ID of the local endpoint group that records CIDR blocks of the VPC subnets.
+* `local_ep_group` (String, Required, List) - Specifies the the local endpoint group that records CIDR blocks of the VPC subnets.
+  The `local_ep_group` block supports:
+  * `name` (String, Optional) - Specifies the name of the Direct Connect endpoint group.
+  * `description` (String, Optional) - Provides supplementary information about the Direct Connect endpoint group.
+  * `endpoints` (List, Required) - Specifies the list of the endpoints in a Direct Connect endpoint group.
+  * `type` (String, Required, ForceNew) - Specifies the type of the Direct Connect endpoints. The value can only be `cidr`. Default value: `cidr`.
 * `name` (String, Required) - Specifies the virtual gateway name.
 * `description` (String, Optional) - Provides supplementary information about the virtual gateway.
 * `asn` (Int, Optional, ForceNew) - Specifies the BGP ASN of the virtual gateway.
@@ -48,6 +45,7 @@ The following attributes are exported:
 * `id` -  ID of the virtual gateway.
 * `status` -  Virtual gateway status.
 * `project_id` -  Project id.
+* `local_ep_group_id` - ID of the local endpoint group that records CIDR blocks of the VPC subnets.
 
 ## Import
 

--- a/docs/resources/dс_virtual_gateway_v2.md
+++ b/docs/resources/dс_virtual_gateway_v2.md
@@ -10,9 +10,9 @@ Up-to-date reference of API arguments for Direct Connect Virtual Gateway you can
 
 ```hcl
 resource "opentelekomcloud_dc_virtual_gateway_v2" "vgw_1" {
-  vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
-  name              = "%s"
-  description       = "acc test"
+  vpc_id      = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  name        = "%s"
+  description = "acc test"
   local_ep_group {
     name        = "tf_eg_1"
     endpoints   = ["10.2.0.0/24", "10.3.0.0/24"]

--- a/opentelekomcloud/acceptance/dcaas/resource_opentelekomcloud_dc_virtual_gateway_v2_test.go
+++ b/opentelekomcloud/acceptance/dcaas/resource_opentelekomcloud_dc_virtual_gateway_v2_test.go
@@ -34,6 +34,8 @@ func TestDirectConnectVirtualGatewayV2Resource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(vg, "asn"),
 					resource.TestCheckResourceAttrSet(vg, "status"),
 					resource.TestCheckResourceAttrSet(vg, "local_ep_group_id"),
+					resource.TestCheckResourceAttr(vg, "local_ep_group.0.type", "cidr"),
+					resource.TestCheckResourceAttr(vg, "local_ep_group.0.endpoints.#", "1"),
 				),
 			},
 			{
@@ -45,6 +47,8 @@ func TestDirectConnectVirtualGatewayV2Resource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(vg, "asn"),
 					resource.TestCheckResourceAttrSet(vg, "status"),
 					resource.TestCheckResourceAttrSet(vg, "local_ep_group_id"),
+					resource.TestCheckResourceAttr(vg, "local_ep_group.0.type", "cidr"),
+					resource.TestCheckResourceAttr(vg, "local_ep_group.0.endpoints.#", "2"),
 				),
 			},
 			{
@@ -118,19 +122,15 @@ func testAccVirtualGatewayV2_basic(name string) string {
 
 %s
 
-resource "opentelekomcloud_dc_endpoint_group_v2" "dc_endpoint_group" {
-  name        = "tf_acc_eg_1"
-  type        = "cidr"
-  endpoints   = ["10.2.0.0/24", "10.3.0.0/24"]
-  description = "first"
-  project_id  = data.opentelekomcloud_identity_project_v3.project.id
-}
-
 resource "opentelekomcloud_dc_virtual_gateway_v2" "vgw_1" {
   vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
   name              = "%s"
   description       = "acc test"
-  local_ep_group_id = opentelekomcloud_dc_endpoint_group_v2.dc_endpoint_group.id
+  local_ep_group {
+    name        = "tf_acc_eg_1"
+    endpoints   = ["10.2.0.0/24"]
+    description = "first"
+  }
 }
 `, common.DataSourceSubnet, common.DataSourceProject, name)
 }
@@ -141,27 +141,15 @@ func testAccVirtualGatewayV2_update(name string) string {
 
 %s
 
-resource "opentelekomcloud_dc_endpoint_group_v2" "dc_endpoint_group" {
-  name        = "tf_acc_eg_1"
-  type        = "cidr"
-  endpoints   = ["10.2.0.0/24", "10.3.0.0/24"]
-  description = "first"
-  project_id  = data.opentelekomcloud_identity_project_v3.project.id
-}
-
-resource "opentelekomcloud_dc_endpoint_group_v2" "dc_endpoint_group_new" {
-  name        = "tf_acc_eg_1"
-  type        = "cidr"
-  endpoints   = ["10.20.0.0/24", "10.30.0.0/24"]
-  description = "first"
-  project_id  = data.opentelekomcloud_identity_project_v3.project.id
-}
-
 resource "opentelekomcloud_dc_virtual_gateway_v2" "vgw_1" {
   vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
   name              = "%s"
   description       = "acc test updated"
-  local_ep_group_id = opentelekomcloud_dc_endpoint_group_v2.dc_endpoint_group_new.id
+  local_ep_group {
+    name        = "tf_acc_eg_1"
+    endpoints   = ["10.2.0.0/24", "10.3.0.0/24"]
+    description = "first"
+  }
 }
 `, common.DataSourceSubnet, common.DataSourceProject, name)
 }

--- a/opentelekomcloud/acceptance/dcaas/resource_opentelekomcloud_dc_virtual_gateway_v2_test.go
+++ b/opentelekomcloud/acceptance/dcaas/resource_opentelekomcloud_dc_virtual_gateway_v2_test.go
@@ -123,9 +123,9 @@ func testAccVirtualGatewayV2_basic(name string) string {
 %s
 
 resource "opentelekomcloud_dc_virtual_gateway_v2" "vgw_1" {
-  vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
-  name              = "%s"
-  description       = "acc test"
+  vpc_id      = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  name        = "%s"
+  description = "acc test"
   local_ep_group {
     name        = "tf_acc_eg_1"
     endpoints   = ["10.2.0.0/24"]
@@ -142,9 +142,9 @@ func testAccVirtualGatewayV2_update(name string) string {
 %s
 
 resource "opentelekomcloud_dc_virtual_gateway_v2" "vgw_1" {
-  vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
-  name              = "%s"
-  description       = "acc test updated"
+  vpc_id      = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  name        = "%s"
+  description = "acc test updated"
   local_ep_group {
     name        = "tf_acc_eg_1"
     endpoints   = ["10.2.0.0/24", "10.3.0.0/24"]

--- a/opentelekomcloud/services/dcaas/common.go
+++ b/opentelekomcloud/services/dcaas/common.go
@@ -4,3 +4,5 @@ const (
 	errCreateClient = "error creating OpenTelekomCloud DCaaSv2 client: %w"
 	keyClientV2     = "dcaas-v2-client"
 )
+
+const egDeprecated = "This resource is not longer supported. Please use opentelekomcloud_dc_virtual_gateway_v2 with local_ep_group block instead."

--- a/opentelekomcloud/services/dcaas/resource_opentelekomcloud_dc_endpoint_group.go
+++ b/opentelekomcloud/services/dcaas/resource_opentelekomcloud_dc_endpoint_group.go
@@ -24,6 +24,8 @@ func ResourceDCEndpointGroupV2() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
+		DeprecationMessage: egDeprecated,
+
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),
 			Delete: schema.DefaultTimeout(10 * time.Minute),
@@ -79,7 +81,7 @@ func resourceDCEndpointGroupV2Create(ctx context.Context, d *schema.ResourceData
 		Name:        d.Get("name").(string),
 		TenantId:    d.Get("project_id").(string),
 		Description: d.Get("description").(string),
-		Endpoints:   GetEndpoints(d),
+		Endpoints:   GetEndpointsValues(d),
 		Type:        d.Get("type").(string),
 	}
 	log.Printf("[DEBUG] DC endpoint group V2 createOpts: %+v", createOpts)
@@ -139,7 +141,7 @@ func resourceDCEndpointGroupV2Delete(ctx context.Context, d *schema.ResourceData
 	return nil
 }
 
-func GetEndpoints(d *schema.ResourceData) []string {
+func GetEndpointsValues(d *schema.ResourceData) []string {
 	endpoints := make([]string, 0)
 	for _, val := range d.Get("endpoints").([]interface{}) {
 		endpoints = append(endpoints, val.(string))


### PR DESCRIPTION
## Summary of the Pull Request
Impossible to properly use endpoint group separately from virtual gateway because of api structure, cyclic dependecies. Make decision to move endpoint group management under virtual gateway resource.
Added deprecation message to `opentelekomcloud_dc_endpoint_group_v2`

## PR Checklist

* [x] Refers to: #2393
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestDirectConnectVirtualGatewayV2Resource_basic
--- PASS: TestDirectConnectVirtualGatewayV2Resource_basic (82.87s)
PASS

Debugger finished with the exit code 0
```
