### PR TITLE
[ECS]: Documentation update with ESSD disk type for `opentelekomcloud_ecs_instance_v1`

### DIFF
--- a/docs/resources/ecs_instance_v1.md
+++ b/docs/resources/ecs_instance_v1.md
@@ -235,6 +235,7 @@ The following arguments are supported:
   * `SSD`: ultra-high I/O disk type. Available for all AZs.
   * `co-p1`: high I/O(performance-optimized) disk type.
   * `uh-l1`: ultra-high I/O(latency-optimized) disk type.
+  * `ESSD`: extreme SSD disk type.
 
 * `system_disk_size` - (Optional) The system disk size in GB, The value range is 1 to 1024.
   Changing this creates a new server.
@@ -276,6 +277,7 @@ The `data_disks` block supports:
   * `SSD`: ultra-high I/O disk type. Available for all AZs.
   * `co-p1`: high I/O(performance-optimized) disk type.
   * `uh-l1`: ultra-high I/O(latency-optimized) disk type.
+  * `ESSD`: extreme SSD disk type.
 
 * `size` - (Required) The size of the data disk in GB. The value range is 10 to 32768.
   Changing this creates a new server.

--- a/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_ecs_instance_v1_test.go
+++ b/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_ecs_instance_v1_test.go
@@ -71,6 +71,7 @@ func TestAccEcsV1InstanceIp(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceInstanceV1Name, "availability_zone", env.OS_AVAILABILITY_ZONE),
 					resource.TestCheckResourceAttr(resourceInstanceV1Name, "auto_recovery", "false"),
 					resource.TestCheckResourceAttr(resourceInstanceV1Name, "security_groups.#", "1"),
+					resource.TestCheckResourceAttr(resourceInstanceV1Name, "data_disks.0.type", "ESSD"),
 					resource.TestCheckResourceAttrSet(resourceInstanceV1Name, "nics.0.port_id"),
 				),
 			},
@@ -582,7 +583,7 @@ resource "opentelekomcloud_ecs_instance_v1" "instance_1" {
 
   data_disks {
     size = 10
-    type = "SAS"
+    type = "ESSD"
   }
 
   password                    = "Password@123"

--- a/releasenotes/notes/ecs_instance_essd-d7be11b5d51b5314.yaml
+++ b/releasenotes/notes/ecs_instance_essd-d7be11b5d51b5314.yaml
@@ -1,0 +1,3 @@
+other:
+  - |
+    **[ECS]** Update documentation for ``resource/opentelekomcloud_ecs_instance_v1`` with new ESSD disk type (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)

--- a/releasenotes/notes/ecs_instance_essd-d7be11b5d51b5314.yaml
+++ b/releasenotes/notes/ecs_instance_essd-d7be11b5d51b5314.yaml
@@ -1,3 +1,3 @@
 other:
   - |
-    **[ECS]** Update documentation for ``resource/opentelekomcloud_ecs_instance_v1`` with new ESSD disk type (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[ECS]** Update documentation for ``resource/opentelekomcloud_ecs_instance_v1`` with new ESSD disk type (`#2439 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2439>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Update provider for `opentelekomcloud_ecs_instance_v1` with new disk type.

## PR Checklist

* [x] Refers to: #2437
* [x] Tests passed.
* [x] Documentation updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccEcsV1InstanceIp
=== PAUSE TestAccEcsV1InstanceIp
=== CONT  TestAccEcsV1InstanceIp
--- PASS: TestAccEcsV1InstanceIp (159.07s)
PASS

Process finished with the exit code 0
```
