### PR TITLE
[FGS]: function graph resource

### DIFF
--- a/docs/resources/fgs_function_v2.md
+++ b/docs/resources/fgs_function_v2.md
@@ -1,0 +1,394 @@
+---
+subcategory: "FunctionGraph"
+---
+
+Up-to-date reference of API arguments for FGS you can get at
+`https://docs.otc.t-systems.com/function-graph/api-ref/apis/index.html`.
+
+# opentelekomcloud_fgs_function_v2
+
+Manages a V2 function graph resource within OpenTelekomCloud.
+
+## Example Usage
+
+### With base64 func code
+
+```hcl
+variable "function_name" {}
+variable "function_codes" {}
+variable "agency_name" {}
+
+resource "opentelekomcloud_fgs_function_v2" "test" {
+  name        = var.function_name
+  app         = "default"
+  agency      = var.agency_name
+  description = "fuction test"
+  handler     = "test.handler"
+  memory_size = 128
+  timeout     = 3
+  runtime     = "Python2.7"
+  code_type   = "inline"
+  func_code   = base64encode(var.function_codes)
+}
+```
+
+### With text code
+
+```hcl
+variable "function_name" {}
+variable "agency_name" {}
+
+resource "opentelekomcloud_fgs_function_v2" "test" {
+  name        = var.function_name
+  app         = "default"
+  agency      = var.agency_name
+  handler     = "test.handler"
+  memory_size = 128
+  timeout     = 3
+  runtime     = "Python2.7"
+  code_type   = "inline"
+  func_code   = <<EOF
+# -*- coding:utf-8 -*-
+import json
+def handler (event, context):
+    return {
+        "statusCode": 200,
+        "isBase64Encoded": False,
+        "body": json.dumps(event),
+        "headers": {
+            "Content-Type": "application/json"
+        }
+    }
+EOF
+}
+```
+
+### Create function using SWR image
+
+```hcl
+variable "function_name" {}
+variable "agency_name" {} // The agent name that authorizes FunctionGraph service SWR administrator privilege
+variable "image_url" {}
+
+resource "opentelekomcloud_fgs_function_v2" "by_swr_image" {
+  name        = var.function_name
+  agency      = var.agency_name
+  handler     = "-"
+  app         = "default"
+  runtime     = "Custom Image"
+  memory_size = 128
+  timeout     = 3
+
+  custom_image {
+    url = var.image_url
+  }
+}
+```
+
+### Create function with an alias for latest version
+
+```hcl
+variable "function_name" {}
+variable "function_codes" {}
+
+resource "opentelekomcloud_fgs_function_v2" "with_alias" {
+  name        = var.function_name
+  app         = "default"
+  handler     = "test.handler"
+  memory_size = 128
+  timeout     = 3
+  runtime     = "Python2.7"
+  code_type   = "inline"
+  func_code   = base64encode(var.function_codes)
+
+  versions {
+    name = "latest"
+
+    aliases {
+      name = "demo"
+    }
+  }
+}
+```
+
+### Create function with log group and stream
+
+```hcl
+variable "function_name" {}
+variable "function_codes" {}
+variable "log_group_id" {}
+variable "log_topic_id" {}
+variable "log_group_name" {}
+variable "log_topic_name" {}
+
+resource "opentelekomcloud_fgs_function_v2" "test" {
+  name        = var.function_name
+  app         = "default"
+  agency      = "test"
+  description = "fuction test"
+  handler     = "test.handler"
+  memory_size = 128
+  timeout     = 3
+  runtime     = "Python2.7"
+  code_type   = "inline"
+  func_code   = base64encode(var.function_codes)
+
+  log_group_id   = var.log_group_id
+  log_topic_id   = var.log_topic_id
+  log_group_name = var.log_group_name
+  log_topic_name = var.log_topic_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required, String, ForceNew) Specifies the name of the function.
+  Changing this will create a new resource.
+
+* `app` - (Required, String) Specifies the group to which the function belongs.
+
+* `memory_size` - (Required, Int) Specifies the memory size allocated to the function, in MByte (MB).
+
+* `runtime` - (Required, String, ForceNew) Specifies the environment for executing the function.
+  The valid values are as follows:
+    + **Java8**
+    + **Java11**
+    + **Node.js6.10**
+    + **Node.js8.10**
+    + **Node.js10.16**
+    + **Node.js12.13**
+    + **Node.js14.18**
+    + **Python2.7**
+    + **Python3.6**
+    + **Python3.9**
+    + **Go1.8**
+    + **Go1.x**
+    + **C#(.NET Core 2.0)**
+    + **C#(.NET Core 2.1)**
+    + **C#(.NET Core 3.1)**
+    + **PHP7.3**
+    + **Custom**
+    + **http**
+
+* `timeout` - (Required, Int) Specifies the timeout interval of the function, in seconds.
+  The value ranges from `3` to `900`.
+
+* `code_type` - (Optional, String) Specifies the function code type, which can be:
+    + **inline**: inline code.
+    + **zip**: ZIP file.
+    + **jar**: JAR file or java functions.
+    + **obs**: function code stored in an OBS bucket.
+    + **Custom-Image-Swr**: function code comes from the SWR custom image.
+
+* `handler` - (Required, String) Specifies the entry point of the function.
+
+* `functiongraph_version` - (Optional, String, ForceNew) Specifies the FunctionGraph version, default value is **v2**.
+  The valid values are as follows:
+    + **v1**
+    + **v2**
+
+* `func_code` - (Optional, String) Specifies the function code.
+  The code value can be encoded using **Base64** or just with the text code.
+  Required if the `code_type` is set to **inline**, **zip**, or **jar**.
+
+* `code_url` - (Optional, String) Specifies the code url.
+  Required if the `code_type` is set to **obs**.
+
+* `code_filename` - (Optional, String) Specifies the name of a function file.
+  Required if the `code_type` is set to **jar** or **zip**.
+
+* `depend_list` - (Optional, List) Specifies the ID list of the dependencies.
+
+* `user_data` - (Optional, String) Specifies the Key/Value information defined for the function.
+
+* `encrypted_user_data` - (Optional, String) Specifies the key/value information defined to be encrypted for the
+  function.
+
+* `agency` - (Optional, String) Specifies the agency. This parameter is mandatory if the function needs to access other
+  cloud services.
+
+* `app_agency` - (Optional, String) Specifies the execution agency enables you to obtain a token or an AK/SK for
+  accessing other cloud services.
+
+* `description` - (Optional, String) Specifies the description of the function.
+
+* `initializer_handler` - (Optional, String) Specifies the initializer of the function.
+
+* `initializer_timeout` - (Optional, Int) Specifies the maximum duration the function can be initialized. Value range:
+  1s to 300s.
+
+* `vpc_id` - (Optional, String) Specifies the ID of VPC.
+
+* `network_id` - (Optional, String) Specifies the network ID of subnet.
+
+* `mount_user_id` - (Optional, Int) Specifies the user ID, a non-0 integer from `–1` to `65,534`.
+  Defaults to `-1`.
+
+* `mount_user_group_id` - (Optional, Int) Specifies the user group ID, a non-0 integer from `–1` to `65,534`.
+  Defaults to `-1`.
+
+* `func_mounts` - (Optional, List) Specifies the file system list. The `func_mounts` object structure is documented
+  below.
+
+* `custom_image` - (Optional, List) Specifies the custom image configuration for creating function.
+  The `custom_image` structure is documented below.
+
+* `max_instance_num` - (Optional, String) Specifies the maximum number of instances of the function.
+  The valid value ranges from `-1` to `1,000`, defaults to `400`.
+    + The minimum value is `-1` and means the number of instances is unlimited.
+    + `0` means this function is disabled.
+    + The empty value means to keep the default (latest updated) value.
+
+  -> This parameter is only supported by the `v2` version of the function.
+
+* `versions` - (Optional, List) Specifies the versions management of the function.
+  The `versions` structure is documented below.
+
+* `tags` - (Optional, Map) Specifies the key/value pairs to associate with the function.
+
+* `log_group_id` - (Optional, String) Specifies the ID of the LTS log group.
+
+* `log_group_name` - (Optional, String) Specifies the name of the LTS log group.
+
+* `log_topic_id` - (Optional, String) Specifies the ID of the LTS log stream.
+
+* `log_topic_name` - (Optional, String) Specifies the name of the LTS stream.
+
+* `reserved_instances` - (Optional, List) Specifies the reserved instance policies of the function.
+  The `reserved_instances` structure is documented below.
+
+* `gpu_memory` - (Optional, Int) Specifies the GPU memory size allocated to the function, in MByte (MB).
+  The valid value ranges form `1,024` to `16,384`, the value must be a multiple of `1,024`.
+  If not specified, the GPU function is disabled.
+
+The `func_mounts` block supports:
+
+* `mount_type` - (Required, String) Specifies the mount type.
+    + **sfs**
+    + **sfsTurbo**
+    + **ecs**
+
+* `mount_resource` - (Required, String) Specifies the ID of the mounted resource (corresponding cloud service).
+
+* `mount_share_path` - (Required, String) Specifies the remote mount path. Example: 192.168.0.12:/data.
+
+* `local_mount_path` - (Required, String) Specifies the function access path.
+
+* `concurrency_num` - (Optional, Int) Specifies the number of concurrent requests of the function.
+  The valid value ranges from `1` to `1,000`, the default value is `1`.
+
+  -> This parameter is only supported by the `v2` version of the function.
+
+The `custom_image` block supports:
+
+* `url` - (Required, String) Specifies the URL of SWR image, the URL must start with `swr.`.
+
+The `versions` block supports:
+
+* `name` - (Required, String) Specifies the version name.
+
+  -> Currently, only supports the management of the default version (**latest**).
+
+* `aliases` - (Optional, List) Specifies the aliases management for specified version.
+  The `aliases` structure is documented below.
+
+The `aliases` block supports:
+
+* `name` - (Required, String) Specifies the name of the version alias.
+
+* `description` - (Optional, String) Specifies the description of the version alias.
+
+The `reserved_instances` block supports:
+
+* `qualifier_type` - (Required, String) Specifies qualifier type of reserved instance. The valid values are as follows:
+    + **version**
+    + **alias**
+
+  -> Reserved instances cannot be configured for both a function alias and the corresponding version. For example,
+  if the alias of the `latest` version is `1.0` and reserved instances have been configured for this version,
+  no more instances can be configured for alias `1.0`.
+
+* `qualifier_name` - (Required, String) Specifies the version name or alias name.
+
+* `count` - (Required, Int) Specifies the number of reserved instance.
+  The valid value ranges from `0` to `1,000`.
+  If this parameter is set to `0`, the reserved instance will not run.
+
+* `idle_mode` - (Optional, Bool) Specifies whether to enable the idle mode. The default value is `false`.
+  If this parameter is enabled, reserved instances are initialized and the mode change needs some time to take effect.
+  You will still be billed at the price of reserved instances for non-idle mode in this period.
+
+* `tactics_config` - (Optional, List) Specifies the auto scaling policies for reserved instance.
+  The `tactics_config` structure is documented below.
+
+The `tactics_config` block supports:
+
+* `cron_configs` - (Optional, List) Specifies the list of scheduled policy configurations.
+  The `cron_configs` structure is documented below.
+
+The `cron_configs` block supports:
+
+* `name` - (Required, String) Specifies the name of scheduled policy configuration.
+  The valid length is limited from `1` to `60` characters, only letters, digits, hyphens (-), and underscores (_) are allowed.
+  The name must start with a letter and ending with a letter or digit.
+
+* `cron` - (Required, String) Specifies the cron expression.
+
+* `count` - (Required, Int) Specifies the number of reserved instance to which the policy belongs.
+  The valid value ranges from `0` to `1,000`.
+
+  -> The number of reserved instances must be greater than or equal to the number of reserved instances in the basic configuration.
+
+* `start_time` - (Required, Int) Specifies the effective timestamp of policy. The unit is `s`, e.g. **1740560074**.
+
+* `expired_time` - (Required, Int) Specifies the expiration timestamp of the policy. The unit is `s`, e.g. **1740560074**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, consist of `urn` and current `version`, the format is `<urn>:<version>`.
+
+* `region` - (Optional, String, ForceNew) The region in which Function resource is create.
+
+* `func_mounts/status` - The status of file system.
+
+* `urn` - Uniform Resource Name.
+
+* `dns_list` - The private DNS configuration of the function network.
+
+* `version` - The version of the function.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
+
+## Import
+
+Functions can be imported using the `id`, e.g.
+
+```bash
+$ terraform import opentelekomcloud_fgs_function_v2.test <id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to the attribute missing from the
+API response. The missing attributes are:
+`app`, `func_code`, `agency`, `tags"`.
+It is generally recommended running `terraform plan` after importing a function.
+You can then decide if changes should be applied to the function, or the resource definition should be updated to align
+with the function. Also you can ignore changes as below.
+
+```hcl
+resource "opentelekomcloud_fgs_function_v2" "test" {
+  lifecycle {
+    ignore_changes = [
+      app, func_code, agency, tags,
+    ]
+  }
+}
+```

--- a/go.mod
+++ b/go.mod
@@ -16,9 +16,9 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.9.3-0.20240423100516-9b4876d6c8d4
+	github.com/opentelekomcloud/gophertelekomcloud v0.9.3
 	github.com/unknwon/com v1.0.1
-	golang.org/x/crypto v0.17.0
+	golang.org/x/crypto v0.18.0
 	golang.org/x/sync v0.1.0
 	gopkg.in/yaml.v2 v2.4.0
 )
@@ -61,7 +61,7 @@ require (
 	github.com/vmihailenco/tagparser v0.1.1 // indirect
 	github.com/zclconf/go-cty v1.12.1 // indirect
 	golang.org/x/net v0.17.0 // indirect
-	golang.org/x/sys v0.15.0 // indirect
+	golang.org/x/sys v0.16.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.9.3-0.20240411163416-797d7983ad21
+	github.com/opentelekomcloud/gophertelekomcloud v0.9.3-0.20240422103354-2cb9c8fa81d9
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.17.0
 	golang.org/x/sync v0.1.0

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.9.3-0.20240422103354-2cb9c8fa81d9
+	github.com/opentelekomcloud/gophertelekomcloud v0.9.3-0.20240423100516-9b4876d6c8d4
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.17.0
 	golang.org/x/sync v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -156,8 +156,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k+Mg7cowZ8yv4Trqw9UsJby758=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.3-0.20240423100516-9b4876d6c8d4 h1:SfBa9bbEjMFEFdVkQpLhI2ZOzSHzlqKDbxXvXVFZ0xI=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.3-0.20240423100516-9b4876d6c8d4/go.mod h1:M1F6OfSRZRzAmAFKQqSLClX952at5hx5rHe4UTEykgg=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.3 h1:zdttgRAWc4uHgJ3PX5hP8ulhT1VYBh2JeRsItNPp8dg=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.3/go.mod h1:M1F6OfSRZRzAmAFKQqSLClX952at5hx5rHe4UTEykgg=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -209,8 +209,8 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/crypto v0.17.0 h1:r8bRNjWL3GshPW3gkd+RpvzWrZAwPS49OmTGZ/uhM4k=
-golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
+golang.org/x/crypto v0.18.0 h1:PGVlW0xEltQnzFZ55hkuX5+KLyrMYhHld1YHO4AKcdc=
+golang.org/x/crypto v0.18.0/go.mod h1:R0j02AL6hcrfOiy9T4ZYp/rcWeMxM3L6QYxlOuEG1mg=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180811021610-c39426892332/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -246,10 +246,10 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
-golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.16.0 h1:xWw16ngr6ZMtmxDyKyIgsE93KNKz5HKmMa3b8ALHidU=
+golang.org/x/sys v0.16.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
-golang.org/x/term v0.15.0 h1:y/Oo/a/q3IXu26lQgl04j/gjuBDOBlx7X6Om1j2CPW4=
+golang.org/x/term v0.16.0 h1:m+B6fahuftsE9qjo0VWp2FW0mB3MTJvR0BaMQrq0pmE=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/go.sum
+++ b/go.sum
@@ -156,8 +156,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k+Mg7cowZ8yv4Trqw9UsJby758=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.3-0.20240411163416-797d7983ad21 h1:zWs3Hs8y3Q9+k9B1u99fOT2Tf8xuTQiVWjNsQ65ye1E=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.3-0.20240411163416-797d7983ad21/go.mod h1:M1F6OfSRZRzAmAFKQqSLClX952at5hx5rHe4UTEykgg=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.3-0.20240422103354-2cb9c8fa81d9 h1:kow5HMvxfO8y1FD+6XldYo3kZBSTkSawLYPT4tE2uCM=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.3-0.20240422103354-2cb9c8fa81d9/go.mod h1:M1F6OfSRZRzAmAFKQqSLClX952at5hx5rHe4UTEykgg=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/go.sum
+++ b/go.sum
@@ -156,8 +156,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k+Mg7cowZ8yv4Trqw9UsJby758=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.3-0.20240422103354-2cb9c8fa81d9 h1:kow5HMvxfO8y1FD+6XldYo3kZBSTkSawLYPT4tE2uCM=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.3-0.20240422103354-2cb9c8fa81d9/go.mod h1:M1F6OfSRZRzAmAFKQqSLClX952at5hx5rHe4UTEykgg=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.3-0.20240423100516-9b4876d6c8d4 h1:SfBa9bbEjMFEFdVkQpLhI2ZOzSHzlqKDbxXvXVFZ0xI=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.3-0.20240423100516-9b4876d6c8d4/go.mod h1:M1F6OfSRZRzAmAFKQqSLClX952at5hx5rHe4UTEykgg=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/opentelekomcloud/acceptance/common/common.go
+++ b/opentelekomcloud/acceptance/common/common.go
@@ -38,6 +38,8 @@ provider opentelekomcloud {
 }
 `, altCloud, altProjectID, altProjectName)
 	AlternativeProviderWithRegionConfig string
+	OTC_BUILD_IMAGE_URL                 = os.Getenv("OTC_BUILD_IMAGE_URL")
+	OTC_BUILD_IMAGE_URL_UPDATED         = os.Getenv("OTC_BUILD_IMAGE_URL_UPDATED")
 )
 
 func init() {
@@ -145,4 +147,16 @@ func TestAccPreCheckServiceAvailability(t *testing.T, service string, regions []
 
 	t.Skipf("Service %s not available or configuration differs in %s", service, env.OS_REGION_NAME)
 	return nil
+}
+
+func TestAccPreCheckComponentDeployment(t *testing.T) {
+	if OTC_BUILD_IMAGE_URL == "" {
+		t.Skip("SWR image URL configuration is not completed for acceptance test of component deployment.")
+	}
+}
+
+func TestAccPreCheckImageUrlUpdated(t *testing.T) {
+	if OTC_BUILD_IMAGE_URL_UPDATED == "" {
+		t.Skip("SWR image update URL configuration is not completed for acceptance test of component deployment.")
+	}
 }

--- a/opentelekomcloud/acceptance/fgs/resource_opentelekomcloud_fgs_function_v2_test.go
+++ b/opentelekomcloud/acceptance/fgs/resource_opentelekomcloud_fgs_function_v2_test.go
@@ -1,1 +1,1019 @@
 package fgs
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/fgs/v2/function"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+)
+
+func getResourceObj(conf *cfg.Config, state *terraform.ResourceState) (interface{}, error) {
+	c, err := conf.FuncGraphV2Client(env.OS_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating OpenTelekomCloud FunctionGraph client: %s", err)
+	}
+	return function.GetMetadata(c, state.Primary.ID)
+}
+
+func TestAccFgsV2Function_basic(t *testing.T) {
+	var (
+		f               function.FuncGraph
+		randName        = fmt.Sprintf("fgs-acc-api%s", acctest.RandString(5))
+		obsObjectConfig = zipFileUploadResourcesConfig()
+		resourceName    = "opentelekomcloud_fgs_function_v2.test"
+	)
+
+	rc := common.InitResourceCheck(
+		resourceName,
+		&f,
+		getResourceObj,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFgsV2Function_basic_step1(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(resourceName, "functiongraph_version", regexp.MustCompile(`v1|v2`)),
+					resource.TestCheckResourceAttr(resourceName, "description", "function test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
+					resource.TestCheckResourceAttrSet(resourceName, "urn"),
+					resource.TestCheckResourceAttrSet(resourceName, "version"),
+					resource.TestCheckResourceAttr(resourceName, "code_type", "inline"),
+				),
+			},
+			{
+				Config: testAccFgsV2Function_basic_step2(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "description", "function test update"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "baar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.newkey", "value"),
+					resource.TestCheckResourceAttrSet(resourceName, "urn"),
+					resource.TestCheckResourceAttrSet(resourceName, "version"),
+				),
+			},
+			{
+				Config: testAccFgsV2Function_basic_step3(randName, obsObjectConfig),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "code_type", "obs"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"app",
+					"func_code",
+					"agency",
+					"tags",
+				},
+			},
+		},
+	})
+}
+
+func TestAccFgsV2Function_text(t *testing.T) {
+	var f function.FuncGraph
+	randName := fmt.Sprintf("fgs-acc-%s", acctest.RandString(5))
+	resourceName := "opentelekomcloud_fgs_function_v2.test"
+
+	rc := common.InitResourceCheck(
+		resourceName,
+		&f,
+		getResourceObj,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFgsV2Function_text(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"app",
+					"func_code",
+				},
+			},
+		},
+	})
+}
+
+func TestAccFgsV2Function_createByImage(t *testing.T) {
+	var f function.FuncGraph
+	randName := fmt.Sprintf("fgs-acc-%s", acctest.RandString(5))
+	rName1 := "opentelekomcloud_fgs_function_v2.create_with_vpc_access"
+	rName2 := "opentelekomcloud_fgs_function_v2.create_without_vpc_access"
+
+	rc1 := common.InitResourceCheck(
+		rName1,
+		&f,
+		getResourceObj,
+	)
+
+	rc2 := common.InitResourceCheck(
+		rName2,
+		&f,
+		getResourceObj,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+			common.TestAccPreCheckComponentDeployment(t)
+			common.TestAccPreCheckImageUrlUpdated(t)
+		},
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      rc1.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFgsV2Function_createByImage_step_1(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc1.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName1, "name", randName+"_1"),
+					resource.TestCheckResourceAttr(rName1, "agency", "functiongraph_swr_trust"),
+					resource.TestCheckResourceAttr(rName1, "runtime", "Custom Image"),
+					resource.TestCheckResourceAttr(rName1, "handler", "-"),
+					resource.TestCheckResourceAttr(rName1, "custom_image.0.url", common.OTC_BUILD_IMAGE_URL),
+					rc2.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName2, "name", randName+"_2"),
+					resource.TestCheckResourceAttr(rName2, "agency", "functiongraph_swr_trust"),
+					resource.TestCheckResourceAttr(rName2, "runtime", "Custom Image"),
+					resource.TestCheckResourceAttr(rName2, "handler", "-"),
+					resource.TestCheckResourceAttr(rName2, "custom_image.0.url", common.OTC_BUILD_IMAGE_URL),
+					resource.TestCheckResourceAttr(rName2, "vpc_id", ""),
+					resource.TestCheckResourceAttr(rName2, "network_id", ""),
+				),
+			},
+			{
+				Config: testAccFgsV2Function_createByImage_step_2(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc1.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName1, "handler", "index.py"),
+					resource.TestCheckResourceAttr(rName1, "vpc_id", ""),
+					resource.TestCheckResourceAttr(rName1, "network_id", ""),
+					resource.TestCheckResourceAttr(rName1, "custom_image.0.url", common.OTC_BUILD_IMAGE_URL_UPDATED),
+					rc2.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName2, "handler", "-"),
+					resource.TestCheckResourceAttr(rName2, "custom_image.0.url", common.OTC_BUILD_IMAGE_URL_UPDATED),
+				),
+			},
+			{
+				ResourceName:      rName1,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"app",
+					"xrole",
+					"agency",
+				},
+			},
+			{
+				ResourceName:      rName2,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"app",
+					"xrole",
+					"agency",
+				},
+			},
+		},
+	})
+}
+
+func TestAccFgsV2Function_logConfig(t *testing.T) {
+	var f function.FuncGraph
+	randName := fmt.Sprintf("fgs-acc-%s", acctest.RandString(5))
+	resourceName := "opentelekomcloud_fgs_function_v2.test"
+
+	rc := common.InitResourceCheck(
+		resourceName,
+		&f,
+		getResourceObj,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFgsV2Function_logConfig(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "functiongraph_version", "v2"),
+					resource.TestCheckResourceAttrSet(resourceName, "log_group_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "log_topic_id"),
+				),
+			},
+			{
+				Config: testAccFgsV2Function_logConfigUpdate(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "functiongraph_version", "v2"),
+					resource.TestCheckResourceAttrSet(resourceName, "log_group_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "log_topic_id"),
+				),
+			},
+		},
+	})
+}
+
+func zipFileUploadResourcesConfig() string {
+	randName := fmt.Sprintf("fgs-acc-%s", acctest.RandString(5))
+
+	return fmt.Sprintf(`
+variable "script_content" {
+  type    = string
+  default = <<EOT
+def main():
+    print("Hello, World!")
+
+if __name__ == "__main__":
+    main()
+EOT
+}
+
+resource "opentelekomcloud_obs_bucket" "test" {
+  bucket = "%[1]s"
+  acl    = "private"
+
+  provisioner "local-exec" {
+    command = "echo '${var.script_content}' >> test.py\nzip -r test.zip test.py"
+  }
+  provisioner "local-exec" {
+    command = "rm test.zip test.py"
+    when    = destroy
+  }
+}
+
+resource "opentelekomcloud_obs_bucket_object" "test" {
+  bucket = opentelekomcloud_obs_bucket.test.bucket
+  key    = "test.zip"
+  source = abspath("./test.zip")
+}`, randName)
+}
+
+func testAccFgsV2Function_basic_step1(rName string) string {
+	//nolint:revive
+	return fmt.Sprintf(`
+resource "opentelekomcloud_fgs_function_v2" "test" {
+  name        = "%s"
+  app         = "default"
+  description = "function test"
+  handler     = "index.handler"
+  memory_size = 128
+  timeout     = 3
+  runtime     = "Python2.7"
+  code_type   = "inline"
+  func_code   = "aW1wb3J0IGpzb24KZGVmIGhhbmRsZXIgKGV2ZW50LCBjb250ZXh0KToKICAgIG91dHB1dCA9ICdIZWxsbyBtZXNzYWdlOiAnICsganNvbi5kdW1wcyhldmVudCkKICAgIHJldHVybiBvdXRwdXQ="
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, rName)
+}
+
+func testAccFgsV2Function_basic_step2(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "opentelekomcloud_fgs_function_v2" "test" {
+  name        = "%[2]s"
+  app         = "default"
+  description = "function test update"
+  handler     = "index.handler"
+  memory_size = 128
+  timeout     = 3
+  runtime     = "Python2.7"
+  code_type   = "inline"
+  func_code   = "aW1wb3J0IGpzb24KZGVmIGhhbmRsZXIgKGV2ZW50LCBjb250ZXh0KToKICAgIG91dHB1dCA9ICdIZWxsbyBtZXNzYWdlOiAnICsganNvbi5kdW1wcyhldmVudCkKICAgIHJldHVybiBvdXRwdXQ="
+  agency      = "function_vpc_trust"
+  vpc_id      = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  network_id  = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+
+  tags = {
+    foo    = "baar"
+    newkey = "value"
+  }
+}
+`, common.DataSourceSubnet, rName)
+}
+
+func testAccFgsV2Function_basic_step3(rName, obsConfig string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+%[2]s
+
+resource "opentelekomcloud_fgs_function_v2" "test" {
+  name        = "%[3]s"
+  app         = "default"
+  description = "fuction test update"
+  handler     = "index.handler"
+  memory_size = 128
+  timeout     = 3
+  runtime     = "Python2.7"
+  code_type   = "obs"
+  code_url    = format("https://%%s/%%s", opentelekomcloud_obs_bucket.test.bucket_domain_name, opentelekomcloud_obs_bucket_object.test.key)
+  agency      = "function_vpc_trust"
+  vpc_id      = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  network_id  = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+
+  tags = {
+    foo    = "baar"
+    newkey = "value"
+  }
+}
+`, common.DataSourceSubnet, obsConfig, rName)
+}
+
+func testAccFgsV2Function_text(rName string) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_fgs_function_v2" "test" {
+  name        = "%s"
+  app         = "default"
+  description = "fuction test"
+  handler     = "index.handler"
+  memory_size = 128
+  timeout     = 3
+  runtime     = "Python2.7"
+  code_type   = "inline"
+
+  func_code = <<EOF
+# -*- coding:utf-8 -*-
+import json
+def handler (event, context):
+    return {
+        "statusCode": 200,
+        "isBase64Encoded": False,
+        "body": json.dumps(event),
+        "headers": {
+            "Content-Type": "application/json"
+        }
+    }
+EOF
+}
+`, rName)
+}
+
+func testAccFgsV2Function_createByImage_step_1(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "opentelekomcloud_fgs_function_v2" "create_with_vpc_access" {
+  name        = "%[2]s_1"
+  app         = "default"
+  handler     = "index.py"
+  memory_size = 128
+  runtime     = "Custom Image"
+  timeout     = 3
+  agency      = "functiongraph_swr_trust"
+  code_type   = "Custom-Image-Swr"
+
+  custom_image {
+    url = "%[3]s"
+  }
+
+  vpc_id      = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  network_id  = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+}
+
+resource "opentelekomcloud_fgs_function_v2" "create_without_vpc_access" {
+  name        = "%[2]s_2"
+  app         = "default"
+  handler     = "index.py"
+  memory_size = 128
+  runtime     = "Custom Image"
+  timeout     = 3
+  agency      = "functiongraph_swr_trust"
+  code_type   = "Custom-Image-Swr"
+
+  custom_image {
+    url = "%[3]s"
+  }
+}
+`, common.DataSourceSubnet, rName, common.OTC_BUILD_IMAGE_URL)
+}
+
+func testAccFgsV2Function_createByImage_step_2(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+# Closs the VPC access
+resource "opentelekomcloud_fgs_function_v2" "create_with_vpc_access" {
+  name        = "%[2]s_1"
+  app         = "default"
+  handler     = "index.py"
+  memory_size = 128
+  runtime     = "Custom Image"
+  timeout     = 3
+  agency      = "functiongraph_swr_trust"
+  code_type   = "Custom-Image-Swr"
+
+  custom_image {
+    url = "%[3]s"
+  }
+}
+
+# Open the VPC access
+resource "opentelekomcloud_fgs_function_v2" "create_without_vpc_access" {
+  name        = "%[2]s_2"
+  app         = "default"
+  handler     = "index.py"
+  memory_size = 128
+  runtime     = "Custom Image"
+  timeout     = 3
+  agency      = "functiongraph_swr_trust"
+  code_type   = "Custom-Image-Swr"
+
+  custom_image {
+    url = "%[3]s"
+  }
+
+  vpc_id      = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  network_id  = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+}
+`, common.DataSourceSubnet, rName, common.OTC_BUILD_IMAGE_URL_UPDATED)
+}
+
+func TestAccFgsV2Function_strategy(t *testing.T) {
+	var (
+		f function.FuncGraph
+
+		name         = fmt.Sprintf("fgs-acc-%s", acctest.RandString(5))
+		resourceName = "opentelekomcloud_fgs_function_v2.test"
+	)
+
+	rc := common.InitResourceCheck(
+		resourceName,
+		&f,
+		getResourceObj,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFunction_strategy_default(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "max_instance_num", "400"),
+				),
+			},
+			{
+				Config: testAccFunction_strategy_defined(name, 1000),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "max_instance_num", "1000"),
+				),
+			},
+			// UpdateMaxInstances doesn't work when max_instance is set to 0
+			// Response: 400 "no param has changed"
+			// {
+			// 	Config: testAccFunction_strategy_defined(name, 0),
+			// 	Check: resource.ComposeTestCheckFunc(
+			// 		rc.CheckResourceExists(),
+			// 		resource.TestCheckResourceAttr(resourceName, "max_instance_num", "0"),
+			// 	),
+			// },
+			{
+				Config: testAccFunction_strategy_defined(name, -1),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "max_instance_num", "-1"),
+				),
+			},
+			{
+				Config: testAccFunction_strategy_default(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "max_instance_num", "-1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"app",
+					"func_code",
+				},
+			},
+		},
+	})
+}
+
+func testAccFunction_strategy_default(name string) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_fgs_function_v2" "test" {
+  functiongraph_version = "v2"
+  name                  = "%[1]s"
+  app                   = "default"
+  handler               = "index.handler"
+  memory_size           = 128
+  timeout               = 3
+  runtime               = "Python2.7"
+  code_type             = "inline"
+  func_code             = "dCA9ICdIZWxsbyBtZXNzYWdlOiAnICsganN="
+}
+`, name)
+}
+
+func testAccFunction_strategy_defined(name string, maxInstanceNum int) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_fgs_function_v2" "test" {
+  functiongraph_version = "v2"
+  name                  = "%[1]s"
+  app                   = "default"
+  handler               = "index.handler"
+  memory_size           = 128
+  timeout               = 3
+  runtime               = "Python2.7"
+  code_type             = "inline"
+  func_code             = "dCA9ICdIZWxsbyBtZXNzYWdlOiAnICsganN="
+  max_instance_num      = %[2]d
+}
+`, name, maxInstanceNum)
+}
+
+func TestAccFgsV2Function_versions(t *testing.T) {
+	var (
+		f function.FuncGraph
+
+		name         = fmt.Sprintf("fgs-acc-%s", acctest.RandString(5))
+		resourceName = "opentelekomcloud_fgs_function_v2.test"
+	)
+
+	rc := common.InitResourceCheck(
+		resourceName,
+		&f,
+		getResourceObj,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFunction_versions_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "versions.0.name", "latest"),
+				),
+			},
+			{
+				Config: testAccFunction_versions_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "versions.0.name", "latest"),
+					resource.TestCheckResourceAttr(resourceName, "versions.0.aliases.0.name", "demo"),
+					resource.TestCheckResourceAttr(resourceName, "versions.0.aliases.0.description",
+						"This is a description of the demo alias"),
+				),
+			},
+			{
+				Config: testAccFunction_versions_step3(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "versions.0.name", "latest"),
+					resource.TestCheckResourceAttr(resourceName, "versions.0.aliases.0.name", "demo_update"),
+					resource.TestCheckResourceAttr(resourceName, "versions.0.aliases.0.description", ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"app",
+					"func_code",
+				},
+			},
+		},
+	})
+}
+
+func testAccFunction_versions_step1(name string) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_fgs_function_v2" "test" {
+  functiongraph_version = "v2"
+  name                  = "%[1]s"
+  app                   = "default"
+  handler               = "index.handler"
+  memory_size           = 128
+  timeout               = 3
+  runtime               = "Python2.7"
+  code_type             = "inline"
+  func_code             = "dCA9ICdIZWxsbyBtZXNzYWdlOiAnICsganN="
+
+  // Test whether 'plan' and 'apply' commands will report an error when only the version number is filled in.
+  versions {
+    name = "latest"
+  }
+}
+`, name)
+}
+
+func testAccFunction_versions_step2(name string) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_fgs_function_v2" "test" {
+  functiongraph_version = "v2"
+  name                  = "%[1]s"
+  app                   = "default"
+  handler               = "index.handler"
+  memory_size           = 128
+  timeout               = 3
+  runtime               = "Python2.7"
+  code_type             = "inline"
+  func_code             = "dCA9ICdIZWxsbyBtZXNzYWdlOiAnICsganN="
+
+  versions {
+    name = "latest"
+
+    aliases {
+      name        = "demo"
+      description = "This is a description of the demo alias"
+    }
+  }
+}
+`, name)
+}
+
+func testAccFunction_versions_step3(name string) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_fgs_function_v2" "test" {
+  functiongraph_version = "v2"
+  name                  = "%[1]s"
+  app                   = "default"
+  handler               = "index.handler"
+  memory_size           = 128
+  timeout               = 3
+  runtime               = "Python2.7"
+  code_type             = "inline"
+  func_code             = "dCA9ICdIZWxsbyBtZXNzYWdlOiAnICsganN="
+
+  versions {
+    name = "latest"
+
+    aliases {
+      name = "demo_update"
+    }
+  }
+}
+`, name)
+}
+
+func testAccFgsV2Function_logConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_logtank_group_v2" "test" {
+  group_name  = "%[1]s"
+  ttl_in_days = 30
+}
+
+resource "opentelekomcloud_logtank_topic_v2" "test" {
+  group_id    = opentelekomcloud_logtank_group_v2.test.id
+  topic_name = "%[1]s"
+}
+
+resource "opentelekomcloud_fgs_function_v2" "test" {
+  name        = "%[1]s"
+  app         = "default"
+  description = "fuction test"
+  handler     = "index.handler"
+  memory_size = 128
+  timeout     = 3
+  runtime     = "Python2.7"
+  code_type   = "inline"
+  func_code   = "dCA9ICdIZWxsbyBtZXNzYWdlOiAnICsganN="
+
+  log_group_id    = opentelekomcloud_logtank_group_v2.test.id
+  log_topic_id   = opentelekomcloud_logtank_topic_v2.test.id
+  log_group_name  = opentelekomcloud_logtank_group_v2.test.group_name
+  log_topic_name = opentelekomcloud_logtank_topic_v2.test.topic_name
+}
+`, rName)
+}
+
+func testAccFgsV2Function_logConfigUpdate(rName string) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_logtank_group_v2" "test" {
+  group_name  = "%[1]s"
+  ttl_in_days = 30
+}
+
+resource "opentelekomcloud_logtank_topic_v2" "test" {
+  group_id    = opentelekomcloud_logtank_group_v2.test.id
+  topic_name = "%[1]s"
+}
+
+resource "opentelekomcloud_logtank_group_v2" "test1" {
+  group_name  = "%[1]s-new"
+  ttl_in_days = 30
+}
+
+resource "opentelekomcloud_logtank_topic_v2" "test1" {
+  group_id    = opentelekomcloud_logtank_group_v2.test1.id
+  topic_name = "%[1]s-new"
+}
+
+resource "opentelekomcloud_fgs_function_v2" "test" {
+  name        = "%[1]s"
+  app         = "default"
+  description = "fuction test"
+  handler     = "index.handler"
+  memory_size = 128
+  timeout     = 3
+  runtime     = "Python2.7"
+  code_type   = "inline"
+  func_code   = "dCA9ICdIZWxsbyBtZXNzYWdlOiAnICsganN="
+
+  log_group_id    = opentelekomcloud_logtank_group_v2.test1.id
+  log_topic_id   = opentelekomcloud_logtank_topic_v2.test1.id
+  log_group_name  = opentelekomcloud_logtank_group_v2.test1.group_name
+  log_topic_name = opentelekomcloud_logtank_topic_v2.test1.topic_name
+}
+`, rName)
+}
+
+func TestAccFgsV2Function_reservedInstance_version(t *testing.T) {
+	var (
+		f            function.FuncGraph
+		name         = fmt.Sprintf("fgs-acc-%s", acctest.RandString(5))
+		resourceName = "opentelekomcloud_fgs_function_v2.test"
+	)
+
+	rc := common.InitResourceCheck(
+		resourceName,
+		&f,
+		getResourceObj,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFgsV2Function_reservedInstance_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "reserved_instances.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "reserved_instances.0.qualifier_name", "latest"),
+					resource.TestCheckResourceAttr(resourceName, "reserved_instances.0.qualifier_type", "version"),
+					resource.TestCheckResourceAttr(resourceName, "reserved_instances.0.count", "1"),
+					resource.TestCheckResourceAttr(resourceName, "reserved_instances.0.idle_mode", "true"),
+					resource.TestCheckResourceAttr(resourceName, "reserved_instances.0.tactics_config.0.cron_configs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "reserved_instances.0.tactics_config.0.cron_configs.0.count", "2"),
+					resource.TestCheckResourceAttr(resourceName, "reserved_instances.0.tactics_config.0.cron_configs.0.cron", "0 */10 * * * ?"),
+					resource.TestCheckResourceAttrSet(resourceName, "reserved_instances.0.tactics_config.0.cron_configs.0.start_time"),
+					resource.TestCheckResourceAttrSet(resourceName, "reserved_instances.0.tactics_config.0.cron_configs.0.expired_time"),
+					resource.TestCheckResourceAttrSet(resourceName, "reserved_instances.0.tactics_config.0.cron_configs.0.name"),
+				),
+			},
+			{
+				Config: testAccFgsV2Function_reservedInstance_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "reserved_instances.0.count", "2"),
+					resource.TestCheckResourceAttr(resourceName, "reserved_instances.0.idle_mode", "false"),
+					resource.TestCheckResourceAttr(resourceName, "reserved_instances.0.tactics_config.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"app",
+					"func_code",
+					"tags",
+				},
+			},
+		},
+	})
+}
+
+func TestAccFgsV2Function_reservedInstance_alias(t *testing.T) {
+	var (
+		f               function.FuncGraph
+		name            = fmt.Sprintf("fgs-acc-%s", acctest.RandString(5))
+		updateAliasName = fmt.Sprintf("fgs-acc-%s-updated", acctest.RandString(5))
+		resourceName    = "opentelekomcloud_fgs_function_v2.test"
+	)
+
+	rc := common.InitResourceCheck(
+		resourceName,
+		&f,
+		getResourceObj,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFgsV2Function_reservedInstance_alias(name, name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "reserved_instances.0.qualifier_name", name),
+					resource.TestCheckResourceAttr(resourceName, "reserved_instances.0.qualifier_type", "alias"),
+					resource.TestCheckResourceAttr(resourceName, "reserved_instances.0.count", "1"),
+					resource.TestCheckResourceAttr(resourceName, "reserved_instances.0.idle_mode", "false"),
+				),
+			},
+			{
+				Config: testAccFgsV2Function_reservedInstance_alias(name, updateAliasName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "reserved_instances.0.qualifier_name", updateAliasName),
+					resource.TestCheckResourceAttr(resourceName, "reserved_instances.0.qualifier_type", "alias"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"app",
+					"func_code",
+					"tags",
+				},
+			},
+		},
+	})
+}
+
+func testAccFgsV2Function_reservedInstance_step1(rName string) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_fgs_function_v2" "test" {
+  name        = "%[1]s"
+  app         = "default"
+  handler     = "index.handler"
+  memory_size = 128
+  timeout     = 3
+  runtime     = "Node.js16.17"
+  code_type   = "inline"
+
+  reserved_instances {
+    qualifier_type = "version"
+    qualifier_name = "latest"
+    count          = 1
+    idle_mode      = true
+
+    tactics_config {
+      cron_configs {
+        name         = "scheme-waekcy"
+        cron         = "0 */10 * * * ?"
+        start_time   = "1708342889"
+        expired_time = "1739878889"
+        count        = 2
+      }
+    }
+  }
+}
+`, rName)
+}
+
+func testAccFgsV2Function_reservedInstance_step2(rName string) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_fgs_function_v2" "test" {
+  name        = "%s"
+  app         = "default"
+  handler     = "index.handler"
+  memory_size = 128
+  timeout     = 3
+  runtime     = "Node.js16.17"
+  code_type   = "inline"
+
+  reserved_instances {
+    qualifier_type = "version"
+    qualifier_name = "latest"
+    count          = 2
+    idle_mode      = false
+  }
+}
+`, rName)
+}
+
+func testAccFgsV2Function_reservedInstance_alias(rName string, aliasName string) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_fgs_function_v2" "test" {
+  name        = "%[1]s"
+  app         = "default"
+  handler     = "index.handler"
+  memory_size = 128
+  timeout     = 3
+  runtime     = "Node.js16.17"
+  code_type   = "inline"
+
+  versions {
+    name = "latest"
+
+    aliases {
+      name = "%[2]s"
+    }
+  }
+
+  reserved_instances {
+    qualifier_type = "alias"
+    qualifier_name = "%[2]s"
+    count          = 1
+    idle_mode      = false
+  }
+}
+`, rName, aliasName)
+}
+
+func TestAccFgsV2Function_concurrencyNum(t *testing.T) {
+	var (
+		f function.FuncGraph
+
+		name         = fmt.Sprintf("fgs-acc-%s", acctest.RandString(5))
+		resourceName = "opentelekomcloud_fgs_function_v2.test"
+	)
+
+	rc := common.InitResourceCheck(
+		resourceName,
+		&f,
+		getResourceObj,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFunction_strategy_default(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "concurrency_num", "1"),
+				),
+			},
+			{
+				Config: testAccFunction_concurrencyNum(name, 1000),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "concurrency_num", "1000"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"app",
+					"func_code",
+				},
+			},
+		},
+	})
+}
+
+func testAccFunction_concurrencyNum(name string, concurrencyNum int) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_fgs_function_v2" "test" {
+  functiongraph_version = "v2"
+  name                  = "%[1]s"
+  app                   = "default"
+  handler               = "index.handler"
+  memory_size           = 128
+  timeout               = 3
+  runtime               = "Python2.7"
+  code_type             = "inline"
+  func_code             = "dCA9ICdIZWxsbyBtZXNzYWdlOiAnICsganN="
+  concurrency_num       = %[2]d
+}
+`, name, concurrencyNum)
+}

--- a/opentelekomcloud/acceptance/fgs/resource_opentelekomcloud_fgs_function_v2_test.go
+++ b/opentelekomcloud/acceptance/fgs/resource_opentelekomcloud_fgs_function_v2_test.go
@@ -1,0 +1,1 @@
+package fgs

--- a/opentelekomcloud/acceptance/fgs/resource_opentelekomcloud_fgs_function_v2_test.go
+++ b/opentelekomcloud/acceptance/fgs/resource_opentelekomcloud_fgs_function_v2_test.go
@@ -401,8 +401,8 @@ resource "opentelekomcloud_fgs_function_v2" "create_with_vpc_access" {
     url = "%[3]s"
   }
 
-  vpc_id      = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
-  network_id  = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  vpc_id     = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  network_id = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
 }
 
 resource "opentelekomcloud_fgs_function_v2" "create_without_vpc_access" {
@@ -457,8 +457,8 @@ resource "opentelekomcloud_fgs_function_v2" "create_without_vpc_access" {
     url = "%[3]s"
   }
 
-  vpc_id      = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
-  network_id  = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  vpc_id     = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  network_id = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
 }
 `, common.DataSourceSubnet, rName, common.OTC_BUILD_IMAGE_URL_UPDATED)
 }
@@ -701,7 +701,7 @@ resource "opentelekomcloud_logtank_group_v2" "test" {
 }
 
 resource "opentelekomcloud_logtank_topic_v2" "test" {
-  group_id    = opentelekomcloud_logtank_group_v2.test.id
+  group_id   = opentelekomcloud_logtank_group_v2.test.id
   topic_name = "%[1]s"
 }
 
@@ -716,9 +716,9 @@ resource "opentelekomcloud_fgs_function_v2" "test" {
   code_type   = "inline"
   func_code   = "dCA9ICdIZWxsbyBtZXNzYWdlOiAnICsganN="
 
-  log_group_id    = opentelekomcloud_logtank_group_v2.test.id
+  log_group_id   = opentelekomcloud_logtank_group_v2.test.id
   log_topic_id   = opentelekomcloud_logtank_topic_v2.test.id
-  log_group_name  = opentelekomcloud_logtank_group_v2.test.group_name
+  log_group_name = opentelekomcloud_logtank_group_v2.test.group_name
   log_topic_name = opentelekomcloud_logtank_topic_v2.test.topic_name
 }
 `, rName)
@@ -732,7 +732,7 @@ resource "opentelekomcloud_logtank_group_v2" "test" {
 }
 
 resource "opentelekomcloud_logtank_topic_v2" "test" {
-  group_id    = opentelekomcloud_logtank_group_v2.test.id
+  group_id   = opentelekomcloud_logtank_group_v2.test.id
   topic_name = "%[1]s"
 }
 
@@ -742,7 +742,7 @@ resource "opentelekomcloud_logtank_group_v2" "test1" {
 }
 
 resource "opentelekomcloud_logtank_topic_v2" "test1" {
-  group_id    = opentelekomcloud_logtank_group_v2.test1.id
+  group_id   = opentelekomcloud_logtank_group_v2.test1.id
   topic_name = "%[1]s-new"
 }
 
@@ -757,9 +757,9 @@ resource "opentelekomcloud_fgs_function_v2" "test" {
   code_type   = "inline"
   func_code   = "dCA9ICdIZWxsbyBtZXNzYWdlOiAnICsganN="
 
-  log_group_id    = opentelekomcloud_logtank_group_v2.test1.id
+  log_group_id   = opentelekomcloud_logtank_group_v2.test1.id
   log_topic_id   = opentelekomcloud_logtank_topic_v2.test1.id
-  log_group_name  = opentelekomcloud_logtank_group_v2.test1.group_name
+  log_group_name = opentelekomcloud_logtank_group_v2.test1.group_name
   log_topic_name = opentelekomcloud_logtank_topic_v2.test1.topic_name
 }
 `, rName)

--- a/opentelekomcloud/common/cfg/config.go
+++ b/opentelekomcloud/common/cfg/config.go
@@ -1132,6 +1132,13 @@ func (c *Config) APIGWV2Client(region string) (*golangsdk.ServiceClient, error) 
 	})
 }
 
+func (c *Config) FuncGraphV2Client(region string) (*golangsdk.ServiceClient, error) {
+	return openstack.NewFuncGraph(c.HwClient, golangsdk.EndpointOpts{
+		Region:       region,
+		Availability: c.getEndpointType(),
+	})
+}
+
 func (c *Config) DwsV2Client(region string) (*golangsdk.ServiceClient, error) {
 	service, err := openstack.NewDWSV1(c.HwClient, golangsdk.EndpointOpts{
 		Region:       region,

--- a/opentelekomcloud/helper/hashcode/hashcode.go
+++ b/opentelekomcloud/helper/hashcode/hashcode.go
@@ -2,6 +2,9 @@ package hashcode
 
 import (
 	"bytes"
+	"crypto/sha1"
+	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"hash/crc32"
 )
@@ -32,4 +35,35 @@ func Strings(strings []string) string {
 	}
 
 	return fmt.Sprintf("%d", String(buf.String()))
+}
+
+func DecodeHashAndHexEncode(v interface{}) string {
+	switch v := v.(type) {
+	case string:
+		return installScriptHashSum(v)
+	default:
+		return ""
+	}
+}
+
+func installScriptHashSum(script string) string {
+	// Check whether the script is not Base64 encoded.
+	// Always calculate hash of base64 decoded value since we
+	// check against double-encoding when setting it
+	v, base64DecodeError := base64.StdEncoding.DecodeString(script)
+	if base64DecodeError != nil {
+		v = []byte(script)
+	}
+
+	hash := sha1.Sum(v)
+	return hex.EncodeToString(hash[:])
+}
+
+// TryBase64EncodeString will encode a string with base64.
+// If the string is already base64 encoded, returns it directly.
+func TryBase64EncodeString(str string) string {
+	if _, err := base64.StdEncoding.DecodeString(str); err != nil {
+		return base64.StdEncoding.EncodeToString([]byte(str))
+	}
+	return str
 }

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -30,6 +30,7 @@ import (
 	elbv2 "github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/services/elb/v2"
 	elbv3 "github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/services/elb/v3"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/services/evs"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/services/fgs"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/services/fw"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/services/gaussdb"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/services/iam"
@@ -402,6 +403,7 @@ func Provider() *schema.Provider {
 			"opentelekomcloud_dws_cluster_v1":                            dws.ResourceDcsInstanceV1(),
 			"opentelekomcloud_ecs_instance_v1":                           ecs.ResourceEcsInstanceV1(),
 			"opentelekomcloud_evs_volume_v3":                             evs.ResourceEvsStorageVolumeV3(),
+			"opentelekomcloud_fgs_function_v2":                           fgs.ResourceFgsFunctionV2(),
 			"opentelekomcloud_fw_firewall_group_v2":                      fw.ResourceFWFirewallGroupV2(),
 			"opentelekomcloud_fw_policy_v2":                              fw.ResourceFWPolicyV2(),
 			"opentelekomcloud_fw_rule_v2":                                fw.ResourceFWRuleV2(),

--- a/opentelekomcloud/services/fgs/common.go
+++ b/opentelekomcloud/services/fgs/common.go
@@ -1,0 +1,20 @@
+package fgs
+
+import "strings"
+
+const (
+	errCreationV2Client = "error creating OpenTelekomCloud FuncGraphV2 client: %w"
+	fgsClientV2         = "fgs-v2-client"
+)
+
+/*
+ * Parse urn according from fun_urn.
+ * If the separator is not ":" then return to the original value.
+ */
+func resourceFgsFunctionUrn(urn string) string {
+	index := strings.LastIndex(urn, ":")
+	if index != -1 {
+		urn = urn[0:index]
+	}
+	return urn
+}

--- a/opentelekomcloud/services/fgs/resource_opentelekomcloud_fgs_function_v2.go
+++ b/opentelekomcloud/services/fgs/resource_opentelekomcloud_fgs_function_v2.go
@@ -1,0 +1,1205 @@
+package fgs
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/pointerto"
+	aliases "github.com/opentelekomcloud/gophertelekomcloud/openstack/fgs/v2/alias"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/fgs/v2/function"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/fgs/v2/reserved"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/fgs/v2/tags"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/helper/hashcode"
+)
+
+func ResourceFgsFunctionV2() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceFgsFunctionV2Create,
+		ReadContext:   resourceFgsFunctionV2Read,
+		UpdateContext: resourceFgsFunctionV2Update,
+		DeleteContext: resourceFgsFunctionV2Delete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"memory_size": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"runtime": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"timeout": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"code_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"handler": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `schema: Required; The entry point of the function.`,
+			},
+			"functiongraph_version": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"v1", "v2",
+				}, false),
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"app": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"code_url": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"code_filename": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"user_data": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"encrypted_user_data": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
+			},
+			"agency": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"app_agency": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"func_code": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				StateFunc: hashcode.DecodeHashAndHexEncode,
+			},
+			"depend_list": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"initializer_handler": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"initializer_timeout": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"vpc_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				RequiredWith: []string{"network_id"},
+			},
+			"network_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				RequiredWith: []string{"vpc_id"},
+			},
+			"dns_list": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				RequiredWith: []string{"vpc_id"},
+			},
+			"mount_user_id": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"mount_user_group_id": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"log_group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				RequiredWith: []string{
+					"log_stream_id", "log_group_name", "log_stream_name"},
+			},
+			"log_stream_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				RequiredWith: []string{"log_group_id"},
+			},
+			"log_group_name": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				RequiredWith: []string{"log_group_id"},
+			},
+			"log_stream_name": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				RequiredWith: []string{"log_group_id"},
+			},
+			"func_mounts": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"mount_type": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"mount_resource": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"mount_share_path": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"local_mount_path": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"custom_image": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"url": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+				ConflictsWith: []string{
+					"code_type",
+				},
+			},
+			"max_instance_num": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^\-?\d+$`),
+					`invalid value of maximum instance number, want an integer number or integer string.`),
+			},
+			"versions": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The version name.",
+						},
+						"aliases": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:        schema.TypeString,
+										Required:    true,
+										Description: "The name of the version alias.",
+									},
+									"description": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: "The description of the version alias.",
+									},
+								},
+							},
+							Description: "The aliases management for specified version.",
+						},
+					},
+				},
+				Description: "The versions management of the function.",
+			},
+			"tags": common.TagsSchema(),
+			"reserved_instances": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"qualifier_type": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"qualifier_name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"count": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+						"idle_mode": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"tactics_config": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem:     tacticsConfigsSchema(),
+						},
+					},
+				},
+			},
+			"concurrency_num": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"gpu_memory": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"gpu_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"urn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func tacticsConfigsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"cron_configs": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"cron": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"count": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+						"start_time": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+						"expired_time": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildCustomImage(imageConfig []interface{}) *function.CustomImage {
+	if len(imageConfig) < 1 {
+		return nil
+	}
+
+	cfg := imageConfig[0].(map[string]interface{})
+	return &function.CustomImage{
+		Enabled: pointerto.Bool(true),
+		Image:   cfg["url"].(string),
+	}
+}
+
+func buildFgsFunctionParameters(d *schema.ResourceData) (function.CreateOpts, error) {
+	// check app and package
+	app, appOk := d.GetOk("app")
+	pkg, pkgOk := d.GetOk("package")
+	if !appOk && !pkgOk {
+		return function.CreateOpts{}, fmt.Errorf("one of app or package must be configured")
+	}
+	packV := ""
+	if appOk {
+		packV = app.(string)
+	} else {
+		packV = pkg.(string)
+	}
+
+	agencyV := ""
+	if v, ok := d.GetOk("agency"); ok {
+		agencyV = v.(string)
+	}
+
+	result := function.CreateOpts{
+		Name:              d.Get("name").(string),
+		Type:              d.Get("functiongraph_version").(string),
+		Package:           packV,
+		CodeType:          d.Get("code_type").(string),
+		CodeURL:           d.Get("code_url").(string),
+		Description:       d.Get("description").(string),
+		CodeFilename:      d.Get("code_filename").(string),
+		Handler:           d.Get("handler").(string),
+		MemorySize:        d.Get("memory_size").(int),
+		Runtime:           d.Get("runtime").(string),
+		Timeout:           d.Get("timeout").(int),
+		UserData:          d.Get("user_data").(string),
+		EncryptedUserData: d.Get("encrypted_user_data").(string),
+		Xrole:             agencyV,
+		CustomImage:       buildCustomImage(d.Get("custom_image").([]interface{})),
+		GpuMemory:         pointerto.Int(d.Get("gpu_memory").(int)),
+	}
+	if v, ok := d.GetOk("func_code"); ok {
+		funcCode := function.FuncCode{
+			File: hashcode.TryBase64EncodeString(v.(string)),
+		}
+		result.FuncCode = &funcCode
+	}
+	if v, ok := d.GetOk("log_group_id"); ok {
+		logConfig := function.FuncLogConfig{
+			GroupID:    v.(string),
+			StreamID:   d.Get("log_stream_id").(string),
+			GroupName:  d.Get("log_group_name").(string),
+			StreamName: d.Get("log_stream_name").(string),
+		}
+		result.LogConfig = &logConfig
+	}
+	return result, nil
+}
+
+func resourceFgsFunctionV2Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	fgsClient, err := config.FuncGraphV2Client(config.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating FunctionGraph v2 client: %s", err)
+	}
+
+	createOpts, err := buildFgsFunctionParameters(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	log.Printf("[DEBUG] Create Options: %#v", createOpts)
+	f, err := function.Create(fgsClient, createOpts)
+	if err != nil {
+		return diag.Errorf("error creating function: %s", err)
+	}
+
+	d.SetId(f.FuncURN)
+	urn := resourceFgsFunctionUrn(d.Id())
+	if d.HasChanges("vpc_id", "func_mounts", "app_agency", "initializer_handler", "initializer_timeout", "concurrency_num") {
+		err := resourceFgsFunctionMetadataUpdate(fgsClient, urn, d)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if d.HasChange("depend_list") {
+		err := resourceFgsFunctionCodeUpdate(fgsClient, urn, d)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if strNum, ok := d.GetOk("max_instance_num"); ok {
+		// The integer string of the maximum instance number has been already checked in the schema validation.
+		maxInstanceNum, _ := strconv.Atoi(strNum.(string))
+
+		_, err = function.UpdateMaxInstances(fgsClient, function.UpdateFuncInstancesOpts{
+			MaxInstanceNum: maxInstanceNum,
+			FuncUrn:        urn,
+		})
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if tagList, ok := d.GetOk("tags"); ok {
+		opts := tags.TagsActionOpts{
+			Tags:   common.ExpandResourceTags(tagList.(map[string]interface{})),
+			Id:     d.Id(),
+			Action: "create",
+		}
+		if err := tags.CreateResourceTag(fgsClient, opts); err != nil {
+			return diag.Errorf("failed to add tags to FunctionGraph function (%s): %s", d.Id(), err)
+		}
+	}
+
+	if err = createFunctionVersions(fgsClient, urn, d.Get("versions").(*schema.Set)); err != nil {
+		return diag.Errorf("error creating function versions: %s", err)
+	}
+
+	if d.HasChanges("reserved_instances") {
+		if err = updateReservedInstanceConfig(fgsClient, d); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	return resourceFgsFunctionV2Read(ctx, d, meta)
+}
+
+func createFunctionVersions(client *golangsdk.ServiceClient, functionUrn string, versionSet *schema.Set) error {
+	for _, v := range versionSet.List() {
+		version := v.(map[string]interface{})
+		versionNum := version["name"].(string)
+		aliasCfg := version["aliases"].([]interface{})
+		if len(aliasCfg) < 1 {
+			continue
+		}
+		alias := aliasCfg[0].(map[string]interface{})
+		opt := aliases.CreateAliasOpts{
+			FuncUrn:     functionUrn,
+			Name:        alias["name"].(string),
+			Version:     versionNum,
+			Description: alias["description"].(string),
+		}
+		_, err := aliases.CreateAlias(client, opt)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func setFgsFunctionApp(d *schema.ResourceData, app string) error {
+	if _, ok := d.GetOk("app"); ok {
+		return d.Set("app", app)
+	}
+	return d.Set("package", app)
+}
+
+func setFgsFunctionVpcAccess(d *schema.ResourceData, funcVpc function.FuncVpc) error {
+	mErr := multierror.Append(
+		d.Set("vpc_id", funcVpc.VpcID),
+		d.Set("network_id", funcVpc.SubnetID),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return fmt.Errorf("error setting vault fields: %s", err)
+	}
+	return nil
+}
+
+func setFunctionMountConfig(d *schema.ResourceData, mountConfig function.MountConfig) error {
+	// set mount_config
+	if mountConfig.MountUser != (function.MountUser{}) {
+		funcMounts := make([]map[string]string, 0, len(mountConfig.FuncMounts))
+		for _, v := range mountConfig.FuncMounts {
+			funcMount := map[string]string{
+				"mount_type":       v.MountType,
+				"mount_resource":   v.MountResource,
+				"mount_share_path": v.MountSharePath,
+				"local_mount_path": v.LocalMountPath,
+			}
+			funcMounts = append(funcMounts, funcMount)
+		}
+		mErr := multierror.Append(
+			d.Set("func_mounts", funcMounts),
+			d.Set("mount_user_id", mountConfig.MountUser.UserID),
+			d.Set("mount_user_group_id", mountConfig.MountUser.UserGroupID),
+		)
+		if err := mErr.ErrorOrNil(); err != nil {
+			return fmt.Errorf("error setting vault fields: %s", err)
+		}
+	}
+	return nil
+}
+
+func flattenFgsCustomImage(imageConfig function.CustomImage) []map[string]interface{} {
+	if (imageConfig != function.CustomImage{}) {
+		return []map[string]interface{}{
+			{
+				"url": imageConfig.Image,
+			},
+		}
+	}
+	return nil
+}
+
+func queryFunctionVersions(client *golangsdk.ServiceClient, functionUrn string) ([]string, error) {
+	queryOpts := aliases.ListVersionOpts{
+		FuncUrn: functionUrn,
+	}
+	versionList, err := aliases.ListVersion(client, queryOpts)
+	if err != nil {
+		return nil, fmt.Errorf("error querying version list for the specified function URN: %s", err)
+	}
+	// The length of the function version list is at least 1 (when creating a function, a version named latest is
+	// created by default).
+	result := make([]string, len(versionList.Functions))
+	for i, version := range versionList.Functions {
+		result[i] = version.Version
+	}
+	return result, nil
+}
+
+func queryFunctionAliases(client *golangsdk.ServiceClient, functionUrn string) (map[string][]interface{}, error) {
+	aliasList, err := aliases.ListAlias(client, functionUrn)
+	if err != nil {
+		return nil, fmt.Errorf("error querying alias list for the specified function URN: %s", err)
+	}
+
+	// Multiple version aliases may exist in the future.
+	result := make(map[string][]interface{})
+	for _, v := range aliasList {
+		result[v.Version] = append(result[v.Version], map[string]interface{}{
+			"name":        v.Name,
+			"description": v.Description,
+		})
+	}
+	return result, nil
+}
+
+func parseFunctionVersions(client *golangsdk.ServiceClient, functionUrn string) ([]map[string]interface{}, error) {
+	versionList, err := queryFunctionVersions(client, functionUrn)
+	if err != nil {
+		return nil, err
+	}
+	aliasesConfig, err := queryFunctionAliases(client, functionUrn)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]map[string]interface{}, 0, len(versionList))
+	for _, versionNum := range versionList {
+		version := map[string]interface{}{
+			"name": versionNum, // The version name, also name as the version number.
+		}
+		if v, ok := aliasesConfig[versionNum]; ok {
+			version["aliases"] = v
+		}
+		result = append(result, version)
+	}
+
+	return result, nil
+}
+
+func flattenTacticsConfigs(policyConfig reserved.TacticsConfig) []map[string]interface{} {
+	if len(policyConfig.CronConfigs) == 0 {
+		return nil
+	}
+
+	cronConfigRst := make([]map[string]interface{}, len(policyConfig.CronConfigs))
+	for i, v := range policyConfig.CronConfigs {
+		cronConfigRst[i] = map[string]interface{}{
+			"name":         v.Name,
+			"cron":         v.Cron,
+			"count":        v.Count,
+			"start_time":   v.StartTime,
+			"expired_time": v.ExpiredTime,
+		}
+	}
+
+	return []map[string]interface{}{
+		{
+			"cron_configs": cronConfigRst,
+		},
+	}
+}
+
+func getReservedInstanceConfig(c *golangsdk.ServiceClient, d *schema.ResourceData) ([]map[string]interface{}, error) {
+	opts := reserved.ListConfigOpts{
+		FuncUrn: d.Id(),
+	}
+	reservedInstances, err := reserved.ListReservedInstConfigs(c, opts)
+	if err != nil {
+		return nil, fmt.Errorf("error getting list of the function reserved instance config: %s", err)
+	}
+
+	result := make([]map[string]interface{}, len(reservedInstances.ReservedInstances))
+	for i, v := range reservedInstances.ReservedInstances {
+		result[i] = map[string]interface{}{
+			"count":          v.MinCount,
+			"idle_mode":      v.IdleMode,
+			"qualifier_name": v.QualifierName,
+			"qualifier_type": v.QualifierType,
+			"tactics_config": flattenTacticsConfigs(v.TacticsConfig),
+		}
+	}
+	return result, nil
+}
+
+func getConcurrencyNum(concurrencyNum *int) int {
+	return *concurrencyNum
+}
+
+func resourceFgsFunctionV2Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	fgsClient, err := config.FuncGraphV2Client(config.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating FunctionGraph client: %s", err)
+	}
+
+	functionUrn := resourceFgsFunctionUrn(d.Id())
+	f, err := function.GetMetadata(fgsClient, functionUrn)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "FunctionGraph function")
+	}
+
+	versionConfig, err := parseFunctionVersions(fgsClient, functionUrn)
+	if err != nil {
+		// Not all regions support the version related API calls.
+		log.Printf("[ERROR] Unable to parsing the function versions: %s", err)
+	}
+	log.Printf("[DEBUG] Retrieved Function %s: %+v", functionUrn, f)
+	mErr := multierror.Append(
+		d.Set("name", f.FuncName),
+		d.Set("code_type", f.CodeType),
+		d.Set("code_url", f.CodeURL),
+		d.Set("description", f.Description),
+		d.Set("code_filename", f.CodeFilename),
+		d.Set("handler", f.Handler),
+		d.Set("memory_size", f.MemorySize),
+		d.Set("runtime", f.Runtime),
+		d.Set("timeout", f.Timeout),
+		d.Set("user_data", f.UserData),
+		d.Set("encrypted_user_data", f.EncryptedUserData),
+		d.Set("version", f.Version),
+		d.Set("urn", functionUrn),
+		d.Set("app_agency", f.AppXrole),
+		d.Set("depend_list", f.DependVersionList),
+		d.Set("initializer_handler", f.InitHandler),
+		d.Set("initializer_timeout", f.InitTimeout),
+		d.Set("functiongraph_version", f.Type),
+		d.Set("custom_image", flattenFgsCustomImage(f.CustomImage)),
+		d.Set("max_instance_num", strconv.Itoa(f.StrategyConfig.Concurrency)),
+		d.Set("dns_list", f.DomainNames),
+		d.Set("log_group_id", f.LogGroupID),
+		d.Set("log_stream_id", f.LogStreamID),
+		d.Set("log_stream_id", f.LogStreamID),
+		d.Set("agency", f.Xrole),
+		setFgsFunctionApp(d, f.Package),
+		setFgsFunctionVpcAccess(d, f.FuncVpc),
+		setFunctionMountConfig(d, f.MountConfig),
+		d.Set("concurrency_num", getConcurrencyNum(pointerto.Int(f.StrategyConfig.ConcurrentNum))),
+		d.Set("versions", versionConfig),
+		d.Set("gpu_memory", f.GpuMemory),
+		d.Set("gpu_type", f.GpuType),
+	)
+
+	reservedInstances, err := getReservedInstanceConfig(fgsClient, d)
+	if err != nil {
+		return diag.Errorf("error retrieving function reserved instance: %s", err)
+	}
+
+	mErr = multierror.Append(mErr,
+		d.Set("reserved_instances", reservedInstances),
+	)
+
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error setting function fields: %s", err)
+	}
+
+	return nil
+}
+
+func updateFunctionTags(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	var (
+		oRaw, nRaw  = d.GetChange("tags")
+		oMap        = oRaw.(map[string]interface{})
+		nMap        = nRaw.(map[string]interface{})
+		functionUrn = d.Id()
+	)
+
+	if len(oMap) > 0 {
+		opts := tags.TagsActionOpts{
+			Tags:   common.ExpandResourceTags(oMap),
+			Id:     functionUrn,
+			Action: "delete",
+		}
+		if err := tags.DeleteResourceTag(client, opts); err != nil {
+			return fmt.Errorf("failed to delete tags from FunctionGraph function (%s): %s", functionUrn, err)
+		}
+	}
+
+	if len(nMap) > 0 {
+		opts := tags.TagsActionOpts{
+			Tags:   common.ExpandResourceTags(nMap),
+			Id:     functionUrn,
+			Action: "create",
+		}
+		if err := tags.CreateResourceTag(client, opts); err != nil {
+			return fmt.Errorf("failed to add tags to FunctionGraph function (%s): %s", functionUrn, err)
+		}
+	}
+	return nil
+}
+
+func deleteFunctionVersions(client *golangsdk.ServiceClient, functionUrn string, versionSet *schema.Set) error {
+	for _, v := range versionSet.List() {
+		version := v.(map[string]interface{})
+		aliasCfg := version["aliases"].([]interface{})
+		if len(aliasCfg) > 0 {
+			alias := aliasCfg[0].(map[string]interface{})
+			err := aliases.Delete(client, functionUrn, alias["name"].(string))
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func updateFunctionVersions(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	var (
+		functionUrn = resourceFgsFunctionUrn(d.Id())
+
+		oldSet, newSet = d.GetChange("versions")
+		decrease       = oldSet.(*schema.Set).Difference(newSet.(*schema.Set))
+		increase       = newSet.(*schema.Set).Difference(oldSet.(*schema.Set))
+	)
+
+	err := deleteFunctionVersions(client, functionUrn, decrease)
+	if err != nil {
+		return fmt.Errorf("error deleting function versions: %s", err)
+	}
+
+	err = createFunctionVersions(client, functionUrn, increase)
+	if err != nil {
+		return fmt.Errorf("error creating function versions: %s", err)
+	}
+
+	return nil
+}
+
+func buildCronConfigs(cronConfigs []interface{}) []reserved.CronConfig {
+	if len(cronConfigs) < 1 {
+		return nil
+	}
+
+	result := make([]reserved.CronConfig, len(cronConfigs))
+	for i, v := range cronConfigs {
+		cronConfig := v.(map[string]interface{})
+		result[i] = reserved.CronConfig{
+			Name:        cronConfig["name"].(string),
+			Cron:        cronConfig["cron"].(string),
+			Count:       cronConfig["count"].(string),
+			StartTime:   cronConfig["start_time"].(int),
+			ExpiredTime: cronConfig["expired_time"].(int),
+		}
+	}
+	return result
+}
+
+func buildTacticsConfigs(tacticsConfigs []interface{}) *reserved.TacticsConfig {
+	if len(tacticsConfigs) < 1 {
+		return nil
+	}
+
+	tacticsConfig := tacticsConfigs[0].(map[string]interface{})
+	result := reserved.TacticsConfig{
+		CronConfigs: buildCronConfigs(tacticsConfig["cron_configs"].([]interface{})),
+	}
+	return &result
+}
+
+func getVersionUrn(client *golangsdk.ServiceClient, functionUrn string, qualifierName string) (string, error) {
+	queryOpts := aliases.ListVersionOpts{
+		FuncUrn: functionUrn,
+	}
+	versionList, err := aliases.ListVersion(client, queryOpts)
+	if err != nil {
+		return "", fmt.Errorf("error querying version list for the specified function URN: %s", err)
+	}
+
+	for _, val := range versionList.Functions {
+		if val.Version == qualifierName {
+			return val.FuncURN, nil
+		}
+	}
+
+	return "", nil
+}
+
+func getReservedInstanceUrn(client *golangsdk.ServiceClient, functionUrn string, policy map[string]interface{}) (string, error) {
+	qualifierName := policy["qualifier_name"].(string)
+	if policy["qualifier_type"].(string) == "version" {
+		urn, err := getVersionUrn(client, functionUrn, qualifierName)
+		if err != nil {
+			return "", err
+		}
+		return urn, nil
+	}
+
+	aliasList, err := aliases.ListAlias(client, functionUrn)
+	if err != nil {
+		return "", fmt.Errorf("error querying alias list for the specified function URN: %s", err)
+	}
+	for _, val := range aliasList {
+		if val.Name == qualifierName {
+			return val.AliasUrn, nil
+		}
+	}
+
+	return "", nil
+}
+
+func removeReservedInstances(client *golangsdk.ServiceClient, functionUrn string, policies []interface{}) error {
+	for _, v := range policies {
+		policy := v.(map[string]interface{})
+		urn, err := getReservedInstanceUrn(client, functionUrn, policy)
+		if err != nil {
+			return err
+		}
+		// Deleting the alias will also delete the corresponding reserved instance.
+		if urn == "" {
+			return nil
+		}
+		opts := reserved.UpdateOpts{
+			FuncUrn:  urn,
+			Count:    0,
+			IdleMode: pointerto.Bool(false),
+		}
+		_, err = reserved.Update(client, opts)
+		if err != nil {
+			return fmt.Errorf("error removing function reversed instance: %s", err)
+		}
+	}
+
+	return nil
+}
+
+func addReservedInstances(client *golangsdk.ServiceClient, functionUrn string, addPolicies []interface{}) error {
+	for _, v := range addPolicies {
+		addPolicy := v.(map[string]interface{})
+		urn, err := getReservedInstanceUrn(client, functionUrn, addPolicy)
+
+		if err != nil {
+			return err
+		}
+
+		opts := reserved.UpdateOpts{
+			FuncUrn:       urn,
+			Count:         addPolicy["count"].(int),
+			IdleMode:      pointerto.Bool(addPolicy["idle_mode"].(bool)),
+			TacticsConfig: buildTacticsConfigs(addPolicy["tactics_config"].([]interface{})),
+		}
+		_, err = reserved.Update(client, opts)
+		if err != nil {
+			return fmt.Errorf("error updating function reversed instance: %s", err)
+		}
+	}
+
+	return nil
+}
+
+func updateReservedInstanceConfig(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	oldRaw, newRaw := d.GetChange("reserved_instances")
+	addRaw := newRaw.(*schema.Set).Difference(oldRaw.(*schema.Set))
+	removeRaw := oldRaw.(*schema.Set).Difference(newRaw.(*schema.Set))
+	functionUrn := resourceFgsFunctionUrn(d.Id())
+	if removeRaw.Len() > 0 {
+		if err := removeReservedInstances(client, functionUrn, removeRaw.List()); err != nil {
+			return err
+		}
+	}
+
+	if addRaw.Len() > 0 {
+		if err := addReservedInstances(client, functionUrn, addRaw.List()); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func resourceFgsFunctionV2Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	fgsClient, err := config.FuncGraphV2Client(config.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating FunctionGraph v2 client: %s", err)
+	}
+
+	urn := resourceFgsFunctionUrn(d.Id())
+
+	// lintignore:R019
+	if d.HasChanges("code_type", "code_url", "code_filename", "depend_list", "func_code") {
+		err := resourceFgsFunctionCodeUpdate(fgsClient, urn, d)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	// lintignore:R019
+	if d.HasChanges("app", "handler", "memory_size", "timeout", "encrypted_user_data",
+		"user_data", "agency", "app_agency", "description", "initializer_handler", "initializer_timeout",
+		"vpc_id", "network_id", "dns_list", "mount_user_id", "mount_user_group_id", "func_mounts", "custom_image",
+		"log_group_id", "log_stream_id", "log_group_name", "log_stream_name", "concurrency_num", "gpu_memory", "gpu_type") {
+		err := resourceFgsFunctionMetadataUpdate(fgsClient, urn, d)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if d.HasChange("max_instance_num") {
+		// The integer string of the maximum instance number has been already checked in the schema validation.
+		maxInstanceNum, _ := strconv.Atoi(d.Get("max_instance_num").(string))
+
+		_, err = function.UpdateMaxInstances(fgsClient, function.UpdateFuncInstancesOpts{
+			FuncUrn:        urn,
+			MaxInstanceNum: maxInstanceNum,
+		})
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if d.HasChange("tags") {
+		if err = updateFunctionTags(fgsClient, d); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if d.HasChange("versions") {
+		if err = updateFunctionVersions(fgsClient, d); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if d.HasChanges("reserved_instances") {
+		if err = updateReservedInstanceConfig(fgsClient, d); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	return resourceFgsFunctionV2Read(ctx, d, meta)
+}
+
+func resourceFgsFunctionV2Delete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	fgsClient, err := config.FuncGraphV2Client(config.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating FunctionGraph v2 client: %s", err)
+	}
+
+	urn := resourceFgsFunctionUrn(d.Id())
+
+	err = function.Delete(fgsClient, urn)
+	if err != nil {
+		return diag.Errorf("error deleting function: %s", err)
+	}
+	return nil
+}
+
+func resourceFgsFunctionMetadataUpdate(fgsClient *golangsdk.ServiceClient, urn string, d *schema.ResourceData) error {
+	// check app and package
+	app, appOk := d.GetOk("app")
+	pkg, pkgOk := d.GetOk("package")
+	if !appOk && !pkgOk {
+		return fmt.Errorf("one of app or package must be configured")
+	}
+	packV := ""
+	if appOk {
+		packV = app.(string)
+	} else {
+		packV = pkg.(string)
+	}
+
+	agencyV := ""
+	if v, ok := d.GetOk("agency"); ok {
+		agencyV = v.(string)
+	}
+
+	updateMetadateOpts := function.UpdateFuncMetadataOpts{
+		Handler:           d.Get("handler").(string),
+		MemorySize:        d.Get("memory_size").(int),
+		Timeout:           d.Get("timeout").(int),
+		Runtime:           d.Get("runtime").(string),
+		Package:           packV,
+		Description:       d.Get("description").(string),
+		UserData:          d.Get("user_data").(string),
+		EncryptedUserData: d.Get("encrypted_user_data").(string),
+		Xrole:             agencyV,
+		AppXrole:          d.Get("app_agency").(string),
+		InitHandler:       d.Get("initializer_handler").(string),
+		InitTimeout:       pointerto.Int(d.Get("initializer_timeout").(int)),
+		CustomImage:       buildCustomImage(d.Get("custom_image").([]interface{})),
+		DomainNames:       d.Get("dns_list").(string),
+		GpuMemory:         pointerto.Int(d.Get("gpu_memory").(int)),
+	}
+
+	if _, ok := d.GetOk("vpc_id"); ok {
+		updateMetadateOpts.FuncVpc = resourceFgsFunctionFuncVpc(d)
+	}
+
+	if _, ok := d.GetOk("func_mounts"); ok {
+		updateMetadateOpts.MountConfig = resourceFgsFunctionMountConfig(d)
+	}
+
+	// check name here as it will only save to sate if specified before
+	if v, ok := d.GetOk("log_group_name"); ok {
+		logConfig := function.FuncLogConfig{
+			GroupID:    d.Get("log_group_id").(string),
+			StreamID:   d.Get("log_stream_id").(string),
+			GroupName:  v.(string),
+			StreamName: d.Get("log_stream_name").(string),
+		}
+		updateMetadateOpts.LogConfig = &logConfig
+	}
+
+	if v, ok := d.GetOk("concurrency_num"); ok {
+		strategyConfig := function.StrategyConfig{
+			ConcurrentNum: v.(int),
+		}
+		updateMetadateOpts.StrategyConfig = &strategyConfig
+	}
+
+	log.Printf("[DEBUG] Metaddata Update Options: %#v", updateMetadateOpts)
+	updateMetadateOpts.FuncUrn = urn
+
+	_, err := function.UpdateFuncMetadata(fgsClient, updateMetadateOpts)
+	if err != nil {
+		return fmt.Errorf("error updating metadata of function: %s", err)
+	}
+
+	return nil
+}
+
+func resourceFgsFunctionCodeUpdate(fgsClient *golangsdk.ServiceClient, urn string, d *schema.ResourceData) error {
+	updateCodeOpts := function.UpdateFuncCodeOpts{
+		CodeType:     d.Get("code_type").(string),
+		CodeURL:      d.Get("code_url").(string),
+		CodeFilename: d.Get("code_filename").(string),
+	}
+
+	if v, ok := d.GetOk("depend_list"); ok {
+		dependListRaw := v.(*schema.Set)
+		dependList := make([]string, 0, dependListRaw.Len())
+		for _, depend := range dependListRaw.List() {
+			dependList = append(dependList, depend.(string))
+		}
+		updateCodeOpts.DependVersionList = dependList
+	}
+
+	if v, ok := d.GetOk("func_code"); ok {
+		funcCode := function.FuncCode{
+			File: hashcode.TryBase64EncodeString(v.(string)),
+		}
+		updateCodeOpts.FuncCode = funcCode
+	}
+
+	updateCodeOpts.FuncUrn = urn
+	log.Printf("[DEBUG] Code Update Options: %#v", updateCodeOpts)
+	_, err := function.UpdateFuncCode(fgsClient, updateCodeOpts)
+	if err != nil {
+		return fmt.Errorf("error updating code of function: %s", err)
+	}
+
+	return nil
+}
+
+func resourceFgsFunctionFuncVpc(d *schema.ResourceData) *function.FuncVpc {
+	var funcVpc function.FuncVpc
+	funcVpc.VpcID = d.Get("vpc_id").(string)
+	funcVpc.SubnetID = d.Get("network_id").(string)
+	return &funcVpc
+}
+
+func resourceFgsFunctionMountConfig(d *schema.ResourceData) *function.MountConfig {
+	var mountConfig function.MountConfig
+	funcMountsRaw := d.Get("func_mounts").([]interface{})
+	if len(funcMountsRaw) >= 1 {
+		funcMounts := make([]function.FuncMount, 0, len(funcMountsRaw))
+		for _, funcMountRaw := range funcMountsRaw {
+			var funcMount function.FuncMount
+			funcMountMap := funcMountRaw.(map[string]interface{})
+			funcMount.MountType = funcMountMap["mount_type"].(string)
+			funcMount.MountResource = funcMountMap["mount_resource"].(string)
+			funcMount.MountSharePath = funcMountMap["mount_share_path"].(string)
+			funcMount.LocalMountPath = funcMountMap["local_mount_path"].(string)
+
+			funcMounts = append(funcMounts, funcMount)
+		}
+
+		mountConfig.FuncMounts = funcMounts
+
+		mountUser := function.MountUser{
+			UserID:      strconv.Itoa(-1),
+			UserGroupID: strconv.Itoa(-1),
+		}
+
+		if v, ok := d.GetOk("mount_user_id"); ok {
+			mountUser.UserID = v.(string)
+		}
+
+		if v, ok := d.GetOk("mount_user_group_id"); ok {
+			mountUser.UserGroupID = v.(string)
+		}
+
+		mountConfig.MountUser = mountUser
+	}
+	return &mountConfig
+}
+
+/*
+ * Parse urn according from fun_urn.
+ * If the separator is not ":" then return to the original value.
+ */
+func resourceFgsFunctionUrn(urn string) string {
+	index := strings.LastIndex(urn, ":")
+	if index != -1 {
+		urn = urn[0:index]
+	}
+	return urn
+}

--- a/releasenotes/notes/fgs_function-61ed2bd530e6b54d.yaml
+++ b/releasenotes/notes/fgs_function-61ed2bd530e6b54d.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    **[FGS]** Added new resource ``resource/opentelekomcloud_fgs_function_v2`` (`#2487 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2487>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Implementation of `opentelekomcloud_fgs_function_v2` base resource.

## PR Checklist

* [ ] Refers to: #xxx
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccFgsV2Function_basic
=== PAUSE TestAccFgsV2Function_basic
=== CONT  TestAccFgsV2Function_basic
--- PASS: TestAccFgsV2Function_basic (81.45s)
PASS

Process finished with the exit code 0


=== RUN   TestAccFgsV2Function_text
=== PAUSE TestAccFgsV2Function_text
=== CONT  TestAccFgsV2Function_text
--- PASS: TestAccFgsV2Function_text (29.65s)
PASS

Process finished with the exit code 0

=== RUN   TestAccFgsV2Function_logConfig
=== PAUSE TestAccFgsV2Function_logConfig
=== CONT  TestAccFgsV2Function_logConfig
--- PASS: TestAccFgsV2Function_logConfig (46.93s)
PASS

Process finished with the exit code 0

=== RUN   TestAccFgsV2Function_strategy
=== PAUSE TestAccFgsV2Function_strategy
=== CONT  TestAccFgsV2Function_strategy
--- PASS: TestAccFgsV2Function_strategy (85.98s)
PASS

Process finished with the exit code 0

=== RUN   TestAccFgsV2Function_versions
=== PAUSE TestAccFgsV2Function_versions
=== CONT  TestAccFgsV2Function_versions
--- PASS: TestAccFgsV2Function_versions (67.60s)
PASS

Process finished with the exit code 0

=== RUN   TestAccFgsV2Function_reservedInstance_version
=== PAUSE TestAccFgsV2Function_reservedInstance_version
=== CONT  TestAccFgsV2Function_reservedInstance_version
--- PASS: TestAccFgsV2Function_reservedInstance_version (49.36s)
PASS

Process finished with the exit code 0

=== RUN   TestAccFgsV2Function_concurrencyNum
=== PAUSE TestAccFgsV2Function_concurrencyNum
=== CONT  TestAccFgsV2Function_concurrencyNum
--- PASS: TestAccFgsV2Function_concurrencyNum (47.30s)
PASS

Process finished with the exit code 0


```
