### PR TITLE
[Fix] bump `gophertelecomcloud` version to fix issue with `isAutoRenew` and `isAutoPay` parameters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20240923143920-cfbac5ea5b49
+	github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20240924114225-79452d81a2fb
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.21.0
 	golang.org/x/sync v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -156,8 +156,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k+Mg7cowZ8yv4Trqw9UsJby758=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20240923143920-cfbac5ea5b49 h1:Tr5h0CTispJm8JLkAUCSRUTzyvDwtJ+NlKK/XIfKiZ8=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20240923143920-cfbac5ea5b49/go.mod h1:M1F6OfSRZRzAmAFKQqSLClX952at5hx5rHe4UTEykgg=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20240924114225-79452d81a2fb h1:16q4CfaA1eKCTywAQtvKHTozd1AGqZPFEeLxfztQ6Ys=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20240924114225-79452d81a2fb/go.mod h1:M1F6OfSRZRzAmAFKQqSLClX952at5hx5rHe4UTEykgg=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/releasenotes/notes/cce-node-pool-response-fix-cbd3318502cf84ae.yaml
+++ b/releasenotes/notes/cce-node-pool-response-fix-cbd3318502cf84ae.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[CCE]** Bump gophertelecomcloud version to fix response for ``isAutoPay``  and ``isAutoRenew`` in ``resource/opentelekomcloud_cce_node_pool_v3`` (`#2658 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2658>`_)


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [x] Refers to: #2654
* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed
```

=== RUN   TestAccCCENodePoolsV3_basic
=== PAUSE TestAccCCENodePoolsV3_basic
=== CONT  TestAccCCENodePoolsV3_basic
    resource_opentelekomcloud_cce_node_pool_v3_test.go:45: Cluster is required by the test. 2 test(s) are using cluster.
    cluster.go:117: Cluster is released by the test. 1 test(s) are still using cluster.
--- PASS: TestAccCCENodePoolsV3_basic (788.50s)
=== RUN   TestAccCCENodePoolsV3_agency
=== PAUSE TestAccCCENodePoolsV3_agency
=== CONT  TestAccCCENodePoolsV3_agency
    resource_opentelekomcloud_cce_node_pool_v3_test.go:107: Cluster is required by the test. 5 test(s) are using cluster.
    cluster.go:117: Cluster is released by the test. 2 test(s) are still using cluster.
--- PASS: TestAccCCENodePoolsV3_agency (667.98s)
=== RUN   TestAccCCENodePoolsV3_randomAZ
=== PAUSE TestAccCCENodePoolsV3_randomAZ
=== CONT  TestAccCCENodePoolsV3_randomAZ
    resource_opentelekomcloud_cce_node_pool_v3_test.go:155: Cluster is required by the test. 3 test(s) are using cluster.
    cluster.go:117: Cluster usage is 0 now, ready to delete the cluster
    cluster.go:80: starting deleting shared cluster
--- PASS: TestAccCCENodePoolsV3_randomAZ (1786.08s)
=== RUN   TestAccCCENodePoolsV3EncryptedVolume
=== PAUSE TestAccCCENodePoolsV3EncryptedVolume
=== CONT  TestAccCCENodePoolsV3EncryptedVolume
    resource_opentelekomcloud_cce_node_pool_v3_test.go:181: Cluster is required by the test. 4 test(s) are using cluster.
    cluster.go:117: Cluster is released by the test. 4 test(s) are still using cluster.
--- PASS: TestAccCCENodePoolsV3EncryptedVolume (658.21s)
=== RUN   TestAccCCENodePoolsV3ExtendParams
=== PAUSE TestAccCCENodePoolsV3ExtendParams
=== CONT  TestAccCCENodePoolsV3ExtendParams
    resource_opentelekomcloud_cce_node_pool_v3_test.go:208: Cluster is required by the test. 1 test(s) are using cluster.
    cluster.go:117: Cluster is released by the test. 3 test(s) are still using cluster.
--- PASS: TestAccCCENodePoolsV3ExtendParams (659.55s)

PASS

Process finished with the exit code 0
```
