### PR TITLE
[WAFD] `res_tenant` fix in `resource/opentelekomcloud_waf_dedicated_instance_v1`

### DIFF
--- a/docs/resources/waf_dedicated_instance_v1.md
+++ b/docs/resources/waf_dedicated_instance_v1.md
@@ -69,6 +69,9 @@ The following arguments are supported:
 * `architecture` - (Optional, String, ForceNew) Dedicated engine CPU architecture. Default value is `x86`.
   Changing this will create a new instance.
 
+* `res_tenant` - (Optional, String, ForceNew) Whether the dedicated WAF instance is network interface type.
+  Default value is `true`. Changing this will create a new instance.
+
 ## Attributes Reference
 
 The following attributes are exported:
@@ -117,4 +120,10 @@ WAF dedicated instance can be imported using the `id`, e.g.
 
 ```bash
 $ terraform import opentelekomcloud_waf_dedicated_instance_v1.wafd <id>
+  lifecycle {
+    ignore_changes = [
+      res_tenant,
+      specification,
+    ]
+  }
 ```

--- a/opentelekomcloud/acceptance/waf/resource_opentelekomcloud_waf_dedicated_instance_v1_test.go
+++ b/opentelekomcloud/acceptance/waf/resource_opentelekomcloud_waf_dedicated_instance_v1_test.go
@@ -56,7 +56,7 @@ func TestAccWafDedicatedInstanceV1_basic(t *testing.T) {
 				ResourceName:            wafdInstanceResourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"specification"},
+				ImportStateVerifyIgnore: []string{"specification", "res_tenant"},
 			},
 		},
 	})

--- a/opentelekomcloud/services/waf/resource_opentelekomcloud_waf_dedicated_instance_v1.go
+++ b/opentelekomcloud/services/waf/resource_opentelekomcloud_waf_dedicated_instance_v1.go
@@ -82,6 +82,12 @@ func ResourceWafDedicatedInstance() *schema.Resource {
 				ForceNew: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"res_tenant": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+				Default:  true,
+			},
 			"server_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -142,7 +148,7 @@ func resourceWafDedicatedInstanceV1Create(ctx context.Context, d *schema.Resourc
 		SubnetId:         d.Get("subnet_id").(string),
 		SecurityGroupsId: groups,
 		Count:            defaultCount,
-		ResTenant:        pointerto.Bool(true),
+		ResTenant:        pointerto.Bool(d.Get("res_tenant").(bool)),
 	}
 
 	r, err := instances.Create(client, opts)

--- a/releasenotes/notes/wafd-res-tenant-attr-ed14456250891133.yaml
+++ b/releasenotes/notes/wafd-res-tenant-attr-ed14456250891133.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  |
+  **[WAF]** Fix setting `res_tenant` attribute in ``resource/opentelekomcloud_waf_dedicated_instance_v1`` (`#2497 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2497>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Now possible to set `res_tenant` attribute on create

## PR Checklist

* [x] Refers to: #2494
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccWafDedicatedInstanceV1_basic
--- PASS: TestAccWafDedicatedInstanceV1_basic (379.55s)
=== RUN   TestAccWafDedicatedInstanceV1_basic
--- PASS: TestAccWafDedicatedInstanceV1_basic (380.92s)
PASS

Process finished with exit code 0
```
