### PR TITLE
[Feat.] added possibility to trigger alarm immediately in `opentelekomcloud_ces_alarmrule`

### DIFF
--- a/docs/resources/ces_alarmrule.md
+++ b/docs/resources/ces_alarmrule.md
@@ -153,10 +153,12 @@ The `dimensions` block supports:
 The `condition` block supports:
 
 * `period` - (Required) Specifies the alarm checking period in seconds. The
-  value can be `1`, `300`, `1200`, `3600`, `14400`, and `86400`.
+  value can be `0`, `1`, `300`, `1200`, `3600`, `14400`, and `86400`.
 
 -> If `period` is set to `1`, the raw metric data is used to determine
   whether to generate an alarm.
+
+-> To trigger an event immediately, simply set the `period` parameter to 0
 
 * `filter` - (Required) Specifies the data rollup methods. The value can be
   `max`, `min`, `average`, `sum`, and `variance`.

--- a/opentelekomcloud/services/ces/resource_opentelekomcloud_ces_alarmrule.go
+++ b/opentelekomcloud/services/ces/resource_opentelekomcloud_ces_alarmrule.go
@@ -152,7 +152,7 @@ func ResourceAlarmRule() *schema.Resource {
 							Required: true,
 							ForceNew: true,
 							ValidateFunc: validation.IntInSlice([]int{
-								1, 300, 1200, 3600, 14400, 86400,
+								0, 1, 300, 1200, 3600, 14400, 86400,
 							}),
 						},
 						"filter": {

--- a/releasenotes/notes/ces-alarmrule-period-8f5bed58bf5d8fea.yaml
+++ b/releasenotes/notes/ces-alarmrule-period-8f5bed58bf5d8fea.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[CES]** Update ``period`` validation in ``resource/opentelekomcloud_ces_alarmrule`` to trigger alarm immediately (`#2818 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2818>`_)


### PR DESCRIPTION
## Summary of the Pull Request

To trigger an event immediately, simply set the "period" parameter to 0 in your API request.
Example API request to create an alarm rule with immediate triggering:
URL: https://ces.eu-de.otc.t-systems.com/V1.0/bdcc63e2876b454bb0f625c9153d3a3e/alarms
Body:
{
    "alarm_name": "alarm-APIMON",
    "metric": {
        "namespace": "SYS.ECS",
        "metric_name": "deleteServer",
        "dimensions": []
    },
    "condition": {
        "comparison_operator": ">=",
        "count": 1,
        "filter": "average",
        "period": 0,
        "unit": "count",
        "value": 1
    },
    "alarm_enabled": true,
    "alarm_action_enabled": false,
    "alarm_level": 2,
    "alarm_type": "EVENT.SYS"
}
Related documentation:
[Creating an Alarm Rule](https://docs.otc.t-systems.com/cloud-eye/api-ref/api_description/alarm_rules/creating_an_alarm_rule.html#ces-03-0031-table1859144073012)
Please note that this information is currently missing from the documentation but will be included in the next update.


## PR Checklist

* [x] Refers to: #2817
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestCESAlarmRule_basic
=== PAUSE TestCESAlarmRule_basic
=== CONT  TestCESAlarmRule_basic
--- PASS: TestCESAlarmRule_basic (171.22s)
=== RUN   TestCESAlarmRule_systemEvents
=== PAUSE TestCESAlarmRule_systemEvents
=== CONT  TestCESAlarmRule_systemEvents
--- PASS: TestCESAlarmRule_systemEvents (39.18s)
=== RUN   TestAccCheckCESV1AlarmValidation
--- PASS: TestAccCheckCESV1AlarmValidation (5.69s)
=== RUN   TestCESAlarmRule_slashes
=== PAUSE TestCESAlarmRule_slashes
=== CONT  TestCESAlarmRule_slashes
--- PASS: TestCESAlarmRule_slashes (86.65s)
PASS

Process finished with exit code 0
```
