### PR TITLE
[RDS]: fix Read and remove redundant type validation

### DIFF
--- a/docs/resources/rds_instance_v3.md
+++ b/docs/resources/rds_instance_v3.md
@@ -340,6 +340,7 @@ The following arguments are supported:
 
 * `ha_replication_mode` - (Optional, ForceNew) Specifies the replication mode for the standby DB instance. For MySQL, the value
   is async or semisync. For PostgreSQL, the value is async or sync. For Microsoft SQL Server, the value is sync.
+  Parameter is required for HA clusters.
 
 -> Async indicates the asynchronous replication mode. `semisync` indicates the
   semi-synchronous replication mode. sync indicates the synchronous

--- a/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
+++ b/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
@@ -258,23 +258,6 @@ func TestAccRdsInstanceV3TemplateConfig(t *testing.T) {
 	})
 }
 
-func TestAccRdsInstanceV3InvalidDBVersion(t *testing.T) {
-	postfix := acctest.RandString(3)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { common.TestAccPreCheck(t) },
-		ProviderFactories: common.TestAccProviderFactories,
-		CheckDestroy:      testAccCheckRdsInstanceV3Destroy,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccRdsInstanceV3InvalidDBVersion(postfix),
-				PlanOnly:    true,
-				ExpectError: regexp.MustCompile(`can't find version.+`),
-			},
-		},
-	})
-}
-
 func TestAccRdsInstanceV3InvalidFlavor(t *testing.T) {
 	postfix := acctest.RandString(3)
 
@@ -758,32 +741,6 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
   }
   flavor         = "rds.pg.c2.large"
   param_group_id = opentelekomcloud_rds_parametergroup_v3.pg2.id
-}
-`, common.DataSourceSecGroupDefault, common.DataSourceSubnet, postfix, env.OS_AVAILABILITY_ZONE)
-}
-
-func testAccRdsInstanceV3InvalidDBVersion(postfix string) string {
-	return fmt.Sprintf(`
-%s
-%s
-
-resource "opentelekomcloud_rds_instance_v3" "instance" {
-  name              = "tf_rds_instance_%s"
-  availability_zone = ["%s"]
-  db {
-    password = "Postgres!12052"
-    type     = "PostgreSQL"
-    version  = "5.6"
-    port     = "8635"
-  }
-  security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
-  subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
-  vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
-  volume {
-    type = "ULTRAHIGH"
-    size = 40
-  }
-  flavor = "rds.pg.c2.large"
 }
 `, common.DataSourceSecGroupDefault, common.DataSourceSubnet, postfix, env.OS_AVAILABILITY_ZONE)
 }

--- a/opentelekomcloud/services/rds/common.go
+++ b/opentelekomcloud/services/rds/common.go
@@ -3,6 +3,7 @@ package rds
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/jmespath/go-jmespath"
 	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
@@ -73,4 +74,15 @@ func handleMultiOperationsError(err error) (bool, error) {
 	}
 	// Operation execution failed due to some resource or server issues, no need to try again.
 	return false, err
+}
+
+func checkMinorVersion(dbInfo map[string]interface{}) bool {
+	// returns true if version is not minor
+	version, ok := dbInfo["version"].(string)
+	if !ok {
+		return true
+	}
+	parts := strings.SplitN(version, ".", 3)
+
+	return len(parts) <= 2
 }

--- a/releasenotes/notes/rds_swiss_fix-32b03c5b5b63a7b6.yaml
+++ b/releasenotes/notes/rds_swiss_fix-32b03c5b5b63a7b6.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    **[RDS]** Fix ``resource/opentelekomcloud_rds_instance_v3`` Read and version check (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+

--- a/releasenotes/notes/rds_swiss_fix-32b03c5b5b63a7b6.yaml
+++ b/releasenotes/notes/rds_swiss_fix-32b03c5b5b63a7b6.yaml
@@ -1,5 +1,5 @@
 ---
 fixes:
   - |
-    **[RDS]** Fix ``resource/opentelekomcloud_rds_instance_v3`` Read and version check (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[RDS]** Fix ``resource/opentelekomcloud_rds_instance_v3`` Read and version check (`#2474 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2474>`_)
 


### PR DESCRIPTION
## Summary of the Pull Request
Fixes for Swisscloud

## PR Checklist

* [x] Refers to: #2472
* [x] Tests passed.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccRdsInstanceV3Basic
--- PASS: TestAccRdsInstanceV3Basic (807.59s)
=== RUN   TestAccRdsPostgre13V3ParamsBasic
--- PASS: TestAccRdsPostgre13V3ParamsBasic (624.13s)
=== RUN   TestAccRdsInstanceV3ElasticIP
--- PASS: TestAccRdsInstanceV3ElasticIP (791.25s)
=== RUN   TestAccRdsInstanceV3HA
--- PASS: TestAccRdsInstanceV3HA (398.02s)
=== RUN   TestAccRdsInstanceV3OptionalParams
--- PASS: TestAccRdsInstanceV3OptionalParams (385.16s)
=== RUN   TestAccRdsInstanceV3Backup
--- PASS: TestAccRdsInstanceV3Backup (362.20s)
=== RUN   TestAccRdsInstanceV3TemplateConfig
--- PASS: TestAccRdsInstanceV3TemplateConfig (477.68s)
=== RUN   TestAccRdsInstanceV3InvalidFlavor
--- PASS: TestAccRdsInstanceV3InvalidFlavor (8.04s)
=== RUN   TestAccRdsInstanceV3_configurationParameters
--- PASS: TestAccRdsInstanceV3_configurationParameters (492.22s)
=== RUN   TestAccRdsInstanceV3TimeZoneAndSSL
--- PASS: TestAccRdsInstanceV3TimeZoneAndSSL (422.67s)
=== RUN   TestAccRdsInstanceV3AutoScaling
--- PASS: TestAccRdsInstanceV3AutoScaling (545.50s)
=== RUN   TestAccRdsInstanceV3RestoreToPITR
--- PASS: TestAccRdsInstanceV3RestoreToPITR (709.78s)
=== RUN   TestAccRdsInstanceV3_SSLEnable
--- PASS: TestAccRdsInstanceV3_SSLEnable (450.82s)
PASS

Process finished with the exit code 0
```
