### PR TITLE
[Fix] CCE: Fix CCE nodes kubernetes tags issue

### DIFF
--- a/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_v3.go
+++ b/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_v3.go
@@ -835,6 +835,8 @@ func setK8sNodeFields(d *schema.ResourceData, config *cfg.Config, clusterID, pri
 		}
 		k8sTags[key] = value
 	}
+	delete(k8sTags, "node.cce.io/billing-mode")
+	delete(k8sTags, "node.cce.io/eni-network-mode")
 	if err := d.Set("k8s_tags", k8sTags); err != nil {
 		return fmt.Errorf("error setting k8s_tags for CCE Node: %w", err)
 	}

--- a/releasenotes/notes/cce-fix-nodes-k8s-tags-2b58607fad288dd3.yaml
+++ b/releasenotes/notes/cce-fix-nodes-k8s-tags-2b58607fad288dd3.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[CCE]** Removed auto-generated k8s tags in ``resource/opentelekomcloud_cce_node_v3`` (`#2757 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2757>`_)


### PR DESCRIPTION
## Summary of the Pull Request

APIs returning extra k8s tags "node.cce.io/billing-mode" and "node.cce.io/eni-network-mode" which leads to plan differences. We remove these two before returning state.

## PR Checklist

* [x] Tests added/passed.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccResourceCCENodesV3TaintsK8sTags
    resource_opentelekomcloud_cce_node_v3_test.go:440: Cluster is required by the test. 1 test(s) are using cluster.
    cluster.go:121: starting creating shared cluster
=== PAUSE TestAccResourceCCENodesV3TaintsK8sTags
=== CONT  TestAccResourceCCENodesV3TaintsK8sTags
    cluster.go:117: Cluster usage is 0 now, ready to delete the cluster
    cluster.go:80: starting deleting shared cluster
--- PASS: TestAccResourceCCENodesV3TaintsK8sTags (665.46s)
PASS
```
