### PR TITLE
[IAM] login_protection now possible to remove from state in `resource/opentelekomcloud_identity_user_v3`

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -156,16 +156,6 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k+Mg7cowZ8yv4Trqw9UsJby758=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.8.1-0.20240116111952-46714d6a306e h1:XDviCtsB5eQPiZSrWbow9n7LDxBEhEZFpVRSl/9BZyM=
-github.com/opentelekomcloud/gophertelekomcloud v0.8.1-0.20240116111952-46714d6a306e/go.mod h1:52hmT1BkuU3niQC6fgHOHdNkYOTh9ry4HYbmuSOjDkw=
-github.com/opentelekomcloud/gophertelekomcloud v0.8.1-0.20240118113117-e9d616499f22 h1:q5sjyUxI5bD1JIYnxP/muFdB8SXR1gNqKJRWDLqGwg4=
-github.com/opentelekomcloud/gophertelekomcloud v0.8.1-0.20240118113117-e9d616499f22/go.mod h1:M1F6OfSRZRzAmAFKQqSLClX952at5hx5rHe4UTEykgg=
-github.com/opentelekomcloud/gophertelekomcloud v0.8.1-0.20240122110039-091711fef789 h1:suTtN0M3BeEBpHfg7Jf9lZs9018mTnNCzDcsFniapCE=
-github.com/opentelekomcloud/gophertelekomcloud v0.8.1-0.20240122110039-091711fef789/go.mod h1:M1F6OfSRZRzAmAFKQqSLClX952at5hx5rHe4UTEykgg=
-github.com/opentelekomcloud/gophertelekomcloud v0.8.1-0.20240123131144-f4f7943050ea h1:ckn+dXw9X/qrsZ7im5Ql7c+b4SmARB0tVjx5P+bN7zo=
-github.com/opentelekomcloud/gophertelekomcloud v0.8.1-0.20240123131144-f4f7943050ea/go.mod h1:M1F6OfSRZRzAmAFKQqSLClX952at5hx5rHe4UTEykgg=
-github.com/opentelekomcloud/gophertelekomcloud v0.8.1-0.20240126173501-8fc2727ee549 h1:ulxXLQUQ70R12sG1OOmWBaXD7GYnrHTu9VlzKUu2wjM=
-github.com/opentelekomcloud/gophertelekomcloud v0.8.1-0.20240126173501-8fc2727ee549/go.mod h1:M1F6OfSRZRzAmAFKQqSLClX952at5hx5rHe4UTEykgg=
 github.com/opentelekomcloud/gophertelekomcloud v0.8.1-0.20240131123828-bbf049e73593 h1:QYlZMMkOYo4zy69bBBRWEYQEPii++LjjNzHL81JadAg=
 github.com/opentelekomcloud/gophertelekomcloud v0.8.1-0.20240131123828-bbf049e73593/go.mod h1:M1F6OfSRZRzAmAFKQqSLClX952at5hx5rHe4UTEykgg=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/opentelekomcloud/acceptance/iam/resource_opentelekomcloud_identity_user_v3_test.go
+++ b/opentelekomcloud/acceptance/iam/resource_opentelekomcloud_identity_user_v3_test.go
@@ -144,6 +144,28 @@ func TestAccIdentityV3User_protection(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "domain_id"),
 				),
 			},
+			{
+				Config: testAccIdentityV3UserProtectionConfigRemove(userName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIdentityV3UserExists(resourceName, &user),
+					resource.TestCheckResourceAttrPtr(resourceName, "name", &user.Name),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "email", "test2@acme.org"),
+					resource.TestCheckResourceAttrSet(resourceName, "domain_id"),
+				),
+			},
+			{
+				Config: testAccIdentityV3UserProtectionConfigReturn(userName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIdentityV3UserExists(resourceName, &user),
+					resource.TestCheckResourceAttrPtr(resourceName, "name", &user.Name),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "email", "test2@acme.org"),
+					resource.TestCheckResourceAttr(resourceName, "login_protection.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "login_protection.0.verification_method", "vmfa"),
+					resource.TestCheckResourceAttrSet(resourceName, "domain_id"),
+				),
+			},
 		},
 	})
 }
@@ -285,6 +307,33 @@ resource "opentelekomcloud_identity_user_v3" "user_1" {
   login_protection {
     enabled             = false
     verification_method = "email"
+  }
+}
+  `, userName)
+}
+
+func testAccIdentityV3UserProtectionConfigRemove(userName string) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_identity_user_v3" "user_1" {
+  name     = "%s"
+  enabled  = false
+  password = "password123@!"
+  email    = "tEst2@acme.org"
+}
+  `, userName)
+}
+
+func testAccIdentityV3UserProtectionConfigReturn(userName string) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_identity_user_v3" "user_1" {
+  name     = "%s"
+  enabled  = false
+  password = "password123@!"
+  email    = "tEst2@acme.org"
+
+  login_protection {
+    enabled             = true
+    verification_method = "vmfa"
   }
 }
   `, userName)

--- a/opentelekomcloud/services/iam/resource_opentelekomcloud_identity_user_v3.go
+++ b/opentelekomcloud/services/iam/resource_opentelekomcloud_identity_user_v3.go
@@ -225,6 +225,17 @@ func resourceIdentityUserV3Read(ctx context.Context, d *schema.ResourceData, met
 	if userProtectionConfig != nil {
 		verMethod := userProtectionConfig.VerificationMethod
 		stateVerMethod := d.Get("login_protection.0.verification_method").(string)
+		if verMethod != "none" {
+			protection := []map[string]interface{}{
+				{
+					"enabled":             userProtectionConfig.Enabled,
+					"verification_method": verMethod,
+				},
+			}
+			mErr = multierror.Append(mErr,
+				d.Set("login_protection", protection),
+			)
+		}
 		if verMethod == "none" && stateVerMethod != "" {
 			verMethod = stateVerMethod
 			protection := []map[string]interface{}{

--- a/releasenotes/notes/iam-user-login-protection-delete-69776f7c0f28097d.yaml
+++ b/releasenotes/notes/iam-user-login-protection-delete-69776f7c0f28097d.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[IAM]** Fix ``login_protection`` deletion in ``resource/opentelekomcloud_identity_user_v3`` (`#2441 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2441>`_)


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [x] Refers to: #2440
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccIdentityV3User_basic
--- PASS: TestAccIdentityV3User_basic (49.43s)
=== RUN   TestAccIdentityV3User_importBasic
--- PASS: TestAccIdentityV3User_importBasic (33.15s)
=== RUN   TestAccCheckIAMV3EmailValidation
--- PASS: TestAccCheckIAMV3EmailValidation (6.14s)
=== RUN   TestAccCheckIAMV3SendEmailValidation
--- PASS: TestAccCheckIAMV3SendEmailValidation (3.93s)
=== RUN   TestAccIdentityV3User_protection
--- PASS: TestAccIdentityV3User_protection (91.01s)
PASS

Process finished with the exit code 0
```
