### PR TITLE
DMS: fix documentation for dedicated instans & add deprecation warning

### DIFF
--- a/docs/resources/dms_instance_v2.md
+++ b/docs/resources/dms_instance_v2.md
@@ -14,6 +14,9 @@ Up-to-date reference of API arguments for DMS instance you can get at
 
 Manages a DMS instance in the OpenTelekomCloud DMS Service (Kafka Premium/Platinum).
 
+~>
+Deprecated, use `opentelekomcloud_dms_dedicated_instance_v2` resource instead
+
 ## Example Usage
 
 ### Automatically detect the correct network

--- a/opentelekomcloud/services/dms/resource_opentelekomcloud_dms_instance_v2.go
+++ b/opentelekomcloud/services/dms/resource_opentelekomcloud_dms_instance_v2.go
@@ -36,6 +36,7 @@ func ResourceDmsInstancesV2() *schema.Resource {
 			Update: schema.DefaultTimeout(50 * time.Minute),
 			Delete: schema.DefaultTimeout(15 * time.Minute),
 		},
+		DeprecationMessage: "Please use `opentelekomcloud_dms_dedicated_instance_v2` resource instead",
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/releasenotes/notes/dmsd_doc_fix-503b4b9f0f568ad1.yaml
+++ b/releasenotes/notes/dmsd_doc_fix-503b4b9f0f568ad1.yaml
@@ -1,0 +1,6 @@
+---
+other:
+  |
+  **[DMS]** Added deprecation warning for ``resource/opentelekomcloud_dms_instance_v2`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/>`_)
+  |
+  **[DMS]** Documentation fix for ``resource/opentelekomcloud_dms_dedicated_instance_v2`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/>`_)

--- a/releasenotes/notes/dmsd_doc_fix-503b4b9f0f568ad1.yaml
+++ b/releasenotes/notes/dmsd_doc_fix-503b4b9f0f568ad1.yaml
@@ -1,6 +1,6 @@
 ---
 other:
   |
-  **[DMS]** Added deprecation warning for ``resource/opentelekomcloud_dms_instance_v2`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/>`_)
+  **[DMS]** Added deprecation warning for ``resource/opentelekomcloud_dms_instance_v2`` (`#2750 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/2750>`_)
   |
-  **[DMS]** Documentation fix for ``resource/opentelekomcloud_dms_dedicated_instance_v2`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/>`_)
+  **[DMS]** Documentation fix for ``resource/opentelekomcloud_dms_dedicated_instance_v2`` (`#2750 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/2750>`_)


### PR DESCRIPTION
## Summary of the Pull Request
- Added example for `opentelekomcloud_dms_dedicated_instance_v2`
- Added deprecation warning for `opentelekomcloud_dms_instance_v2`

## PR Checklist

* [x] Refers to: #2681
* [ ] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

