### PR TITLE
Update addon-templates-v1.19.8.md

### DIFF
--- a/opentelekomcloud/services/cce/addon-templates-v1.19.8.md
+++ b/opentelekomcloud/services/cce/addon-templates-v1.19.8.md
@@ -183,6 +183,8 @@ See the [OTC Cloud Container Engine Addon Documentation](https://docs.otc.t-syst
 
 ##### `custom`
 
+-> If you are using OBS to host the nvidia driver set `is_driver_from_nvidia` to `false`. If you are downloading it from a public URL you have to set `is_driver_from_nvidia` to `true`.
+
 ```json
 {
   "is_driver_from_nvidia": true,


### PR DESCRIPTION
## Summary of the Pull Request
hello there,
this was causing some confusion for one of the OTC customers. What is happening if you have `is_driver_from_nvidia = false` (which is default on the API) then in the CCE deployment of GPU beta your URL will be prefixed with `obs://` which will break the public URL you are trying to use.

## PR Checklist

* [ ] Refers to: #xxx
* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (101.71s)
=== RUN   TestAccSomethingV0_timeout
--- PASS: TestAccSomethingV0_timeout (128.67s)
PASS

Process finished with exit code 0
```
