### PR TITLE
Improve cce_addon_v3 documentation

### DIFF
--- a/docs/resources/cce_addon_v3.md
+++ b/docs/resources/cce_addon_v3.md
@@ -120,7 +120,7 @@ resource "opentelekomcloud_cce_addon_v3" "autoscaler" {
           }
         ]
       }
-      EOF
+    EOF
   }
 }
 

--- a/docs/resources/cce_addon_v3.md
+++ b/docs/resources/cce_addon_v3.md
@@ -56,7 +56,7 @@ data "opentelekomcloud_identity_project_v3" "this" {}
 
 data "opentelekomcloud_cce_addon_template_v3" "autoscaler" {
   addon_version = var.autoscaler_version
-  addon_name = "autoscaler"
+  addon_name    = "autoscaler"
 }
 
 resource opentelekomcloud_cce_cluster_v3 cluster_1 {

--- a/docs/resources/cce_addon_v3.md
+++ b/docs/resources/cce_addon_v3.md
@@ -120,7 +120,7 @@ resource "opentelekomcloud_cce_addon_v3" "autoscaler" {
           }
         ]
       }
-        EOF
+      EOF
   }
 }
 

--- a/releasenotes/notes/cce-addon-v3-doc-e57dce0587feed06.yaml
+++ b/releasenotes/notes/cce-addon-v3-doc-e57dce0587feed06.yaml
@@ -1,0 +1,4 @@
+---
+other:
+  - |
+    **[CCE]** Change example in ``resource/opentelekomcloud_cce_addon_v3`` documentation (`#2436 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2436>`_)


### PR DESCRIPTION
## Summary of the Pull Request
hello there,

I tried to improve the documentation of `cce_addon_v3` so users have an example how to use data sources instead of hardcoded strings and versions.

proof that it works:
```terraform
Terraform will perform the following actions:

  # opentelekomcloud_cce_addon_v3.autoscaler will be created
  + resource "opentelekomcloud_cce_addon_v3" "autoscaler" {
      + cluster_id       = "DELETED"
      + description      = (known after apply)
      + id               = (known after apply)
      + name             = (known after apply)
      + template_name    = "autoscaler"
      + template_version = "1.25.21"

      + values {
          + basic  = {
              + "cceEndpoint" = "https://cce.eu-de.otc.t-systems.com"
              + "ecsEndpoint" = "https://ecs.eu-de.otc.t-systems.com"
              + "region"      = "eu-de"
              + "swr_addr"    = "100.125.7.25:20202"
              + "swr_user"    = "cce-addons"
            }
          + custom = {
              + "cluster_id"                     = "DELETED"
              + "coresTotal"                     = "32000"
              + "expander"                       = "priority"
              + "logLevel"                       = "4"
              + "maxEmptyBulkDeleteFlag"         = "10"
              + "maxNodeProvisionTime"           = "15"
              + "maxNodesTotal"                  = "1000"
              + "memoryTotal"                    = "128000"
              + "scaleDownDelayAfterAdd"         = "10"
              + "scaleDownDelayAfterDelete"      = "11"
              + "scaleDownDelayAfterFailure"     = "3"
              + "scaleDownEnabled"               = "true"
              + "scaleDownUnneededTime"          = "10"
              + "scaleDownUtilizationThreshold"  = "0.5"
              + "scaleUpCpuUtilizationThreshold" = "1"
              + "scaleUpMemUtilizationThreshold" = "1"
              + "scaleUpUnscheduledPodEnabled"   = "true"
              + "scaleUpUtilizationEnabled"      = "true"
              + "tenant_id"                      = "DELETED"
              + "unremovableNodeRecheckTimeout"  = "5"
            }
          + flavor = jsonencode(
                {
                  + description = "Has only one instance"
                  + name        = "Single"
                  + replicas    = 1
                  + resources   = [
                      + {
                          + limitsCpu   = "1000m"
                          + limitsMem   = "1000Mi"
                          + name        = "autoscaler"
                          + requestsCpu = "500m"
                          + requestsMem = "500Mi"
                        },
                    ]
                }
            )
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

opentelekomcloud_cce_addon_v3.autoscaler: Creating...
opentelekomcloud_cce_addon_v3.autoscaler: Still creating... [10s elapsed]
opentelekomcloud_cce_addon_v3.autoscaler: Creation complete after 12s [id=a630c413-c98f-11ee-aaeb-02550a10003c]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

## PR Checklist

* [ ] Refers to: #xxx
* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (101.71s)
=== RUN   TestAccSomethingV0_timeout
--- PASS: TestAccSomethingV0_timeout (128.67s)
PASS

Process finished with exit code 0
```
