### PR TITLE
[Fix] fix update when source_port not set

### DIFF
--- a/opentelekomcloud/services/fw/resource_opentelekomcloud_fw_rule_v2.go
+++ b/opentelekomcloud/services/fw/resource_opentelekomcloud_fw_rule_v2.go
@@ -205,7 +205,7 @@ func resourceFWRuleV2Update(ctx context.Context, d *schema.ResourceData, meta in
 		sourcePort := d.Get("source_port").(string)
 		updateOpts.SourcePort = &sourcePort
 		if *updateOpts.SourcePort == "" {
-			updateOpts.SourcePort = nil
+			updateOpts.SourcePort = pointerto.String("0")
 		}
 	}
 	if d.HasChange("protocol") {
@@ -237,9 +237,11 @@ func resourceFWRuleV2Update(ctx context.Context, d *schema.ResourceData, meta in
 		updateOpts.Enabled = &enabled
 	}
 
-	if d.Get("protocol").(string) != "icmp" && (updateOpts.DestinationPort == nil && updateOpts.SourcePort == nil) {
+	if d.Get("protocol").(string) != "icmp" && (updateOpts.DestinationPort == nil) { // && updateOpts.SourcePort == nil) {
 		updateOpts.DestinationPort = pointerto.String(d.Get("destination_port").(string))
-		updateOpts.SourcePort = pointerto.String(d.Get("source_port").(string))
+		if d.Get("source_port").(string) != "" {
+			updateOpts.SourcePort = pointerto.String(d.Get("source_port").(string))
+		}
 	}
 
 	log.Printf("[DEBUG] Updating firewall rules: %#v", updateOpts)

--- a/opentelekomcloud/services/fw/resource_opentelekomcloud_fw_rule_v2.go
+++ b/opentelekomcloud/services/fw/resource_opentelekomcloud_fw_rule_v2.go
@@ -237,7 +237,7 @@ func resourceFWRuleV2Update(ctx context.Context, d *schema.ResourceData, meta in
 		updateOpts.Enabled = &enabled
 	}
 
-	if d.Get("protocol").(string) != "icmp" && (updateOpts.DestinationPort == nil) { // && updateOpts.SourcePort == nil) {
+	if d.Get("protocol").(string) != "icmp" && (updateOpts.DestinationPort == nil && updateOpts.SourcePort == nil) {
 		updateOpts.DestinationPort = pointerto.String(d.Get("destination_port").(string))
 		if d.Get("source_port").(string) != "" {
 			updateOpts.SourcePort = pointerto.String(d.Get("source_port").(string))

--- a/opentelekomcloud/services/fw/resource_opentelekomcloud_fw_rule_v2.go
+++ b/opentelekomcloud/services/fw/resource_opentelekomcloud_fw_rule_v2.go
@@ -205,7 +205,7 @@ func resourceFWRuleV2Update(ctx context.Context, d *schema.ResourceData, meta in
 		sourcePort := d.Get("source_port").(string)
 		updateOpts.SourcePort = &sourcePort
 		if *updateOpts.SourcePort == "" {
-			updateOpts.SourcePort = pointerto.String("0")
+			updateOpts.SourcePort = nil
 		}
 	}
 	if d.HasChange("protocol") {

--- a/releasenotes/notes/fix-fw-rule-source-port-update-5019f21141505c3c.yaml
+++ b/releasenotes/notes/fix-fw-rule-source-port-update-5019f21141505c3c.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[IAM]** Fix updating rule when source_port is empty in ``resource/opentelekomcloud_fw_rule_v2`` (`#2715 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/2715>`_)


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [x] Refers to: #2711
* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccFWRuleV2_basic
--- PASS: TestAccFWRuleV2_basic (57.94s)
=== RUN   TestAccFWRuleV2_anyProtocol
--- PASS: TestAccFWRuleV2_anyProtocol (46.55s)
=== RUN   TestAccFWRuleV2_TCPtoICMP
--- PASS: TestAccFWRuleV2_TCPtoICMP (76.22s)
=== RUN   TestAccFWRuleV2_TCPUpdate
--- PASS: TestAccFWRuleV2_TCPUpdate (40.18s)
=== RUN   TestAccFWRuleV2_emptySourcePort
--- PASS: TestAccFWRuleV2_emptySourcePort (88.37s)
PASS

Process finished with the exit code 0
```
