### PR TITLE
[Feat.] DMS: Add new resource opentelekomcloud_dms_topic_v2

### DIFF
--- a/docs/resources/dms_topic_v1.md
+++ b/docs/resources/dms_topic_v1.md
@@ -14,6 +14,9 @@ Up-to-date reference of API arguments for DMS topic you can get at
 
 Manages a DMS topic in the OpenTelekomCloud DMS Service (Kafka Premium/Platinum).
 
+~>
+Deprecated, use `opentelekomcloud_dms_topic_v2` resource instead
+
 ## Example Usage: creating dms instance with topic
 
 ```hcl

--- a/docs/resources/dms_topic_v2.md
+++ b/docs/resources/dms_topic_v2.md
@@ -1,0 +1,100 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+layout: "opentelekomcloud"
+page_title: "OpenTelekomCloud: opentelekomcloud_dms_topic_v2"
+sidebar_current: "docs-opentelekomcloud-resource-dms-topic-v2"
+description: |-
+  Manages a DMS Topic V2 resource within OpenTelekomCloud.
+---
+
+Up-to-date reference of API arguments for DMS topic you can get at
+[documentation portal](https://docs.otc.t-systems.com/distributed-message-service/api-ref/apis_v2_recommended/topic_management/index.html#topic-300000004)
+
+# opentelekomcloud_dms_topic_v2
+
+Manages a DMS topic V2 in the OpenTelekomCloud DMS Service (Kafka Premium/Platinum).
+
+## Example Usage: creating dms instance with topic
+
+```hcl
+resource "opentelekomcloud_networking_secgroup_v2" "secgroup_1" {
+  name        = "secgroup_1"
+  description = "secgroup_1"
+}
+
+data "opentelekomcloud_dms_az_v1" "az_1" {
+  name = "eu-de-01"
+}
+
+data "opentelekomcloud_dms_product_v1" "product_1" {
+  engine            = "kafka"
+  version           = "2.3.0"
+  instance_type     = "cluster"
+  partition_num     = 300
+  storage           = 600
+  storage_spec_code = "dms.physical.storage.high"
+}
+
+resource "opentelekomcloud_dms_instance_v1" "instance_1" {
+  name              = "kafka-test"
+  engine            = "kafka"
+  product_id        = data.opentelekomcloud_dms_product_v1.product_1.id
+  engine_version    = data.opentelekomcloud_dms_product_v1.product_1.version
+  specification     = data.opentelekomcloud_dms_product_v1.product_1.bandwidth
+  partition_num     = data.opentelekomcloud_dms_product_v1.product_1.partition_num
+  storage_spec_code = data.opentelekomcloud_dms_product_v1.product_1.storage_spec_code
+  storage_space     = data.opentelekomcloud_dms_product_v1.product_1.storage
+  available_zones   = [data.opentelekomcloud_dms_az_v1.az_1.id]
+  security_group_id = opentelekomcloud_networking_secgroup_v2.secgroup_1.id
+  vpc_id            = var.vpc_id
+  subnet_id         = var.subnet_id
+  access_user       = var.access_user
+  password          = var.password
+}
+
+resource "opentelekomcloud_dms_topic_v2" "topic_1" {
+  instance_id      = resource.opentelekomcloud_dms_instance_v1.instance_1.id
+  name             = "topic-test"
+  partition        = 10
+  replication      = 2
+  sync_replication = true
+  retention_time   = 80
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `instance_id` - (Required) Indicates the ID of primary DMS instance.
+
+* `name` - (Required) Indicates the name of a topic.
+
+* `partition` - (Optional) Indicates the number of topic partitions,
+  which is used to set the number of concurrently consumed messages.
+  Value range: `1–200`. Default value: `3`.
+
+* `replication` - (Optional) Indicates the number of replicas,
+  which is configured to ensure data reliability.
+  Value range: `1–3`. Default value: `3`.
+
+* `sync_replication` - (Optional) Indicates whether to enable synchronous replication.
+  After this function is enabled, the `acks` parameter on the producer client must be set to `–1`.
+  Otherwise, this parameter does not take effect.
+
+* `retention_time` - (Required) Indicates the retention period of a message. Its default value is `72`.
+  Value range: `1–720`. Default value: `72`. Unit: `hour`.
+
+* `sync_message_flush` - (Optional) Indicates whether to enable synchronous flushing.
+  Default value: `false`. Synchronous flushing compromises performance.
+
+
+## Attributes Reference
+
+All above argument parameters can be exported as attribute parameters along with attribute reference.
+
+* `size` - The partition size of the topic.
+
+* `remain_partitions` - Number of remaining partitions.
+
+* `max_partitions` - Total partitions number.

--- a/docs/resources/dms_topic_v2.md
+++ b/docs/resources/dms_topic_v2.md
@@ -66,26 +66,26 @@ resource "opentelekomcloud_dms_topic_v2" "topic_1" {
 
 The following arguments are supported:
 
-* `instance_id` - (Required) Indicates the ID of primary DMS instance.
+* `instance_id` - (Required, String, ForceNew) Indicates the ID of primary DMS instance.
 
-* `name` - (Required) Indicates the name of a topic.
+* `name` - (Required, String, ForceNew) Indicates the name of a topic.
 
-* `partition` - (Optional) Indicates the number of topic partitions,
+* `partition` - (Optional, Int, ForceNew) Indicates the number of topic partitions,
   which is used to set the number of concurrently consumed messages.
   Value range: `1–200`. Default value: `3`.
 
-* `replication` - (Optional) Indicates the number of replicas,
+* `replication` - (Optional, Int, ForceNew) Indicates the number of replicas,
   which is configured to ensure data reliability.
   Value range: `1–3`. Default value: `3`.
 
-* `sync_replication` - (Optional) Indicates whether to enable synchronous replication.
+* `sync_replication` - (Optional, Bool, ForceNew) Indicates whether to enable synchronous replication.
   After this function is enabled, the `acks` parameter on the producer client must be set to `–1`.
   Otherwise, this parameter does not take effect.
 
-* `retention_time` - (Required) Indicates the retention period of a message. Its default value is `72`.
+* `retention_time` - (Optional, Int, ForceNew) Indicates the retention period of a message. Its default value is `72`.
   Value range: `1–720`. Default value: `72`. Unit: `hour`.
 
-* `sync_message_flush` - (Optional) Indicates whether to enable synchronous flushing.
+* `sync_message_flush` - (Optional, Bool, ForceNew) Indicates whether to enable synchronous flushing.
   Default value: `false`. Synchronous flushing compromises performance.
 
 
@@ -98,3 +98,11 @@ All above argument parameters can be exported as attribute parameters along with
 * `remain_partitions` - Number of remaining partitions.
 
 * `max_partitions` - Total partitions number.
+
+## Import
+
+DMS topics can be imported using their `topic_name` and related `instance_id`, separated by a slash, e.g.
+
+```bash
+$ terraform import opentelekomcloud_dms_topic_v2.test_topic <instance_id>/<topic_name>
+```

--- a/docs/resources/dms_topic_v2.md
+++ b/docs/resources/dms_topic_v2.md
@@ -35,7 +35,7 @@ data "opentelekomcloud_dms_product_v1" "product_1" {
   storage_spec_code = "dms.physical.storage.high"
 }
 
-resource "opentelekomcloud_dms_instance_v1" "instance_1" {
+resource "opentelekomcloud_dms_instance_v2" "instance_1" {
   name              = "kafka-test"
   engine            = "kafka"
   product_id        = data.opentelekomcloud_dms_product_v1.product_1.id

--- a/opentelekomcloud/acceptance/dms/resource_opentelekomcloud_dms_topic_v2_test.go
+++ b/opentelekomcloud/acceptance/dms/resource_opentelekomcloud_dms_topic_v2_test.go
@@ -1,0 +1,73 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+)
+
+const resourceTopicV2Name = "opentelekomcloud_dms_topic_v2.topic_1"
+
+func TestAccDmsTopicsV2_basic(t *testing.T) {
+	var instanceName = fmt.Sprintf("dms_instance_%s", acctest.RandString(5))
+	var topicName = fmt.Sprintf("topic_instance_%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDmsV1InstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDmsV2TopicBasic(instanceName, topicName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceTopicV2Name, "partition", "200"),
+					resource.TestCheckResourceAttr(resourceTopicV2Name, "replication", "3"),
+					resource.TestCheckResourceAttr(resourceTopicV2Name, "sync_replication", "true"),
+					resource.TestCheckResourceAttr(resourceTopicV2Name, "retention_time", "600"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDmsV2TopicBasic(instanceName string, topicName string) string {
+	return fmt.Sprintf(`
+%s
+
+%s
+
+data "opentelekomcloud_dms_az_v1" "az_1" {}
+
+data "opentelekomcloud_dms_product_v1" "product_1" {
+  engine        = "kafka"
+  instance_type = "cluster"
+  version       = "2.3.0"
+}
+
+resource "opentelekomcloud_dms_instance_v1" "instance_1" {
+  name              = "%s"
+  engine            = "kafka"
+  storage_space     = data.opentelekomcloud_dms_product_v1.product_1.storage
+  access_user       = "user"
+  password          = "Dmstest@123"
+  vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
+  subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  available_zones   = [data.opentelekomcloud_dms_az_v1.az_1.id]
+  product_id        = data.opentelekomcloud_dms_product_v1.product_1.id
+  engine_version    = data.opentelekomcloud_dms_product_v1.product_1.version
+  storage_spec_code = data.opentelekomcloud_dms_product_v1.product_1.storage_spec_code
+}
+
+resource "opentelekomcloud_dms_topic_v2" "topic_1" {
+  instance_id      = resource.opentelekomcloud_dms_instance_v1.instance_1.id
+  name             = "%s"
+  partition        = 200
+  replication      = 3
+  sync_replication = true
+  retention_time   = 600
+}`, common.DataSourceSecGroupDefault, common.DataSourceSubnet, instanceName, topicName)
+}

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -453,6 +453,7 @@ func Provider() *schema.Provider {
 			"opentelekomcloud_dms_smart_connect_v2":                      dms.ResourceDmsSmartConnectV2(),
 			"opentelekomcloud_dms_smart_connect_task_v2":                 dms.ResourceDmsSmartConnectTaskV2(),
 			"opentelekomcloud_dms_topic_v1":                              dms.ResourceDmsTopicsV1(),
+			"opentelekomcloud_dms_topic_v2":                              dms.ResourceDmsTopicsV2(),
 			"opentelekomcloud_dms_user_v2":                               dms.ResourceDmsUsersV2(),
 			"opentelekomcloud_dms_user_permission_v1":                    dms.ResourceDmsUsersPermissionV1(),
 			"opentelekomcloud_drs_task_v3":                               drs.ResourceDrsTaskV3(),

--- a/opentelekomcloud/services/dms/common.go
+++ b/opentelekomcloud/services/dms/common.go
@@ -10,6 +10,7 @@ const (
 	errCreationClient   = "error creating OpenTelekomCloud DMSv1 client: %w"
 	errCreationClientV2 = "error creating OpenTelekomCloud DMSv2 client: %w"
 	dmsClientV2         = "dms-v2-client"
+	dmsV1Deprecated     = "This resource API is deprecated. Please use opentelekomcloud_dms_topic_v2 instead."
 )
 
 func MarshalValue(i interface{}) string {

--- a/opentelekomcloud/services/dms/resource_opentelekomcloud_dms_topic_v2.go
+++ b/opentelekomcloud/services/dms/resource_opentelekomcloud_dms_topic_v2.go
@@ -2,7 +2,9 @@ package dms
 
 import (
 	"context"
+	"fmt"
 	"log"
+	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -21,7 +23,7 @@ func ResourceDmsTopicsV2() *schema.Resource {
 		ReadContext:   resourceDmsTopicsV2Read,
 		DeleteContext: resourceDmsTopicsV2Delete,
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceDmsTopicV2ImportState,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -188,4 +190,15 @@ func resourceDmsTopicsV2Delete(ctx context.Context, d *schema.ResourceData, meta
 	log.Printf("[DEBUG] Dms topic %s deactivated.", d.Id())
 	d.SetId("")
 	return nil
+}
+
+func resourceDmsTopicV2ImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,
+	error) {
+	parts := strings.SplitN(d.Id(), "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format for import ID, want '<instance_id>/<topic_name>', but '%s'", d.Id())
+	}
+
+	d.SetId(parts[1])
+	return []*schema.ResourceData{d}, d.Set("instance_id", parts[0])
 }

--- a/releasenotes/notes/dms_topic_v2-9f2c975e198c242c.yaml
+++ b/releasenotes/notes/dms_topic_v2-9f2c975e198c242c.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    **[DMS]** Add new resource ``resource/opentelekomcloud_dms_topic_v2`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/>`_)
+deprecations:
+  - |
+    **[DMS]** ``resource/opentelekomcloud_dms_topic_v1`` is deprecated in favor of ``resource/opentelekomcloud_dms_topic_v2``
+    (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)

--- a/releasenotes/notes/dms_topic_v2-9f2c975e198c242c.yaml
+++ b/releasenotes/notes/dms_topic_v2-9f2c975e198c242c.yaml
@@ -1,8 +1,8 @@
 ---
 features:
   - |
-    **[DMS]** Add new resource ``resource/opentelekomcloud_dms_topic_v2`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/>`_)
+    **[DMS]** Add new resource ``resource/opentelekomcloud_dms_topic_v2`` (`#2766 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2766>`_)
 deprecations:
   - |
     **[DMS]** ``resource/opentelekomcloud_dms_topic_v1`` is deprecated in favor of ``resource/opentelekomcloud_dms_topic_v2``
-    (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    (`#2766 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2766>`_)


### PR DESCRIPTION
## Summary of the Pull Request
New resource `opentelekomcloud_dms_topic_v2` introduced.
`opentelekomcloud_dms_topic_v1` is deprecated due to api going out-of-date. 

## PR Checklist

* [x] Refers to: #2741
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccDmsTopicsV2_basic
--- PASS: TestAccDmsTopicsV2_basic (647.36s)
PASS

Process finished with the exit code 0

=== RUN   TestAccDmsTopicsV1_basic
--- PASS: TestAccDmsTopicsV1_basic (649.04s)
PASS

Process finished with the exit code 0

```
