### PR TITLE
[RDS]: fix ssl enable for MySql instances

### DIFF
--- a/releasenotes/notes/rds_ssl_fix-79bd50448c6941a4.yaml
+++ b/releasenotes/notes/rds_ssl_fix-79bd50448c6941a4.yaml
@@ -1,4 +1,4 @@
 ---
 enhancements:
   - |
-    **[RDS]** Fix ssl for mysql instances for ``resource/opentelekomcloud_rds_instance_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[RDS]** Fix ssl for mysql instances for ``resource/opentelekomcloud_rds_instance_v3`` (`#2443 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2443>`_)

--- a/releasenotes/notes/rds_ssl_fix-79bd50448c6941a4.yaml
+++ b/releasenotes/notes/rds_ssl_fix-79bd50448c6941a4.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[RDS]** Fix ssl for mysql instances for ``resource/opentelekomcloud_rds_instance_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Fix SSL for MySql instances

## PR Checklist

* [x] Refers to: #2438
* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccRdsInstanceV3Basic
--- PASS: TestAccRdsInstanceV3Basic (843.96s)
=== RUN   TestAccRdsPostgre13V3ParamsBasic
--- PASS: TestAccRdsPostgre13V3ParamsBasic (468.36s)
=== RUN   TestAccRdsInstanceV3ElasticIP
--- PASS: TestAccRdsInstanceV3ElasticIP (780.94s)
=== RUN   TestAccRdsInstanceV3HA
--- PASS: TestAccRdsInstanceV3HA (388.72s)
=== RUN   TestAccRdsInstanceV3OptionalParams
--- PASS: TestAccRdsInstanceV3OptionalParams (368.69s)
=== RUN   TestAccRdsInstanceV3Backup
--- PASS: TestAccRdsInstanceV3Backup (401.11s)
=== RUN   TestAccRdsInstanceV3TemplateConfig
--- PASS: TestAccRdsInstanceV3TemplateConfig (466.92s)
=== RUN   TestAccRdsInstanceV3InvalidDBVersion
--- PASS: TestAccRdsInstanceV3InvalidDBVersion (5.68s)
=== RUN   TestAccRdsInstanceV3InvalidFlavor
--- PASS: TestAccRdsInstanceV3InvalidFlavor (6.04s)
=== RUN   TestAccRdsInstanceV3_configurationParameters
--- PASS: TestAccRdsInstanceV3_configurationParameters (391.44s)
=== RUN   TestAccRdsInstanceV3AutoScaling
--- PASS: TestAccRdsInstanceV3AutoScaling (544.25s)
=== RUN   TestAccRdsInstanceV3RestoreToPITR
--- PASS: TestAccRdsInstanceV3RestoreToPITR (690.27s)
=== RUN   TestAccRdsInstanceV3_SSLEnable
--- PASS: TestAccRdsInstanceV3_SSLEnable (508.34s)
PASS

Process finished with the exit code 0
```
