### PR TITLE
[Feat.] Retry when send_welcome_email fails

### DIFF
--- a/releasenotes/notes/iam-users-retry-email-34cd4aaa9b04d600.yaml
+++ b/releasenotes/notes/iam-users-retry-email-34cd4aaa9b04d600.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[IAM]** Added retry func for ``send_welcome_email`` for ``resource/opentelekomcloud_identity_user_v3`` (`#2803 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2803>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Implemented a retry mechanism to attempt sending the Welcome Email up to three times within a 6-second interval in case of failure.

## PR Checklist

* [x] Refers to: #2484
* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccIdentityV3User_basic
--- PASS: TestAccIdentityV3User_basic (48.45s)
=== RUN   TestAccCheckIAMV3EmailValidation
--- PASS: TestAccCheckIAMV3EmailValidation (4.37s)
=== RUN   TestAccCheckIAMV3SendEmailValidation
--- PASS: TestAccCheckIAMV3SendEmailValidation (3.60s)
=== RUN   TestAccIdentityV3User_protection
--- PASS: TestAccIdentityV3User_protection (83.36s)
PASS

Process finished with the exit code 0

```
