### PR TITLE
[Fix] os_scheduler_hints now marked as computed

### DIFF
--- a/opentelekomcloud/services/ecs/resource_opentelekomcloud_ecs_instance_v1.go
+++ b/opentelekomcloud/services/ecs/resource_opentelekomcloud_ecs_instance_v1.go
@@ -224,6 +224,7 @@ func ResourceEcsInstanceV1() *schema.Resource {
 			"os_scheduler_hints": {
 				Type:     schema.TypeSet,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/releasenotes/notes/ecs-instance-scheduler-hints-fix-097ea89595f74dc9.yaml
+++ b/releasenotes/notes/ecs-instance-scheduler-hints-fix-097ea89595f74dc9.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    **[ECS]** Fix setting new attribute ``os_scheduler_hints`` to state in ``resource/opentelekomcloud_ecs_instance_v1``
+    (`#2685 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2685>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Need to set attribute as computed to not fail refresh check.
Also tests were refactored.

## PR Checklist

* [x] Refers to: #2665
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccEcsV1InstanceBasic
=== PAUSE TestAccEcsV1InstanceBasic
=== CONT  TestAccEcsV1InstanceBasic
--- PASS: TestAccEcsV1InstanceBasic (234.23s)
=== RUN   TestAccEcsV1InstanceIp
=== PAUSE TestAccEcsV1InstanceIp
=== CONT  TestAccEcsV1InstanceIp
--- PASS: TestAccEcsV1InstanceIp (182.05s)
=== RUN   TestAccEcsV1InstanceDeleted
=== PAUSE TestAccEcsV1InstanceDeleted
=== CONT  TestAccEcsV1InstanceDeleted
--- PASS: TestAccEcsV1InstanceDeleted (349.35s)
=== RUN   TestAccEcsV1InstanceDiskTypeValidation
=== PAUSE TestAccEcsV1InstanceDiskTypeValidation
=== CONT  TestAccEcsV1InstanceDiskTypeValidation
--- PASS: TestAccEcsV1InstanceDiskTypeValidation (13.21s)
=== RUN   TestAccEcsV1InstanceVPCValidation
=== PAUSE TestAccEcsV1InstanceVPCValidation
=== CONT  TestAccEcsV1InstanceVPCValidation
--- PASS: TestAccEcsV1InstanceVPCValidation (190.75s)
=== RUN   TestAccEcsV1InstanceVolumeAttach
=== PAUSE TestAccEcsV1InstanceVolumeAttach
=== CONT  TestAccEcsV1InstanceVolumeAttach
--- PASS: TestAccEcsV1InstanceVolumeAttach (245.31s)
PASS

Process finished with the exit code 0
```
