### PR TITLE
[DCS]: option to choose `private_ip` on instance creation

### DIFF
--- a/docs/resources/dcs_instance_v1.md
+++ b/docs/resources/dcs_instance_v1.md
@@ -96,6 +96,8 @@ The following arguments are supported:
 * `description` - (Optional, String) Indicates the description of an instance. It is a character
   string containing not more than `1024` characters.
 
+* `private_ip` - (Optional, String) IP address that is manually specified for a DCS instance.
+
 * `engine` - (Required, ForceNew, String) Indicates a cache engine. Only `Redis` is supported. Changing this
   creates a new instance.
 

--- a/opentelekomcloud/acceptance/dcs/resource_opentelekomcloud_dcs_instance_v1_test.go
+++ b/opentelekomcloud/acceptance/dcs/resource_opentelekomcloud_dcs_instance_v1_test.go
@@ -46,6 +46,27 @@ func TestAccDcsInstancesV1_basic(t *testing.T) {
 	})
 }
 
+func TestAccDcsInstancesV1_privateIPs(t *testing.T) {
+	var instance lifecycle.Instance
+	var instanceName = fmt.Sprintf("dcs_instance_%s", acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDcsV1InstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDcsV1InstancePrivateIPs(instanceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDcsV1InstanceExists(resourceInstanceName, instance),
+					resource.TestCheckResourceAttr(resourceInstanceName, "name", instanceName),
+					resource.TestCheckResourceAttr(resourceInstanceName, "engine", "Redis"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDcsInstancesV1_basicSingleInstance(t *testing.T) {
 	var instance lifecycle.Instance
 	var instanceName = fmt.Sprintf("dcs_instance_%s", acctest.RandString(5))
@@ -736,6 +757,50 @@ resource "opentelekomcloud_dcs_instance_v1" "instance_1" {
   subnet_id       = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   available_zones = [data.opentelekomcloud_dcs_az_v1.az_1.id]
   product_id      = data.opentelekomcloud_dcs_product_v1.product_1.id
+}
+`, common.DataSourceSecGroupDefault, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, instanceName)
+}
+
+func testAccDcsV1InstancePrivateIPs(instanceName string) string {
+	return fmt.Sprintf(`
+%s
+
+%s
+
+data "opentelekomcloud_dcs_az_v1" "az_1" {
+  port = "8002"
+  code = "%s"
+}
+
+data "opentelekomcloud_dcs_product_v1" "product_1" {
+  spec_code = "redis.ha.xu1.tiny.r2.128"
+}
+
+resource "opentelekomcloud_dcs_instance_v1" "instance_1" {
+  name              = "%s"
+  engine_version    = "5.0"
+  password          = "Hungarian_rapsody"
+  engine            = "Redis"
+  capacity          = 0.125
+  vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  available_zones   = [data.opentelekomcloud_dcs_az_v1.az_1.id]
+  private_ip        = cidrhost(data.opentelekomcloud_vpc_subnet_v1.shared_subnet.cidr, 6)
+  product_id        = data.opentelekomcloud_dcs_product_v1.product_1.id
+  security_group_id = "dummy-sg-id"
+  backup_policy {
+    backup_type = "manual"
+    begin_at    = "00:00-01:00"
+    period_type = "weekly"
+    backup_at   = [4]
+    save_days   = 1
+  }
+
+  configuration {
+    parameter_id    = "1"
+    parameter_name  = "timeout"
+    parameter_value = "100"
+  }
 }
 `, common.DataSourceSecGroupDefault, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, instanceName)
 }

--- a/opentelekomcloud/acceptance/dcs/resource_opentelekomcloud_dcs_instance_v1_test.go
+++ b/opentelekomcloud/acceptance/dcs/resource_opentelekomcloud_dcs_instance_v1_test.go
@@ -150,22 +150,6 @@ func TestAccASV1Configuration_invalidEngineVersion(t *testing.T) {
 	})
 }
 
-func TestAccASV1Configuration_invalidResourceSpecCode(t *testing.T) {
-	var instanceName = fmt.Sprintf("dcs_instance_%s", acctest.RandString(5))
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { common.TestAccPreCheck(t) },
-		ProviderFactories: common.TestAccProviderFactories,
-		CheckDestroy:      testAccCheckDcsV1InstanceDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccDcsV1InstanceResourceSpecCode(instanceName),
-				PlanOnly:    true,
-				ExpectError: regexp.MustCompile(`DCS Redis 6.0 instance does not support cluster mode+`),
-			},
-		},
-	})
-}
-
 func TestAccASV1Configuration_WhitelistValidation(t *testing.T) {
 	var instanceName = fmt.Sprintf("dcs_instance_%s", acctest.RandString(5))
 	resource.ParallelTest(t, resource.TestCase{
@@ -443,37 +427,6 @@ resource "opentelekomcloud_dcs_instance_v1" "instance_1" {
   available_zones   = [data.opentelekomcloud_dcs_az_v1.az_1.id]
   product_id        = data.opentelekomcloud_dcs_product_v1.product_1.id
   security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
-}
-`, common.DataSourceSecGroupDefault, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, instanceName)
-}
-
-func testAccDcsV1InstanceResourceSpecCode(instanceName string) string {
-	return fmt.Sprintf(`
-%s
-
-%s
-
-data "opentelekomcloud_dcs_az_v1" "az_1" {
-  port = "8002"
-  code = "%s"
-}
-
-data "opentelekomcloud_dcs_product_v1" "product_1" {
-  spec_code = "redis.single.xu1.tiny.128"
-}
-
-resource "opentelekomcloud_dcs_instance_v1" "instance_1" {
-  name               = "%s"
-  engine_version     = "6.0"
-  password           = "Hungarian_rapsody"
-  engine             = "Redis"
-  capacity           = 0.125
-  vpc_id             = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
-  subnet_id          = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
-  available_zones    = [data.opentelekomcloud_dcs_az_v1.az_1.id]
-  product_id         = data.opentelekomcloud_dcs_product_v1.product_1.id
-  security_group_id  = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
-  resource_spec_code = "dcs.cluster"
 }
 `, common.DataSourceSecGroupDefault, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, instanceName)
 }

--- a/opentelekomcloud/services/dcs/resource_opentelekomcloud_dcs_instance_v1.go
+++ b/opentelekomcloud/services/dcs/resource_opentelekomcloud_dcs_instance_v1.go
@@ -95,6 +95,11 @@ func ResourceDcsInstanceV1() *schema.Resource {
 				ForceNew: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"private_ip": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 			"created_at": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -416,6 +421,11 @@ func resourceDcsInstancesV1Create(ctx context.Context, d *schema.ResourceData, m
 		InstanceBackupPolicy: getInstanceBackupPolicy(d),
 		MaintainBegin:        d.Get("maintain_begin").(string),
 		MaintainEnd:          d.Get("maintain_end").(string),
+	}
+
+	if ip, ok := d.GetOk("private_ip"); ok {
+		createOpts.PrivateIps = []string{ip.(string)}
+		log.Printf("[DEBUG] private ip: %#v", createOpts.PrivateIps[0])
 	}
 
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)

--- a/opentelekomcloud/services/dcs/resource_opentelekomcloud_dcs_instance_v1.go
+++ b/opentelekomcloud/services/dcs/resource_opentelekomcloud_dcs_instance_v1.go
@@ -755,13 +755,6 @@ func validateEngine(_ context.Context, d *schema.ResourceDiff, _ interface{}) er
 		return fmt.Errorf("DCS Redis 3.0 instance does not support whitelisting")
 	}
 
-	resourceSpecCode, ok := d.GetOk("resource_spec_code")
-	if ok {
-		if resourceSpecCode.(string) == "dcs.cluster" && engineVersion == "6.0" {
-			return fmt.Errorf("DCS Redis 6.0 instance does not support cluster mode")
-		}
-	}
-
 	return nil
 }
 

--- a/releasenotes/notes/dcs_private_ip-bc2b8cc7ada85973.yaml
+++ b/releasenotes/notes/dcs_private_ip-bc2b8cc7ada85973.yaml
@@ -2,3 +2,6 @@
 enhancements:
   - |
     **[DCS]** `private_ip` feature implemented for ``resource/opentelekomcloud_dcs_instance_v1`` (`#2421 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2421>`_)
+fixes:
+  - |
+    **[DCS]** Remove invalid test and check for ``resource/opentelekomcloud_dcs_instance_v1`` (`#2421 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2421>`_)

--- a/releasenotes/notes/dcs_private_ip-bc2b8cc7ada85973.yaml
+++ b/releasenotes/notes/dcs_private_ip-bc2b8cc7ada85973.yaml
@@ -1,4 +1,4 @@
 ---
 enhancements:
   - |
-    **[DCS]** `private_ip` feature implemented for ``resource/opentelekomcloud_dcs_instance_v1`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[DCS]** `private_ip` feature implemented for ``resource/opentelekomcloud_dcs_instance_v1`` (`#2421 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2421>`_)

--- a/releasenotes/notes/dcs_private_ip-bc2b8cc7ada85973.yaml
+++ b/releasenotes/notes/dcs_private_ip-bc2b8cc7ada85973.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[DCS]** `private_ip` feature implemented for ``resource/opentelekomcloud_dcs_instance_v1`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Option to manually choose `private_ip` for DCS instance.

## PR Checklist

* [x] Refers to: #2420
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccDcsInstancesV1_basic
=== PAUSE TestAccDcsInstancesV1_basic
=== CONT  TestAccDcsInstancesV1_basic
--- PASS: TestAccDcsInstancesV1_basic (116.52s)
=== RUN   TestAccDcsInstancesV1_privateIPs
=== PAUSE TestAccDcsInstancesV1_privateIPs
=== CONT  TestAccDcsInstancesV1_privateIPs
--- PASS: TestAccDcsInstancesV1_privateIPs (92.77s)
=== RUN   TestAccDcsInstancesV1_basicSingleInstance
=== PAUSE TestAccDcsInstancesV1_basicSingleInstance
=== CONT  TestAccDcsInstancesV1_basicSingleInstance
--- PASS: TestAccDcsInstancesV1_basicSingleInstance (80.47s)
=== RUN   TestAccDcsInstancesV1_basicNoPasswordAccess
=== PAUSE TestAccDcsInstancesV1_basicNoPasswordAccess
=== CONT  TestAccDcsInstancesV1_basicNoPasswordAccess
--- PASS: TestAccDcsInstancesV1_basicNoPasswordAccess (81.14s)
=== RUN   TestAccDcsInstancesV1_basicEngineV3Instance
=== PAUSE TestAccDcsInstancesV1_basicEngineV3Instance
=== CONT  TestAccDcsInstancesV1_basicEngineV3Instance
--- PASS: TestAccDcsInstancesV1_basicEngineV3Instance (382.85s)
=== RUN   TestAccASV1Configuration_invalidEngineVersion
=== PAUSE TestAccASV1Configuration_invalidEngineVersion
=== CONT  TestAccASV1Configuration_invalidEngineVersion
--- PASS: TestAccASV1Configuration_invalidEngineVersion (3.19s)
=== RUN   TestAccASV1Configuration_WhitelistValidation
=== PAUSE TestAccASV1Configuration_WhitelistValidation
=== CONT  TestAccASV1Configuration_WhitelistValidation
--- PASS: TestAccASV1Configuration_WhitelistValidation (4.34s)
=== RUN   TestAccDcsInstancesV1_Whitelist
=== PAUSE TestAccDcsInstancesV1_Whitelist
=== CONT  TestAccDcsInstancesV1_Whitelist
--- PASS: TestAccDcsInstancesV1_Whitelist (192.56s)
=== RUN   TestAccDCSInstanceV1_importBasic
--- PASS: TestAccDCSInstanceV1_importBasic (99.47s)
PASS

Process finished with the exit code 0
```
