### PR TITLE
CCE: Node pool

### DIFF
--- a/docs/resources/cce_node_pool_v3.md
+++ b/docs/resources/cce_node_pool_v3.md
@@ -11,6 +11,8 @@ Provides a node pool resource management of a container cluster.
 
 ## Example Usage
 
+### Basic example
+
 ```hcl
 variable "cluster_id" {}
 variable "ssh_key" {}
@@ -51,14 +53,82 @@ resource "opentelekomcloud_cce_node_pool_v3" "node_pool_1" {
 }
 ```
 
+### Node pool with storage settings
+
+```hcl
+variable "cluster_id" {}
+variable "ssh_key" {}
+variable "ssh_key_id" {}
+variable "availability_zone" {}
+
+resource "opentelekomcloud_cce_node_pool_v3" "node_pool" {
+  cluster_id         = var.cluster_id
+  name               = "opentelekomcloud-cce-node-pool"
+  os                 = "EulerOS 2.9"
+  flavor             = "s2.large.2"
+  initial_node_count = 1
+  key_pair           = var.ssh_key
+  availability_zone  = "random"
+
+  root_volume {
+    size       = 40
+    volumetype = "SSD"
+  }
+  data_volumes {
+    size       = 100
+    volumetype = "SSD"
+  }
+
+  storage = <<EOF
+        {
+    "storageSelectors": [
+        {
+            "name": "cceUse",
+            "storageType": "evs",
+            "matchLabels": {
+                "size": "100",
+                "volumeType": "SSD",
+                "count": "1",
+				"metadataEncrypted": "1",
+				"metadataCmkid": "${var.ssh_key_id}"
+            }
+        }
+    ],
+    "storageGroups": [
+        {
+            "name": "vgpaas",
+            "selectorNames": [
+                "cceUse"
+            ],
+            "cceManaged": true,
+            "virtualSpaces": [
+                {
+                    "name": "runtime",
+                    "size": "90%"
+                },
+                {
+                    "name": "kubernetes",
+                    "size": "10%"
+                }
+            ]
+        }
+    ]
+}
+EOF
+
+  max_pods         = 16
+  docker_base_size = 32
+}
+```
+
 ## Argument Reference
 The following arguments are supported:
 
-* `cluster_id` - (Required) ID of the cluster. Changing this parameter will create a new resource.
+* `cluster_id` - (Required, ForceNew, String) ID of the cluster. Changing this parameter will create a new resource.
 
-* `flavor` - (Required) Specifies the flavor id. Changing this parameter will create a new resource.
+* `flavor` - (Required, ForceNew, String) Specifies the flavor id. Changing this parameter will create a new resource.
 
-* `availability_zone` - (Required) Specify the name of the available partition (AZ). If zone is not
+* `availability_zone` - (Required, ForceNew, String) Specify the name of the available partition (AZ). If zone is not
   specified than `node_pool` will be in randomly selected AZ. The default value is `random`. Changing
   this parameter will create a new resource.
 
@@ -69,83 +139,87 @@ smaller the number of existing nodes have a higher priority. If AZs have the sam
 the AZ based on the AZ sequence. For more details see
 [API documentation](https://docs.otc.t-systems.com/en-us/api2/cce/cce_02_0354.html#cce_02_0354__table620623542313)
 
-* `key_pair` - (Optional) Key pair name when logging in to select the key pair mode.
+* `key_pair` - (Optional, ForceNew, String) Key pair name when logging in to select the key pair mode.
   This parameter and password are alternative. Changing this parameter will create a new resource.
 
-* `password` - (Optional) Key pair name when logging in to select the key pair mode.
+* `password` - (Optional, ForceNew, String) Key pair name when logging in to select the key pair mode.
   This parameter and password are alternative. Changing this parameter will create a new resource.
 
-* `os` - (Optional) Node OS. Changing this parameter will create a new resource.
+* `os` - (Optional, ForceNew, String) Node OS. Changing this parameter will create a new resource.
   Supported OS depends on kubernetes version of the cluster.
   * Clusters of Kubernetes `v1.13` or later support `EulerOS 2.5`.
   * Clusters of Kubernetes `v1.17` or later support `EulerOS 2.5` and `CentOS 7.7`.
   * Clusters of Kubernetes `v1.21` or later support `EulerOS 2.5`, `EulerOS 2.9`, and `CentOS 7.7`.
   * Clusters of Kubernetes `v1.25` or later support `EulerOS 2.5`, `EulerOS 2.9`, `CentOS 7.7` and `Ubuntu 22.04`.
 
-* `name` - (Required) Node Pool Name.
+* `name` - (Required, String) Node Pool Name.
 
-* `initial_node_count` - (Required) Initial number of expected nodes in the node pool.
+* `initial_node_count` - (Required, Int) Initial number of expected nodes in the node pool.
 
-* `subnet_id` - (Optional) The ID of the subnet to which the NIC belongs. Changing this parameter will create a new resource.
+* `subnet_id` - (Optional, String, ForceNew) The ID of the subnet to which the NIC belongs. Changing this parameter will create a new resource.
 
-* `preinstall` - (Optional) Script required before installation. The input value can be a Base64 encoded string or not.
+* `preinstall` - (Optional, String, ForceNew) Script required before installation. The input value can be a Base64 encoded string or not.
   Changing this parameter will create a new resource.
 
-* `postinstall` - (Optional) Script required after installation. The input value can be a Base64 encoded string or not.
+* `postinstall` - (Optional, String, ForceNew) Script required after installation. The input value can be a Base64 encoded string or not.
   Changing this parameter will create a new resource.
 
-* `max_pods` - (Optional) The maximum number of instances a node is allowed to create.
+* `max_pods` - (Optional, Int, ForceNew) The maximum number of instances a node is allowed to create.
   Changing this parameter will create a new node pool.
 
-* `docker_base_size` - (Optional) Available disk space of a single Docker container on the node using the device mapper.
+* `docker_base_size` - (Optional, Int, ForceNew) Available disk space of a single Docker container on the node using the device mapper.
   Changing this parameter will create a new node pool.
 
-* `docker_lvm_config_override` - (Optional) `ConfigMap` of the Docker data disk.
+* `docker_lvm_config_override` - (Optional, String, ForceNew) `ConfigMap` of the Docker data disk.
   Changing this parameter will create a new node.
 
-* `scale_enable` - (Optional) Whether to enable auto scaling. If Autoscaler is enabled, install the autoscaler add-on to use the auto scaling feature.
+* `scale_enable` - (Optional, Bool) Whether to enable auto scaling. If Autoscaler is enabled, install the autoscaler add-on to use the auto scaling feature.
 
-* `min_node_count` - (Optional) Minimum number of nodes allowed if auto scaling is enabled.
+* `min_node_count` - (Optional, Int) Minimum number of nodes allowed if auto scaling is enabled.
 
-* `max_node_count` - (Optional) Maximum number of nodes allowed if auto scaling is enabled.
+* `max_node_count` - (Optional, Int) Maximum number of nodes allowed if auto scaling is enabled.
 
-* `scale_down_cooldown_time` - (Optional) Interval between two scaling operations, in minutes.
+* `scale_down_cooldown_time` - (Optional, Int) Interval between two scaling operations, in minutes.
 
-* `server_group_reference` - (Optional) ECS group ID. If this parameter is specified, all nodes in the node pool will be created in this ECS group.
+* `server_group_reference` - (Optional, String, ForceNew) ECS group ID. If this parameter is specified, all nodes in the node pool will be created in this ECS group.
 
-* `priority` - (Optional) Weight of a node pool. A node pool with a higher weight has a higher priority during scaling.
+* `priority` - (Optional, Int) Weight of a node pool. A node pool with a higher weight has a higher priority during scaling.
 
-* `user_tags` - (Optional) Tag of a VM, key/value pair format. Changing this parameter will create a new resource.
+* `user_tags` - (Optional, Map, ForceNew) Tag of a VM, key/value pair format. Changing this parameter will create a new resource.
 
-* `k8s_tags` - (Optional) Tags of a Kubernetes node, key/value pair format.
+* `k8s_tags` - (Optional, Map) Tags of a Kubernetes node, key/value pair format.
 
-* `runtime` - (Optional) Container runtime. Changing this parameter will create a new resource.
+* `runtime` - (Optional, String, ForceNew) Container runtime. Changing this parameter will create a new resource.
               Use with high-caution, may trigger resource recreation. Options are:
               `docker` - Docker
               `containerd` - Containerd
 
-* `agency_name` - (Optional) IAM agency name. Changing this parameter will create a new resource.
+* `agency_name` - (Optional, String, ForceNew) IAM agency name. Changing this parameter will create a new resource.
 
-* `taints` - (Optional) Taints to created nodes to configure anti-affinity.
-  * `key` - (Required) A key must contain 1 to 63 characters starting with a letter or digit. Only letters, digits, hyphens (-), underscores (_), and periods (.) are allowed. A DNS subdomain name can be used as the prefix of a key.
-  * `value` - (Required) A value must start with a letter or digit and can contain a maximum of 63 characters, including letters, digits, hyphens (-), underscores (_), and periods (.).
-  * `effect` - (Optional) Available options are `NoSchedule`, `PreferNoSchedule`, and `NoExecute`.
+* `storage` - (Optional, String, ForceNew) Specifies the json string vary depending on CCE node pools storage options.
+  -> Please refer to the [documentation](https://docs.otc.t-systems.com/cloud-container-engine/api-ref/apis/cluster_management/querying_a_specified_node_pool.html#cce-02-0355-response-storage)
+  for actual fields.
 
-* `root_volume` - (Required) It corresponds to the system disk related configuration. Changing this parameter will create a new resource.
-  * `size` - (Required) Disk size in GB.
-  * `volumetype` - (Required) Disk type.
-  * `extend_params` - (Optional) Disk expansion parameters. A list of strings which describes additional disk parameters.
-  * `extend_param` **DEPRECATED** - (Optional) Disk expansion parameters.
+* `taints` - (Optional, List) Taints to created nodes to configure anti-affinity.
+  * `key` - (Required, String) A key must contain 1 to 63 characters starting with a letter or digit. Only letters, digits, hyphens (-), underscores (_), and periods (.) are allowed. A DNS subdomain name can be used as the prefix of a key.
+  * `value` - (Required, String) A value must start with a letter or digit and can contain a maximum of 63 characters, including letters, digits, hyphens (-), underscores (_), and periods (.).
+  * `effect` - (Optional, String) Available options are `NoSchedule`, `PreferNoSchedule`, and `NoExecute`.
+
+* `root_volume` - (Required, List, ForceNew) It corresponds to the system disk related configuration. Changing this parameter will create a new resource.
+  * `size` - (Required, Int, ForceNew) Disk size in GB.
+  * `volumetype` - (Required, String, ForceNew) Disk type.
+  * `extend_params` - (Optional, Map, ForceNew) Disk expansion parameters. A list of strings which describes additional disk parameters.
+  * `extend_param` **DEPRECATED** - (Optional, String, ForceNew) Disk expansion parameters.
   Please use alternative parameter `extend_params`.
-  * `kms_id` - (Optional) The Encryption KMS ID of the system volume. By default, it tries to get from env by `OS_KMS_ID`.
+  * `kms_id` - (Optional, String, ForceNew) The Encryption KMS ID of the system volume. By default, it tries to get from env by `OS_KMS_ID`.
 
-* `data_volumes` - (Required) Represents the data disk to be created. Changing this parameter will create a new resource.
-  * `size` - (Required) Disk size in GB.
-  * `volumetype` - (Required) Disk type.
-  * `extend_params` - (Optional) Disk expansion parameters. A list of strings which describes additional disk parameters.
-  * `extend_param` **DEPRECATED** - (Optional) Disk expansion parameters.
+* `data_volumes` - (Required, List, ForceNew) Represents the data disk to be created. Changing this parameter will create a new resource.
+  * `size` - (Required, Int, ForceNew) Disk size in GB.
+  * `volumetype` - (Required, String, ForceNew) Disk type.
+  * `extend_params` - (Optional, Map, ForceNew) Disk expansion parameters. A list of strings which describes additional disk parameters.
+  * `extend_param` **DEPRECATED** - (Optional, String, ForceNew) Disk expansion parameters.
     Please use alternative parameter `extend_params`.
-  * `kms_id` - (Optional) The Encryption KMS ID of the data volume. By default, it tries to get from env by `OS_KMS_ID`.
+  * `kms_id` - (Optional, String, ForceNew) The Encryption KMS ID of the data volume. By default, it tries to get from env by `OS_KMS_ID`.
 
 -> To enable encryption with the KMS. Firstly, you need to create the agency to grant KMS rights to EVS.
 The agency has to be created for a new project first with a user who has security `admin` permissions.

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20240610123057-fc33945827cb
+	github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20240625100213-628c0f959754
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.21.0
 	golang.org/x/sync v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -156,8 +156,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k+Mg7cowZ8yv4Trqw9UsJby758=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20240610123057-fc33945827cb h1:HAG4fZEmj3fERTtSkvjw5Fe774oGjCSCkN1LFu1U34o=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20240610123057-fc33945827cb/go.mod h1:M1F6OfSRZRzAmAFKQqSLClX952at5hx5rHe4UTEykgg=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20240625100213-628c0f959754 h1:gpqJnZQIz2Ca36JrgOcVxm26k6KUZ4j9xRUncy2Fw00=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20240625100213-628c0f959754/go.mod h1:M1F6OfSRZRzAmAFKQqSLClX952at5hx5rHe4UTEykgg=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_node_pool_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_node_pool_v3_test.go
@@ -222,6 +222,31 @@ func TestAccCCENodePoolsV3ExtendParams(t *testing.T) {
 	})
 }
 
+func TestAccCCENodePoolsV3Storage(t *testing.T) {
+	var nodePool nodepools.NodePool
+	rc := common.InitResourceCheck(
+		nodePoolResourceName,
+		&nodePool,
+		getNodePoolFunc,
+	)
+	t.Parallel()
+	shared.BookCluster(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccCCEKeyPairPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCCENodePoolV3Storage,
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+				),
+			},
+		},
+	})
+}
+
 var testAccCCENodePoolV3Basic = fmt.Sprintf(`
 %s
 
@@ -312,7 +337,7 @@ var testAccCCENodePoolV3RandomAZ = fmt.Sprintf(`
 resource "opentelekomcloud_cce_node_pool_v3" "node_pool" {
   cluster_id         = data.opentelekomcloud_cce_cluster_v3.cluster.id
   name               = "opentelekomcloud-cce-node-pool"
-  os                 = "EulerOS 2.5"
+  os                 = "EulerOS 2.9"
   flavor             = "s2.large.2"
   initial_node_count = 1
   key_pair           = "%s"
@@ -340,7 +365,7 @@ var testAccCCENodePoolV3Encrypted = fmt.Sprintf(`
 resource "opentelekomcloud_cce_node_pool_v3" "node_pool" {
   cluster_id         = data.opentelekomcloud_cce_cluster_v3.cluster.id
   name               = "opentelekomcloud-cce-node-pool"
-  os                 = "EulerOS 2.5"
+  os                 = "EulerOS 2.9"
   flavor             = "s2.large.2"
   initial_node_count = 1
   key_pair           = "%s"
@@ -370,7 +395,7 @@ var testAccCCENodePoolV3ExtendParams = fmt.Sprintf(`
 resource "opentelekomcloud_cce_node_pool_v3" "node_pool" {
   cluster_id         = data.opentelekomcloud_cce_cluster_v3.cluster.id
   name               = "opentelekomcloud-cce-node-pool"
-  os                 = "EulerOS 2.5"
+  os                 = "EulerOS 2.9"
   flavor             = "s2.large.2"
   initial_node_count = 1
   key_pair           = "%s"
@@ -436,3 +461,65 @@ resource "opentelekomcloud_cce_node_pool_v3" "node_pool" {
     "kubelet.kubernetes.io/namespace" = "muh"
   }
 }`, shared.DataSourceCluster, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME)
+
+var testAccCCENodePoolV3Storage = fmt.Sprintf(`
+%[1]s
+
+resource "opentelekomcloud_cce_node_pool_v3" "node_pool" {
+  cluster_id         = data.opentelekomcloud_cce_cluster_v3.cluster.id
+  name               = "opentelekomcloud-cce-node-pool"
+  os                 = "EulerOS 2.9"
+  flavor             = "s2.large.2"
+  initial_node_count = 1
+  key_pair           = "%[2]s"
+  availability_zone  = "random"
+
+  root_volume {
+    size       = 40
+    volumetype = "SSD"
+  }
+  data_volumes {
+    size       = 100
+    volumetype = "SSD"
+  }
+
+  storage = <<EOF
+        {
+    "storageSelectors": [
+        {
+            "name": "cceUse",
+            "storageType": "evs",
+            "matchLabels": {
+                "size": "100",
+                "volumeType": "SSD",
+                "count": "1",
+				"metadataEncrypted": "1",
+				"metadataCmkid": "%[3]s"
+            }
+        }
+    ],
+    "storageGroups": [
+        {
+            "name": "vgpaas",
+            "selectorNames": [
+                "cceUse"
+            ],
+            "cceManaged": true,
+            "virtualSpaces": [
+                {
+                    "name": "runtime",
+                    "size": "90%%"
+                },
+                {
+                    "name": "kubernetes",
+                    "size": "10%%"
+                }
+            ]
+        }
+    ]
+}
+EOF
+
+  max_pods         = 16
+  docker_base_size = 32
+}`, shared.DataSourceCluster, env.OS_KEYPAIR_NAME, env.OS_KMS_ID)

--- a/releasenotes/notes/cce_node_pool_storage-070fe1b01033035e.yaml
+++ b/releasenotes/notes/cce_node_pool_storage-070fe1b01033035e.yaml
@@ -1,4 +1,4 @@
 ---
 enhancements:
   - |
-    **[CCE]** Add storage support for ``resource/opentelekomcloud_cce_node_pool_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[CCE]** Add storage support for ``resource/opentelekomcloud_cce_node_pool_v3`` (`#2564 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2564>`_)

--- a/releasenotes/notes/cce_node_pool_storage-070fe1b01033035e.yaml
+++ b/releasenotes/notes/cce_node_pool_storage-070fe1b01033035e.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[CCE]** Add storage support for ``resource/opentelekomcloud_cce_node_pool_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Storage feature for CCE node pool resource.

## PR Checklist

* [x] Refers to: #2557
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccCCENodePoolsV3_basic
=== PAUSE TestAccCCENodePoolsV3_basic
=== CONT  TestAccCCENodePoolsV3_basic
    resource_opentelekomcloud_cce_node_pool_v3_test.go:45: Cluster is required by the test. 3 test(s) are using cluster.
    cluster.go:117: Cluster usage is 0 now, ready to delete the cluster
    cluster.go:80: starting deleting shared cluster
=== RUN   TestAccCCENodePoolsV3_agency
=== PAUSE TestAccCCENodePoolsV3_agency
=== CONT  TestAccCCENodePoolsV3_agency
    resource_opentelekomcloud_cce_node_pool_v3_test.go:107: Cluster is required by the test. 6 test(s) are using cluster.
    cluster.go:117: Cluster is released by the test. 2 test(s) are still using cluster.
--- PASS: TestAccCCENodePoolsV3_agency (340.28s)
=== RUN   TestAccCCENodePoolsV3_randomAZ
=== PAUSE TestAccCCENodePoolsV3_randomAZ
=== CONT  TestAccCCENodePoolsV3_randomAZ
    resource_opentelekomcloud_cce_node_pool_v3_test.go:155: Cluster is required by the test. 5 test(s) are using cluster.
    cluster.go:117: Cluster is released by the test. 3 test(s) are still using cluster.
--- PASS: TestAccCCENodePoolsV3_randomAZ (327.51s)
=== RUN   TestAccCCENodePoolsV3EncryptedVolume
=== PAUSE TestAccCCENodePoolsV3EncryptedVolume
=== CONT  TestAccCCENodePoolsV3EncryptedVolume
    resource_opentelekomcloud_cce_node_pool_v3_test.go:181: Cluster is required by the test. 1 test(s) are using cluster.
    cluster.go:117: Cluster is released by the test. 1 test(s) are still using cluster.
--- PASS: TestAccCCENodePoolsV3EncryptedVolume (347.99s)
=== RUN   TestAccCCENodePoolsV3ExtendParams
=== PAUSE TestAccCCENodePoolsV3ExtendParams
=== CONT  TestAccCCENodePoolsV3ExtendParams
    resource_opentelekomcloud_cce_node_pool_v3_test.go:208: Cluster is required by the test. 4 test(s) are using cluster.
    cluster.go:117: Cluster is released by the test. 4 test(s) are still using cluster.
--- PASS: TestAccCCENodePoolsV3ExtendParams (327.22s)
=== RUN   TestAccCCENodePoolsV3Storage
=== PAUSE TestAccCCENodePoolsV3Storage
=== CONT  TestAccCCENodePoolsV3Storage
--- PASS: TestAccCCENodePoolsV3Storage (32.32s)

--- PASS: TestAccCCENodePoolsV3_basic (618.52s)
PASS

Process finished with the exit code 0
=== RUN   TestAccCCENodePoolsV3StorageJsonEncode
=== PAUSE TestAccCCENodePoolsV3StorageJsonEncode
=== CONT  TestAccCCENodePoolsV3StorageJsonEncode
    resource_opentelekomcloud_cce_node_pool_v3_test.go:258: Cluster is required by the test. 1 test(s) are using cluster.
    cluster.go:117: Cluster usage is 0 now, ready to delete the cluster
    cluster.go:80: starting deleting shared cluster
--- PASS: TestAccCCENodePoolsV3StorageJsonEncode (466.14s)
PASS

Process finished with the exit code 0
```
