### PR TITLE
[OBS]: worm policy implementation

### DIFF
--- a/docs/resources/obs_bucket.md
+++ b/docs/resources/obs_bucket.md
@@ -55,6 +55,18 @@ resource "opentelekomcloud_obs_bucket" "b" {
 }
 ```
 
+### WORM policy with versioning enabled
+
+```hcl
+resource "opentelekomcloud_obs_bucket" "b" {
+  bucket     = "my-tf-test-bucket"
+  versioning = true
+  worm_policy {
+    years = 1
+  }
+}
+```
+
 ### Enable Logging
 
 ```hcl
@@ -367,6 +379,9 @@ The following arguments are supported:
 
 * `logging` - (Optional) A settings of bucket logging (documented below).
 
+* `worm_policy` - (Optional) A settings of bucket default WORM policy and a retention period (documented below).
+  `worm_policy` requires `versioning` to be enabled.
+
 * `website` - (Optional) A website object (documented below).
 
 * `cors_rule` - (Optional) A rule of Cross-Origin Resource Sharing (documented below).
@@ -389,6 +404,14 @@ The `logging` object supports the following:
   The acl policy of the target bucket should be `log-delivery-write`.
 
 * `target_prefix` - (Optional) To specify a key prefix for log objects.
+
+The `worm_policy` object supports the following:
+
+* `days` - (Optional) Default protection period, in `days`.
+  The value is from `1` to `36500`.
+
+* `years` - (Optional) Default protection period, in years. In a leap year, only 365 days are calculated.
+  The value is from `1` to `100`.
 
 The `website` object supports the following:
 

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.8.1-0.20240123131144-f4f7943050ea
+	github.com/opentelekomcloud/gophertelekomcloud v0.8.1-0.20240126173501-8fc2727ee549
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.17.0
 	golang.org/x/sync v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -164,6 +164,8 @@ github.com/opentelekomcloud/gophertelekomcloud v0.8.1-0.20240122110039-091711fef
 github.com/opentelekomcloud/gophertelekomcloud v0.8.1-0.20240122110039-091711fef789/go.mod h1:M1F6OfSRZRzAmAFKQqSLClX952at5hx5rHe4UTEykgg=
 github.com/opentelekomcloud/gophertelekomcloud v0.8.1-0.20240123131144-f4f7943050ea h1:ckn+dXw9X/qrsZ7im5Ql7c+b4SmARB0tVjx5P+bN7zo=
 github.com/opentelekomcloud/gophertelekomcloud v0.8.1-0.20240123131144-f4f7943050ea/go.mod h1:M1F6OfSRZRzAmAFKQqSLClX952at5hx5rHe4UTEykgg=
+github.com/opentelekomcloud/gophertelekomcloud v0.8.1-0.20240126173501-8fc2727ee549 h1:ulxXLQUQ70R12sG1OOmWBaXD7GYnrHTu9VlzKUu2wjM=
+github.com/opentelekomcloud/gophertelekomcloud v0.8.1-0.20240126173501-8fc2727ee549/go.mod h1:M1F6OfSRZRzAmAFKQqSLClX952at5hx5rHe4UTEykgg=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/opentelekomcloud/acceptance/nat/resource_opentelekomcloud_nat_dnat_rule_v2_test.go
+++ b/opentelekomcloud/acceptance/nat/resource_opentelekomcloud_nat_dnat_rule_v2_test.go
@@ -85,7 +85,7 @@ func testAccCheckNatDnatDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := dnatrules.Get(client, rs.Primary.ID).Extract()
+		_, err := dnatrules.Get(client, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("dnat rule still exists")
 		}
@@ -111,7 +111,7 @@ func testAccCheckNatDnatExists(n string) resource.TestCheckFunc {
 			return fmt.Errorf("error creating OpenTelekomCloud NATv2 client: %w", err)
 		}
 
-		found, err := dnatrules.Get(client, rs.Primary.ID).Extract()
+		found, err := dnatrules.Get(client, rs.Primary.ID)
 		if err != nil {
 			return err
 		}

--- a/opentelekomcloud/acceptance/obs/resource_opentelekomcloud_obs_bucket_test.go
+++ b/opentelekomcloud/acceptance/obs/resource_opentelekomcloud_obs_bucket_test.go
@@ -237,6 +237,32 @@ func TestAccObsBucket_pfs(t *testing.T) {
 	})
 }
 
+func TestAccObsBucket_WormPolicy(t *testing.T) {
+	rInt := acctest.RandInt()
+	resourceName := "opentelekomcloud_obs_bucket.bucket"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckObsBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccObsBucketWormPolicyBasic(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "worm_policy.0.days", "15"),
+				),
+			},
+			{
+				Config: testAccObsBucketWormPolicyUpdate(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "worm_policy.0.years", "1"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckObsBucketDestroy(s *terraform.State) error {
 	config := common.TestAccProvider.Meta().(*cfg.Config)
 	client, err := config.NewObjectStorageClient(env.OS_REGION_NAME)
@@ -633,6 +659,28 @@ func testAccObsBucketPfs(randInt int) string {
 resource "opentelekomcloud_obs_bucket" "bucket" {
   bucket      = "tf-test-bucket-%d"
   parallel_fs = true
+}
+`, randInt)
+}
+
+func testAccObsBucketWormPolicyBasic(randInt int) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_obs_bucket" "bucket" {
+  bucket      = "tf-test-bucket-%d"
+  worm_policy {
+	days = 15
+	}
+}
+`, randInt)
+}
+
+func testAccObsBucketWormPolicyUpdate(randInt int) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_obs_bucket" "bucket" {
+  bucket      = "tf-test-bucket-%d"
+  worm_policy {
+	years = 1
+	}
 }
 `, randInt)
 }

--- a/opentelekomcloud/services/nat/resource_opentelekomcloud_nat_dnat_rule_v2.go
+++ b/opentelekomcloud/services/nat/resource_opentelekomcloud_nat_dnat_rule_v2.go
@@ -155,7 +155,7 @@ func createRuleWithRetry(ctx context.Context, client *golangsdk.ServiceClient, o
 	var rule *dnatrules.DnatRule
 	err := resource.RetryContext(ctx, timeout, func() *resource.RetryError {
 		var err error
-		rule, err = dnatrules.Create(client, opts).Extract()
+		rule, err = dnatrules.Create(client, opts)
 		if err != nil {
 			// we are retrying DnatRuleInValidPortID which is HTTP 400
 			if _, ok := err.(golangsdk.ErrDefault400); ok {
@@ -179,22 +179,22 @@ func resourceNatDnatRuleRead(_ context.Context, d *schema.ResourceData, meta int
 	if err != nil {
 		return fmterr.Errorf(ErrCreationClient, err)
 	}
-	dnatRule, err := dnatrules.Get(client, d.Id()).Extract()
+	dnatRule, err := dnatrules.Get(client, d.Id())
 	if err != nil {
 		return common.CheckDeletedDiag(d, err, "dnat rule")
 	}
 
 	mErr := multierror.Append(
-		d.Set("floating_ip_id", dnatRule.FloatingIpID),
+		d.Set("floating_ip_id", dnatRule.FloatingIpId),
 		d.Set("internal_service_port", dnatRule.InternalServicePort),
-		d.Set("nat_gateway_id", dnatRule.NatGatewayID),
-		d.Set("port_id", dnatRule.PortID),
+		d.Set("nat_gateway_id", dnatRule.NatGatewayId),
+		d.Set("port_id", dnatRule.PortId),
 		d.Set("private_ip", dnatRule.PrivateIp),
 		d.Set("protocol", dnatRule.Protocol),
 		d.Set("external_service_port", dnatRule.ExternalServicePort),
 		d.Set("floating_ip_address", dnatRule.FloatingIpAddress),
 		d.Set("status", dnatRule.Status),
-		d.Set("tenant_id", dnatRule.TenantID),
+		d.Set("tenant_id", dnatRule.ProjectId),
 	)
 
 	if err := mErr.ErrorOrNil(); err != nil {
@@ -232,7 +232,7 @@ func resourceNatDnatRuleDelete(ctx context.Context, d *schema.ResourceData, meta
 
 func waitForDnatRuleActive(client *golangsdk.ServiceClient, dnatRuleID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		n, err := dnatrules.Get(client, dnatRuleID).Extract()
+		n, err := dnatrules.Get(client, dnatRuleID)
 		if err != nil {
 			return nil, "", err
 		}
@@ -250,7 +250,7 @@ func waitForDnatRuleDelete(client *golangsdk.ServiceClient, dnatRuleID string) r
 	return func() (interface{}, string, error) {
 		log.Printf("[DEBUG] Attempting to delete OpenTelekomCloud DNAT Rule %s.\n", dnatRuleID)
 
-		n, err := dnatrules.Get(client, dnatRuleID).Extract()
+		n, err := dnatrules.Get(client, dnatRuleID)
 		if err != nil {
 			if _, ok := err.(golangsdk.ErrDefault404); ok {
 				log.Printf("[DEBUG] Successfully deleted OpenTelekomCloud DNAT Rule %s", dnatRuleID)
@@ -259,7 +259,7 @@ func waitForDnatRuleDelete(client *golangsdk.ServiceClient, dnatRuleID string) r
 			return n, "ACTIVE", err
 		}
 
-		if err := dnatrules.Delete(client, dnatRuleID).ExtractErr(); err != nil {
+		if err := dnatrules.Delete(client, dnatRuleID); err != nil {
 			if _, ok := err.(golangsdk.ErrDefault404); ok {
 				log.Printf("[DEBUG] Successfully deleted OpenTelekomCloud DNAT Rule %s", dnatRuleID)
 				return n, "DELETED", nil

--- a/releasenotes/notes/obs_worm_policy-9fba76bcb1f7f6d2.yaml
+++ b/releasenotes/notes/obs_worm_policy-9fba76bcb1f7f6d2.yaml
@@ -1,0 +1,8 @@
+---
+enhancements:
+  - |
+    **[OBS]** Worm policies implementation for ``resource/opentelekomcloud_obs_bucket`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+
+other:
+  - |
+    **[NAT]** Refactoring of ``resource/opentelekomcloud_nat_dnat_rule_v2`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)

--- a/releasenotes/notes/obs_worm_policy-9fba76bcb1f7f6d2.yaml
+++ b/releasenotes/notes/obs_worm_policy-9fba76bcb1f7f6d2.yaml
@@ -1,8 +1,8 @@
 ---
 enhancements:
   - |
-    **[OBS]** Worm policies implementation for ``resource/opentelekomcloud_obs_bucket`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[OBS]** Worm policies implementation for ``resource/opentelekomcloud_obs_bucket`` (`#2428 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2428>`_)
 
 other:
   - |
-    **[NAT]** Refactoring of ``resource/opentelekomcloud_nat_dnat_rule_v2`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[NAT]** Refactoring of ``resource/opentelekomcloud_nat_dnat_rule_v2`` (`#2428 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2428>`_)


### PR DESCRIPTION
## Summary of the Pull Request
- Worm policy for obs bucket
- Small DNAT resource refactoring

## PR Checklist

* [x] Refers to: #2425
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
### OBS
=== RUN   TestAccObsBucket_basic
=== PAUSE TestAccObsBucket_basic
=== CONT  TestAccObsBucket_basic
--- PASS: TestAccObsBucket_basic (62.77s)
=== RUN   TestAccObsBucket_tags
=== PAUSE TestAccObsBucket_tags
=== CONT  TestAccObsBucket_tags
--- PASS: TestAccObsBucket_tags (23.10s)
=== RUN   TestAccObsBucket_versioning
=== PAUSE TestAccObsBucket_versioning
=== CONT  TestAccObsBucket_versioning
--- PASS: TestAccObsBucket_versioning (42.84s)
=== RUN   TestAccObsBucket_logging
=== PAUSE TestAccObsBucket_logging
=== CONT  TestAccObsBucket_logging
--- PASS: TestAccObsBucket_logging (28.53s)
=== RUN   TestAccObsBucket_lifecycle
=== PAUSE TestAccObsBucket_lifecycle
=== CONT  TestAccObsBucket_lifecycle
--- PASS: TestAccObsBucket_lifecycle (23.68s)
=== RUN   TestAccObsBucket_website
=== PAUSE TestAccObsBucket_website
=== CONT  TestAccObsBucket_website
--- PASS: TestAccObsBucket_website (23.59s)
=== RUN   TestAccObsBucket_cors
=== PAUSE TestAccObsBucket_cors
=== CONT  TestAccObsBucket_cors
--- PASS: TestAccObsBucket_cors (23.89s)
=== RUN   TestAccObsBucket_notifications
=== PAUSE TestAccObsBucket_notifications
=== CONT  TestAccObsBucket_notifications
--- PASS: TestAccObsBucket_notifications (30.71s)
=== RUN   TestAccObsBucket_pfs
=== PAUSE TestAccObsBucket_pfs
=== CONT  TestAccObsBucket_pfs
--- PASS: TestAccObsBucket_pfs (23.82s)
=== RUN   TestAccObsBucket_WormPolicy
=== PAUSE TestAccObsBucket_WormPolicy
=== CONT  TestAccObsBucket_WormPolicy
--- PASS: TestAccObsBucket_WormPolicy (43.10s)
=== RUN   TestAccOBSBucket_VersioningObjectLockValidation
=== PAUSE TestAccOBSBucket_VersioningObjectLockValidation
=== CONT  TestAccOBSBucket_VersioningObjectLockValidation
--- PASS: TestAccOBSBucket_VersioningObjectLockValidation (4.13s)
PASS

Process finished with the exit code 0

### DNAT
=== RUN   TestAccNatDnat_basic
--- PASS: TestAccNatDnat_basic (85.58s)
=== RUN   TestAccNatDnatRule_withPort
--- PASS: TestAccNatDnatRule_withPort (97.94s)
=== RUN   TestAccNatDnat_importBasic
--- PASS: TestAccNatDnat_importBasic (92.04s)
PASS

Process finished with the exit code 0
```
