### PR TITLE
KMS: keys refactoring

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20241104181956-db479a6d384d
+	github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20241112105509-5302c2d01fe6
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.21.0
 	golang.org/x/sync v0.1.0

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20241111133703-101a74fd5b4e
+	github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20241112162134-960efd8ff98a
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.21.0
 	golang.org/x/sync v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -156,8 +156,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k+Mg7cowZ8yv4Trqw9UsJby758=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20241104181956-db479a6d384d h1:6nr8FpvqTw30NPORd7XIKKUW0EtYEKzWbxEO5mF/00g=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20241104181956-db479a6d384d/go.mod h1:M1F6OfSRZRzAmAFKQqSLClX952at5hx5rHe4UTEykgg=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20241112105509-5302c2d01fe6 h1:GZntbcJOEqWKli/oIJMDZzvzBYGuHnqxVlsj4dX0ngs=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20241112105509-5302c2d01fe6/go.mod h1:M1F6OfSRZRzAmAFKQqSLClX952at5hx5rHe4UTEykgg=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/go.sum
+++ b/go.sum
@@ -156,10 +156,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k+Mg7cowZ8yv4Trqw9UsJby758=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20241104181956-db479a6d384d h1:6nr8FpvqTw30NPORd7XIKKUW0EtYEKzWbxEO5mF/00g=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20241104181956-db479a6d384d/go.mod h1:M1F6OfSRZRzAmAFKQqSLClX952at5hx5rHe4UTEykgg=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20241111133703-101a74fd5b4e h1:/rdKqoWltx2CwxKQQ4hPxuxX6ip2JQ8lAazWTvtji3k=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20241111133703-101a74fd5b4e/go.mod h1:M1F6OfSRZRzAmAFKQqSLClX952at5hx5rHe4UTEykgg=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20241112162134-960efd8ff98a h1:MasOCdy6QVtflzeAnkx7rhR1LcpHsQIkygAJLWCHyX0=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20241112162134-960efd8ff98a/go.mod h1:M1F6OfSRZRzAmAFKQqSLClX952at5hx5rHe4UTEykgg=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/opentelekomcloud/acceptance/kms/resource_opentelekomcloud_kms_key_v1_test.go
+++ b/opentelekomcloud/acceptance/kms/resource_opentelekomcloud_kms_key_v1_test.go
@@ -58,7 +58,7 @@ func testAccCheckKmsV1KeyDestroy(s *terraform.State) error {
 		if rs.Type != "opentelekomcloud_kms_key_v1" {
 			continue
 		}
-		v, err := keys.Get(client, rs.Primary.ID).ExtractKeyInfo()
+		v, err := keys.Get(client, rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -85,7 +85,7 @@ func testAccCheckKmsV1KeyExists(n string, key *keys.Key) resource.TestCheckFunc 
 		if err != nil {
 			return fmt.Errorf("error creating OpenTelekomCloud KMSv1 client: %s", err)
 		}
-		found, err := keys.Get(client, rs.Primary.ID).ExtractKeyInfo()
+		found, err := keys.Get(client, rs.Primary.ID)
 		if err != nil {
 			return err
 		}

--- a/opentelekomcloud/services/kms/data_source_opentelekomcloud_kms_data_key_v1.go
+++ b/opentelekomcloud/services/kms/data_source_opentelekomcloud_kms_data_key_v1.go
@@ -54,13 +54,13 @@ func dataSourceKmsDataKeyV1Read(_ context.Context, d *schema.ResourceData, meta 
 		return fmterr.Errorf("error creating OpenTelekomCloud kms key client: %s", err)
 	}
 
-	req := &keys.DataEncryptOpts{
+	req := keys.DataEncryptOpts{
 		KeyID:             d.Get("key_id").(string),
 		EncryptionContext: d.Get("encryption_context").(string),
 		DatakeyLength:     d.Get("datakey_length").(string),
 	}
 	log.Printf("[DEBUG] KMS get data key for key: %s", d.Get("key_id").(string))
-	v, err := keys.DataEncryptGet(KmsDataKeyV1Client, req).ExtractDataKey()
+	v, err := keys.DataEncryptGet(KmsDataKeyV1Client, req)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/opentelekomcloud/services/kms/data_source_opentelekomcloud_kms_key_v1.go
+++ b/opentelekomcloud/services/kms/data_source_opentelekomcloud_kms_key_v1.go
@@ -94,12 +94,12 @@ func dataSourceKmsKeyV1Read(_ context.Context, d *schema.ResourceData, meta inte
 	nextMarker := ""
 	var allKeys []keys.Key
 	for isListKey {
-		req := &keys.ListOpts{
+		req := keys.ListOpts{
 			KeyState: d.Get("key_state").(string),
 			Marker:   nextMarker,
 		}
 
-		v, err := keys.List(client, req).ExtractListKey()
+		v, err := keys.List(client, req)
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/releasenotes/notes/kms_key_refactor-0b21ecebef3e4f0b.yaml
+++ b/releasenotes/notes/kms_key_refactor-0b21ecebef3e4f0b.yaml
@@ -1,0 +1,4 @@
+---
+other:
+  - |
+    **[KMS]** Refactoring of KMS keys (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)

--- a/releasenotes/notes/kms_key_refactor-0b21ecebef3e4f0b.yaml
+++ b/releasenotes/notes/kms_key_refactor-0b21ecebef3e4f0b.yaml
@@ -1,4 +1,4 @@
 ---
 other:
   - |
-    **[KMS]** Refactoring of KMS keys (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[KMS]** Refactoring of KMS keys (`#2720 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2720>`_)


### PR DESCRIPTION
## Summary of the Pull Request
KMS keys refactoring

## PR Checklist

* [x] Refers to: #2707
* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
2024/11/12 08:59:50 [INFO] Building Swift S3 auth structure
2024/11/12 08:59:50 [INFO] Setting AWS metadata API timeout to 100ms
2024/11/12 08:59:52 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2024/11/12 08:59:52 [INFO] Swift S3 Auth provider used: "StaticProvider"
=== RUN   TestAccKmsKeyV1_basic
--- PASS: TestAccKmsKeyV1_basic (192.59s)
=== RUN   TestAccKmsKey_isEnabled
--- PASS: TestAccKmsKey_isEnabled (270.68s)
=== RUN   TestAccKmsKey_rotation
--- PASS: TestAccKmsKey_rotation (113.89s)
=== RUN   TestAccKmsKey_cancelDeletion
--- PASS: TestAccKmsKey_cancelDeletion (114.79s)
=== RUN   TestAccKmsKey_cancelDeletionWithRotation
--- PASS: TestAccKmsKey_cancelDeletionWithRotation (114.05s)
PASS

Process finished with the exit code 0

2024/11/12 10:08:04 [INFO] Building Swift S3 auth structure
2024/11/12 10:08:04 [INFO] Setting AWS metadata API timeout to 100ms
2024/11/12 10:08:05 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2024/11/12 10:08:05 [INFO] Swift S3 Auth provider used: "StaticProvider"
=== RUN   TestAccKmsDataKeyV1DataSource_basic
--- PASS: TestAccKmsDataKeyV1DataSource_basic (187.50s)
PASS

Process finished with the exit code 0

=== RUN   TestAccKmsKeyV1DataSource_basic
--- PASS: TestAccKmsKeyV1DataSource_basic (49.49s)
PASS

Process finished with the exit code 0
```
