### PR TITLE
[VPC] new `data-source/opentelekomcloud_vpc_route_table_v1`

### DIFF
--- a/docs/data-sources/vpc_route_table.md
+++ b/docs/data-sources/vpc_route_table.md
@@ -1,0 +1,56 @@
+---
+subcategory: "Virtual Private Cloud (VPC)"
+---
+
+# opentelekomcloud_vpc_route_table_v1
+
+Provides details about a specific VPC route table.
+
+## Example Usage
+
+```hcl
+variable "vpc_id" {}
+
+# get the default route table
+data "opentelekomcloud_vpc_route_table_v1" "default" {
+  vpc_id = var.vpc_id
+}
+
+# get a custom route table
+data "opentelekomcloud_vpc_route_table_v1" "custom" {
+  vpc_id = var.vpc_id
+  name   = "my"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `vpc_id` - (Required, String) Specifies the VPC ID where the route table resides.
+
+* `name` - (Optional, String) Specifies the name of the route table.
+
+* `id` - (Optional, String) Specifies the ID of the route table.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `default` - Whether the route table is default or not.
+
+* `description` - The supplementary information about the route table.
+
+* `subnets` - An array of one or more subnets associating with the route table.
+
+* `region` - The region in which belongs the vpc route table.
+*
+* `route` - The route object list. The [route object](#route_object) is documented below.
+
+<a name="route_object"></a>
+The `route` block supports:
+
+* `type` - The route type.
+* `destination` - The destination address in the CIDR notation format
+* `nexthop` - The next hop.
+* `description` - The description about the route.

--- a/opentelekomcloud/acceptance/vpc/data_source_opentelekomcloud_vpc_route_table_v1_test.go
+++ b/opentelekomcloud/acceptance/vpc/data_source_opentelekomcloud_vpc_route_table_v1_test.go
@@ -1,0 +1,87 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+)
+
+func TestAccVpcRouteTableDataSource_basic(t *testing.T) {
+	rName := tools.RandomString("rtb-", 5)
+	dataSourceName := "data.opentelekomcloud_vpc_route_table_v1.drtb"
+	dc := common.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceRouteTable_base(rName),
+			},
+			{
+				Config: testAccDataSourceRouteTable_default(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "default", "true"),
+					resource.TestCheckResourceAttr(dataSourceName, "subnets.#", "1"),
+				),
+			},
+			{
+				Config: testAccDataSourceRouteTable_custom(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "default", "false"),
+					resource.TestCheckResourceAttr(dataSourceName, "subnets.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceRouteTable_base(rName string) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_vpc_v1" "vpc" {
+  name = "%[1]s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "opentelekomcloud_vpc_subnet_v1" "subnet" {
+  name       = "%[1]s"
+  cidr       = "192.168.0.0/24"
+  gateway_ip = "192.168.0.1"
+  vpc_id     = opentelekomcloud_vpc_v1.vpc.id
+}
+`, rName)
+}
+
+func testAccDataSourceRouteTable_default(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "opentelekomcloud_vpc_route_table_v1" "drtb" {
+  vpc_id = opentelekomcloud_vpc_v1.vpc.id
+}
+`, testAccDataSourceRouteTable_base(rName))
+}
+
+func testAccDataSourceRouteTable_custom(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "opentelekomcloud_vpc_route_table_v1" "rtb" {
+  name        = "%[2]s"
+  vpc_id      = opentelekomcloud_vpc_v1.vpc.id
+  description = "created by terraform"
+}
+
+data "opentelekomcloud_vpc_route_table_v1" "drtb" {
+  vpc_id = opentelekomcloud_vpc_v1.vpc.id
+  name   = "%[2]s"
+
+  depends_on = [opentelekomcloud_vpc_route_table_v1.rtb]
+}
+`, testAccDataSourceRouteTable_base(rName), rName)
+}

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -343,6 +343,7 @@ func Provider() *schema.Provider {
 			"opentelekomcloud_vpc_peering_connection_v2":         vpc.DataSourceVpcPeeringConnectionV2(),
 			"opentelekomcloud_vpc_route_v2":                      vpc.DataSourceVPCRouteV2(),
 			"opentelekomcloud_vpc_route_ids_v2":                  vpc.DataSourceVPCRouteIdsV2(),
+			"opentelekomcloud_vpc_route_table_v1":                vpc.DataSourceVPCRouteTableV1(),
 			"opentelekomcloud_vpc_subnet_v1":                     vpc.DataSourceVpcSubnetV1(),
 			"opentelekomcloud_vpc_subnet_ids_v1":                 vpc.DataSourceVpcSubnetIdsV1(),
 			"opentelekomcloud_vpnaas_service_v2":                 vpn.DataSourceVpnServiceV2(),

--- a/opentelekomcloud/services/vpc/data_source_opentelekomcloud_vpc_route_table_v1.go
+++ b/opentelekomcloud/services/vpc/data_source_opentelekomcloud_vpc_route_table_v1.go
@@ -1,0 +1,147 @@
+package vpc
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v1/routetables"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+)
+
+func DataSourceVPCRouteTableV1() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceVpcRouteTableV1Read,
+
+		Schema: map[string]*schema.Schema{
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"default": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"subnets": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"region": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"route": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"destination": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"nexthop": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceVpcRouteTableV1Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := config.NetworkingV1Client(config.GetRegion(d))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	listOpts := routetables.ListOpts{
+		VpcID: d.Get("vpc_id").(string),
+		ID:    d.Get("id").(string),
+	}
+	allRouteTables, err := routetables.List(client, listOpts)
+	if err != nil {
+		return diag.Errorf("unable to retrieve OpenTelekomCloud VPC route tables: %s", err)
+	}
+
+	if len(allRouteTables) < 1 {
+		return diag.Errorf("your query returned no results. " +
+			"Please change your search criteria and try again.")
+	}
+
+	var rtbID string
+	if v, ok := d.GetOk("name"); ok {
+		filterName := v.(string)
+		for _, rtb := range allRouteTables {
+			if filterName == rtb.Name {
+				rtbID = rtb.ID
+				break
+			}
+		}
+	} else {
+		// find the default route table if name was not specified
+		for _, rtb := range allRouteTables {
+			if rtb.Default {
+				rtbID = rtb.ID
+				break
+			}
+		}
+	}
+
+	if rtbID == "" {
+		return diag.Errorf("your query returned no results. " +
+			"Please change your search criteria and try again.")
+	}
+
+	// call Get API to retrieve more details about the route table
+	routeTable, err := routetables.Get(client, rtbID)
+	if err != nil {
+		return diag.Errorf("unable to retrieve OpenTelekomCloud route VPC table %s: %s", rtbID, err)
+	}
+
+	log.Printf("[DEBUG] Retrieved VPC route table %s: %+v", rtbID, routeTable)
+	d.SetId(rtbID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", config.GetRegion(d)),
+		d.Set("vpc_id", routeTable.VpcID),
+		d.Set("name", routeTable.Name),
+		d.Set("description", routeTable.Description),
+		d.Set("default", routeTable.Default),
+		d.Set("subnets", expandRouteTableSubnets(routeTable.Subnets)),
+		d.Set("route", expandRouteTableRoutes(routeTable.Routes)),
+	)
+
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error saving OpenTelekomCloud VPC route table: %s", err)
+	}
+
+	return nil
+}

--- a/releasenotes/notes/vpc-ds-route-table-ee017513d31e5863.yaml
+++ b/releasenotes/notes/vpc-ds-route-table-ee017513d31e5863.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    **New Data Source:** ``opentelekomcloud_vpc_route_table_v1``
+    (`#2563 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2563>`_)


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [x] Refers to: #2562
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccVpcRouteTableDataSource_basic
=== PAUSE TestAccVpcRouteTableDataSource_basic
=== CONT  TestAccVpcRouteTableDataSource_basic
--- PASS: TestAccVpcRouteTableDataSource_basic (99.39s)
PASS

Process finished with the exit code 0
```
