### PR TITLE
[Feat.] Ecs V1 auto AZ selection

### DIFF
--- a/docs/resources/ecs_instance_v1.md
+++ b/docs/resources/ecs_instance_v1.md
@@ -288,7 +288,11 @@ The following arguments are supported:
   to associate with the server. If this parameter is left blank, the `default`
   security group is bound to the ECS by default.
 
-* `availability_zone` - (Required, String, ForceNew) The availability zone in which to create the server.
+* `availability_zone` - (Optional, String, ForceNew) The availability zone in which to create the server.
+
+  -> **NOTE:**
+  If this parameter is not specified, the system automatically selects an AZ.
+
   Changing this creates a new server.
 
 * `os_scheduler_hints` - (Optional, Map, ForceNew) Schedules ECSs, for example, by configuring an ECS group. The `os_scheduler_hints` object structure is documented below. Changing this creates a new server.

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20241022142145-30e3307593c0
+	github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20241104181956-db479a6d384d
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.21.0
 	golang.org/x/sync v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -156,8 +156,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k+Mg7cowZ8yv4Trqw9UsJby758=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20241022142145-30e3307593c0 h1:YcA98zw9ixAlabmnLOasuKHJTlMTZ+gTpicOlH94BZA=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20241022142145-30e3307593c0/go.mod h1:M1F6OfSRZRzAmAFKQqSLClX952at5hx5rHe4UTEykgg=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20241104181956-db479a6d384d h1:6nr8FpvqTw30NPORd7XIKKUW0EtYEKzWbxEO5mF/00g=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20241104181956-db479a6d384d/go.mod h1:M1F6OfSRZRzAmAFKQqSLClX952at5hx5rHe4UTEykgg=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/opentelekomcloud/services/ecs/resource_opentelekomcloud_ecs_instance_v1.go
+++ b/opentelekomcloud/services/ecs/resource_opentelekomcloud_ecs_instance_v1.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/pointerto"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/tags"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/compute/v2/extensions/secgroups"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/compute/v2/servers"
@@ -218,7 +219,8 @@ func ResourceEcsInstanceV1() *schema.Resource {
 			},
 			"availability_zone": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 			"os_scheduler_hints": {
@@ -277,7 +279,7 @@ func resourceEcsInstanceV1Create(ctx context.Context, d *schema.ResourceData, me
 		KeyName:          d.Get("key_name").(string),
 		VpcId:            d.Get("vpc_id").(string),
 		SecurityGroups:   resourceInstanceSecGroupsV1(d),
-		AvailabilityZone: d.Get("availability_zone").(string),
+		AvailabilityZone: pointerto.String(d.Get("availability_zone").(string)),
 		Nics:             resourceInstanceNicsV1(d),
 		RootVolume:       resourceInstanceRootVolumeV1(d),
 		DataVolumes:      resourceInstanceDataVolumesV1(d),

--- a/releasenotes/notes/ecs-v1-random-az-bf388b21e495b818.yaml
+++ b/releasenotes/notes/ecs-v1-random-az-bf388b21e495b818.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[ECS]** Auto AZ selection support for ``resource/opentelekomcloud_ecs_instance_v1`` (`#2705 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2705>`_)


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [x] Refers to: #2699
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccEcsV1InstanceBasic
=== PAUSE TestAccEcsV1InstanceBasic
=== CONT  TestAccEcsV1InstanceBasic
--- PASS: TestAccEcsV1InstanceBasic (232.22s)
=== RUN   TestAccEcsV1InstanceIp
=== PAUSE TestAccEcsV1InstanceIp
=== CONT  TestAccEcsV1InstanceIp
--- PASS: TestAccEcsV1InstanceIp (174.68s)
=== RUN   TestAccEcsV1InstanceDeleted
=== PAUSE TestAccEcsV1InstanceDeleted
=== CONT  TestAccEcsV1InstanceDeleted
--- PASS: TestAccEcsV1InstanceDeleted (309.00s)
=== RUN   TestAccEcsV1InstanceDiskTypeValidation
=== PAUSE TestAccEcsV1InstanceDiskTypeValidation
=== CONT  TestAccEcsV1InstanceDiskTypeValidation
--- PASS: TestAccEcsV1InstanceDiskTypeValidation (13.92s)
=== RUN   TestAccEcsV1InstanceVPCValidation
=== PAUSE TestAccEcsV1InstanceVPCValidation
=== CONT  TestAccEcsV1InstanceVPCValidation
--- PASS: TestAccEcsV1InstanceVPCValidation (219.95s)
=== RUN   TestAccEcsV1InstanceEncryption
=== PAUSE TestAccEcsV1InstanceEncryption
=== CONT  TestAccEcsV1InstanceEncryption
    resource_opentelekomcloud_ecs_instance_v1_test.go:214: OS_KMS_ID is not set
--- SKIP: TestAccEcsV1InstanceEncryption (0.00s)

Test ignored.
=== RUN   TestAccEcsV1InstanceVolumeAttach
=== PAUSE TestAccEcsV1InstanceVolumeAttach
=== CONT  TestAccEcsV1InstanceVolumeAttach
--- PASS: TestAccEcsV1InstanceVolumeAttach (252.75s)
=== RUN   TestAccEcsV1InstanceWithoutAZ
=== PAUSE TestAccEcsV1InstanceWithoutAZ
=== CONT  TestAccEcsV1InstanceWithoutAZ
--- PASS: TestAccEcsV1InstanceWithoutAZ (148.92s)
PASS

Process finished with the exit code 0
```
