### PR TITLE
[Feat.] New resource `opentelekomcloud_css_cluster_restart_v1`

### DIFF
--- a/docs/resources/css_cluster_restart_v1.md
+++ b/docs/resources/css_cluster_restart_v1.md
@@ -1,0 +1,43 @@
+---
+subcategory: "Cloud Search Service (CSS)"
+layout: "opentelekomcloud"
+page_title: "OpenTelekomCloud: opentelekomcloud_css_cluster_restart_v1"
+sidebar_current: "docs-opentelekomcloud-resource-css-cluster-restart-v1"
+description: |-
+  Manages CSS cluster restart resource within OpenTelekomCloud.
+---
+
+# opentelekomcloud_css_cluster_restart_v1
+
+Manages CSS cluster restart resource within OpenTelekomCloud.
+
+## Example Usage
+
+```hcl
+variable "cluster_id" {}
+
+resource "opentelekomcloud_css_cluster_restart_v1" "test" {
+  cluster_id = var.cluster_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `cluster_id` - (Required, String, ForceNew) Specifies the ID of the CSS cluster.
+  Changing this creates a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `region` - The region in which the resource created.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 60 minutes.

--- a/opentelekomcloud/acceptance/css/resource_opentelekomcloud_css_cluster_restart_v1_test.go
+++ b/opentelekomcloud/acceptance/css/resource_opentelekomcloud_css_cluster_restart_v1_test.go
@@ -1,0 +1,59 @@
+package acceptance
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/css/v1/clusters"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+)
+
+func getCssClusterFunc(conf *cfg.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.CssV1Client(env.OS_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating CSS v1 client: %s", err)
+	}
+	return clusters.Get(client, state.Primary.ID)
+}
+
+func TestAccCssClusterRestart_basic(t *testing.T) {
+	clusterID := os.Getenv("OS_CSS_CLUSTER_ID")
+	if clusterID == "" {
+		t.Skip("OS_CSS_CLUSTER_ID env var is not set")
+	}
+	resourceName := "opentelekomcloud_css_cluster_restart_v1.r"
+
+	var obj clusters.Cluster
+	rc := common.InitResourceCheck(
+		resourceName,
+		&obj,
+		getCssClusterFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCssClusterRestart_basic(clusterID),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+				),
+			},
+		},
+	})
+}
+
+func testAccCssClusterRestart_basic(clusterId string) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_css_cluster_restart_v1" "r" {
+  cluster_id = "%s"
+}
+`, clusterId)
+}

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -425,6 +425,7 @@ func Provider() *schema.Provider {
 			"opentelekomcloud_cts_tracker_v1":                            cts.ResourceCTSTrackerV1(),
 			"opentelekomcloud_cts_tracker_v3":                            cts.ResourceCTSTrackerV3(),
 			"opentelekomcloud_css_cluster_v1":                            css.ResourceCssClusterV1(),
+			"opentelekomcloud_css_cluster_restart_v1":                    css.ResourceCssClusterRestartV1(),
 			"opentelekomcloud_css_configuration_v1":                      css.ResourceCssConfigurationV1(),
 			"opentelekomcloud_css_snapshot_configuration_v1":             css.ResourceCssSnapshotConfigurationV1(),
 			"opentelekomcloud_direct_connect_v2":                         dcaas.ResourceDirectConnectV2(),

--- a/opentelekomcloud/services/css/resource_opentelekomcloud_css_cluster_restart_v1.go
+++ b/opentelekomcloud/services/css/resource_opentelekomcloud_css_cluster_restart_v1.go
@@ -1,0 +1,116 @@
+package css
+
+import (
+	"context"
+	"log"
+	"math"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/css/v1/clusters"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
+)
+
+func ResourceCssClusterRestartV1() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceCssClusterRestartV1Create,
+		ReadContext:   resourceCssClusterRestartV1Read,
+		DeleteContext: resourceCssClusterRestartV1Delete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(60 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"cluster_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"region": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceCssClusterRestartV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
+		return config.CssV1Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(clientError, err)
+	}
+
+	clusterID := d.Get("cluster_id").(string)
+	// Check whether the cluster status is available.
+	secondsWait := int(math.Round(d.Timeout(schema.TimeoutCreate).Seconds()))
+	err = checkClusterOperationCompleted(client, clusterID, secondsWait)
+	if err != nil {
+		return fmterr.Errorf("error waiting for OpenTelekomCloud CSS cluster to be ready: %s", err)
+	}
+
+	err = clusters.RestartCluster(client, clusterID)
+	if err != nil {
+		return diag.Errorf("error restart OpenTelekomCloud CSS cluster, err: %s", err)
+	}
+
+	// Check whether the cluster restart is complete
+	err = checkClusterOperationCompleted(client, clusterID, secondsWait)
+	if err != nil {
+		return fmterr.Errorf("error waiting for OpenTelekomCloud CSS cluster to be ready: %s", err)
+	}
+
+	d.SetId(clusterID)
+
+	return nil
+}
+
+func resourceCssClusterRestartV1Read(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceCssClusterRestartV1Delete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting restart resource is not supported. The restart resource is only removed from the state," +
+		" the cluster instance remains in the cloud."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}
+
+func checkClusterOperationCompleted(client *golangsdk.ServiceClient, id string, timeout int) error {
+	return golangsdk.WaitFor(timeout, func() (bool, error) {
+		cluster, err := clusters.Get(client, id)
+		if err != nil {
+			if _, ok := err.(golangsdk.BaseError); ok {
+				return true, err
+			}
+			log.Printf("Error waiting for CSS cluster: %s", err)
+			return false, nil
+		}
+		if cluster.Status != "200" {
+			return false, nil
+		}
+		if cluster.Actions != nil && len(cluster.Actions) > 0 {
+			return false, nil
+		}
+		if cluster.Instances == nil {
+			return false, nil
+		}
+		for _, v := range cluster.Instances {
+			if v.Status != "200" {
+				return false, nil
+			}
+		}
+		return true, nil
+	})
+}

--- a/releasenotes/notes/css-cluster-restart-2e047d27261e196e.yaml
+++ b/releasenotes/notes/css-cluster-restart-2e047d27261e196e.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[CSS]** New resource ``resource/opentelekomcloud_css_cluster_restart_v1`` (`#2793 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2793>`_)

--- a/releasenotes/notes/css-configuration-e67a9f30b1e1704b.yaml
+++ b/releasenotes/notes/css-configuration-e67a9f30b1e1704b.yaml
@@ -1,4 +1,4 @@
 ---
 enhancements:
   - |
-    **[DCS]** New resource ``resource/opentelekomcloud_css_configuration_v1`` (`#2792 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2792>`_)
+    **[CSS]** New resource ``resource/opentelekomcloud_css_configuration_v1`` (`#2792 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2792>`_)


### PR DESCRIPTION
## Summary of the Pull Request
For restarting existing cluster

## PR Checklist

* [x] Refers to: #2789
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccCssClusterRestart_basic
=== PAUSE TestAccCssClusterRestart_basic
=== CONT  TestAccCssClusterRestart_basic
    testing_new.go:84: Error running post-test destroy, there may be dangling resources: failed to destroy the opentelekomcloud_css_cluster_restart_v1 resource: ddff60c3-6102-41cf-98b7-d87ea6e78ced still exists
--- PASS: TestAccCssClusterRestart_basic (60.44s)

PASS

Process finished with exit code 0
```
