### PR TITLE
[NETWORK] port association resource and ids data source

### DIFF
--- a/docs/data-sources/networking_port_ids_v2.md
+++ b/docs/data-sources/networking_port_ids_v2.md
@@ -1,0 +1,51 @@
+---
+subcategory: "Virtual Private Cloud (VPC)"
+---
+
+# opentelekomcloud_networking_port_ids_v2
+
+Use this data source to get a list of OpenTelekomCloud Port IDs matching the
+specified criteria.
+
+## Example Usage
+
+```hcl
+data "opentelekomcloud_networking_port_ids_v2" "ports" {
+  name = "port"
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional, String) The region in which to obtain the V2 Neutron client.
+  A Neutron client is needed to retrieve port ids. If omitted, the
+  `region` argument of the provider is used.
+
+* `project_id` - (Optional, String) The owner of the port.
+
+* `name` - (Optional, String) The name of the port.
+
+* `admin_state_up` - (Optional, Bool) The administrative state of the port.
+
+* `network_id` - (Optional, String) The ID of the network the port belongs to.
+
+* `device_owner` - (Optional, String) The device owner of the port.
+
+* `mac_address` - (Optional, String) The MAC address of the port.
+
+* `device_id` - (Optional, String) The ID of the device the port belongs to.
+
+* `fixed_ip` - (Optional, String) The port IP address filter.
+
+* `status` - (Optional, String) The status of the port.
+
+* `security_group_ids` - (Optional, List) The list of port security group IDs to filter.
+
+* `sort_key` - (Optional) Sort ports based on a certain key. Defaults to none.
+
+* `sort_direction` - (Optional) Order the results in either `asc` or `desc`.
+  Defaults to none.
+
+## Attributes Reference
+
+`ids` is set to the list of OpenTelekomCloud Port IDs.

--- a/docs/resources/networking_port_secgroup_associate_v2.md
+++ b/docs/resources/networking_port_secgroup_associate_v2.md
@@ -1,0 +1,71 @@
+---
+subcategory: "Virtual Private Cloud (VPC)"
+---
+
+# opentelekomcloud_networking_port_secgroup_associate_v2
+
+Manages a V2 port's security groups within OpenTelekomCloud. Useful, when the port was
+created not by Terraform (e.g. Manila or LBaaS). It should not be used, when the
+port was created directly within Terraform.
+
+When the resource is deleted, Terraform doesn't delete the port, but unsets the
+list of user defined security group IDs.  However, if `force` is set to `true`
+and the resource is deleted, Terraform will remove all assigned security group
+IDs.
+
+## Example Usage
+
+```hcl
+data "opentelekomcloud_networking_port_v2" "system_port" {
+  fixed_ip = "10.0.0.10"
+}
+
+data "opentelekomcloud_networking_secgroup_v2" "secgroup" {
+  name = "secgroup"
+}
+
+resource "opentelekomcloud_networking_port_secgroup_associate_v2" "port_1" {
+  port_id = data.opentelekomcloud_networking_port_v2.system_port.id
+  security_group_ids = [
+    data.opentelekomcloud_networking_secgroup_v2.secgroup.id,
+  ]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional) The region in which to obtain the V2 networking client.
+  A networking client is needed to manage a port. If omitted, the
+  `region` argument of the provider is used. Changing this creates a new
+  resource.
+
+* `port_id` - (Required) An UUID of the port to apply security groups to.
+
+* `security_group_ids` - (Required) A list of security group IDs to apply to
+  the port. The security groups must be specified by ID and not name (as
+  opposed to how they are configured with the Compute Instance).
+
+* `force` - (Optional) Whether to replace or append the list of security
+  groups, specified in the `security_group_ids`. Defaults to `false`.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `all_security_group_ids` - The collection of Security Group IDs on the port
+  which have been explicitly and implicitly added.
+
+## Import
+
+Port security group association can be imported using the `id` of the port, e.g.
+
+```
+$ terraform import opentelekomcloud_networking_port_secgroup_associate_v2.port_1 eae26a3e-1c33-4cc1-9c31-5ght78rdf12
+  lifecycle {
+    ignore_changes = [
+      force,
+      security_group_ids,
+    ]
+  }

--- a/opentelekomcloud/acceptance/vpc/data_source_opentelekomcloud_networking_port_ids_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/data_source_opentelekomcloud_networking_port_ids_v2_test.go
@@ -1,0 +1,74 @@
+package acceptance
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
+)
+
+func TestAccNetworkingV2PortIDsDataSource_basic(t *testing.T) {
+	dataSourceName := "data.opentelekomcloud_networking_port_ids_v2.ports"
+	port1Name := "opentelekomcloud_networking_port_v2.port_1"
+	port2Name := "opentelekomcloud_networking_port_v2.port_2"
+	t.Parallel()
+	quotas.BookOne(t, quotas.SecurityGroup)
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkingV2PortIDsDataSourceBasic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "ids.#", "2"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "ids.0", port1Name, "id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "ids.1", port2Name, "id"),
+				),
+			},
+		},
+	})
+}
+
+const testAccNetworkingV2PortIDsDataSourceBasic = `
+resource "opentelekomcloud_networking_network_v2" "network_1" {
+  name           = "acc_network_1"
+  admin_state_up = "true"
+}
+
+resource "opentelekomcloud_networking_secgroup_v2" "sg_1" {
+  name        = "acc_secgroup_1"
+  description = "acc_secgroup_1"
+}
+
+resource "opentelekomcloud_networking_port_v2" "port_1" {
+  name           = "port_1"
+  network_id     = opentelekomcloud_networking_network_v2.network_1.id
+  admin_state_up = "true"
+
+  security_group_ids = [
+    opentelekomcloud_networking_secgroup_v2.sg_1.id
+  ]
+}
+
+resource "opentelekomcloud_networking_port_v2" "port_2" {
+  name           = "port_2"
+  network_id     = opentelekomcloud_networking_network_v2.network_1.id
+  admin_state_up = "true"
+
+  security_group_ids = [
+    opentelekomcloud_networking_secgroup_v2.sg_1.id
+  ]
+}
+
+data "opentelekomcloud_networking_port_ids_v2" "ports" {
+  sort_direction = "asc"
+  sort_key       = "name"
+
+  network_id = opentelekomcloud_networking_network_v2.network_1.id
+  depends_on = [
+    opentelekomcloud_networking_port_v2.port_1,
+    opentelekomcloud_networking_port_v2.port_2,
+  ]
+}
+`

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_port_secgroup_associate_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_port_secgroup_associate_test.go
@@ -1,0 +1,102 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/ports"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+)
+
+const resourcePortAssociateName = "opentelekomcloud_networking_port_secgroup_associate_v2.associate"
+
+func getPortResourceFunc(cfg *cfg.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NetworkingV2Client(env.OS_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Networking v2 client: %s", err)
+	}
+	return ports.Get(client, state.Primary.Attributes["port_id"]).Extract()
+}
+
+func TestAccApiPublishment_basic(t *testing.T) {
+	var port ports.Port
+	rc := common.InitResourceCheck(
+		resourcePortAssociateName,
+		&port,
+		getPortResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+		},
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPortAssociate_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					testAccCheckNetworkingV2PortSecGroupAssociateCountSecurityGroups(&port, 2),
+				),
+			},
+			{
+				ResourceName:            resourcePortAssociateName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force", "security_group_ids"},
+			},
+		},
+	})
+}
+
+func testAccCheckNetworkingV2PortSecGroupAssociateCountSecurityGroups(port *ports.Port, expected int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if len(port.SecurityGroups) != expected {
+			return fmt.Errorf("expected %d Security Groups, got %d", expected, len(port.SecurityGroups))
+		}
+
+		return nil
+	}
+}
+
+const testAccNetworkingV2PortSecGroupAssociate = `
+resource "opentelekomcloud_networking_network_v2" "network_1" {
+  name           = "acc_network_1"
+  admin_state_up = "true"
+}
+
+resource "opentelekomcloud_networking_secgroup_v2" "secgroup_1" {
+  name        = "secgroup_1"
+  description = "terraform security group acceptance test"
+}
+
+resource "opentelekomcloud_networking_secgroup_v2" "secgroup_2" {
+  name        = "secgroup_2"
+  description = "terraform security group acceptance test"
+}
+
+resource "opentelekomcloud_networking_port_v2" "port" {
+  name           = "port_1"
+  network_id     = opentelekomcloud_networking_network_v2.network_1.id
+  admin_state_up = "true"
+}
+`
+
+func testAccPortAssociate_basic() string {
+	return fmt.Sprintf(`
+%s
+
+resource "opentelekomcloud_networking_port_secgroup_associate_v2" "associate" {
+  port_id = opentelekomcloud_networking_port_v2.port.id
+  force   = "false"
+  security_group_ids = [
+    opentelekomcloud_networking_secgroup_v2.secgroup_1.id,
+  ]
+}
+`, testAccNetworkingV2PortSecGroupAssociate)
+}

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_port_secgroup_associate_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_port_secgroup_associate_test.go
@@ -22,7 +22,7 @@ func getPortResourceFunc(cfg *cfg.Config, state *terraform.ResourceState) (inter
 	return ports.Get(client, state.Primary.Attributes["port_id"]).Extract()
 }
 
-func TestAccApiPublishment_basic(t *testing.T) {
+func TestAccNetworkingV2PortAssociate_basic(t *testing.T) {
 	var port ports.Port
 	rc := common.InitResourceCheck(
 		resourcePortAssociateName,

--- a/opentelekomcloud/common/utils.go
+++ b/opentelekomcloud/common/utils.go
@@ -391,3 +391,20 @@ func ExpandToStringListBySet(v *schema.Set) []string {
 
 	return s
 }
+
+// SliceUnion returns a new slice containing the union of elements from both slices,
+// without any duplicates.
+func SliceUnion(a, b []string) []string {
+	var res []string
+	for _, i := range a {
+		if !StrSliceContains(res, i) {
+			res = append(res, i)
+		}
+	}
+	for _, k := range b {
+		if !StrSliceContains(res, k) {
+			res = append(res, k)
+		}
+	}
+	return res
+}

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -313,6 +313,7 @@ func Provider() *schema.Provider {
 			"opentelekomcloud_nat_gateway_v2":                    nat.DataSourceNatGatewayV2(),
 			"opentelekomcloud_networking_network_v2":             vpc.DataSourceNetworkingNetworkV2(),
 			"opentelekomcloud_networking_port_v2":                vpc.DataSourceNetworkingPortV2(),
+			"opentelekomcloud_networking_port_ids_v2":            vpc.DataSourceNetworkingPortIDsV2(),
 			"opentelekomcloud_networking_secgroup_v2":            vpc.DataSourceNetworkingSecGroupV2(),
 			"opentelekomcloud_networking_secgroup_rule_ids_v2":   vpc.DataSourceNetworkingSecGroupRuleIdsV2(),
 			"opentelekomcloud_obs_bucket":                        obs.DataSourceObsBucket(),
@@ -349,6 +350,7 @@ func Provider() *schema.Provider {
 
 		ResourcesMap: map[string]*schema.Resource{
 			"opentelekomcloud_antiddos_v1":                               antiddos.ResourceAntiDdosV1(),
+			"opentelekomcloud_apigw_acl_policy_v2":                       apigw.ResourceAPIAclPolicyV2(),
 			"opentelekomcloud_apigw_api_v2":                              apigw.ResourceAPIApiV2(),
 			"opentelekomcloud_apigw_api_publishment_v2":                  apigw.ResourceAPIApiPublishmentV2(),
 			"opentelekomcloud_apigw_environment_v2":                      apigw.ResourceAPIEnvironmentv2(),
@@ -466,6 +468,7 @@ func Provider() *schema.Provider {
 			"opentelekomcloud_networking_floatingip_associate_v2":        vpc.ResourceNetworkingFloatingIPAssociateV2(),
 			"opentelekomcloud_networking_network_v2":                     vpc.ResourceNetworkingNetworkV2(),
 			"opentelekomcloud_networking_port_v2":                        vpc.ResourceNetworkingPortV2(),
+			"opentelekomcloud_networking_port_secgroup_associate_v2":     vpc.ResourceNetworkingPortSecGroupAssociateV2(),
 			"opentelekomcloud_networking_router_v2":                      vpc.ResourceNetworkingRouterV2(),
 			"opentelekomcloud_networking_router_interface_v2":            vpc.ResourceNetworkingRouterInterfaceV2(),
 			"opentelekomcloud_networking_router_route_v2":                vpc.ResourceNetworkingRouterRouteV2(),

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -349,8 +349,8 @@ func Provider() *schema.Provider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"opentelekomcloud_antiddos_v1":                               antiddos.ResourceAntiDdosV1(),
-			"opentelekomcloud_apigw_acl_policy_v2":                       apigw.ResourceAPIAclPolicyV2(),
+			"opentelekomcloud_antiddos_v1": antiddos.ResourceAntiDdosV1(),
+			// "opentelekomcloud_apigw_acl_policy_v2":                       apigw.ResourceAPIAclPolicyV2(),
 			"opentelekomcloud_apigw_api_v2":                              apigw.ResourceAPIApiV2(),
 			"opentelekomcloud_apigw_api_publishment_v2":                  apigw.ResourceAPIApiPublishmentV2(),
 			"opentelekomcloud_apigw_environment_v2":                      apigw.ResourceAPIEnvironmentv2(),

--- a/opentelekomcloud/services/vpc/data_source_opentelekomcloud_networking_port_ids_v2.go
+++ b/opentelekomcloud/services/vpc/data_source_opentelekomcloud_networking_port_ids_v2.go
@@ -1,0 +1,215 @@
+package vpc
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/helper/hashcode"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/ports"
+)
+
+func DataSourceNetworkingPortIDsV2() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceNetworkingPortIDsV2Read,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"network_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"tenant_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"device_owner": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"mac_address": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"device_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"fixed_ip": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IsIPAddress,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"security_group_ids": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+			"sort_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"sort_direction": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"asc", "desc",
+				}, true),
+			},
+			"ids": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceNetworkingPortIDsV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, keyClientV2, func() (*golangsdk.ServiceClient, error) {
+		return config.NetworkingV2Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV2Client, err)
+	}
+
+	listOpts := ports.ListOpts{}
+	var listOptsBuilder ports.ListOptsBuilder
+
+	if v, ok := d.GetOk("sort_key"); ok {
+		listOpts.SortKey = v.(string)
+	}
+	if v, ok := d.GetOk("sort_direction"); ok {
+		listOpts.SortDir = v.(string)
+	}
+	if v, ok := d.GetOk("name"); ok {
+		listOpts.Name = v.(string)
+	}
+	if v, ok := d.GetOk("network_id"); ok {
+		listOpts.NetworkID = v.(string)
+	}
+	if v, ok := d.GetOk("status"); ok {
+		listOpts.Status = v.(string)
+	}
+	if v, ok := d.GetOk("tenant_id"); ok {
+		listOpts.TenantID = v.(string)
+	}
+	if v, ok := d.GetOk("project_id"); ok {
+		listOpts.ProjectID = v.(string)
+	}
+	if v, ok := d.GetOk("device_owner"); ok {
+		listOpts.DeviceOwner = v.(string)
+	}
+	if v, ok := d.GetOk("mac_address"); ok {
+		listOpts.MACAddress = v.(string)
+	}
+	if v, ok := d.GetOk("device_id"); ok {
+		listOpts.DeviceID = v.(string)
+	}
+	listOptsBuilder = listOpts
+
+	allPages, err := ports.List(client, listOptsBuilder).AllPages()
+	if err != nil {
+		return diag.Errorf("unable to list OpenTelekomCloud ports: %s", err)
+	}
+
+	allPorts, err := ports.ExtractPorts(allPages)
+	if err != nil {
+		return diag.Errorf("unable to retrieve OpenTelekomCloud: %s", err)
+	}
+
+	if len(allPorts) == 0 {
+		log.Printf("[DEBUG] No ports in OpenTelekomCloud found")
+	}
+
+	portsList := make([]ports.Port, 0, len(allPorts))
+	portIDs := make([]string, 0, len(allPorts))
+
+	// Filter returned Fixed IPs by a "fixed_ip".
+	if v, ok := d.GetOk("fixed_ip"); ok {
+		for _, p := range allPorts {
+			for _, ipObject := range p.FixedIPs {
+				if v.(string) == ipObject.IPAddress {
+					portsList = append(portsList, p)
+				}
+			}
+		}
+		if len(portsList) == 0 {
+			log.Printf("[DEBUG] No ports in OpenTelekomCloud found after the 'fixed_ip' filter")
+		}
+	} else {
+		portsList = allPorts
+	}
+
+	securityGroups := common.ExpandToStringSlice(d.Get("security_group_ids").(*schema.Set).List())
+	if len(securityGroups) > 0 {
+		var sgPorts []ports.Port
+		for _, p := range portsList {
+			for _, sg := range p.SecurityGroups {
+				if common.StrSliceContains(securityGroups, sg) {
+					sgPorts = append(sgPorts, p)
+				}
+			}
+		}
+		if len(sgPorts) == 0 {
+			log.Printf("[DEBUG] No ports in OpenTelekomCloud found after the 'security_group_ids' filter")
+		}
+		portsList = sgPorts
+	}
+
+	for _, p := range portsList {
+		portIDs = append(portIDs, p.ID)
+	}
+
+	log.Printf("[DEBUG] Retrieved %d ports in OpenTelekomCloud: %+v", len(portsList), portsList)
+	portID := fmt.Sprintf("%d", hashcode.String(strings.Join(portIDs, "")))
+	d.SetId(portID)
+	mErr := multierror.Append(nil,
+		d.Set("ids", portIDs),
+		d.Set("region", config.GetRegion(d)),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error saving port (%s) fields: %s", portID, err)
+	}
+	return nil
+}

--- a/opentelekomcloud/services/vpc/resource_opentelekomcloud_networking_port_secgroup_associate_v2.go
+++ b/opentelekomcloud/services/vpc/resource_opentelekomcloud_networking_port_secgroup_associate_v2.go
@@ -1,0 +1,219 @@
+package vpc
+
+import (
+	"context"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/ports"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
+)
+
+func ResourceNetworkingPortSecGroupAssociateV2() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceNetworkingPortSecGroupAssociateV2Create,
+		ReadContext:   resourceNetworkingPortSecGroupAssociateV2Read,
+		UpdateContext: resourceNetworkingPortSecGroupAssociateV2Update,
+		DeleteContext: resourceNetworkingPortSecGroupAssociateV2Delete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"port_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"security_group_ids": {
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+			"force": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"all_security_group_ids": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+		},
+	}
+}
+
+func resourceNetworkingPortSecGroupAssociateV2Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, keyClientV2, func() (*golangsdk.ServiceClient, error) {
+		return config.NetworkingV2Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV2Client, err)
+	}
+
+	securityGroups := common.ExpandToStringSlice(d.Get("security_group_ids").(*schema.Set).List())
+	portID := d.Get("port_id").(string)
+
+	port, err := ports.Get(client, portID).Extract()
+	if err != nil {
+		return diag.Errorf("unable to get OpenTelekomCloud %s Port: %s", portID, err)
+	}
+
+	log.Printf("[DEBUG] Retrieved Port %s: %+v", portID, port)
+
+	var updateOpts ports.UpdateOpts
+	var force bool
+	if v, ok := d.GetOk("force"); ok {
+		force = v.(bool)
+	}
+
+	if force {
+		updateOpts.SecurityGroups = &securityGroups
+	} else {
+		sg := common.SliceUnion(port.SecurityGroups, securityGroups)
+		updateOpts.SecurityGroups = &sg
+	}
+
+	log.Printf("[DEBUG] Port Security Group Associate Options: %#v", updateOpts.SecurityGroups)
+
+	_, err = ports.Update(client, portID, updateOpts).Extract()
+	if err != nil {
+		return diag.Errorf("error associating OpenTelekomCloud %s port with '%s' security groups: %s", portID, strings.Join(securityGroups, ","), err)
+	}
+
+	d.SetId(portID)
+
+	clientCtx := common.CtxWithClient(ctx, client, keyClientV2)
+	return resourceNetworkingPortSecGroupAssociateV2Read(clientCtx, d, meta)
+}
+
+func resourceNetworkingPortSecGroupAssociateV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, keyClientV2, func() (*golangsdk.ServiceClient, error) {
+		return config.NetworkingV2Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV2Client, err)
+	}
+
+	port, err := ports.Get(client, d.Id()).Extract()
+	if err != nil {
+		return diag.FromErr(common.CheckDeleted(d, err, "error fetching OpenTelekomCloud port security groups"))
+	}
+
+	force := false
+	if v, ok := d.GetOk("force"); ok {
+		force = v.(bool)
+	}
+	mErr := multierror.Append(nil,
+		d.Set("all_security_group_ids", port.SecurityGroups),
+		d.Set("force", force),
+		d.Set("port_id", d.Id()),
+		d.Set("region", config.GetRegion(d)),
+	)
+
+	if force {
+		mErr = multierror.Append(mErr, d.Set("security_group_ids", port.SecurityGroups))
+	} else {
+		allSet := d.Get("all_security_group_ids").(*schema.Set)
+		desiredSet := d.Get("security_group_ids").(*schema.Set)
+		actualSet := allSet.Intersection(desiredSet)
+		if !actualSet.Equal(desiredSet) {
+			mErr = multierror.Append(mErr, d.Set("security_group_ids", common.ExpandToStringSlice(actualSet.List())))
+		}
+	}
+	if mErr.ErrorOrNil() != nil {
+		return diag.Errorf("error saving port resource fields: %s", mErr)
+	}
+
+	return nil
+}
+
+func resourceNetworkingPortSecGroupAssociateV2Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, keyClientV2, func() (*golangsdk.ServiceClient, error) {
+		return config.NetworkingV2Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV2Client, err)
+	}
+
+	var updateOpts ports.UpdateOpts
+	var force bool
+	if v, ok := d.GetOk("force"); ok {
+		force = v.(bool)
+	}
+
+	if force {
+		securityGroups := ResourcePortSecurityGroupsV2(d)
+		updateOpts.SecurityGroups = &securityGroups
+	} else {
+		allSet := d.Get("all_security_group_ids").(*schema.Set)
+		oldIDs, newIDs := d.GetChange("security_group_ids")
+		oldSet, newSet := oldIDs.(*schema.Set), newIDs.(*schema.Set)
+		allWithoutOld := allSet.Difference(oldSet)
+		newSecurityGroups := common.ExpandToStringSlice(allWithoutOld.Union(newSet).List())
+		updateOpts.SecurityGroups = &newSecurityGroups
+	}
+
+	if d.HasChange("security_group_ids") || d.HasChange("force") {
+		log.Printf("[DEBUG] Port Security Group Update Options: %#v", updateOpts.SecurityGroups)
+		_, err = ports.Update(client, d.Id(), updateOpts).Extract()
+		if err != nil {
+			return diag.Errorf("Error updating OpenTelekomCloud Port: %s", err)
+		}
+	}
+
+	clientCtx := common.CtxWithClient(ctx, client, keyClientV2)
+	return resourceNetworkingPortSecGroupAssociateV2Read(clientCtx, d, meta)
+}
+
+func resourceNetworkingPortSecGroupAssociateV2Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, keyClientV2, func() (*golangsdk.ServiceClient, error) {
+		return config.NetworkingV2Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV2Client, err)
+	}
+
+	var updateOpts ports.UpdateOpts
+	var force bool
+	if v, ok := d.GetOk("force"); ok {
+		force = v.(bool)
+	}
+
+	if force {
+		updateOpts.SecurityGroups = &[]string{}
+	} else {
+		allSet := d.Get("all_security_group_ids").(*schema.Set)
+		oldSet := d.Get("security_group_ids").(*schema.Set)
+		allWithoutOld := allSet.Difference(oldSet)
+		newSecurityGroups := common.ExpandToStringSlice(allWithoutOld.List())
+		updateOpts.SecurityGroups = &newSecurityGroups
+	}
+	log.Printf("[DEBUG] Port security groups disassociation options: %#v", updateOpts.SecurityGroups)
+
+	_, err = ports.Update(client, d.Id(), updateOpts).Extract()
+	if err != nil {
+		return diag.FromErr(common.CheckDeleted(d, err, "error disassociating OpenTelekomCloud port security groups"))
+	}
+
+	return nil
+}

--- a/releasenotes/notes/network-port-sg-associate-72fc7dbe0a1cb0bc.yaml
+++ b/releasenotes/notes/network-port-sg-associate-72fc7dbe0a1cb0bc.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    **[NETWORK]** New resource ``resource/opentelekomcloud_networking_port_secgroup_associate_v2`` (`#2493 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2493>`_)
+  - |
+    **[NETWORK]** New data-source ``data-source/opentelekomcloud_networking_port_ids_v2`` (`#2493 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2493>`_)


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [ ] Refers to: #xxx
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccNetworkingV2PortAssociate_basic
=== PAUSE TestAccNetworkingV2PortAssociate_basic
=== CONT  TestAccNetworkingV2PortAssociate_basic
--- PASS: TestAccNetworkingV2PortAssociate_basic (66.75s)
PASS

Process finished with the exit code 0

=== RUN   TestAccNetworkingV2PortIDsDataSource_basic
=== PAUSE TestAccNetworkingV2PortIDsDataSource_basic
=== CONT  TestAccNetworkingV2PortIDsDataSource_basic
--- PASS: TestAccNetworkingV2PortIDsDataSource_basic (56.40s)
PASS

Process finished with the exit code 0
```
