### PR TITLE
[Refactor] CCE: Refactor CCE Nodepools

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20241211090426-8e0297aa1379
+	github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20241212123948-a742635bfc3d
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.23.0
 	golang.org/x/sync v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -156,8 +156,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k+Mg7cowZ8yv4Trqw9UsJby758=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20241211090426-8e0297aa1379 h1:E4Oc5QRAPwLanhJv0igiuVPQ5j1+4WYzck8EVNV+u/A=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20241211090426-8e0297aa1379/go.mod h1:M1F6OfSRZRzAmAFKQqSLClX952at5hx5rHe4UTEykgg=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20241212123948-a742635bfc3d h1:+rq5zAupTnmmdVpN9TzUzZ69BiVNuk8BZ/8f/Vdobv8=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20241212123948-a742635bfc3d/go.mod h1:M1F6OfSRZRzAmAFKQqSLClX952at5hx5rHe4UTEykgg=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_node_pool_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_node_pool_v3_test.go
@@ -23,7 +23,7 @@ func getNodePoolFunc(conf *cfg.Config, state *terraform.ResourceState) (interfac
 	if err != nil {
 		return nil, fmt.Errorf("error creating OpenTelekomCloud CCE client: %s", err)
 	}
-	return nodepools.Get(client, state.Primary.Attributes["cluster_id"], state.Primary.ID).Extract()
+	return nodepools.Get(client, state.Primary.Attributes["cluster_id"], state.Primary.ID)
 }
 
 func TestAccCCENodePoolsV3_basic(t *testing.T) {

--- a/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_pool_v3.go
+++ b/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_pool_v3.go
@@ -415,13 +415,13 @@ func resourceCCENodePoolV3Create(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)
-	pool, err := nodepools.Create(client, clusterID, createOpts).Extract()
+	pool, err := nodepools.Create(client, clusterID, createOpts)
 	switch err.(type) {
 	case golangsdk.ErrDefault403:
 		if _, err := clusterStateConf.WaitForStateContext(ctx); err != nil {
 			return fmterr.Errorf("error waiting for cluster to be available: %w", err)
 		}
-		retried, err := nodepools.Create(client, clusterID, createOpts).Extract()
+		retried, err := nodepools.Create(client, clusterID, createOpts)
 		if err != nil {
 			return fmterr.Errorf(createError, err)
 		}
@@ -459,7 +459,7 @@ func resourceCCENodePoolV3Read(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	clusterID := d.Get("cluster_id").(string)
-	s, err := nodepools.Get(client, clusterID, d.Id()).Extract()
+	s, err := nodepools.Get(client, clusterID, d.Id())
 	if err != nil {
 		return common.CheckDeletedDiag(d, err, "CCE Node Pool")
 	}
@@ -576,7 +576,7 @@ func resourceCCENodePoolV3Update(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	clusterID := d.Get("cluster_id").(string)
-	_, err = nodepools.Update(client, clusterID, d.Id(), updateOpts).Extract()
+	_, err = nodepools.Update(client, clusterID, d.Id(), updateOpts)
 	if err != nil {
 		return fmterr.Errorf("error updating Open Telekom Cloud CCE Node Pool: %w", err)
 	}
@@ -608,7 +608,7 @@ func resourceCCENodePoolV3Delete(ctx context.Context, d *schema.ResourceData, me
 
 	clusterID := d.Get("cluster_id").(string)
 
-	if err := nodepools.Delete(client, clusterID, d.Id()).ExtractErr(); err != nil {
+	if err := nodepools.Delete(client, clusterID, d.Id()); err != nil {
 		return fmterr.Errorf("error deleting Open Telekom Cloud CCE Node Pool: %w", err)
 	}
 
@@ -632,7 +632,7 @@ func resourceCCENodePoolV3Delete(ctx context.Context, d *schema.ResourceData, me
 
 func waitForCceNodePoolActive(cceClient *golangsdk.ServiceClient, clusterId, nodePoolId string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		n, err := nodepools.Get(cceClient, clusterId, nodePoolId).Extract()
+		n, err := nodepools.Get(cceClient, clusterId, nodePoolId)
 		if err != nil {
 			return nil, "", err
 		}
@@ -644,7 +644,7 @@ func waitForCceNodePoolDelete(cceClient *golangsdk.ServiceClient, clusterID, nod
 	return func() (interface{}, string, error) {
 		log.Printf("[DEBUG] Attempting to delete Open Telekom Cloud CCE Node Pool %s.\n", nodePoolID)
 
-		r, err := nodepools.Get(cceClient, clusterID, nodePoolID).Extract()
+		r, err := nodepools.Get(cceClient, clusterID, nodePoolID)
 
 		if err != nil {
 			if _, ok := err.(golangsdk.ErrDefault404); ok {

--- a/releasenotes/notes/cce-refactor-nodepools-905cdebba03e93a2.yaml
+++ b/releasenotes/notes/cce-refactor-nodepools-905cdebba03e93a2.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[CCE]** Refactor v3 nodepool tests and fixed to match changes in gopher (`#2763 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2763>`_)


### PR DESCRIPTION
## Summary of the Pull Request

Apply changes from gopher in provider

## PR Checklist

* [x] Tests added/passed.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== NAME  TestAccCCENodePoolsV3EncryptedVolume
    cluster.go:117: Cluster is released by the test. 4 test(s) are still using cluster.
--- PASS: TestAccCCENodePoolsV3EncryptedVolume (598.32s)
=== NAME  TestAccCCENodePoolsV3_randomAZ
    cluster.go:117: Cluster is released by the test. 3 test(s) are still using cluster.
--- PASS: TestAccCCENodePoolsV3_randomAZ (598.59s)
=== NAME  TestAccCCENodePoolsV3ExtendParams
    cluster.go:117: Cluster is released by the test. 2 test(s) are still using cluster.
--- PASS: TestAccCCENodePoolsV3ExtendParams (640.92s)
=== NAME  TestAccCCENodePoolsV3_SecurityGroupIds
    cluster.go:117: Cluster is released by the test. 1 test(s) are still using cluster.
--- PASS: TestAccCCENodePoolsV3_SecurityGroupIds (682.35s)
=== NAME  TestAccCCENodePoolsV3_basic
    cluster.go:117: Cluster usage is 0 now, ready to delete the cluster
    cluster.go:80: starting deleting shared cluster
--- PASS: TestAccCCENodePoolsV3_basic (903.77s)
```
**Skipped tests**: 
- TestAccCCENodePoolsV3StorageJsonEncode
- TestAccCCENodePoolsV3Storage
- TestAccCCENodePoolsV3_agency