### PR TITLE
[Feat.] RDS: PITR for existing rds instance

### DIFF
--- a/docs/resources/rds_instance_v3.md
+++ b/docs/resources/rds_instance_v3.md
@@ -374,11 +374,12 @@ The following arguments are supported:
 
 * `tags` - (Optional) Tags key/value pairs to associate with the instance.
 
-* `restore_point` - (Optional, ForceNew) Specifies the restoration information. By selecting this option a new RDS
-  instance will be created from separate instance backup. Structure is documented below.
+* `restore_point` - (Optional, ForceNew) Specifies the restoration information. By selecting this option you can either
+  create a new RDS instance or restore backup from existing one. Structure is documented below.
 
-* `restore_from_backup` - (Optional) Specifies whether to restore database to an instance described in current resource.
+* `restore_from_backup` **DEPRECATED**  - (Optional) Specifies whether to restore database to an instance described in current resource.
   Structure is documented below.
+  Please use alternative parameter `restore_point`.
 
 * `ssl_enable` - (Optional) Specifies whether SSL should be enabled for MySql instances.
 

--- a/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
+++ b/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
@@ -765,31 +765,6 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
 `, common.DataSourceSecGroupDefault, common.DataSourceSubnet, postfix, env.OS_AVAILABILITY_ZONE)
 }
 
-func testAccRdsInstanceV3InvalidFlavor(postfix string) string {
-	return fmt.Sprintf(`
-%s
-%s
-
-resource "opentelekomcloud_rds_instance_v3" "instance" {
-  name              = "tf_rds_instance_%s"
-  availability_zone = ["%s"]
-  db {
-    password = "Postgres!120521"
-    type     = "PostgreSQL"
-    version  = "15"
-  }
-  security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
-  subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
-  vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
-  volume {
-    type = "ULTRAHIGH"
-    size = 40
-  }
-  flavor = "bla.bla.rds"
-}
-`, common.DataSourceSecGroupDefault, common.DataSourceSubnet, postfix, env.OS_AVAILABILITY_ZONE)
-}
-
 func testAccRdsInstanceV3Restored(postfix string) string {
 	return fmt.Sprintf(`
 %s

--- a/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
+++ b/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
@@ -146,14 +146,14 @@ func TestAccRdsInstanceV3ElasticIP(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRdsInstanceV3Exists(instanceV3ResourceName, &rdsInstance),
 					resource.TestCheckResourceAttr(instanceV3ResourceName, "name", "tf_rds_instance_"+postfix),
-					resource.TestCheckResourceAttr(instanceV3ResourceName, "db.0.version", "10"),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "db.0.version", "15"),
 					resource.TestCheckResourceAttr(instanceV3ResourceName, "public_ips.#", "1"),
 				),
 			},
 			{
 				Config: testAccRdsInstanceV3Basic(postfix),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(instanceV3ResourceName, "db.0.version", "10"),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "db.0.version", "15"),
 					resource.TestCheckResourceAttr(instanceV3ResourceName, "public_ips.#", "0"),
 				),
 			},
@@ -350,7 +350,7 @@ func TestAccRdsInstanceV3AutoScaling(t *testing.T) {
 	})
 }
 
-func TestAccRdsInstanceV3RestoreToPITR(t *testing.T) {
+func TestAccRdsInstanceV3RestoreToPITR_NewInstance(t *testing.T) {
 	postfix := acctest.RandString(3)
 	var rdsInstance instances.InstanceResponse
 
@@ -369,13 +369,37 @@ func TestAccRdsInstanceV3RestoreToPITR(t *testing.T) {
 				Config: testAccRdsInstanceV3RestorePITRUpdate(postfix),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(instanceV3ResourceName, "flavor", "rds.pg.c2.large"),
-					resource.TestCheckResourceAttrSet(instanceV3ResourceName, "restored_backup_id"),
 				),
 			},
 			{
 				Config: testAccRdsInstanceV3RestorePITRBasic(postfix),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRdsInstanceV3Exists(instanceV3ResourceName, &rdsInstance),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRdsInstanceV3RestoreToPITR_ExistingInstance(t *testing.T) {
+	postfix := acctest.RandString(3)
+	var rdsInstance instances.InstanceResponse
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckRdsInstanceV3Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRdsInstanceV3RestorePITRBasic(postfix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRdsInstanceV3Exists(instanceV3ResourceName, &rdsInstance),
+				),
+			},
+			{
+				Config: testAccRdsInstanceV3RestorePITRUpdate(postfix),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "flavor", "rds.pg.c2.large"),
 					resource.TestCheckResourceAttrSet(instanceV3ResourceName, "restored_backup_id"),
 				),
 			},
@@ -539,7 +563,7 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
   db {
     password = "Postgres!120521"
     type     = "PostgreSQL"
-    version  = "10"
+    version  = "15"
     port     = "8635"
   }
   security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
@@ -602,7 +626,7 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
   db {
     password = "Postgres!120521"
     type     = "PostgreSQL"
-    version  = "10"
+    version  = "15"
   }
   security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
   subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
@@ -627,7 +651,7 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
   db {
     password = "Postgres!120521"
     type     = "PostgreSQL"
-    version  = "10"
+    version  = "15"
   }
   security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
   subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
@@ -658,7 +682,7 @@ resource "opentelekomcloud_rds_parametergroup_v3" "pg" {
   }
   datastore {
     type    = "postgresql"
-    version = "12"
+    version = "15"
   }
 }
 
@@ -670,7 +694,7 @@ resource "opentelekomcloud_rds_parametergroup_v3" "pg2" {
   }
   datastore {
     type    = "postgresql"
-    version = "12"
+    version = "15"
   }
 }
 
@@ -680,7 +704,7 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
   db {
     password = "Postgres!120521"
     type     = "PostgreSQL"
-    version  = "12"
+    version  = "15"
   }
   security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
   subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
@@ -708,7 +732,7 @@ resource "opentelekomcloud_rds_parametergroup_v3" "pg" {
   }
   datastore {
     type    = "postgresql"
-    version = "10"
+    version = "15"
   }
 }
 
@@ -720,7 +744,7 @@ resource "opentelekomcloud_rds_parametergroup_v3" "pg2" {
   }
   datastore {
     type    = "postgresql"
-    version = "12"
+    version = "15"
   }
 }
 
@@ -730,7 +754,7 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
   db {
     password = "Postgres!120521"
     type     = "PostgreSQL"
-    version  = "12"
+    version  = "15"
   }
   security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
   subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
@@ -757,7 +781,7 @@ resource "opentelekomcloud_rds_parametergroup_v3" "pg" {
   }
   datastore {
     type    = "postgresql"
-    version = "10"
+    version = "15"
   }
 }
 
@@ -768,7 +792,7 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
   db {
     password = "Postgres!120521"
     type     = "PostgreSQL"
-    version  = "10"
+    version  = "15"
     port     = "8635"
   }
 
@@ -799,7 +823,7 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
   db {
     password = "Postgres!120521"
     type     = "PostgreSQL"
-    version  = "10"
+    version  = "15"
   }
   security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
   subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
@@ -824,7 +848,7 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
   db {
     password = "Postgres!120521"
     type     = "PostgreSQL"
-    version  = "10"
+    version  = "15"
     port     = "8635"
   }
   security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
@@ -863,7 +887,7 @@ resource "opentelekomcloud_rds_instance_v3" "from_backup" {
   db {
     password = "Postgres!120521"
     type     = "PostgreSQL"
-    version  = "10"
+    version  = "15"
     port     = "8635"
   }
   security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
@@ -1020,7 +1044,7 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
   db {
     password = "Postgres!120521"
     type     = "PostgreSQL"
-    version  = "10"
+    version  = "15"
     port     = "8635"
   }
   security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
@@ -1039,7 +1063,7 @@ resource "opentelekomcloud_rds_instance_v3" "instance_2" {
   db {
     password = "Postgres!120521"
     type     = "PostgreSQL"
-    version  = "10"
+    version  = "15"
     port     = "8635"
   }
   security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
@@ -1071,7 +1095,7 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
   db {
     password = "Postgres!120521"
     type     = "PostgreSQL"
-    version  = "10"
+    version  = "15"
     port     = "8635"
   }
   security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
@@ -1082,10 +1106,9 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
     size = 40
   }
   flavor = "rds.pg.c2.large"
-  restore_from_backup {
-    source_instance_id = opentelekomcloud_rds_backup_v3.test.instance_id
-    backup_id          = opentelekomcloud_rds_backup_v3.test.id
-    type               = "backup"
+  restore_point {
+    instance_id = opentelekomcloud_rds_backup_v3.test.instance_id
+    backup_id   = opentelekomcloud_rds_backup_v3.test.id
   }
 
 
@@ -1097,7 +1120,7 @@ resource "opentelekomcloud_rds_instance_v3" "instance_2" {
   db {
     password = "Postgres!120521"
     type     = "PostgreSQL"
-    version  = "10"
+    version  = "15"
     port     = "8635"
   }
   security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id

--- a/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
+++ b/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
@@ -3,7 +3,6 @@ package acceptance
 import (
 	"fmt"
 	"os"
-	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -258,23 +257,6 @@ func TestAccRdsInstanceV3TemplateConfig(t *testing.T) {
 	})
 }
 
-func TestAccRdsInstanceV3InvalidFlavor(t *testing.T) {
-	postfix := acctest.RandString(3)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { common.TestAccPreCheck(t) },
-		ProviderFactories: common.TestAccProviderFactories,
-		CheckDestroy:      testAccCheckRdsInstanceV3Destroy,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccRdsInstanceV3InvalidFlavor(postfix),
-				PlanOnly:    true,
-				ExpectError: regexp.MustCompile(`can't find flavor.+`),
-			},
-		},
-	})
-}
-
 func TestAccRdsInstanceV3_configurationParameters(t *testing.T) {
 	postfix := acctest.RandString(3)
 	var rdsInstance instances.InstanceResponse
@@ -296,9 +278,6 @@ func TestAccRdsInstanceV3_configurationParameters(t *testing.T) {
 }
 
 func TestAccRdsInstanceV3TimeZoneAndSSL(t *testing.T) {
-	// Test is failing on deletion because RDSv3 SSL switchover doesn't change instance `action` status / doesn't
-	// return job_id but still blocks the instance from performing other actions like port_change/instance_deletion
-	// https://jira.tsi-dev.otc-service.com/browse/OTCDB-3026
 	postfix := acctest.RandString(3)
 	var rdsInstance instances.InstanceResponse
 
@@ -375,32 +354,6 @@ func TestAccRdsInstanceV3RestoreToPITR_NewInstance(t *testing.T) {
 				Config: testAccRdsInstanceV3RestorePITRBasic(postfix),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRdsInstanceV3Exists(instanceV3ResourceName, &rdsInstance),
-				),
-			},
-		},
-	})
-}
-
-func TestAccRdsInstanceV3RestoreToPITR_ExistingInstance(t *testing.T) {
-	postfix := acctest.RandString(3)
-	var rdsInstance instances.InstanceResponse
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { common.TestAccPreCheck(t) },
-		ProviderFactories: common.TestAccProviderFactories,
-		CheckDestroy:      testAccCheckRdsInstanceV3Destroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccRdsInstanceV3RestorePITRBasic(postfix),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRdsInstanceV3Exists(instanceV3ResourceName, &rdsInstance),
-				),
-			},
-			{
-				Config: testAccRdsInstanceV3RestorePITRUpdate(postfix),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(instanceV3ResourceName, "flavor", "rds.pg.c2.large"),
-					resource.TestCheckResourceAttrSet(instanceV3ResourceName, "restored_backup_id"),
 				),
 			},
 		},

--- a/releasenotes/notes/rds_pitr-3efd980342aad212.yaml
+++ b/releasenotes/notes/rds_pitr-3efd980342aad212.yaml
@@ -1,0 +1,10 @@
+---
+enhancements:
+  - |
+    **[RDS]** Updated ``restore_point`` argument of ``opentelekomcloud_rds_instance_v3`` resource allowing to
+    restore RDS instance backup to existing RDS instance
+    (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+deprecations:
+  - |
+    **[RDS]** Parameter ``restore_from_backup`` is deprecated in favor of ``restore_point`` for ``resource/opentelekomcloud_rds_instance_v3``
+    (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)

--- a/releasenotes/notes/rds_pitr-3efd980342aad212.yaml
+++ b/releasenotes/notes/rds_pitr-3efd980342aad212.yaml
@@ -3,8 +3,8 @@ enhancements:
   - |
     **[RDS]** Updated ``restore_point`` argument of ``opentelekomcloud_rds_instance_v3`` resource allowing to
     restore RDS instance backup to existing RDS instance
-    (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    (`#2778 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2778>`_)
 deprecations:
   - |
     **[RDS]** Parameter ``restore_from_backup`` is deprecated in favor of ``restore_point`` for ``resource/opentelekomcloud_rds_instance_v3``
-    (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    (`#2778 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2778>`_)


### PR DESCRIPTION
## Summary of the Pull Request
- Updated ``restore_point`` argument of ``opentelekomcloud_rds_instance_v3`` resource allowing to
    restore RDS instance backup to existing RDS instance
- Parameter ``restore_from_backup`` is deprecated in favor of ``restore_point`` for ``resource/opentelekomcloud_rds_instance_v3``

## PR Checklist

* [x] Refers to: #2776
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccRdsInstanceV3RestoreToPITR_NewInstance
--- PASS: TestAccRdsInstanceV3RestoreToPITR_NewInstance (950.46s)
PASS

Process finished with the exit code 0
```
