### PR TITLE
[OBS]: Object deletion sync for bucket replication

### DIFF
--- a/docs/resources/obs_bucket_replication.md
+++ b/docs/resources/obs_bucket_replication.md
@@ -49,6 +49,7 @@ resource "opentelekomcloud_obs_bucket_replication" "test" {
     storage_class   = "COLD"
     enabled         = true
     history_enabled = false
+    delete_data     = true
   }
 }
 ```
@@ -94,6 +95,9 @@ The `rule` block supports:
 
 * `history_enabled` - (Optional) Specifies cross-region replication history rule status. Defaults to `false`.
   If the value is `true`, historical objects meeting this rule are copied.
+
+* `delete_data` - (Optional) Specifies cross-region replication object deletion operations status. Defaults to `false`.
+  If the value is `true`, object deletion for the source bucket will be replicated to the destination bucket.
 
 ## Attribute Reference
 

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.8.1-0.20240126173501-8fc2727ee549
+	github.com/opentelekomcloud/gophertelekomcloud v0.8.1-0.20240131123828-bbf049e73593
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.17.0
 	golang.org/x/sync v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -166,6 +166,8 @@ github.com/opentelekomcloud/gophertelekomcloud v0.8.1-0.20240123131144-f4f794305
 github.com/opentelekomcloud/gophertelekomcloud v0.8.1-0.20240123131144-f4f7943050ea/go.mod h1:M1F6OfSRZRzAmAFKQqSLClX952at5hx5rHe4UTEykgg=
 github.com/opentelekomcloud/gophertelekomcloud v0.8.1-0.20240126173501-8fc2727ee549 h1:ulxXLQUQ70R12sG1OOmWBaXD7GYnrHTu9VlzKUu2wjM=
 github.com/opentelekomcloud/gophertelekomcloud v0.8.1-0.20240126173501-8fc2727ee549/go.mod h1:M1F6OfSRZRzAmAFKQqSLClX952at5hx5rHe4UTEykgg=
+github.com/opentelekomcloud/gophertelekomcloud v0.8.1-0.20240131123828-bbf049e73593 h1:QYlZMMkOYo4zy69bBBRWEYQEPii++LjjNzHL81JadAg=
+github.com/opentelekomcloud/gophertelekomcloud v0.8.1-0.20240131123828-bbf049e73593/go.mod h1:M1F6OfSRZRzAmAFKQqSLClX952at5hx5rHe4UTEykgg=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/opentelekomcloud/acceptance/obs/resource_opentelekomcloud_obs_bucket_replication_test.go
+++ b/opentelekomcloud/acceptance/obs/resource_opentelekomcloud_obs_bucket_replication_test.go
@@ -41,6 +41,7 @@ func TestAccObsBucketReplication_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceReplication, "id", testAccObsBucketName(rInt)),
 					resource.TestCheckResourceAttr(resourceReplication, "agency", "test-obs-agency"),
 					resource.TestCheckResourceAttr(resourceReplication, "destination_bucket", destBucket),
+					resource.TestCheckResourceAttr(resourceReplication, "rule.0.delete_data", "true"),
 				),
 			},
 		},
@@ -133,6 +134,10 @@ resource "opentelekomcloud_obs_bucket_replication" "test" {
   destination_bucket = "%s"
   agency             = opentelekomcloud_identity_agency_v3.agency_obs.name
 
+  rule {
+    prefix      = "test"
+    delete_data = true
+  }
 }
 `, randInt, env.OS_TENANT_NAME, destBucket)
 }

--- a/opentelekomcloud/services/obs/resource_opentelekomcloud_obs_bucket_replication.go
+++ b/opentelekomcloud/services/obs/resource_opentelekomcloud_obs_bucket_replication.go
@@ -71,6 +71,11 @@ func ResourceObsBucketReplication() *schema.Resource {
 							Optional: true,
 							Default:  false,
 						},
+						"delete_data": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
 						"id": {
 							Type:     schema.TypeString,
 							Computed: true,
@@ -98,6 +103,12 @@ func buildReplicationRuleFromRawMap(rawMap map[string]interface{}, destBucket, p
 		replicationRule.HistoricalObjectReplication = "Enabled"
 	} else {
 		replicationRule.HistoricalObjectReplication = "Disabled"
+	}
+
+	if deletionEnabled, ok := rawMap["delete_data"].(bool); ok && deletionEnabled {
+		replicationRule.DeleteData = "Enabled"
+	} else {
+		replicationRule.DeleteData = "Disabled"
 	}
 
 	if val, ok := rawMap["storage_class"].(string); ok {
@@ -180,6 +191,7 @@ func flattenDestinationRules(output *obs.GetBucketReplicationOutput) []map[strin
 			"storage_class":   rule.StorageClass,
 			"enabled":         rule.Status == obs.RuleStatusEnabled,
 			"history_enabled": rule.HistoricalObjectReplication == "Enabled",
+			"delete_data":     rule.DeleteData == "Enabled",
 			"id":              rule.ID,
 		}
 	}

--- a/releasenotes/notes/obs_replication_deletion-61ba247bc3cde501.yaml
+++ b/releasenotes/notes/obs_replication_deletion-61ba247bc3cde501.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[OBS]** Add option to synchronize object deletion for ``opentelekomcloud_obs_bucket_replication`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)

--- a/releasenotes/notes/obs_replication_deletion-61ba247bc3cde501.yaml
+++ b/releasenotes/notes/obs_replication_deletion-61ba247bc3cde501.yaml
@@ -1,4 +1,4 @@
 ---
 enhancements:
   - |
-    **[OBS]** Add option to synchronize object deletion for ``opentelekomcloud_obs_bucket_replication`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[OBS]** Add option to synchronize object deletion for ``opentelekomcloud_obs_bucket_replication`` (`#2430 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2430>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Add option to synchronise object deletion for bucket cross-region replciation.

## PR Checklist

* [x] Refers to: #2429
* [x] Tests passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccObsBucketReplication_basic
=== PAUSE TestAccObsBucketReplication_basic
=== CONT  TestAccObsBucketReplication_basic
--- PASS: TestAccObsBucketReplication_basic (51.29s)
=== RUN   TestAccOBSReplication_importBasic
--- PASS: TestAccOBSReplication_importBasic (35.28s)
PASS

Process finished with the exit code 0
```
