### PR TITLE
[WAFD]: reference table name regex fix

### DIFF
--- a/opentelekomcloud/acceptance/waf/resource_opentelekomcloud_waf_dedicated_reference_table_v1_test.go
+++ b/opentelekomcloud/acceptance/waf/resource_opentelekomcloud_waf_dedicated_reference_table_v1_test.go
@@ -18,7 +18,7 @@ const wafdRefTableResourceName = "opentelekomcloud_waf_dedicated_reference_table
 
 func TestAccWafDedicatedReferenceTableV1_basic(t *testing.T) {
 	var refTable rules.ReferenceTable
-	var name = fmt.Sprintf("wafd_rt_%s", acctest.RandString(5))
+	var name = fmt.Sprintf("wafd_rt.v1-%s", acctest.RandString(5))
 	updateName := name + "_update"
 
 	resource.Test(t, resource.TestCase{

--- a/opentelekomcloud/services/waf/resource_opentelekomcloud_waf_dedicated_reference_table_v1.go
+++ b/opentelekomcloud/services/waf/resource_opentelekomcloud_waf_dedicated_reference_table_v1.go
@@ -37,9 +37,9 @@ func ResourceWafReferenceTableV1() *schema.Resource {
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
-				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^(\w{1,64})$`),
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9\-_.]{1,64}$`),
 					"The name can contains of 1 to 64 characters."+
-						"Only letters, digits and underscores (_) are allowed."),
+						"Only digits, letters, hyphens (-), underscores (_), and periods (.) are allowed."),
 			},
 			"type": {
 				Type:     schema.TypeString,

--- a/releasenotes/notes/wafd_reference_regex-6f75c76cefcaecd2.yaml
+++ b/releasenotes/notes/wafd_reference_regex-6f75c76cefcaecd2.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  |
+  **[WAF]** Fix ``resource/opentelekomcloud_waf_dedicated_reference_table_v1`` name validation (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)

--- a/releasenotes/notes/wafd_reference_regex-6f75c76cefcaecd2.yaml
+++ b/releasenotes/notes/wafd_reference_regex-6f75c76cefcaecd2.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   |
-  **[WAF]** Fix ``resource/opentelekomcloud_waf_dedicated_reference_table_v1`` name validation (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+  **[WAF]** Fix ``resource/opentelekomcloud_waf_dedicated_reference_table_v1`` name validation (`#2468 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2468>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Fix name regex for `opentelekomcloud_waf_dedicated_reference_table_v1` resource.

## PR Checklist

* [x] Refers to: #2465
* [x] Tests added/passed.
* [ ] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccWafDedicatedReferenceTableV1_basic
--- PASS: TestAccWafDedicatedReferenceTableV1_basic (44.26s)
PASS

Process finished with the exit code 0
```
