### PR TITLE
[WAF] fix setting timeout block in `resource/opentelekomcloud_waf_dedicated_domain_v1`

### DIFF
--- a/opentelekomcloud/services/waf/resource_opentelekomcloud_waf_dedicated_domain_v1.go
+++ b/opentelekomcloud/services/waf/resource_opentelekomcloud_waf_dedicated_domain_v1.go
@@ -155,20 +155,22 @@ func ResourceWafDedicatedDomain() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				MaxItems: 1,
-				ForceNew: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"connect_timeout": {
 							Type:     schema.TypeInt,
 							Optional: true,
+							Computed: true,
 						},
 						"send_timeout": {
 							Type:     schema.TypeInt,
 							Optional: true,
+							Computed: true,
 						},
 						"read_timeout": {
 							Type:     schema.TypeInt,
 							Optional: true,
+							Computed: true,
 						},
 					},
 				},
@@ -475,12 +477,10 @@ func updateWafDedicatedDomain(client *golangsdk.ServiceClient, d *schema.Resourc
 
 	if v, ok := d.GetOk("timeout_config"); ok && len(v.([]interface{})) > 0 {
 		rawArray := v.([]interface{})[0].(map[string]interface{})
-		updateOpts = domains.UpdateOpts{
-			TimeoutConfig: &domains.TimeoutConfigObject{
-				ConnectionTimeout: rawArray["connect_timeout"].(int),
-				SendTimeout:       rawArray["send_timeout"].(int),
-				ReadTimeout:       rawArray["read_timeout"].(int),
-			},
+		updateOpts.TimeoutConfig = &domains.TimeoutConfigObject{
+			ConnectionTimeout: rawArray["connect_timeout"].(int),
+			SendTimeout:       rawArray["send_timeout"].(int),
+			ReadTimeout:       rawArray["read_timeout"].(int),
 		}
 	}
 

--- a/releasenotes/notes/wafd-domain-timeout-settings-528bb4d353cbffde.yaml
+++ b/releasenotes/notes/wafd-domain-timeout-settings-528bb4d353cbffde.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    **[WAF]** Fix update of ``timeout_config`` in ``resource/opentelekomcloud_waf_dedicated_domain_v1``
+    (`#2572 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2572>`_)


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [x] Refers to: #2565
* [x] Tests added/passed.
* [ ] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccWafDedicatedDomainV1_basic
2024/07/01 13:00:43 [DEBUG] The opentelekomcloud Waf dedicated instance test running in 'eu-de' region.
--- PASS: TestAccWafDedicatedDomainV1_basic (104.50s)
=== RUN   TestAccWafDedicatedDomainV1_timeoutConfig
--- PASS: TestAccWafDedicatedDomainV1_timeoutConfig (68.90s)
=== RUN   TestAccWafDedicatedDomainV1_httpsConfig
--- PASS: TestAccWafDedicatedDomainV1_httpsConfig (53.33s)
PASS
```
