### PR TITLE
[Fix] Fixes state change conf for stopping servers

### DIFF
--- a/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_instance_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_instance_v2_test.go
@@ -776,7 +776,7 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   security_groups = ["default"]
   network {
     uuid        = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
-    fixed_ip_v4 = "10.0.0.24"
+    fixed_ip_v4 = cidrhost(data.opentelekomcloud_vpc_subnet_v1.shared_subnet.cidr, 24)
   }
   stop_before_destroy = true
 }

--- a/releasenotes/notes/compute-instance-v2-stop-state-9409c8e329287910.yaml
+++ b/releasenotes/notes/compute-instance-v2-stop-state-9409c8e329287910.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[ECS]** Fixed ``stop_before_destroy`` state check before delete in ``resource/opentelekomcloud_compute_instance_v2`` (`#2703 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2703>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Added stateConf for stop operation

## PR Checklist

* [x] Refers to: #2696 
* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccComputeV2Instance_basic
=== PAUSE TestAccComputeV2Instance_basic
=== CONT  TestAccComputeV2Instance_basic
--- PASS: TestAccComputeV2Instance_basic (140.26s)
=== RUN   TestAccComputeV2Instance_imageByName
--- PASS: TestAccComputeV2Instance_imageByName (95.17s)
=== RUN   TestAccComputeV2Instance_multiSecgroup
=== PAUSE TestAccComputeV2Instance_multiSecgroup
=== CONT  TestAccComputeV2Instance_multiSecgroup
--- PASS: TestAccComputeV2Instance_multiSecgroup (151.43s)
=== RUN   TestAccComputeV2Instance_bootFromImage
=== PAUSE TestAccComputeV2Instance_bootFromImage
=== CONT  TestAccComputeV2Instance_bootFromImage
--- PASS: TestAccComputeV2Instance_bootFromImage (84.34s)
=== RUN   TestAccComputeV2Instance_bootFromVolume
=== PAUSE TestAccComputeV2Instance_bootFromVolume
=== CONT  TestAccComputeV2Instance_bootFromVolume
--- PASS: TestAccComputeV2Instance_bootFromVolume (84.79s)
=== RUN   TestAccComputeV2Instance_importBootFromVolumeImage
=== PAUSE TestAccComputeV2Instance_importBootFromVolumeImage
=== CONT  TestAccComputeV2Instance_importBootFromVolumeImage
--- PASS: TestAccComputeV2Instance_importBootFromVolumeImage (106.86s)
=== RUN   TestAccComputeV2Instance_bootFromVolumeVolume
=== PAUSE TestAccComputeV2Instance_bootFromVolumeVolume
=== CONT  TestAccComputeV2Instance_bootFromVolumeVolume
--- PASS: TestAccComputeV2Instance_bootFromVolumeVolume (93.98s)
=== RUN   TestAccComputeV2Instance_metadata
=== PAUSE TestAccComputeV2Instance_metadata
=== CONT  TestAccComputeV2Instance_metadata
--- PASS: TestAccComputeV2Instance_metadata (114.41s)
=== RUN   TestAccComputeV2Instance_timeout
=== PAUSE TestAccComputeV2Instance_timeout
=== CONT  TestAccComputeV2Instance_timeout
--- PASS: TestAccComputeV2Instance_timeout (82.80s)
=== RUN   TestAccComputeV2Instance_autoRecovery
=== PAUSE TestAccComputeV2Instance_autoRecovery
=== CONT  TestAccComputeV2Instance_autoRecovery
--- PASS: TestAccComputeV2Instance_autoRecovery (120.35s)
=== RUN   TestAccComputeV2Instance_initialStateActive
=== PAUSE TestAccComputeV2Instance_initialStateActive
=== CONT  TestAccComputeV2Instance_initialStateActive
--- PASS: TestAccComputeV2Instance_initialStateActive (159.86s)
=== RUN   TestAccComputeV2Instance_initialStateShutoff
=== PAUSE TestAccComputeV2Instance_initialStateShutoff
=== CONT  TestAccComputeV2Instance_initialStateShutoff
--- PASS: TestAccComputeV2Instance_initialStateShutoff (193.96s)
=== RUN   TestAccComputeV2Instance_crazyNICs
=== PAUSE TestAccComputeV2Instance_crazyNICs
=== CONT  TestAccComputeV2Instance_crazyNICs
--- PASS: TestAccComputeV2Instance_crazyNICs (215.55s)
=== RUN   TestAccComputeV2Instance_changeFixedIP
=== PAUSE TestAccComputeV2Instance_changeFixedIP
=== CONT  TestAccComputeV2Instance_changeFixedIP
--- PASS: TestAccComputeV2Instance_changeFixedIP (90.18s)
PASS

Process finished with the exit code 0
```
