### PR TITLE
[Feat.] DMS: Add smart connect task action

### DIFF
--- a/docs/resources/dms_smart_connect_task_action.md
+++ b/docs/resources/dms_smart_connect_task_action.md
@@ -1,0 +1,82 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+layout: "opentelekomcloud"
+page_title: "OpenTelekomCloud: opentelekomcloud_dms_smart_connect_task_action"
+sidebar_current: "docs-opentelekomcloud-resource-dms-smart-connect-task-action"
+description: |-
+  Start or pause an up-to-date DMS Smart Connect Task v2 resource within OpenTelekomCloud.
+---
+
+Up-to-date reference of API arguments for DMS instance you can get at
+[documentation portal](https://docs.otc.t-systems.com/distributed-message-service/api-ref/apis_v2_recommended/smart_connect/index.html)
+
+# opentelekomcloud_dms_smart_connect_task_action
+
+Start or pause a DMS kafka smart connect task resource within OpenTelekomCloud.
+
+## Example Usage
+
+### Pause a task
+
+```hcl
+variable "instance_id" {}
+variable "task_id" {}
+
+resource "opentelekomcloud_dms_smart_connect_task_action" "test" {
+  instance_id = var.instance_id
+  task_id     = var.task_id
+  action      = "pause"
+}
+```
+
+### Resume a paused task
+
+```hcl
+variable "instance_id" {}
+variable "task_id" {}
+
+resource "opentelekomcloud_dms_smart_connect_task_action" "test" {
+  instance_id = var.instance_id
+  task_id     = var.task_id
+  action      = "resume"
+}
+```
+
+### Start or restart a running or paused task
+
+```hcl
+variable "instance_id" {}
+variable "task_id" {}
+
+resource "opentelekomcloud_dms_smart_connect_task_action" "test" {
+  instance_id = var.instance_id
+  task_id     = var.task_id
+  action      = "restart"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `instance_id` - (Required, String, ForceNew) Specifies the kafka instance ID.
+
+* `task_id` - (Required, String, ForceNew) Specifies the smart connect task ID.
+
+* `action` - (Required, String, ForceNew) Specifies the action to be performed on the smart connect task.
+  Supported values: `pause`, `resume`, `restart`
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `task_status` - Indicates the status of the smart connect task.
+
+* `region` - The region in which the resource is created.
+
+
+## Timeouts
+
+This resource provides the following timeout configuration options:
+
+* `create` - Default is 30 minutes.

--- a/docs/resources/dms_smart_connect_task_action.md
+++ b/docs/resources/dms_smart_connect_task_action.md
@@ -1,8 +1,8 @@
 ---
 subcategory: "Distributed Message Service (DMS)"
 layout: "opentelekomcloud"
-page_title: "OpenTelekomCloud: opentelekomcloud_dms_smart_connect_task_action"
-sidebar_current: "docs-opentelekomcloud-resource-dms-smart-connect-task-action"
+page_title: "OpenTelekomCloud: opentelekomcloud_dms_smart_connect_task_action_v2"
+sidebar_current: "docs-opentelekomcloud-resource-dms-smart-connect-task-action-v2"
 description: |-
   Start or pause an up-to-date DMS Smart Connect Task v2 resource within OpenTelekomCloud.
 ---
@@ -10,7 +10,7 @@ description: |-
 Up-to-date reference of API arguments for DMS instance you can get at
 [documentation portal](https://docs.otc.t-systems.com/distributed-message-service/api-ref/apis_v2_recommended/smart_connect/index.html)
 
-# opentelekomcloud_dms_smart_connect_task_action
+# opentelekomcloud_dms_smart_connect_task_action_v2
 
 Start or pause a DMS kafka smart connect task resource within OpenTelekomCloud.
 
@@ -22,7 +22,7 @@ Start or pause a DMS kafka smart connect task resource within OpenTelekomCloud.
 variable "instance_id" {}
 variable "task_id" {}
 
-resource "opentelekomcloud_dms_smart_connect_task_action" "test" {
+resource "opentelekomcloud_dms_smart_connect_task_action_v2" "test" {
   instance_id = var.instance_id
   task_id     = var.task_id
   action      = "pause"
@@ -35,7 +35,7 @@ resource "opentelekomcloud_dms_smart_connect_task_action" "test" {
 variable "instance_id" {}
 variable "task_id" {}
 
-resource "opentelekomcloud_dms_smart_connect_task_action" "test" {
+resource "opentelekomcloud_dms_smart_connect_task_action_v2" "test" {
   instance_id = var.instance_id
   task_id     = var.task_id
   action      = "resume"
@@ -48,7 +48,7 @@ resource "opentelekomcloud_dms_smart_connect_task_action" "test" {
 variable "instance_id" {}
 variable "task_id" {}
 
-resource "opentelekomcloud_dms_smart_connect_task_action" "test" {
+resource "opentelekomcloud_dms_smart_connect_task_action_v2" "test" {
   instance_id = var.instance_id
   task_id     = var.task_id
   action      = "restart"

--- a/opentelekomcloud/acceptance/dms/resource_opentelekomcloud_dms_smart_connect_task_action_test.go
+++ b/opentelekomcloud/acceptance/dms/resource_opentelekomcloud_dms_smart_connect_task_action_test.go
@@ -1,0 +1,94 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
+)
+
+func TestAccDmsKafkav2SmartConnectTaskAction_basic(t *testing.T) {
+	var obj interface{}
+	rName := fmt.Sprintf("dms-acc-api%s", acctest.RandString(5))
+	resourceName := "opentelekomcloud_dms_smart_connect_task_v2.test"
+
+	rc := common.InitResourceCheck(
+		resourceName,
+		&obj,
+		getDmsKafkav2SmartConnectTaskResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+			common.TestAccPreCheckOBS(t)
+		},
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDmsKafkav2SmartConnectTaskAction_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+				),
+			},
+		},
+	})
+}
+
+func testDmsKafkav2SmartConnectTaskAction_basic(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "opentelekomcloud_obs_bucket" "test" {
+  bucket        = "%[2]s"
+  storage_class = "STANDARD"
+  acl           = "private"
+}
+
+resource "opentelekomcloud_dms_smart_connect_v2" "test" {
+  instance_id       = opentelekomcloud_dms_dedicated_instance_v2.test.id
+  storage_spec_code = "dms.physical.storage.high.v2"
+  node_count        = 2
+  bandwidth         = "100MB"
+}
+
+resource "opentelekomcloud_dms_topic_v1" "test" {
+  instance_id    = opentelekomcloud_dms_dedicated_instance_v2.test.id
+  name           = "%[2]s"
+  partition      = 10
+  retention_time = 36
+}
+
+resource "opentelekomcloud_dms_smart_connect_task_v2" "test" {
+  depends_on = [opentelekomcloud_dms_smart_connect_v2.test, opentelekomcloud_dms_topic_v1.test]
+
+  instance_id      = opentelekomcloud_dms_dedicated_instance_v2.test.id
+  task_name        = "%[2]s"
+  destination_type = "OBS_SINK"
+  topics           = [opentelekomcloud_dms_topic_v1.test.name]
+
+  destination_task {
+    consumer_strategy     = "latest"
+    destination_file_type = "TEXT"
+    access_key            = "%[3]s"
+    secret_key            = "%[4]s"
+    obs_bucket_name       = opentelekomcloud_obs_bucket.test.bucket
+    partition_format      = "yyyy/MM/dd/HH/mm"
+    record_delimiter      = ";"
+    deliver_time_interval = 300
+  }
+}
+
+resource "opentelekomcloud_dms_smart_connect_task_action" "test" {
+  depends_on = [opentelekomcloud_dms_smart_connect_task_v2.test]
+
+  instance_id      = opentelekomcloud_dms_dedicated_instance_v2.test.id
+  task_id        = opentelekomcloud_dms_smart_connect_task_v2.test.id
+  action = "pause"
+}
+`, testAccKafkaInstance_newFormat(rName), rName, env.OS_ACCESS_KEY, env.OS_SECRET_KEY)
+}

--- a/opentelekomcloud/acceptance/dms/resource_opentelekomcloud_dms_smart_connect_task_action_test.go
+++ b/opentelekomcloud/acceptance/dms/resource_opentelekomcloud_dms_smart_connect_task_action_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
 )
 
-func TestAccDmsKafkav2SmartConnectTaskAction_basic(t *testing.T) {
+func TestAccDmsKafkav2SmartConnectTaskActionV2_basic(t *testing.T) {
 	var obj interface{}
 	rName := fmt.Sprintf("dms-acc-api%s", acctest.RandString(5))
 	resourceName := "opentelekomcloud_dms_smart_connect_task_v2.test"
@@ -83,7 +83,7 @@ resource "opentelekomcloud_dms_smart_connect_task_v2" "test" {
   }
 }
 
-resource "opentelekomcloud_dms_smart_connect_task_action" "test" {
+resource "opentelekomcloud_dms_smart_connect_task_action_v2" "test" {
   depends_on = [opentelekomcloud_dms_smart_connect_task_v2.test]
 
   instance_id = opentelekomcloud_dms_dedicated_instance_v2.test.id

--- a/opentelekomcloud/acceptance/dms/resource_opentelekomcloud_dms_smart_connect_task_action_test.go
+++ b/opentelekomcloud/acceptance/dms/resource_opentelekomcloud_dms_smart_connect_task_action_test.go
@@ -86,9 +86,9 @@ resource "opentelekomcloud_dms_smart_connect_task_v2" "test" {
 resource "opentelekomcloud_dms_smart_connect_task_action" "test" {
   depends_on = [opentelekomcloud_dms_smart_connect_task_v2.test]
 
-  instance_id      = opentelekomcloud_dms_dedicated_instance_v2.test.id
-  task_id        = opentelekomcloud_dms_smart_connect_task_v2.test.id
-  action = "pause"
+  instance_id = opentelekomcloud_dms_dedicated_instance_v2.test.id
+  task_id     = opentelekomcloud_dms_smart_connect_task_v2.test.id
+  action      = "pause"
 }
 `, testAccKafkaInstance_newFormat(rName), rName, env.OS_ACCESS_KEY, env.OS_SECRET_KEY)
 }

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -452,6 +452,7 @@ func Provider() *schema.Provider {
 			"opentelekomcloud_dms_dedicated_instance_v2":                 dms.ResourceDmsDedicatedInstanceV2(),
 			"opentelekomcloud_dms_smart_connect_v2":                      dms.ResourceDmsSmartConnectV2(),
 			"opentelekomcloud_dms_smart_connect_task_v2":                 dms.ResourceDmsSmartConnectTaskV2(),
+			"opentelekomcloud_dms_smart_connect_task_action":             dms.ResourceDmsSmartConnectTaskAction(),
 			"opentelekomcloud_dms_topic_v1":                              dms.ResourceDmsTopicsV1(),
 			"opentelekomcloud_dms_topic_v2":                              dms.ResourceDmsTopicsV2(),
 			"opentelekomcloud_dms_user_v2":                               dms.ResourceDmsUsersV2(),

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -452,7 +452,7 @@ func Provider() *schema.Provider {
 			"opentelekomcloud_dms_dedicated_instance_v2":                 dms.ResourceDmsDedicatedInstanceV2(),
 			"opentelekomcloud_dms_smart_connect_v2":                      dms.ResourceDmsSmartConnectV2(),
 			"opentelekomcloud_dms_smart_connect_task_v2":                 dms.ResourceDmsSmartConnectTaskV2(),
-			"opentelekomcloud_dms_smart_connect_task_action":             dms.ResourceDmsSmartConnectTaskAction(),
+			"opentelekomcloud_dms_smart_connect_task_action_v2":          dms.ResourceDmsSmartConnectTaskActionV2(),
 			"opentelekomcloud_dms_topic_v1":                              dms.ResourceDmsTopicsV1(),
 			"opentelekomcloud_dms_topic_v2":                              dms.ResourceDmsTopicsV2(),
 			"opentelekomcloud_dms_user_v2":                               dms.ResourceDmsUsersV2(),

--- a/opentelekomcloud/services/dms/resource_opentelekomcloud_dms_smart_connect_task_action.go
+++ b/opentelekomcloud/services/dms/resource_opentelekomcloud_dms_smart_connect_task_action.go
@@ -1,0 +1,101 @@
+package dms
+
+import (
+	"context"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/dms/v2/smart_connect"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
+)
+
+func ResourceDmsSmartConnectTaskAction() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDmsV2SmartConnectTaskActionCreate,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"task_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"action": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"restart", "resume", "pause",
+				}, true),
+			},
+			"task_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"region": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceDmsV2SmartConnectTaskActionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, dmsClientV2, func() (*golangsdk.ServiceClient, error) {
+		return config.DmsV2Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationClientV2, err)
+	}
+
+	instanceId := d.Get("instance_id").(string)
+	taskId := d.Get("task_id").(string)
+	action := d.Get("action").(string)
+
+	switch action {
+	case "pause":
+		err = smart_connect.PauseTask(client, instanceId, taskId)
+		if err != nil {
+			return diag.Errorf("error pausing DMS kafka smart connect task: %v", err)
+		}
+	case "resume":
+		err = smart_connect.RestartTask(client, instanceId, taskId)
+		if err != nil {
+			return diag.Errorf("error resuming DMS kafka smart connect task: %v", err)
+		}
+	case "restart":
+		err = smart_connect.StartOrRestartTask(client, instanceId, taskId)
+		if err != nil {
+			return diag.Errorf("error resuming DMS kafka smart connect task: %v", err)
+		}
+	default:
+		return diag.Errorf("invalid action")
+	}
+
+	getTask, err := smart_connect.GetTask(client, d.Get("instance_id").(string), d.Id())
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving DMS kafka smart connect task")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", config.GetRegion(d)),
+		d.Set("status", getTask.Status),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}

--- a/opentelekomcloud/services/dms/resource_opentelekomcloud_dms_smart_connect_task_action.go
+++ b/opentelekomcloud/services/dms/resource_opentelekomcloud_dms_smart_connect_task_action.go
@@ -15,7 +15,7 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
 )
 
-func ResourceDmsSmartConnectTaskAction() *schema.Resource {
+func ResourceDmsSmartConnectTaskActionV2() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceDmsV2SmartConnectTaskActionCreate,
 		ReadContext:   resourceDmsV2SmartConnectTaskActionRead,

--- a/releasenotes/notes/dms-smart-connect-task-action-f0960f2d7de739bb.yaml
+++ b/releasenotes/notes/dms-smart-connect-task-action-f0960f2d7de739bb.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   - |
-    **[DMS]** Add new resource ``resource/opentelekomcloud_dms_smart_connect_task_action`` (`#2680 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2680>`_)
+    **[DMS]** Add new resource ``resource/opentelekomcloud_dms_smart_connect_task_action_v2`` (`#2680 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2680>`_)

--- a/releasenotes/notes/dms-smart-connect-task-action-f0960f2d7de739bb.yaml
+++ b/releasenotes/notes/dms-smart-connect-task-action-f0960f2d7de739bb.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    **[DMS]** Add new resource ``resource/opentelekomcloud_dms_smart_connect_task_action`` (`#2680 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2680>`_)


### PR DESCRIPTION
## Summary of the Pull Request

Add new resource opentelekomcloud_dms_smart_connect_task_action_v2. 
With the new resource it is possible...

1. [To pause a smart connect task](https://docs.otc.t-systems.com/distributed-message-service/api-ref/apis_v2_recommended/smart_connect/pausing_a_smart_connect_task.html)
2. [To resume a smart connect task](https://docs.otc.t-systems.com/distributed-message-service/api-ref/apis_v2_recommended/smart_connect/restarting_a_smart_connect_task.html)
3. [To start or restart a smart connect task](https://docs.otc.t-systems.com/distributed-message-service/api-ref/apis_v2_recommended/smart_connect/starting_a_smart_connect_task_or_restarting_a_paused_or_running_smart_connect_task.html)

## PR Checklist

* [x] Refers to: #2729 
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccDmsKafkav2SmartConnectTaskActionV2_basic
=== PAUSE TestAccDmsKafkav2SmartConnectTaskActionV2_basic
=== CONT  TestAccDmsKafkav2SmartConnectTaskActionV2_basic
--- PASS: TestAccDmsKafkav2SmartConnectTaskActionV2_basic (1242.92s)
PASS
```

Note: Manually verified test results.