### PR TITLE
[WAFD]: timeout settings for domain

### DIFF
--- a/docs/resources/waf_dedicated_domain_v1.md
+++ b/docs/resources/waf_dedicated_domain_v1.md
@@ -32,6 +32,12 @@ resource "opentelekomcloud_waf_dedicated_domain_v1" "domain_1" {
     type            = "ipv4"
     vpc_id          = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
   }
+
+  timeout_config {
+    connect_timeout = 150
+    read_timeout    = 200
+    send_timeout    = 100
+  }
 }
 ```
 
@@ -160,6 +166,16 @@ The following arguments are supported:
 
   -> **NOTE:** Tls must be set to `TLS v1.2`, and cipher must be set to `cipher_2`.
 
+* `timeout_config` - (Optional, List) Specifies the timeout configuration.
+  The `timeout_config` structure is documented below.
+
+The `timeout_config` block supports:
+
+* `connect_timeout` - (Optional, Int) Specifies the timeout in seconds for WAF to connect to the origin server.
+
+* `read_timeout` - (Optional, Int) Specifies the timeout in seconds for WAF to receive responses from the origin server.
+
+* `write_timeout` - (Optional, Int) Specifies the timeout in seconds for WAF to send requests to the origin server.
 
 ## Attributes Reference
 

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.9.1-0.20240313140551-3f39e43bf104
+	github.com/opentelekomcloud/gophertelekomcloud v0.9.3-0.20240411163416-797d7983ad21
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.17.0
 	golang.org/x/sync v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -156,8 +156,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k+Mg7cowZ8yv4Trqw9UsJby758=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.1-0.20240313140551-3f39e43bf104 h1:HePUjJe/F1ksMx7UE74oNPTa8dp9zAs9+CUZE5DZnhk=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.1-0.20240313140551-3f39e43bf104/go.mod h1:M1F6OfSRZRzAmAFKQqSLClX952at5hx5rHe4UTEykgg=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.3-0.20240411163416-797d7983ad21 h1:zWs3Hs8y3Q9+k9B1u99fOT2Tf8xuTQiVWjNsQ65ye1E=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.3-0.20240411163416-797d7983ad21/go.mod h1:M1F6OfSRZRzAmAFKQqSLClX952at5hx5rHe4UTEykgg=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/releasenotes/notes/wafd_domain_timeout-96024ce3368eafd6.yaml
+++ b/releasenotes/notes/wafd_domain_timeout-96024ce3368eafd6.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  |
+  **[WAF]** Add `timeout_config` setting for ``resource/opentelekomcloud_waf_dedicated_domain_v1`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)

--- a/releasenotes/notes/wafd_domain_timeout-96024ce3368eafd6.yaml
+++ b/releasenotes/notes/wafd_domain_timeout-96024ce3368eafd6.yaml
@@ -1,4 +1,4 @@
 ---
 enhancements:
   |
-  **[WAF]** Add `timeout_config` setting for ``resource/opentelekomcloud_waf_dedicated_domain_v1`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+  **[WAF]** Add `timeout_config` setting for ``resource/opentelekomcloud_waf_dedicated_domain_v1`` (`#2483 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2483>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Added timeout settings for `opentelekomcloud_waf_dedicated_domain_v1`.

## PR Checklist

* [x] Refers to: #2480
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccWafDedicatedDomainV1_timeoutConfig
2024/04/12 11:12:39 [DEBUG] The opentelekomcloud Waf dedicated instance test running in 'eu-de' region.
--- PASS: TestAccWafDedicatedDomainV1_timeoutConfig (90.20s)
PASS

Process finished with the exit code 0

=== RUN   TestAccWafDedicatedDomainV1_basic
2024/04/12 11:14:26 [DEBUG] The opentelekomcloud Waf dedicated instance test running in 'eu-de' region.
--- PASS: TestAccWafDedicatedDomainV1_basic (133.43s)
PASS

Process finished with the exit code 0
```
