### PR TITLE
[Refactor] CCE: Refactor CCE nodes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20241202142411-fd6fb8c8c54d
+	github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20241205120206-477490ae82ff
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.23.0
 	golang.org/x/sync v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -156,8 +156,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k+Mg7cowZ8yv4Trqw9UsJby758=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20241202142411-fd6fb8c8c54d h1:7bxIT3di/P4VxlwCoc8jkaeQzTh896lbWiHq3UbcA8E=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20241202142411-fd6fb8c8c54d/go.mod h1:M1F6OfSRZRzAmAFKQqSLClX952at5hx5rHe4UTEykgg=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20241205120206-477490ae82ff h1:VFHE+geNpvJV8NpJ2cRzqjpwevph9DL8ExWmubteCjc=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20241205120206-477490ae82ff/go.mod h1:M1F6OfSRZRzAmAFKQqSLClX952at5hx5rHe4UTEykgg=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_node_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_node_v3_test.go
@@ -18,7 +18,6 @@ import (
 
 const (
 	resourceNameNode  = "opentelekomcloud_cce_node_v3.node_1"
-	resourceNameNode2 = "opentelekomcloud_cce_node_v3.node_2"
 	resourceNameNode3 = "opentelekomcloud_cce_node_v3.node_3"
 	resourceNameNode4 = "opentelekomcloud_cce_node_v3.node_4"
 )
@@ -130,7 +129,6 @@ func TestAccCCENodesV3Timeout(t *testing.T) {
 }
 func TestAccCCENodesV3OS(t *testing.T) {
 	var node nodes.Nodes
-	var node2 nodes.Nodes
 	var node3 nodes.Nodes
 	var node4 nodes.Nodes
 
@@ -148,8 +146,6 @@ func TestAccCCENodesV3OS(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCCENodeV3Exists(resourceNameNode, shared.DataSourceClusterName, &node),
 					resource.TestCheckResourceAttr(resourceNameNode, "os", "EulerOS 2.5"),
-					testAccCheckCCENodeV3Exists(resourceNameNode2, shared.DataSourceClusterName, &node2),
-					resource.TestCheckResourceAttr(resourceNameNode2, "os", "CentOS 7.7"),
 					testAccCheckCCENodeV3Exists(resourceNameNode3, shared.DataSourceClusterName, &node3),
 					resource.TestCheckResourceAttr(resourceNameNode3, "os", "EulerOS 2.9"),
 					testAccCheckCCENodeV3Exists(resourceNameNode4, shared.DataSourceClusterName, &node4),
@@ -428,7 +424,7 @@ func testAccCheckCCENodeV3Destroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := nodes.Get(client, clusterID, rs.Primary.ID).Extract()
+		_, err := nodes.Get(client, clusterID, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("node still exists")
 		}
@@ -461,7 +457,7 @@ func testAccCheckCCENodeV3Exists(n string, cluster string, node *nodes.Nodes) re
 			return fmt.Errorf("error creating OpenTelekomCloud CCE client: %s", err)
 		}
 
-		found, err := nodes.Get(client, c.Primary.ID, rs.Primary.ID).Extract()
+		found, err := nodes.Get(client, c.Primary.ID, rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -499,25 +495,6 @@ resource "opentelekomcloud_cce_node_v3" "node_1" {
   }
 }
 
-resource "opentelekomcloud_cce_node_v3" "node_2" {
-  cluster_id = data.opentelekomcloud_cce_cluster_v3.cluster.id
-  name       = "test-node"
-  flavor_id  = "s2.large.2"
-  os         = "CentOS 7.7"
-
-  availability_zone = "%[2]s"
-  key_pair          = "%[3]s"
-
-  root_volume {
-    size       = 40
-    volumetype = "SATA"
-  }
-
-  data_volumes {
-    size       = 100
-    volumetype = "SATA"
-  }
-}
 
 resource "opentelekomcloud_cce_node_v3" "node_3" {
   cluster_id = data.opentelekomcloud_cce_cluster_v3.cluster.id

--- a/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_node_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_node_v3_test.go
@@ -18,8 +18,8 @@ import (
 
 const (
 	resourceNameNode  = "opentelekomcloud_cce_node_v3.node_1"
+	resourceNameNode2 = "opentelekomcloud_cce_node_v3.node_2"
 	resourceNameNode3 = "opentelekomcloud_cce_node_v3.node_3"
-	resourceNameNode4 = "opentelekomcloud_cce_node_v3.node_4"
 )
 
 func getCceNodeResourceFunc(cfg *cfg.Config, state *terraform.ResourceState) (interface{}, error) {
@@ -30,7 +30,7 @@ func getCceNodeResourceFunc(cfg *cfg.Config, state *terraform.ResourceState) (in
 	return nodes.Get(client, state.Primary.Attributes["cluster_id"], state.Primary.ID)
 }
 
-func TestAccCCENodesV3Basic(t *testing.T) {
+func TestAccResourceCCENodesV3Basic(t *testing.T) {
 	var node nodes.Nodes
 
 	rc := common.InitResourceCheck(
@@ -72,25 +72,30 @@ func TestAccCCENodesV3Basic(t *testing.T) {
 	})
 }
 
-func TestAccCCENodesV3Agency(t *testing.T) {
+func TestAccResourceCCENodesV3Agency(t *testing.T) {
 	var node nodes.Nodes
 
-	t.Parallel()
-	shared.BookCluster(t)
-	quotas.BookMany(t, singleNodeQuotas.X(2))
+	rc := common.InitResourceCheck(
+		resourceNameNode,
+		&node,
+		getCceNodeResourceFunc,
+	)
 
-	ip, _ := cidr.Host(shared.SubnetNet, 14)
+	shared.BookCluster(t)
+	t.Parallel()
+
+	ip, _ := cidr.Host(shared.SubnetNet, 200)
 	privateIP := ip.String()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccCCEKeyPairPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
-		CheckDestroy:      testAccCheckCCENodeV3Destroy,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCCENodeV3Agency(privateIP),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCCENodeV3Exists(resourceNameNode, shared.DataSourceClusterName, &node),
+					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceNameNode, "name", "test-node"),
 					resource.TestCheckResourceAttr(resourceNameNode, "flavor_id", "s2.large.2"),
 					resource.TestCheckResourceAttr(resourceNameNode, "os", "EulerOS 2.9"),
@@ -102,7 +107,7 @@ func TestAccCCENodesV3Agency(t *testing.T) {
 	})
 }
 
-func TestAccCCENodesV3Multiple(t *testing.T) {
+func TestAccResourceCCENodesV3Multiple(t *testing.T) {
 	t.Parallel()
 	shared.BookCluster(t)
 	quotas.BookMany(t, singleNodeQuotas.X(2))
@@ -110,7 +115,6 @@ func TestAccCCENodesV3Multiple(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccCCEKeyPairPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
-		CheckDestroy:      testAccCheckCCENodeV3Destroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCCENodeV3Multiple,
@@ -119,31 +123,47 @@ func TestAccCCENodesV3Multiple(t *testing.T) {
 	})
 }
 
-func TestAccCCENodesV3Timeout(t *testing.T) {
+func TestAccResourceCCENodesV3Timeout(t *testing.T) {
 	var node nodes.Nodes
+	rc := common.InitResourceCheck(
+		resourceNameNode,
+		&node,
+		getCceNodeResourceFunc,
+	)
 
-	t.Parallel()
 	shared.BookCluster(t)
+	t.Parallel()
 	quotas.BookMany(t, singleNodeQuotas)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccCCEKeyPairPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
-		CheckDestroy:      testAccCheckCCENodeV3Destroy,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCCENodeV3Timeout,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCCENodeV3Exists(resourceNameNode, shared.DataSourceClusterName, &node),
+					rc.CheckResourceExists(),
 				),
 			},
 		},
 	})
 }
-func TestAccCCENodesV3OS(t *testing.T) {
-	var node nodes.Nodes
+func TestAccResourceCCENodesV3OS(t *testing.T) {
+	var node2 nodes.Nodes
 	var node3 nodes.Nodes
-	var node4 nodes.Nodes
+
+	rc2 := common.InitResourceCheck(
+		resourceNameNode2,
+		&node2,
+		getCceNodeResourceFunc,
+	)
+
+	rc3 := common.InitResourceCheck(
+		resourceNameNode3,
+		&node3,
+		getCceNodeResourceFunc,
+	)
 
 	t.Parallel()
 	shared.BookCluster(t)
@@ -157,23 +177,27 @@ func TestAccCCENodesV3OS(t *testing.T) {
 			{
 				Config: testAccCCENodeV3OS,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCCENodeV3Exists(resourceNameNode, shared.DataSourceClusterName, &node),
-					resource.TestCheckResourceAttr(resourceNameNode, "os", "EulerOS 2.5"),
-					testAccCheckCCENodeV3Exists(resourceNameNode3, shared.DataSourceClusterName, &node3),
-					resource.TestCheckResourceAttr(resourceNameNode3, "os", "EulerOS 2.9"),
-					testAccCheckCCENodeV3Exists(resourceNameNode4, shared.DataSourceClusterName, &node4),
-					resource.TestCheckResourceAttr(resourceNameNode4, "os", "Ubuntu 22.04"),
+					rc2.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceNameNode2, "os", "EulerOS 2.9"),
+					rc3.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceNameNode3, "os", "Ubuntu 22.04"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccCCENodesV3BandWidthResize(t *testing.T) {
+func TestAccResourceCCENodesV3BandWidthResize(t *testing.T) {
 	var node nodes.Nodes
 
-	t.Parallel()
+	rc := common.InitResourceCheck(
+		resourceNameNode,
+		&node,
+		getCceNodeResourceFunc,
+	)
+
 	shared.BookCluster(t)
+	t.Parallel()
 	qts := quotas.MultipleQuotas{{Q: quotas.FloatingIP, Count: 1}}
 	qts = append(qts, singleNodeQuotas...)
 	quotas.BookMany(t, qts)
@@ -181,12 +205,12 @@ func TestAccCCENodesV3BandWidthResize(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccCCEKeyPairPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
-		CheckDestroy:      testAccCheckCCENodeV3Destroy,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCCENodeV3Ip,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCCENodeV3Exists(resourceNameNode, shared.DataSourceClusterName, &node),
+					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceNameNode, "iptype", "5_bgp"),
 					resource.TestCheckResourceAttr(resourceNameNode, "sharetype", "PER"),
 					resource.TestCheckResourceAttr(resourceNameNode, "bandwidth_charge_mode", "traffic"),
@@ -196,7 +220,7 @@ func TestAccCCENodesV3BandWidthResize(t *testing.T) {
 			{
 				Config: testAccCCENodeV3BandWidthResize,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCCENodeV3Exists(resourceNameNode, shared.DataSourceClusterName, &node),
+					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceNameNode, "bandwidth_size", "10"),
 				),
 			},
@@ -204,11 +228,17 @@ func TestAccCCENodesV3BandWidthResize(t *testing.T) {
 	})
 }
 
-func TestAccCCENodesV3_eipIds(t *testing.T) {
+func TestAccResourceCCENodesV3_eipIds(t *testing.T) {
 	var node nodes.Nodes
+	rc := common.InitResourceCheck(
+		resourceNameNode,
+		&node,
+		getCceNodeResourceFunc,
+	)
 
-	t.Parallel()
 	shared.BookCluster(t)
+	t.Parallel()
+
 	qts := []*quotas.ExpectedQuota{{Q: quotas.FloatingIP, Count: 2}}
 	qts = append(qts, singleNodeQuotas...)
 	quotas.BookMany(t, qts)
@@ -216,29 +246,35 @@ func TestAccCCENodesV3_eipIds(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccCCEKeyPairPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
-		CheckDestroy:      testAccCheckCCENodeV3Destroy,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCCENodeV3IpIDs,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCCENodeV3Exists(resourceNameNode, shared.DataSourceClusterName, &node),
+					rc.CheckResourceExists(),
 				),
 			},
 			{
 				Config: testAccCCENodeV3IpIDsUnset,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCCENodeV3Exists(resourceNameNode, shared.DataSourceClusterName, &node),
+					rc.CheckResourceExists(),
 				),
 			},
 		},
 	})
 }
 
-func TestAccCCENodesV3IpSetNull(t *testing.T) {
+func TestAccResourceCCENodesV3IpSetNull(t *testing.T) {
 	var node nodes.Nodes
+	rc := common.InitResourceCheck(
+		resourceNameNode,
+		&node,
+		getCceNodeResourceFunc,
+	)
 
-	t.Parallel()
 	shared.BookCluster(t)
+	t.Parallel()
+
 	qts := []*quotas.ExpectedQuota{{Q: quotas.FloatingIP, Count: 2}}
 	qts = append(qts, singleNodeQuotas...)
 	quotas.BookMany(t, qts)
@@ -246,12 +282,12 @@ func TestAccCCENodesV3IpSetNull(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccCCEKeyPairPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
-		CheckDestroy:      testAccCheckCCENodeV3Destroy,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCCENodeV3Ip,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCCENodeV3Exists(resourceNameNode, shared.DataSourceClusterName, &node),
+					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceNameNode, "iptype", "5_bgp"),
 					resource.TestCheckResourceAttr(resourceNameNode, "sharetype", "PER"),
 					resource.TestCheckResourceAttr(resourceNameNode, "bandwidth_charge_mode", "traffic"),
@@ -260,18 +296,23 @@ func TestAccCCENodesV3IpSetNull(t *testing.T) {
 			{
 				Config: testAccCCENodeV3IpUnset,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCCENodeV3Exists(resourceNameNode, shared.DataSourceClusterName, &node),
+					rc.CheckResourceExists(),
 				),
 			},
 		},
 	})
 }
 
-func TestAccCCENodesV3IpCreate(t *testing.T) {
+func TestAccResourceCCENodesV3IpCreate(t *testing.T) {
 	var node nodes.Nodes
+	rc := common.InitResourceCheck(
+		resourceNameNode,
+		&node,
+		getCceNodeResourceFunc,
+	)
 
-	t.Parallel()
 	shared.BookCluster(t)
+	t.Parallel()
 	qts := []*quotas.ExpectedQuota{{Q: quotas.FloatingIP, Count: 1}}
 	qts = append(qts, singleNodeQuotas...)
 	quotas.BookMany(t, qts)
@@ -279,29 +320,34 @@ func TestAccCCENodesV3IpCreate(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccCCEKeyPairPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
-		CheckDestroy:      testAccCheckCCENodeV3Destroy,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCCENodeV3IpUnset,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCCENodeV3Exists(resourceNameNode, shared.DataSourceClusterName, &node),
+					rc.CheckResourceExists(),
 				),
 			},
 			{
 				Config: testAccCCENodeV3Ip,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCCENodeV3Exists(resourceNameNode, shared.DataSourceClusterName, &node),
+					rc.CheckResourceExists(),
 				),
 			},
 		},
 	})
 }
 
-func TestAccCCENodesV3IpWithExtendedParameters(t *testing.T) {
+func TestAccResourceCCENodesV3IpWithExtendedParameters(t *testing.T) {
 	var node nodes.Nodes
+	rc := common.InitResourceCheck(
+		resourceNameNode,
+		&node,
+		getCceNodeResourceFunc,
+	)
 
-	t.Parallel()
 	shared.BookCluster(t)
+	t.Parallel()
 	qts := []*quotas.ExpectedQuota{{Q: quotas.FloatingIP, Count: 2}}
 	qts = append(qts, singleNodeQuotas...)
 	quotas.BookMany(t, qts)
@@ -309,12 +355,12 @@ func TestAccCCENodesV3IpWithExtendedParameters(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccCCEKeyPairPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
-		CheckDestroy:      testAccCheckCCENodeV3Destroy,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCCENodeV3IpParams,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCCENodeV3Exists(resourceNameNode, shared.DataSourceClusterName, &node),
+					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceNameNode, "iptype", "5_bgp"),
 					resource.TestCheckResourceAttr(resourceNameNode, "sharetype", "PER"),
 					resource.TestCheckResourceAttr(resourceNameNode, "bandwidth_charge_mode", "traffic"),
@@ -324,44 +370,57 @@ func TestAccCCENodesV3IpWithExtendedParameters(t *testing.T) {
 	})
 }
 
-func TestAccCCENodesV3IpNulls(t *testing.T) {
+func TestAccResourceCCENodesV3IpNulls(t *testing.T) {
 	var node nodes.Nodes
+	rc := common.InitResourceCheck(
+		resourceNameNode,
+		&node,
+		getCceNodeResourceFunc,
+	)
 
-	t.Parallel()
 	shared.BookCluster(t)
+	t.Parallel()
+
 	quotas.BookMany(t, singleNodeQuotas)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccCCEKeyPairPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
-		CheckDestroy:      testAccCheckCCENodeV3Destroy,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCCENodeV3IpNull,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCCENodeV3Exists(resourceNameNode, shared.DataSourceClusterName, &node),
+					rc.CheckResourceExists(),
 				),
 			},
 		},
 	})
 }
 
-func TestAccCCENodesV3EncryptedVolume(t *testing.T) {
+func TestAccResourceCCENodesV3EncryptedVolume(t *testing.T) {
 	var node nodes.Nodes
 
-	t.Parallel()
+	rc := common.InitResourceCheck(
+		resourceNameNode,
+		&node,
+		getCceNodeResourceFunc,
+	)
+
 	shared.BookCluster(t)
+	t.Parallel()
+
 	quotas.BookMany(t, singleNodeQuotas)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccCCEKeyPairPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
-		CheckDestroy:      testAccCheckCCENodeV3Destroy,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCCENodeV3EncryptedVolume,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCCENodeV3Exists(resourceNameNode, shared.DataSourceClusterName, &node),
+					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceNameNode, "data_volumes.0.kms_id", env.OS_KMS_ID),
 					resource.TestCheckResourceAttr(resourceNameNode, "root_volume.0.kms_id", env.OS_KMS_ID),
 				),
@@ -370,11 +429,17 @@ func TestAccCCENodesV3EncryptedVolume(t *testing.T) {
 	})
 }
 
-func TestAccCCENodesV3TaintsK8sTags(t *testing.T) {
+func TestAccResourceCCENodesV3TaintsK8sTags(t *testing.T) {
 	var node nodes.Nodes
+	rc := common.InitResourceCheck(
+		resourceNameNode,
+		&node,
+		getCceNodeResourceFunc,
+	)
 
-	t.Parallel()
 	shared.BookCluster(t)
+	t.Parallel()
+
 	quotas.BookMany(t, singleNodeQuotas)
 
 	ip, _ := cidr.Host(shared.SubnetNet, 15)
@@ -383,12 +448,12 @@ func TestAccCCENodesV3TaintsK8sTags(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccCCEKeyPairPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
-		CheckDestroy:      testAccCheckCCENodeV3Destroy,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCCENodeV3TaintsK8sTags(privateIP),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCCENodeV3Exists(resourceNameNode, shared.DataSourceClusterName, &node),
+					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceNameNode, "taints.0.key", "dedicated"),
 					resource.TestCheckResourceAttr(resourceNameNode, "taints.0.value", "database"),
 					resource.TestCheckResourceAttr(resourceNameNode, "taints.0.effect", "NoSchedule"),
@@ -399,21 +464,28 @@ func TestAccCCENodesV3TaintsK8sTags(t *testing.T) {
 	})
 }
 
-func TestAccCCENodesV3_extendParams(t *testing.T) {
+func TestAccResourceCCENodesV3_extendParams(t *testing.T) {
 	var node nodes.Nodes
-	t.Parallel()
+	rc := common.InitResourceCheck(
+		resourceNameNode,
+		&node,
+		getCceNodeResourceFunc,
+	)
+
 	shared.BookCluster(t)
+	t.Parallel()
+
 	quotas.BookMany(t, singleNodeQuotas)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccCCEKeyPairPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
-		CheckDestroy:      testAccCheckCCENodeV3Destroy,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCCENodeV3ExtendParams,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCCENodeV3Exists(resourceNameNode, shared.DataSourceClusterName, &node),
+					rc.CheckResourceExists(),
 				),
 			},
 		},
@@ -446,72 +518,12 @@ func testAccCheckCCENodeV3Destroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckCCENodeV3Exists(n string, cluster string, node *nodes.Nodes) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("not found: %s", n)
-		}
-		c, ok := s.RootModule().Resources[cluster]
-		if !ok {
-			return fmt.Errorf("cluster not found: %s", c)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no ID is set")
-		}
-		if c.Primary.ID == "" {
-			return fmt.Errorf("cluster id is not set")
-		}
-
-		config := common.TestAccProvider.Meta().(*cfg.Config)
-		client, err := config.CceV3Client(env.OS_REGION_NAME)
-		if err != nil {
-			return fmt.Errorf("error creating OpenTelekomCloud CCE client: %s", err)
-		}
-
-		found, err := nodes.Get(client, c.Primary.ID, rs.Primary.ID)
-		if err != nil {
-			return err
-		}
-
-		if found.Metadata.Id != rs.Primary.ID {
-			return fmt.Errorf("node not found")
-		}
-
-		*node = *found
-
-		return nil
-	}
-}
-
 var testAccCCENodeV3OS = fmt.Sprintf(`
 %s
 
-resource "opentelekomcloud_cce_node_v3" "node_1" {
+resource "opentelekomcloud_cce_node_v3" "node_2" {
   cluster_id = data.opentelekomcloud_cce_cluster_v3.cluster.id
-  name       = "test-node"
-  flavor_id  = "s2.large.2"
-  os         = "EulerOS 2.5"
-
-  availability_zone = "%[2]s"
-  key_pair          = "%[3]s"
-
-  root_volume {
-    size       = 40
-    volumetype = "SATA"
-  }
-
-  data_volumes {
-    size       = 100
-    volumetype = "SATA"
-  }
-}
-
-
-resource "opentelekomcloud_cce_node_v3" "node_3" {
-  cluster_id = data.opentelekomcloud_cce_cluster_v3.cluster.id
-  name       = "test-node"
+  name       = "test-node-euler"
   flavor_id  = "s2.large.2"
   os         = "EulerOS 2.9"
 
@@ -529,9 +541,9 @@ resource "opentelekomcloud_cce_node_v3" "node_3" {
   }
 }
 
-resource "opentelekomcloud_cce_node_v3" "node_4" {
+resource "opentelekomcloud_cce_node_v3" "node_3" {
   cluster_id = data.opentelekomcloud_cce_cluster_v3.cluster.id
-  name       = "test-node"
+  name       = "test-node-ubuntu"
   flavor_id  = "s2.large.2"
   os         = "Ubuntu 22.04"
 

--- a/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_v3.go
+++ b/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_v3.go
@@ -589,7 +589,7 @@ func resourceCCENodeV3Create(ctx context.Context, d *schema.ResourceData, meta i
 	stateCluster := &resource.StateChangeConf{
 		Target:     []string{"Available"},
 		Refresh:    waitForClusterAvailable(client, clusterID),
-		Timeout:    15 * time.Minute,
+		Timeout:    20 * time.Minute,
 		Delay:      15 * time.Second,
 		MinTimeout: 3 * time.Second,
 	}

--- a/releasenotes/notes/cce-refactor-nodes-64c5205dc4a2b762.yaml
+++ b/releasenotes/notes/cce-refactor-nodes-64c5205dc4a2b762.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[CCE]** Refactor v3 node tests and fixed to match changes in gopher (`#2756 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2756>`_)


### PR DESCRIPTION
## Summary of the Pull Request

Apply changes from gopher in provider

## PR Checklist

* [x] Tests added/passed.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccResourceCCENodesV3Basic
    resource_opentelekomcloud_cce_node_v3_test.go:45: Cluster is required by the test. 1 test(s) are using cluster.
    cluster.go:121: starting creating shared cluster
    cluster.go:117: Cluster usage is 0 now, ready to delete the cluster
    cluster.go:80: starting deleting shared cluster
--- PASS: TestAccResourceCCENodesV3Basic (742.68s)
=== NAME  TestAccResourceCCENodesV3EncryptedVolume
    cluster.go:117: Cluster is released by the test. 11 test(s) are still using cluster.
--- PASS: TestAccResourceCCENodesV3EncryptedVolume (262.20s)
=== NAME  TestAccResourceCCENodesV3Timeout
    cluster.go:117: Cluster is released by the test. 10 test(s) are still using cluster.
--- PASS: TestAccResourceCCENodesV3Timeout (272.40s)
=== NAME  TestAccResourceCCENodesV3IpNulls
    cluster.go:117: Cluster is released by the test. 9 test(s) are still using cluster.
--- PASS: TestAccResourceCCENodesV3IpNulls (293.45s)
=== NAME  TestAccResourceCCENodesV3IpWithExtendedParameters
    cluster.go:117: Cluster is released by the test. 8 test(s) are still using cluster.
--- PASS: TestAccResourceCCENodesV3IpWithExtendedParameters (303.52s)
=== NAME  TestAccResourceCCENodesV3IpCreate
    cluster.go:117: Cluster is released by the test. 7 test(s) are still using cluster.
--- PASS: TestAccResourceCCENodesV3IpCreate (335.90s)
=== NAME  TestAccResourceCCENodesV3_extendParams
    cluster.go:117: Cluster is released by the test. 5 test(s) are still using cluster.
--- PASS: TestAccResourceCCENodesV3_extendParams (548.83s)
=== NAME  TestAccResourceCCENodesV3Multiple
    cluster.go:117: Cluster is released by the test. 4 test(s) are still using cluster.
--- PASS: TestAccResourceCCENodesV3Multiple (586.56s)
=== NAME  TestAccResourceCCENodesV3_eipIds
    cluster.go:117: Cluster is released by the test. 3 test(s) are still using cluster.
--- PASS: TestAccResourceCCENodesV3_eipIds (676.41s)
=== NAME  TestAccResourceCCENodesV3BandWidthResize
    cluster.go:117: Cluster is released by the test. 2 test(s) are still using cluster.
--- PASS: TestAccResourceCCENodesV3BandWidthResize (915.95s)
=== NAME  TestAccResourceCCENodesV3OS
    cluster.go:117: Cluster is released by the test. 1 test(s) are still using cluster.
--- PASS: TestAccResourceCCENodesV3OS (929.26s)
=== NAME  TestAccResourceCCENodesV3IpSetNull
    cluster.go:117: Cluster usage is 0 now, ready to delete the cluster
    cluster.go:80: starting deleting shared cluster
--- PASS: TestAccResourceCCENodesV3IpSetNull (1143.53s)
PASS
```
