### PR TITLE
[NETWORK] port extended dhcp opts in `resource/opentelekomcloud_networking_port_v2`

### DIFF
--- a/docs/resources/networking_port_v2.md
+++ b/docs/resources/networking_port_v2.md
@@ -40,66 +40,65 @@ resource "opentelekomcloud_networking_subnet_v2" "subnet_1" {
 
 The following arguments are supported:
 
-* `name` - (Optional) A unique name for the port. Changing this
+* `name` - (Optional, String) A unique name for the port. Changing this
   updates the `name` of an existing port.
 
-* `network_id` - (Required) The ID of the network to attach the port to. Changing
+* `network_id` - (Required, String, ForceNew) The ID of the network to attach the port to. Changing
   this creates a new port.
 
-* `admin_state_up` - (Optional) Administrative up/down status for the port
+* `admin_state_up` - (Optional, Bool) Administrative up/down status for the port
   (must be "true" or "false" if provided). Changing this updates the
   `admin_state_up` of an existing port.
 
-* `mac_address` - (Optional) Specify a specific MAC address for the port. Changing
+* `mac_address` - (Optional, String, ForceNew) Specify a specific MAC address for the port. Changing
   this creates a new port.
 
-* `tenant_id` - (Optional) The owner of the Port. Required if admin wants
+* `tenant_id` - (Optional, String, ForceNew) The owner of the Port. Required if admin wants
   to create a port for another tenant. Changing this creates a new port.
 
-* `device_owner` - (Optional) The device owner of the Port. Changing this creates
+* `device_owner` - (Optional. String, ForceNew) The device owner of the Port. Changing this creates
   a new port.
 
-* `security_group_ids` - (Optional) A list of security group IDs to apply to the
+* `security_group_ids` - (Optional, List) A list of security group IDs to apply to the
   port. The security groups must be specified by ID and not name (as opposed
   to how they are configured with the Compute Instance).
 
-* `no_security_groups` - (Optional) If set to `true`, then no security groups
+* `no_security_groups` - (Optional, Bool) If set to `true`, then no security groups
   are applied to the port. If set to `false` and no `security_group_ids` are specified,
   then the port will yield to the default behavior of the Networking service,
   which is to usually apply the `"default"` security group.
 
-* `port_security_enabled` - (Optional) Whether to explicitly enable or disable
+* `port_security_enabled` - (Optional, Bool) Whether to explicitly enable or disable
   port security on the port. Port Security is usually enabled by default, so
   omitting argument will usually result in a value of `true`. Setting this
   explicitly to `false` will disable port security. In order to disable port
   security, the port must not have any security groups. Valid values are `true`
   and `false`.
 
-* `device_id` - (Optional) The ID of the device attached to the port. Changing this
+* `device_id` - (Optional, String, ForceNew) The ID of the device attached to the port. Changing this
   creates a new port.
 
-* `fixed_ip` - (Optional) An array of desired IPs for this port. The structure is
+* `fixed_ip` - (Optional, List) An array of desired IPs for this port. The structure is
   described below. A single `fixed_ip` entry is allowed for a port.
+  The `fixed_ip` block supports:
+  * `subnet_id` - (Required, String) Subnet in which to allocate IP address for
+    this port.
+  * `ip_address` - (Optional, String) IP address desired in the subnet for this port. If
+    you don't specify `ip_address`, an available IP address from the specified
+    subnet will be allocated to this port.
 
-* `allowed_address_pairs` - (Optional) An IP/MAC Address pair of additional IP
+* `allowed_address_pairs` - (Optional, Map) An IP/MAC Address pair of additional IP
   addresses that can be active on this port. The structure is described below.
+  The `allowed_address_pairs` block supports:
+  * `ip_address` - (Required, String) The additional IP address.
+  * `mac_address` - (Optional, String) The additional MAC address.
 
-* `value_specs` - (Optional) Map of additional options.
+* `extra_dhcp_option` - (Optional, Map) Specifies the extended DHCP option. This is an extended attribute.
+  The `extra_dhcp_option` block supports:
+  * `name` - (Required, String) Specifies the option name.
+  * `value` - (Required, String) Specifies the option value.
 
-The `fixed_ip` block supports:
-
-* `subnet_id` - (Required) Subnet in which to allocate IP address for
-this port.
-
-* `ip_address` - (Optional) IP address desired in the subnet for this port. If
-you don't specify `ip_address`, an available IP address from the specified
-subnet will be allocated to this port.
-
-The `allowed_address_pairs` block supports:
-
-* `ip_address` - (Required) The additional IP address.
-
-* `mac_address` - (Optional) The additional MAC address.
+* `value_specs` - (Optional, Map) Map of additional options.
 
 
 ## Attributes Reference

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_port_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_port_v2_test.go
@@ -561,8 +561,8 @@ resource "opentelekomcloud_networking_subnet_v2" "subnet_1" {
 }
 
 resource "opentelekomcloud_networking_port_v2" "port_1" {
-  name                  = "port_1"
-  network_id            = opentelekomcloud_networking_network_v2.network_1.id
+  name       = "port_1"
+  network_id = opentelekomcloud_networking_network_v2.network_1.id
   fixed_ip {
     subnet_id  = opentelekomcloud_networking_subnet_v2.subnet_1.id
     ip_address = "192.168.199.23"
@@ -586,8 +586,8 @@ resource "opentelekomcloud_networking_subnet_v2" "subnet_1" {
 }
 
 resource "opentelekomcloud_networking_port_v2" "port_1" {
-  name                  = "port_1"
-  network_id            = opentelekomcloud_networking_network_v2.network_1.id
+  name       = "port_1"
+  network_id = opentelekomcloud_networking_network_v2.network_1.id
   fixed_ip {
     subnet_id  = opentelekomcloud_networking_subnet_v2.subnet_1.id
     ip_address = "192.168.199.23"

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_port_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_port_v2_test.go
@@ -161,6 +161,40 @@ func TestAccNetworkingV2Port_portSecurity_enabled(t *testing.T) {
 	})
 }
 
+func TestAccNetworkingV2Port_extendedDhcpOpts(t *testing.T) {
+	var port testPortWithExtensions
+	resourceName := "opentelekomcloud_networking_port_v2.port_1"
+	t.Parallel()
+	qts := subnetQuotas()
+	quotas.BookMany(t, qts)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckNetworkingV2PortDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkingV2PortExtendedDHCPOpts,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingV2PortWithExtensionsExists(resourceName, &port),
+					resource.TestCheckResourceAttr(resourceName, "extra_dhcp_option.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "extra_dhcp_option.0.name", "A"),
+					resource.TestCheckResourceAttr(resourceName, "extra_dhcp_option.0.value", "MY_VAL"),
+				),
+			},
+			{
+				Config: testAccNetworkingV2PortExtendedDHCPOptsUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingV2PortWithExtensionsExists(resourceName, &port),
+					resource.TestCheckResourceAttr(resourceName, "extra_dhcp_option.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "extra_dhcp_option.0.name", "B"),
+					resource.TestCheckResourceAttr(resourceName, "extra_dhcp_option.0.value", "MY_VAL_UPDATED"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccNetworkingV2Port_noPortSecurityNoSecurityGroups(t *testing.T) {
 	var port testPortWithExtensions
 	resourceName := "opentelekomcloud_networking_port_v2.port_1"
@@ -511,6 +545,56 @@ resource "opentelekomcloud_networking_port_v2" "port_1" {
   timeouts {
     create = "5m"
     delete = "5m"
+  }
+}
+`
+
+const testAccNetworkingV2PortExtendedDHCPOpts = `
+resource "opentelekomcloud_networking_network_v2" "network_1" {
+  name = "network_1"
+}
+resource "opentelekomcloud_networking_subnet_v2" "subnet_1" {
+  name       = "subnet_1"
+  cidr       = "192.168.199.0/24"
+  ip_version = 4
+  network_id = opentelekomcloud_networking_network_v2.network_1.id
+}
+
+resource "opentelekomcloud_networking_port_v2" "port_1" {
+  name                  = "port_1"
+  network_id            = opentelekomcloud_networking_network_v2.network_1.id
+  fixed_ip {
+    subnet_id  = opentelekomcloud_networking_subnet_v2.subnet_1.id
+    ip_address = "192.168.199.23"
+  }
+  extra_dhcp_option {
+    name  = "A"
+    value = "MY_VAL"
+  }
+}
+`
+
+const testAccNetworkingV2PortExtendedDHCPOptsUpdate = `
+resource "opentelekomcloud_networking_network_v2" "network_1" {
+  name = "network_1"
+}
+resource "opentelekomcloud_networking_subnet_v2" "subnet_1" {
+  name       = "subnet_1"
+  cidr       = "192.168.199.0/24"
+  ip_version = 4
+  network_id = opentelekomcloud_networking_network_v2.network_1.id
+}
+
+resource "opentelekomcloud_networking_port_v2" "port_1" {
+  name                  = "port_1"
+  network_id            = opentelekomcloud_networking_network_v2.network_1.id
+  fixed_ip {
+    subnet_id  = opentelekomcloud_networking_subnet_v2.subnet_1.id
+    ip_address = "192.168.199.23"
+  }
+  extra_dhcp_option {
+    name  = "B"
+    value = "MY_VAL_UPDATED"
   }
 }
 `

--- a/releasenotes/notes/network-port-ext-dhcp-ce443b397a12fc86.yaml
+++ b/releasenotes/notes/network-port-ext-dhcp-ce443b397a12fc86.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[NETWORK]** Add `extra_dhcp_opts` support in ``resource/opentelekomcloud_networking_port_v2`` (`#2491 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2491>`_)


### PR DESCRIPTION
## Summary of the Pull Request
```
extra_dhcp_option {
    name  = "B"
    value = "MY_VAL_UPDATED"
}
```
## PR Checklist

* [ ] Refers to: #xxx
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccNetworkingV2Port_basic
=== PAUSE TestAccNetworkingV2Port_basic
=== CONT  TestAccNetworkingV2Port_basic
--- PASS: TestAccNetworkingV2Port_basic (70.49s)
=== RUN   TestAccNetworkingV2Port_importBasic
=== PAUSE TestAccNetworkingV2Port_importBasic
=== CONT  TestAccNetworkingV2Port_importBasic
--- PASS: TestAccNetworkingV2Port_importBasic (75.56s)
=== RUN   TestAccNetworkingV2Port_noip
=== PAUSE TestAccNetworkingV2Port_noip
=== CONT  TestAccNetworkingV2Port_noip
--- PASS: TestAccNetworkingV2Port_noip (70.79s)
=== RUN   TestAccNetworkingV2Port_allowedAddressPairs
=== PAUSE TestAccNetworkingV2Port_allowedAddressPairs
=== CONT  TestAccNetworkingV2Port_allowedAddressPairs
--- PASS: TestAccNetworkingV2Port_allowedAddressPairs (88.22s)
=== RUN   TestAccNetworkingV2Port_portSecurity_enabled
=== PAUSE TestAccNetworkingV2Port_portSecurity_enabled
=== CONT  TestAccNetworkingV2Port_portSecurity_enabled
--- PASS: TestAccNetworkingV2Port_portSecurity_enabled (88.68s)
=== RUN   TestAccNetworkingV2Port_extendedDhcpOpts
=== PAUSE TestAccNetworkingV2Port_extendedDhcpOpts
=== CONT  TestAccNetworkingV2Port_extendedDhcpOpts
--- PASS: TestAccNetworkingV2Port_extendedDhcpOpts (89.34s)
=== RUN   TestAccNetworkingV2Port_noPortSecurityNoSecurityGroups
=== PAUSE TestAccNetworkingV2Port_noPortSecurityNoSecurityGroups
=== CONT  TestAccNetworkingV2Port_noPortSecurityNoSecurityGroups
--- PASS: TestAccNetworkingV2Port_noPortSecurityNoSecurityGroups (69.93s)
=== RUN   TestAccNetworkingV2Port_timeout
=== PAUSE TestAccNetworkingV2Port_timeout
=== CONT  TestAccNetworkingV2Port_timeout
--- PASS: TestAccNetworkingV2Port_timeout (70.46s)
PASS

Process finished with the exit code 0
```
