### PR TITLE
IAM: `all_projects` option for iam agencies

### DIFF
--- a/docs/resources/identity_agency_v3.md
+++ b/docs/resources/identity_agency_v3.md
@@ -23,7 +23,17 @@ resource "opentelekomcloud_identity_agency_v3" "agency" {
   delegated_domain_name = "***"
   project_role {
     project = "eu-de"
-    roles   = ["KMS Administrator", ]
+    roles = [
+      "KMS Administrator",
+      "CCE ReadOnlyAccess",
+    ]
+  }
+  project_role {
+    all_projects = true
+    roles = [
+      "CES Administrator",
+      "ER ReadOnlyAccess",
+    ]
   }
   domain_roles = ["Anti-DDoS Administrator", ]
 }
@@ -35,25 +45,29 @@ resource "opentelekomcloud_identity_agency_v3" "agency" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of agency. The name is a string of 1 to 64
+* `name` - (Required, String, ForceNew) The name of agency. The name is a string of 1 to 64
   characters.
 
-* `description` - (Optional) Provides supplementary information about the
+* `description` - (Optional, String, ForceNew) Provides supplementary information about the
   agency. The value is a string of 0 to 255 characters.
 
-* `delegated_domain_name` - (Required) The name of delegated domain.
+* `delegated_domain_name` - (Required, String) The name of delegated domain.
 
-* `project_role` - (Optional) An array of roles and projects which are used to
+* `project_role` - (Optional, List) An array of roles and projects which are used to
   grant permissions to agency on project. The structure is documented below.
 
-* `domain_roles` - (optional) An array of role names which stand for the
+* `domain_roles` - (Optional, List) An array of role names which stand for the
   permissions to be granted to agency on domain.
 
 The `project_role` block supports:
 
-* `project` - (Required) The name of project
+* `project` - (Optional, String) The name of project
+  Either `project` or `all_projects` must be provided to specify single `project_role` element.
 
-* `roles` - (Required) An array of role names
+* `roles` - (Required, List) An array of role names
+
+* `all_projects` - (Optional, Bool) Whether roles are applied to all projects.
+  Either `project` or `all_projects` must be provided to specify single `project_role` element.
 
 -> **Note**: One or both of `project_role` and `domain_roles` must be input when creating an agency.
 

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20241014133241-5aeb4ae3c923
+	github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20241022142145-30e3307593c0
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.21.0
 	golang.org/x/sync v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -156,8 +156,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k+Mg7cowZ8yv4Trqw9UsJby758=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20241014133241-5aeb4ae3c923 h1:MpNSBYYCO8Ilgkjc9E5Ec4DyZZTJ64VJxIj0wJXgD/M=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20241014133241-5aeb4ae3c923/go.mod h1:M1F6OfSRZRzAmAFKQqSLClX952at5hx5rHe4UTEykgg=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20241022142145-30e3307593c0 h1:YcA98zw9ixAlabmnLOasuKHJTlMTZ+gTpicOlH94BZA=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20241022142145-30e3307593c0/go.mod h1:M1F6OfSRZRzAmAFKQqSLClX952at5hx5rHe4UTEykgg=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/opentelekomcloud/acceptance/iam/resource_opentelekomcloud_identity_agency_v3_test.go
+++ b/opentelekomcloud/acceptance/iam/resource_opentelekomcloud_identity_agency_v3_test.go
@@ -37,6 +37,14 @@ func TestAccIdentityV3Agency_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceAgencyName, "delegated_domain_name", "op_svc_evs"),
 				),
 			},
+			{
+				Config: testAccIdentityV3AgencyUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIdentityV3AgencyExists(resourceAgencyName, &a),
+					resource.TestCheckResourceAttr(resourceAgencyName, "name", "test"),
+					resource.TestCheckResourceAttr(resourceAgencyName, "delegated_domain_name", "op_svc_evs"),
+				),
+			},
 		},
 	})
 }
@@ -123,9 +131,38 @@ resource "opentelekomcloud_identity_agency_v3" "agency_1" {
   name                  = "test"
   delegated_domain_name = "op_svc_evs"
   project_role {
-    project = "%s"
+    project = "%[1]s"
     roles = [
       "KMS Administrator",
+      "CCE ReadOnlyAccess",
     ]
   }
+  project_role {
+    all_projects = true
+    roles = [
+      "CES Administrator",
+      "ER ReadOnlyAccess",
+    ]
+  }
+}`, env.OS_TENANT_NAME)
+
+var testAccIdentityV3AgencyUpdate = fmt.Sprintf(`
+resource "opentelekomcloud_identity_agency_v3" "agency_1" {
+  name                  = "test"
+  delegated_domain_name = "op_svc_evs"
+  project_role {
+    project = "%[1]s"
+    roles = [
+      "CCE ReadOnlyAccess",
+      "WAF FullAccess",
+    ]
+  }
+  project_role {
+    all_projects = true
+    roles = [
+      "CES Administrator",
+      "DRS FullWithOutDeletePermission",
+    ]
+  }
+
 }`, env.OS_TENANT_NAME)

--- a/opentelekomcloud/services/iam/common.go
+++ b/opentelekomcloud/services/iam/common.go
@@ -70,3 +70,12 @@ func buildStatementsSet(role *policies.Policy) ([]interface{}, error) {
 
 	return statements, nil
 }
+
+func findKeyByValue(m map[string]string, searchValue string) (string, bool) {
+	for key, value := range m {
+		if value == searchValue {
+			return key, true
+		}
+	}
+	return "", false
+}

--- a/opentelekomcloud/services/iam/resource_opentelekomcloud_identity_agency_v3.go
+++ b/opentelekomcloud/services/iam/resource_opentelekomcloud_identity_agency_v3.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	newAgency "github.com/opentelekomcloud/gophertelekomcloud/openstack/identity/v3.0/agency"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/identity/v3/agency"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/identity/v3/domains"
 	sdkprojects "github.com/opentelekomcloud/gophertelekomcloud/openstack/identity/v3/projects"
@@ -82,7 +83,13 @@ func ResourceIdentityAgencyV3() *schema.Resource {
 						},
 						"project": {
 							Type:     schema.TypeString,
-							Required: true,
+							Optional: true,
+							Computed: true,
+						},
+						"all_projects": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Computed: true,
 						},
 					},
 				},
@@ -103,7 +110,13 @@ func ResourceIdentityAgencyV3() *schema.Resource {
 func resourceIdentityAgencyProRoleHash(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
-	buf.WriteString(fmt.Sprintf("%s-", m["project"].(string)))
+	if m["project"] != nil {
+		buf.WriteString(fmt.Sprintf("%s-", m["project"].(string)))
+	}
+
+	if m["all_projects"] != nil {
+		buf.WriteString(fmt.Sprintf("%t-", m["all_projects"].(bool)))
+	}
 
 	r := m["roles"].(*schema.Set).List()
 	s := make([]string, len(r))
@@ -262,9 +275,14 @@ func changeToPRPair(prs *schema.Set) (r map[string]bool) {
 		pr := v.(map[string]interface{})
 
 		pn := pr["project"].(string)
+		pa := pr["all_projects"].(bool)
 		rs := pr["roles"].(*schema.Set)
 		for _, role := range rs.List() {
-			r[pn+"|"+role.(string)] = true
+			if pa {
+				r["all_projects"+"|"+role.(string)] = true
+			} else {
+				r[pn+"|"+role.(string)] = true
+			}
 		}
 	}
 	return
@@ -323,26 +341,29 @@ func resourceIdentityAgencyV3Create(ctx context.Context, d *schema.ResourceData,
 
 	d.SetId(a.ID)
 
-	projects, err := listProjectsOfDomain(domainID, client)
-	if err != nil {
-		return fmterr.Errorf("error querying the projects, err=%s", err)
-	}
-
 	roles, err := allRolesOfDomain(domainID, client)
 	if err != nil {
 		return fmterr.Errorf("error querying the roles, err=%s", err)
 	}
 
+	projects, err := listProjectsOfDomain(domainID, client)
+	if err != nil {
+		return fmterr.Errorf("error querying the projects, err=%s", err)
+	}
+
 	agencyID := a.ID
 	for _, v := range prs.List() {
+		var pn, pid string
 		pr := v.(map[string]interface{})
-		pn := pr["project"].(string)
+		rs := pr["roles"].(*schema.Set)
+		pa := pr["all_projects"].(bool)
+
+		pn = pr["project"].(string)
 		pid, ok := projects[pn]
-		if !ok {
+		if !ok && !pa {
 			return fmterr.Errorf("the project(%s) does not exist", pn)
 		}
 
-		rs := pr["roles"].(*schema.Set)
 		for _, role := range rs.List() {
 			r := role.(string)
 			rid, ok := roles[r]
@@ -350,10 +371,22 @@ func resourceIdentityAgencyV3Create(ctx context.Context, d *schema.ResourceData,
 				return fmterr.Errorf("the role(%s) does not exist", r)
 			}
 
-			err = agency.AttachRoleByProject(client, agencyID, pid, rid).ExtractErr()
-			if err != nil {
-				return fmterr.Errorf("error attaching role(%s) by project{%s} to agency(%s), err=%s",
-					rid, pid, agencyID, err)
+			if pa {
+				domainId, err := getDomainID(config, client)
+				if err != nil {
+					return fmterr.Errorf("error getting the domain id, err=%s", err)
+				}
+				err = newAgency.GrantAgencyAllProjects(client, domainId, agencyID, rid)
+				if err != nil {
+					return fmterr.Errorf("error attaching role(%s) to agency(%s) for all projects, err=%s",
+						rid, agencyID, err)
+				}
+			} else {
+				err = agency.AttachRoleByProject(client, agencyID, pid, rid).ExtractErr()
+				if err != nil {
+					return fmterr.Errorf("error attaching role(%s) by project{%s} to agency(%s), err=%s",
+						rid, pid, agencyID, err)
+				}
 			}
 		}
 	}
@@ -423,6 +456,32 @@ func resourceIdentityAgencyV3Read(_ context.Context, d *schema.ResourceData, met
 			"roles":   &v,
 		})
 	}
+
+	domainId, err := getDomainID(config, client)
+	if err != nil {
+		return fmterr.Errorf("error quering domain id, err=%s", err)
+	}
+
+	allRoles, err := newAgency.ListAgencyAllProjects(client, domainId, agencyID)
+	if err != nil {
+		return fmterr.Errorf("error querying the roles given all_projects scope, err=%s", err)
+	}
+	if len(allRoles.Roles) > 0 {
+		domainRoles, err := allRolesOfDomain(domainId, client)
+		if err != nil {
+			return fmterr.Errorf("error querying domain roles, err=%s", err)
+		}
+		rl := schema.Set{F: schema.HashString}
+		for _, v := range allRoles.Roles {
+			displayName, _ := findKeyByValue(domainRoles, v.Id)
+			rl.Add(displayName)
+		}
+		prs.Add(map[string]interface{}{
+			"all_projects": true,
+			"roles":        &rl,
+		})
+	}
+
 	err = d.Set("project_role", &prs)
 	if err != nil {
 		log.Printf("[ERROR]Set project_role failed, err=%s", err)
@@ -498,37 +557,61 @@ func resourceIdentityAgencyV3Update(ctx context.Context, d *schema.ResourceData,
 		deleteprs, addprs := diffChangeOfProjectRole(o.(*schema.Set), n.(*schema.Set))
 		for _, v := range deleteprs {
 			pr := strings.Split(v, "|")
-			pid, ok := projects[pr[0]]
-			if !ok {
-				return fmterr.Errorf("the project(%s) does not exist", pr[0])
-			}
 			rid, ok := roles[pr[1]]
 			if !ok {
 				return fmterr.Errorf("the role(%s) does not exist", pr[1])
 			}
+			if pr[0] == "all_projects" {
+				domainID, err = getDomainID(config, client)
+				if err != nil {
+					return fmterr.Errorf("error getting the domain id, err=%s", err)
+				}
+				err = newAgency.RemoveAgencyAllProjects(client, domainID, aID, rid)
+				if err != nil && !common.IsResourceNotFound(err) {
+					return fmterr.Errorf("error detaching role(%s) for all projects from agency(%s), err=%s",
+						rid, aID, err)
+				}
+			} else {
+				pid, ok := projects[pr[0]]
+				if !ok {
+					return fmterr.Errorf("the project(%s) does not exist", pr[0])
+				}
 
-			err = agency.DetachRoleByProject(client, aID, pid, rid).ExtractErr()
-			if err != nil && !common.IsResourceNotFound(err) {
-				return fmterr.Errorf("error detaching role(%s) by project{%s} from agency(%s), err=%s",
-					rid, pid, aID, err)
+				err = agency.DetachRoleByProject(client, aID, pid, rid).ExtractErr()
+				if err != nil && !common.IsResourceNotFound(err) {
+					return fmterr.Errorf("error detaching role(%s) by project{%s} from agency(%s), err=%s",
+						rid, pid, aID, err)
+				}
 			}
 		}
 
 		for _, v := range addprs {
 			pr := strings.Split(v, "|")
-			pid, ok := projects[pr[0]]
-			if !ok {
-				return fmterr.Errorf("the project(%s) does not exist", pr[0])
-			}
 			rid, ok := roles[pr[1]]
 			if !ok {
 				return fmterr.Errorf("the role(%s) does not exist", pr[1])
 			}
+			if pr[0] == "all_projects" {
+				domainID, err = getDomainID(config, client)
+				if err != nil {
+					return fmterr.Errorf("error getting the domain id, err=%s", err)
+				}
+				err = newAgency.GrantAgencyAllProjects(client, domainID, aID, rid)
+				if err != nil && !common.IsResourceNotFound(err) {
+					return fmterr.Errorf("error attaching role(%s) for all projects from agency(%s), err=%s",
+						rid, aID, err)
+				}
+			} else {
+				pid, ok := projects[pr[0]]
+				if !ok {
+					return fmterr.Errorf("the project(%s) does not exist", pr[0])
+				}
 
-			err = agency.AttachRoleByProject(client, aID, pid, rid).ExtractErr()
-			if err != nil {
-				return fmterr.Errorf("error attaching role(%s) by project{%s} to agency(%s), err=%s",
-					rid, pid, aID, err)
+				err = agency.AttachRoleByProject(client, aID, pid, rid).ExtractErr()
+				if err != nil {
+					return fmterr.Errorf("error attaching role(%s) by project{%s} to agency(%s), err=%s",
+						rid, pid, aID, err)
+				}
 			}
 		}
 	}

--- a/releasenotes/notes/iam_agency_allproj-6f70436dc14c410b.yaml
+++ b/releasenotes/notes/iam_agency_allproj-6f70436dc14c410b.yaml
@@ -1,4 +1,4 @@
 ---
 enhancements:
   - |
-    **[IAM]** Added `all_projects` setting for ``resource/opentelekomcloud_identity_agency_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[IAM]** Added `all_projects` setting for ``resource/opentelekomcloud_identity_agency_v3`` (`#2689 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2689>`_)

--- a/releasenotes/notes/iam_agency_allproj-6f70436dc14c410b.yaml
+++ b/releasenotes/notes/iam_agency_allproj-6f70436dc14c410b.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[IAM]** Added `all_projects` setting for ``resource/opentelekomcloud_identity_agency_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Possibility to set agency permissions to `all_projects`

## PR Checklist

* [x] Refers to: #2687
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
2024/10/23 15:54:45 [INFO] Building Swift S3 auth structure
2024/10/23 15:54:45 [INFO] Setting AWS metadata API timeout to 100ms
2024/10/23 15:54:47 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2024/10/23 15:54:47 [INFO] Swift S3 Auth provider used: "StaticProvider"
=== RUN   TestAccIdentityV3Agency_basic
--- PASS: TestAccIdentityV3Agency_basic (203.17s)
PASS

Process finished with the exit code 0

2024/10/23 15:58:51 [INFO] Building Swift S3 auth structure
2024/10/23 15:58:51 [INFO] Setting AWS metadata API timeout to 100ms
2024/10/23 15:58:52 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2024/10/23 15:58:52 [INFO] Swift S3 Auth provider used: "StaticProvider"
=== RUN   TestAccIdentityV3Agency_importBasic
--- PASS: TestAccIdentityV3Agency_importBasic (142.18s)
PASS

Process finished with the exit code 0

```
