### PR TITLE
[Fix] CCE: Fix kubeconfig insecure-skip-tls-verify

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20250114085603-274cd406ed0d
+	github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20250115114430-7a5bd79761bd
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.31.0
 	golang.org/x/sync v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -156,12 +156,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k+Mg7cowZ8yv4Trqw9UsJby758=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20241217130728-c35f3bd67003 h1:yZzN1AJUxA1fpFZSsgokbCfBWS+/McwRSlc56A2oqjU=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20241217130728-c35f3bd67003/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20250110095240-c5e793bd3e9c h1:unSvIZSJ0xWPRiFNfS7u/11B3j1HtPO/wh6wRirJ6u0=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20250110095240-c5e793bd3e9c/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20250114085603-274cd406ed0d h1:VfXw7flhcMF/VCPsG0eSy6GpWaNnYQfJjgSa7Ws+Z8M=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20250114085603-274cd406ed0d/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20250115114430-7a5bd79761bd h1:ODSt/BKKotvfJLv/PcIjYOtD5EbPUTgJdwMDVEyu9UQ=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20250115114430-7a5bd79761bd/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/releasenotes/notes/cce-fix-kubeconfig-3231d2eb4889439e.yaml
+++ b/releasenotes/notes/cce-fix-kubeconfig-3231d2eb4889439e.yaml
@@ -1,0 +1,4 @@
+---
+doc:
+  - |
+    **[CCE]** Fixed kubeconfig in ``datasource/opentelekomcloud_cce_cluster_kubeconfig_v3`` (`#2785 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2785>`_)


### PR DESCRIPTION
## Summary of the Pull Request

Update go mod to fetch new gopher version. Required changes already done in gopher i.e. add missing key insecure-skip-tls-verify in clusters in kubeconfig when cluster is external. 

## PR Checklist

* [x] Refers to: #2779 
* [x] Tests added/passed.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccCCEKubeConfigV3DataSource_basic
=== PAUSE TestAccCCEKubeConfigV3DataSource_basic
=== CONT  TestAccCCEKubeConfigV3DataSource_basic
--- PASS: TestAccCCEKubeConfigV3DataSource_basic (692.91s)
PASS
```
