### PR TITLE
[Network] Doc deprecation message to router_route_v2 and refactoring

### DIFF
--- a/docs/resources/networking_router_route_v2.md
+++ b/docs/resources/networking_router_route_v2.md
@@ -10,6 +10,7 @@ description: |-
 Up-to-date reference of API arguments for VPC router route you can get at
 [documentation portal](https://docs.otc.t-systems.com/virtual-private-cloud/api-ref/native_openstack_neutron_apis_v2.0/router)
 
+**DEPRECATED**
 # opentelekomcloud_networking_router_route_v2
 
 Creates a routing entry on a OpenTelekomCloud V2 router.

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_router_route_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_router_route_v2_test.go
@@ -75,7 +75,8 @@ func TestAccNetworkingV2RouterRoute_basic(t *testing.T) {
 }
 
 func TestAccNetworkingV2RouterRoute_ecs(t *testing.T) {
-	resourceName := "opentelekomcloud_networking_router_route_v2.router_route_1"
+	resourceName1 := "opentelekomcloud_networking_router_route_v2.router_route_1"
+	resourceName2 := "opentelekomcloud_networking_router_route_v2.router_route_2"
 	name := fmt.Sprintf("router_acc_route%s", acctest.RandString(10))
 	t.Parallel()
 	qts := []*quotas.ExpectedQuota{
@@ -92,13 +93,15 @@ func TestAccNetworkingV2RouterRoute_ecs(t *testing.T) {
 			{
 				Config: testAccNetworkingV2RouterRouteEcs(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNetworkingV2RouterRouteExists(resourceName),
+					testAccCheckNetworkingV2RouterRouteExists(resourceName1),
+					testAccCheckNetworkingV2RouterRouteExists(resourceName2),
 				),
 			},
 			{
 				Config: testAccNetworkingV2RouterRouteEcsUpdate(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNetworkingV2RouterRouteExists(resourceName),
+					testAccCheckNetworkingV2RouterRouteExists(resourceName1),
+					testAccCheckNetworkingV2RouterRouteExists(resourceName2),
 				),
 			},
 		},
@@ -450,6 +453,14 @@ resource "opentelekomcloud_networking_router_route_v2" "router_route_1" {
   depends_on = ["opentelekomcloud_networking_router_interface_v2.int_1"]
   router_id  = opentelekomcloud_networking_router_v2.router_1.id
 }
+
+resource "opentelekomcloud_networking_router_route_v2" "router_route_2" {
+  destination_cidr = "10.0.1.0/24"
+  next_hop         = "192.168.199.250"
+
+  depends_on = ["opentelekomcloud_networking_router_interface_v2.int_1"]
+  router_id  = opentelekomcloud_networking_router_v2.router_1.id
+}
 `, name, env.OS_AVAILABILITY_ZONE, common.DataSourceImage)
 }
 
@@ -514,6 +525,14 @@ resource "opentelekomcloud_networking_router_interface_v2" "int_1" {
 resource "opentelekomcloud_networking_router_route_v2" "router_route_1" {
   destination_cidr = "192.168.254.254/32"
   next_hop         = opentelekomcloud_compute_instance_v2.instance_1.network[0].fixed_ip_v4
+
+  depends_on = ["opentelekomcloud_networking_router_interface_v2.int_1"]
+  router_id  = opentelekomcloud_networking_router_v2.router_1.id
+}
+
+resource "opentelekomcloud_networking_router_route_v2" "router_route_2" {
+  destination_cidr = "10.0.1.0/24"
+  next_hop         = "192.168.199.250"
 
   depends_on = ["opentelekomcloud_networking_router_interface_v2.int_1"]
   router_id  = opentelekomcloud_networking_router_v2.router_1.id

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_router_route_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_router_route_v2_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
@@ -67,6 +68,37 @@ func TestAccNetworkingV2RouterRoute_basic(t *testing.T) {
 				Config: testAccNetworkingV2RouterRouteDestroy,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkingV2RouterRouteEmpty("opentelekomcloud_networking_router_v2.router_1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetworkingV2RouterRoute_ecs(t *testing.T) {
+	resourceName := "opentelekomcloud_networking_router_route_v2.router_route_1"
+	name := fmt.Sprintf("router_acc_route%s", acctest.RandString(10))
+	t.Parallel()
+	qts := []*quotas.ExpectedQuota{
+		{Q: quotas.Router, Count: 1},
+		{Q: quotas.Network, Count: 1},
+		{Q: quotas.Subnet, Count: 1},
+	}
+	quotas.BookMany(t, qts)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkingV2RouterRouteEcs(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingV2RouterRouteExists(resourceName),
+				),
+			},
+			{
+				Config: testAccNetworkingV2RouterRouteEcsUpdate(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingV2RouterRouteExists(resourceName),
 				),
 			},
 		},
@@ -353,3 +385,138 @@ resource "opentelekomcloud_networking_router_interface_v2" "int_2" {
   port_id   = opentelekomcloud_networking_port_v2.port_2.id
 }
 `
+
+func testAccNetworkingV2RouterRouteEcs(name string) string {
+	return fmt.Sprintf(`
+%[3]s
+
+data "opentelekomcloud_images_image_v2" "other_image" {
+  name        = "Standard_Debian_12_amd64_bios_latest"
+  most_recent = true
+}
+
+resource "opentelekomcloud_networking_router_v2" "router_1" {
+  name           = "%[1]s_router"
+  admin_state_up = "true"
+}
+
+resource "opentelekomcloud_networking_network_v2" "network_1" {
+  name           = "%[1]s_network"
+  admin_state_up = "true"
+}
+
+resource "opentelekomcloud_networking_subnet_v2" "subnet_1" {
+  cidr       = "192.168.199.0/24"
+  ip_version = 4
+  network_id = opentelekomcloud_networking_network_v2.network_1.id
+}
+
+resource "opentelekomcloud_networking_port_v2" "port_1" {
+  name       = "%[1]s_port"
+  network_id = opentelekomcloud_networking_network_v2.network_1.id
+  fixed_ip {
+    subnet_id = opentelekomcloud_networking_subnet_v2.subnet_1.id
+  }
+}
+
+resource "opentelekomcloud_networking_port_v2" "instance_port_1" {
+  name       = "%[1]s_port"
+  network_id = opentelekomcloud_networking_network_v2.network_1.id
+  fixed_ip {
+    subnet_id = opentelekomcloud_networking_subnet_v2.subnet_1.id
+  }
+}
+
+resource "opentelekomcloud_compute_instance_v2" "instance_1" {
+  name              = "%[1]s_instance"
+  security_groups   = ["default"]
+  availability_zone = "%[2]s"
+  image_id          = data.opentelekomcloud_images_image_v2.latest_image.id
+
+  network {
+    port = opentelekomcloud_networking_port_v2.instance_port_1.id
+  }
+}
+
+resource "opentelekomcloud_networking_router_interface_v2" "int_1" {
+  router_id = opentelekomcloud_networking_router_v2.router_1.id
+  port_id   = opentelekomcloud_networking_port_v2.port_1.id
+}
+
+resource "opentelekomcloud_networking_router_route_v2" "router_route_1" {
+  destination_cidr = "192.168.254.254/32"
+  next_hop         = opentelekomcloud_compute_instance_v2.instance_1.network[0].fixed_ip_v4
+
+  depends_on = ["opentelekomcloud_networking_router_interface_v2.int_1"]
+  router_id  = opentelekomcloud_networking_router_v2.router_1.id
+}
+`, name, env.OS_AVAILABILITY_ZONE, common.DataSourceImage)
+}
+
+func testAccNetworkingV2RouterRouteEcsUpdate(name string) string {
+	return fmt.Sprintf(`
+%[3]s
+
+
+data "opentelekomcloud_images_image_v2" "other_image" {
+  name        = "Standard_Debian_12_amd64_bios_latest"
+  most_recent = true
+}
+
+resource "opentelekomcloud_networking_router_v2" "router_1" {
+  name           = "%[1]s_router"
+  admin_state_up = "true"
+}
+
+resource "opentelekomcloud_networking_network_v2" "network_1" {
+  name           = "%[1]s_network"
+  admin_state_up = "true"
+}
+
+resource "opentelekomcloud_networking_subnet_v2" "subnet_1" {
+  cidr       = "192.168.199.0/24"
+  ip_version = 4
+  network_id = opentelekomcloud_networking_network_v2.network_1.id
+}
+
+resource "opentelekomcloud_networking_port_v2" "port_1" {
+  name       = "%[1]s_port"
+  network_id = opentelekomcloud_networking_network_v2.network_1.id
+  fixed_ip {
+    subnet_id = opentelekomcloud_networking_subnet_v2.subnet_1.id
+  }
+}
+
+resource "opentelekomcloud_networking_port_v2" "instance_port_1" {
+  name       = "%[1]s_port"
+  network_id = opentelekomcloud_networking_network_v2.network_1.id
+  fixed_ip {
+    subnet_id = opentelekomcloud_networking_subnet_v2.subnet_1.id
+  }
+}
+
+resource "opentelekomcloud_compute_instance_v2" "instance_1" {
+  name              = "%[1]s_instance"
+  security_groups   = ["default"]
+  availability_zone = "%[2]s"
+  image_id          = data.opentelekomcloud_images_image_v2.other_image.id
+
+  network {
+    port = opentelekomcloud_networking_port_v2.instance_port_1.id
+  }
+}
+
+resource "opentelekomcloud_networking_router_interface_v2" "int_1" {
+  router_id = opentelekomcloud_networking_router_v2.router_1.id
+  port_id   = opentelekomcloud_networking_port_v2.port_1.id
+}
+
+resource "opentelekomcloud_networking_router_route_v2" "router_route_1" {
+  destination_cidr = "192.168.254.254/32"
+  next_hop         = opentelekomcloud_compute_instance_v2.instance_1.network[0].fixed_ip_v4
+
+  depends_on = ["opentelekomcloud_networking_router_interface_v2.int_1"]
+  router_id  = opentelekomcloud_networking_router_v2.router_1.id
+}
+`, name, env.OS_AVAILABILITY_ZONE, common.DataSourceImage)
+}

--- a/releasenotes/notes/network-route-v2-ref-9679902686614fd0.yaml
+++ b/releasenotes/notes/network-route-v2-ref-9679902686614fd0.yaml
@@ -1,0 +1,6 @@
+---
+other:
+  - |
+    **[NETWORK]** Refactoring of ``resource/opentelekomcloud_networking_router_route_v2`` (`#2669 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2669>`_)
+  - |
+    **[NETWORK]** Deprecation message in documentation for ``resource/opentelekomcloud_networking_router_route_v2`` (`#2669 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2669>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Resource not presented in docportal, it means that it is deprecated.
But still works, so refactored and added test case with instance recreation.

## PR Checklist

* [x] Refers to: #2652
* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccNetworkingV2RouterRoute_basic
=== PAUSE TestAccNetworkingV2RouterRoute_basic
=== CONT  TestAccNetworkingV2RouterRoute_basic
--- PASS: TestAccNetworkingV2RouterRoute_basic (233.55s)
PASS

=== RUN   TestAccNetworkingV2RouterRoute_ecs
=== PAUSE TestAccNetworkingV2RouterRoute_ecs
=== CONT  TestAccNetworkingV2RouterRoute_ecs
--- PASS: TestAccNetworkingV2RouterRoute_ecs (340.75s)
PASS

Debugger finished with the exit code 0
```
