### PR TITLE
[DCAAS]: feature to provide both IPV4 and IPV6 addresses

### DIFF
--- a/docs/resources/dс_virtual_gateway_v2.md
+++ b/docs/resources/dс_virtual_gateway_v2.md
@@ -18,6 +18,11 @@ resource "opentelekomcloud_dc_virtual_gateway_v2" "vgw_1" {
     endpoints   = ["10.2.0.0/24", "10.3.0.0/24"]
     description = "first"
   }
+  local_ep_group_v6 {
+    name        = "tf_eg_2"
+    endpoints   = ["2a07:8700:2:4::/64", "2a07:8700:2:54::/64"]
+    description = "first"
+  }
 }
 ```
 
@@ -26,28 +31,49 @@ resource "opentelekomcloud_dc_virtual_gateway_v2" "vgw_1" {
 The following arguments are supported:
 
 * `vpc_id` (String, Required, ForceNew) - Specifies the ID of the VPC to be accessed.
-* `local_ep_group` (String, Required, List) - Specifies the the local endpoint group that records CIDR blocks of the VPC subnets.
-  The `local_ep_group` block supports:
-  * `name` (String, Optional) - Specifies the name of the Direct Connect endpoint group.
-  * `description` (String, Optional) - Provides supplementary information about the Direct Connect endpoint group.
-  * `endpoints` (List, Required) - Specifies the list of the endpoints in a Direct Connect endpoint group.
-    `IPv4` and `IPv6` CIDRs endpoints should be assigned in separate resources.
-     Changing endpoint type (from `IPv4` to `IPv6` or back) is not supported.
-  * `type` (String, Required, ForceNew) - Specifies the type of the Direct Connect endpoints. The value can only be `cidr`. Default value: `cidr`.
-* `name` (String, Required) - Specifies the virtual gateway name.
+
+* `local_ep_group` (String, Optional, List) - Specifies the local endpoint group that records CIDR IPV4 blocks of the VPC subnets.
+  At least one of `local_ep_group` or `local_ep_group_v6` should be specified.
+  The [object](#local_group) structure is documented below.
+
+* `local_ep_group_v6` (String, Optional, List) - Specifies the local endpoint group that records CIDR IPV6 blocks of the VPC subnets.
+  At least one of `local_ep_group` or `local_ep_group_v6` should be specified.
+  The [object](#local_group) structure is documented below.
+
+* `name` (String, Required) - Specifies the virtual gateway name.]()
+
 * `description` (String, Optional) - Provides supplementary information about the virtual gateway.
+
 * `asn` (Int, Optional, ForceNew) - Specifies the BGP ASN of the virtual gateway.
+
 * `device_id` (String, Optional) - Specifies the ID of the physical device used by the virtual gateway.
+
 * `project_id` (String, Optional) - Specifies the project ID.
+
 * `redundant_device_id` (String, Optional) - Specifies the ID of the redundant physical device used by the virtual gateway.
+
+  <a name="local_group"></a>
+  The `local_group` block supports:
+
+    * `name` (String, Optional) - Specifies the name of the Direct Connect endpoint group.
+
+    * `description` (Str[ing, Optional) - Provides supplementary information about the Direct Connect endpoint group.
+
+    * `endpoints` (List, Required) - Specifies the list of the endpoints in a Direct Connect endpoint group.
+
+    * `type` (String, Required, ForceNew) - Specifies the type of the Direct Connect endpoints. The value can only be `cidr`. Default value: `cidr`.
 
 ## Attributes Reference
 
 The following attributes are exported:
 
 * `id` -  ID of the virtual gateway.
+
 * `status` -  Virtual gateway status.
-* `local_ep_group_id` - ID of the local endpoint group that records CIDR blocks of the VPC subnets.
+
+* `local_ep_group_id` - ID of the local IPV4 endpoint group that records CIDR blocks of the VPC subnets.
+
+* `local_ep_group_ipv6_id` - ID of the local IPV6 endpoint group that records CIDR blocks of the VPC subnets.
 
 ## Import
 

--- a/opentelekomcloud/acceptance/dcaas/resource_opentelekomcloud_dc_virtual_gateway_v2_test.go
+++ b/opentelekomcloud/acceptance/dcaas/resource_opentelekomcloud_dc_virtual_gateway_v2_test.go
@@ -60,7 +60,7 @@ func TestDirectConnectVirtualGatewayV2Resource_basic(t *testing.T) {
 	})
 }
 
-func TestDirectConnectVirtualGatewayV2ResourceIpv6_basic(t *testing.T) {
+func TestDirectConnectVirtualGatewayV2ResourceIpv6_combined(t *testing.T) {
 	gwName := fmt.Sprintf("dc-%s", acctest.RandString(5))
 	var gateway virtualgateway.VirtualGateway
 	resource.Test(t, resource.TestCase{
@@ -74,8 +74,8 @@ func TestDirectConnectVirtualGatewayV2ResourceIpv6_basic(t *testing.T) {
 					testAccCheckDirectConnectVirtualGatewayV2Exists(vg, &gateway),
 					resource.TestCheckResourceAttr(vg, "name", gwName),
 					resource.TestCheckResourceAttrSet(vg, "local_ep_group_ipv6_id"),
-					resource.TestCheckResourceAttr(vg, "local_ep_group.0.type", "cidr"),
-					resource.TestCheckResourceAttr(vg, "local_ep_group.0.endpoints.#", "1"),
+					resource.TestCheckResourceAttr(vg, "local_ep_group_v6.0.type", "cidr"),
+					resource.TestCheckResourceAttr(vg, "local_ep_group_v6.0.endpoints.#", "1"),
 				),
 			},
 			{
@@ -84,18 +84,42 @@ func TestDirectConnectVirtualGatewayV2ResourceIpv6_basic(t *testing.T) {
 					testAccCheckDirectConnectVirtualGatewayV2Exists(vg, &gateway),
 					resource.TestCheckResourceAttr(vg, "name", gwName+"updated"),
 					resource.TestCheckResourceAttrSet(vg, "local_ep_group_ipv6_id"),
-					resource.TestCheckResourceAttr(vg, "local_ep_group.0.type", "cidr"),
-					resource.TestCheckResourceAttr(vg, "local_ep_group.0.endpoints.#", "2"),
+					resource.TestCheckResourceAttr(vg, "local_ep_group_v6.0.type", "cidr"),
+					resource.TestCheckResourceAttr(vg, "local_ep_group_v6.0.endpoints.#", "2"),
 				),
 			},
-			// Changing address types doesn't work because previous one can't be unbound
-			// {
-			// 	Config: testAccVirtualGatewayV2_basic(gwName),
-			// 	Check: resource.ComposeTestCheckFunc(
-			// 		testAccCheckDirectConnectVirtualGatewayV2Exists(vg, &gateway),
-			// 		resource.TestCheckResourceAttrSet(vg, "local_ep_group_id"),
-			// 	),
-			// },
+			{
+				Config: testAccVirtualGatewayV2_combined(gwName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDirectConnectVirtualGatewayV2Exists(vg, &gateway),
+					resource.TestCheckResourceAttr(vg, "name", gwName),
+					resource.TestCheckResourceAttr(vg, "description", "acc test"),
+					resource.TestCheckResourceAttrSet(vg, "asn"),
+					resource.TestCheckResourceAttrSet(vg, "status"),
+					resource.TestCheckResourceAttrSet(vg, "local_ep_group_id"),
+					resource.TestCheckResourceAttrSet(vg, "local_ep_group_ipv6_id"),
+					resource.TestCheckResourceAttr(vg, "local_ep_group.0.type", "cidr"),
+					resource.TestCheckResourceAttr(vg, "local_ep_group.0.endpoints.#", "1"),
+					resource.TestCheckResourceAttr(vg, "local_ep_group_v6.0.type", "cidr"),
+					resource.TestCheckResourceAttr(vg, "local_ep_group_v6.0.endpoints.#", "1"),
+				),
+			},
+			{
+				Config: testAccVirtualGatewayV2_combinedUpdate(gwName + "updated"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDirectConnectVirtualGatewayV2Exists(vg, &gateway),
+					resource.TestCheckResourceAttr(vg, "name", gwName+"updated"),
+					resource.TestCheckResourceAttr(vg, "description", "acc test updated"),
+					resource.TestCheckResourceAttrSet(vg, "asn"),
+					resource.TestCheckResourceAttrSet(vg, "status"),
+					resource.TestCheckResourceAttrSet(vg, "local_ep_group_id"),
+					resource.TestCheckResourceAttrSet(vg, "local_ep_group_ipv6_id"),
+					resource.TestCheckResourceAttr(vg, "local_ep_group.0.type", "cidr"),
+					resource.TestCheckResourceAttr(vg, "local_ep_group.0.endpoints.#", "2"),
+					resource.TestCheckResourceAttr(vg, "local_ep_group_v6.0.type", "cidr"),
+					resource.TestCheckResourceAttr(vg, "local_ep_group_v6.0.endpoints.#", "2"),
+				),
+			},
 		},
 	})
 }
@@ -204,7 +228,7 @@ resource "opentelekomcloud_dc_virtual_gateway_v2" "vgw_1" {
   vpc_id      = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
   name        = "%s"
   description = "acc test"
-  local_ep_group {
+  local_ep_group_v6 {
     name        = "tf_acc_eg_1"
     endpoints   = ["2a07:8700:2:4::/64"]
     description = "first"
@@ -223,7 +247,56 @@ resource "opentelekomcloud_dc_virtual_gateway_v2" "vgw_1" {
   vpc_id      = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
   name        = "%s"
   description = "acc test updated"
+  local_ep_group_v6 {
+    name        = "tf_acc_eg_1"
+    endpoints   = ["2a07:8700:2:4::/64", "2a07:8700:2:54::/64"]
+    description = "first"
+  }
+}
+`, common.DataSourceSubnet, common.DataSourceProject, name)
+}
+
+func testAccVirtualGatewayV2_combined(name string) string {
+	return fmt.Sprintf(`
+%s
+
+%s
+
+resource "opentelekomcloud_dc_virtual_gateway_v2" "vgw_1" {
+  vpc_id      = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  name        = "%s"
+  description = "acc test"
   local_ep_group {
+    name        = "tf_acc_eg_1"
+    endpoints   = ["10.2.0.0/24"]
+    description = "first"
+  }
+
+  local_ep_group_v6 {
+    name        = "tf_acc_eg_1"
+    endpoints   = ["2a07:8700:2:4::/64"]
+    description = "first"
+  }
+}
+`, common.DataSourceSubnet, common.DataSourceProject, name)
+}
+
+func testAccVirtualGatewayV2_combinedUpdate(name string) string {
+	return fmt.Sprintf(`
+%s
+
+%s
+
+resource "opentelekomcloud_dc_virtual_gateway_v2" "vgw_1" {
+  vpc_id      = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  name        = "%s"
+  description = "acc test updated"
+  local_ep_group {
+    name        = "tf_acc_eg_1"
+    endpoints   = ["10.2.0.0/24", "10.3.0.0/24"]
+    description = "first"
+  }
+  local_ep_group_v6 {
     name        = "tf_acc_eg_1"
     endpoints   = ["2a07:8700:2:4::/64", "2a07:8700:2:54::/64"]
     description = "first"

--- a/opentelekomcloud/services/dcaas/common.go
+++ b/opentelekomcloud/services/dcaas/common.go
@@ -1,7 +1,5 @@
 package dcaas
 
-import "strings"
-
 const (
 	errCreateClient = "error creating OpenTelekomCloud DCaaSv2 client: %w"
 	keyClientV2     = "dcaas-v2-client"
@@ -15,8 +13,4 @@ func GetEndpoints(e []interface{}) []string {
 		endpoints = append(endpoints, val.(string))
 	}
 	return endpoints
-}
-
-func isIpv6Block(endpoint []string) bool {
-	return strings.Contains(endpoint[0], ":")
 }

--- a/releasenotes/notes/dc_gateway_update-963e490ec34670c6.yaml
+++ b/releasenotes/notes/dc_gateway_update-963e490ec34670c6.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   |
-  **[DCAAS]** Feature to provide both IPV4 and IPV6 addresses for ``resource/opentelekomcloud_dc_virtual_gateway_v2`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+  **[DCAAS]** Feature to provide both IPV4 and IPV6 addresses for ``resource/opentelekomcloud_dc_virtual_gateway_v2`` (`#2542 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2542>`_)

--- a/releasenotes/notes/dc_gateway_update-963e490ec34670c6.yaml
+++ b/releasenotes/notes/dc_gateway_update-963e490ec34670c6.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  |
+  **[DCAAS]** Feature to provide both IPV4 and IPV6 addresses for ``resource/opentelekomcloud_dc_virtual_gateway_v2`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Both Ipv4 and Ipv6 addresses can now be provided.

## PR Checklist

* [x] Refers to: #2516
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestDirectConnectVirtualGatewayV2Resource_basic
--- PASS: TestDirectConnectVirtualGatewayV2Resource_basic (51.81s)
=== RUN   TestDirectConnectVirtualGatewayV2ResourceIpv6_combined
--- PASS: TestDirectConnectVirtualGatewayV2ResourceIpv6_combined (89.51s)
PASS

Process finished with the exit code 0
```
