### PR TITLE
[Feat.]: RDS name update 

### DIFF
--- a/docs/resources/rds_instance_v3.md
+++ b/docs/resources/rds_instance_v3.md
@@ -326,11 +326,11 @@ The following arguments are supported:
   Use data source [opentelekomcloud_rds_flavors_v3](../data-sources/rds_flavors_v3.md) to get a list of available flavor names.
   Examples could be `rds.pg.n1.large.4` or `rds.pg.x1.8xlarge.4.ha` for HA clusters.
 
-* `name` - (Required, ForceNew) Specifies the DB instance name. The DB instance name of the same type
+* `name` - (Required) Specifies the DB instance name. The DB instance name of the same type
   must be unique for the same tenant. The value must be 4 to 64
   characters in length and start with a letter. It is case-sensitive
   and can contain only letters, digits, hyphens (-), and underscores
-  (_).  Changing this parameter will create a new resource.
+  (_).
 
 * `security_group_id` - (Required) Specifies the security group which the RDS DB instance belongs to.
   Changing this parameter will create a new resource.

--- a/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
+++ b/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
@@ -30,7 +30,7 @@ func TestAccRdsInstanceV3Basic(t *testing.T) {
 				Config: testAccRdsInstanceV3Basic(postfix),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRdsInstanceV3Exists(instanceV3ResourceName, &rdsInstance),
-					resource.TestCheckResourceAttr(instanceV3ResourceName, "flavor", "rds.pg.c2.medium"),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "flavor", "rds.pg.n1.large.4"),
 					resource.TestCheckResourceAttr(instanceV3ResourceName, "db.0.port", "8635"),
 					resource.TestCheckResourceAttr(instanceV3ResourceName, "name", "tf_rds_instance_"+postfix),
 					resource.TestCheckResourceAttr(instanceV3ResourceName, "db.0.type", "PostgreSQL"),
@@ -46,9 +46,10 @@ func TestAccRdsInstanceV3Basic(t *testing.T) {
 			{
 				Config: testAccRdsInstanceV3Update(postfix),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(instanceV3ResourceName, "flavor", "rds.pg.c2.medium"),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "flavor", "rds.pg.n1.large.4"),
 					resource.TestCheckResourceAttr(instanceV3ResourceName, "volume.0.size", "100"),
 					resource.TestCheckResourceAttr(instanceV3ResourceName, "tags.muh", "value-update"),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "name", "tf_rds_instance_updated_"+postfix),
 					resource.TestCheckResourceAttr(instanceV3ResourceName, "db.0.port", "8636"),
 					resource.TestCheckResourceAttr(instanceV3ResourceName, "lower_case_table_names", "0"),
 				),
@@ -448,10 +449,10 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
   subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
   volume {
-    type = "ULTRAHIGH"
+    type = "CLOUDSSD"
     size = 40
   }
-  flavor = "rds.pg.c2.medium"
+  flavor = "rds.pg.n1.large.4"
   backup_strategy {
     start_time = "08:00-09:00"
     keep_days  = 0
@@ -475,7 +476,7 @@ resource "opentelekomcloud_networking_secgroup_v2" "secgroup" {
 }
 
 resource "opentelekomcloud_rds_instance_v3" "instance" {
-  name              = "tf_rds_instance_%s"
+  name              = "tf_rds_instance_updated_%s"
   availability_zone = ["%s"]
   db {
     password = "Postgres!120521"
@@ -487,10 +488,10 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
   subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
   volume {
-    type = "ULTRAHIGH"
+    type = "CLOUDSSD"
     size = 100
   }
-  flavor = "rds.pg.c2.medium"
+  flavor = "rds.pg.n1.large.4"
   backup_strategy {
     start_time = "08:00-09:00"
     keep_days  = 1

--- a/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_instance_v3.go
+++ b/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_instance_v3.go
@@ -157,7 +157,6 @@ func ResourceRdsInstanceV3() *schema.Resource {
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
 			},
 			"security_group_id": {
 				Type:     schema.TypeString,
@@ -837,6 +836,16 @@ func resourceRdsInstanceV3Update(ctx context.Context, d *schema.ResourceData, me
 	})
 	if err != nil {
 		return fmterr.Errorf(errCreateClient, err)
+	}
+
+	if d.HasChange("name") {
+		err = instances.UpdateInstanceName(client, instances.UpdateInstanceNameOpts{
+			Name:       d.Get("name").(string),
+			InstanceId: d.Id(),
+		})
+		if err != nil {
+			return fmterr.Errorf("error changing instance name: %s ", err)
+		}
 	}
 
 	if d.HasChange("restore_from_backup") {

--- a/releasenotes/notes/rds_name_update-ae237b65fc611230.yaml
+++ b/releasenotes/notes/rds_name_update-ae237b65fc611230.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[RDS]** Remove ForceNew from `name` parameter for ``resource/opentelekomcloud_rds_instance_v3`` (`#2808 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2808>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Name change of`opentelekomcloud_rds_instance_v3` resource doesn't force resource recreation.

## PR Checklist

* [x] Refers to: #2805
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccRdsInstanceV3Basic
--- PASS: TestAccRdsInstanceV3Basic (760.66s)
PASS

Process finished with the exit code 0
```
