### PR TITLE
[Feat.] IMS: Add user input field hw_firmware_type to ims_image_v2

### DIFF
--- a/docs/resources/ims_image_v2.md
+++ b/docs/resources/ims_image_v2.md
@@ -67,80 +67,58 @@ resource "opentelekomcloud_ims_image_v2" "image_volume" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the image.
+* `name` - (Required, String) The name of the image.
 
-* `description` - (Optional) A description of the image. Changing this creates a new image.
+* `description` - (Optional, String, ForceNew) A description of the image. Changing this creates a new image.
 
-* `min_ram` - (Optional) The minimum memory of the image in the unit of MB.
+* `min_ram` - (Optional, Integer, ForceNew) The minimum memory of the image in the unit of MB.
   The default value is 0, indicating that the memory is not restricted.
   Changing this creates a new image.
 
-* `max_ram` - (Optional) The maximum memory of the image in the unit of MB.
+* `max_ram` - (Optional, Integer, ForceNew) The maximum memory of the image in the unit of MB.
   Changing this creates a new image.
 
-* `tags` - (Optional) The tags of the image.
+* `tags` - (Optional, List) The tags of the image.
 
-* `instance_id` - (Optional) The ID of the ECS that needs to be converted into an image.
+* `instance_id` - (Optional, String, ForceNew) The ID of the ECS that needs to be converted into an image.
   This parameter is mandatory when you create a private image from an ECS.
   Changing this creates a new image.
 
-* `volume_id` - (Optional) Specifies the data disk ID.
+* `volume_id` - (Optional, String, ForceNew) Specifies the data disk ID.
   This parameter is mandatory when you create a private image from a volume.
   Changing this creates a new image.
 
-* `image_url` - (Optional) The URL of the external image file in the OBS bucket.
+* `image_url` - (Optional, String, ForceNew) The URL of the external image file in the OBS bucket.
   This parameter is mandatory when you create a private image from an external file
   uploaded to an OBS bucket. The format is *OBS bucket name:Image file name*.
   Changing this creates a new image.
 
-* `min_disk` - (Optional) The minimum size of the system disk in the unit of GB.
+* `min_disk` - (Optional, Integer, ForceNew) The minimum size of the system disk in the unit of GB.
   This parameter is mandatory when you create a private image from an external file
   uploaded to an OBS bucket. The value ranges from 1 GB to 1024 GB.
   Changing this creates a new image.
 
-* `os_version` - (Optional) The OS version.
+* `os_version` - (Optional, String, ForceNew) The OS version.
   This parameter is valid when you create a private image from an external file.
   This parameter is mandatory when you create a private image from a volume.
   uploaded to an OBS bucket. Changing this creates a new image.
 
-* `is_config` - (Optional) If automatic configuration is required, set the value to true.
+* `is_config` - (Optional, Boolean, ForceNew) If automatic configuration is required, set the value to true.
   Otherwise, set the value to false. Changing this creates a new image.
 
-* `cmk_id` - (Optional) The master key used for encrypting an image.
+* `cmk_id` - (Optional, String, ForceNew) The master key used for encrypting an image.
   Changing this creates a new image.
 
-* `type` - (Optional) The image type. Must be one of `ECS`, `FusionCompute`, `BMS`,
+* `type` - (Optional, String, ForceNew) The image type. Must be one of `ECS`, `FusionCompute`, `BMS`,
   `Ironic` or `IsoImage`. Changing this creates a new image.
+
+* `hw_firmware_type` - (Optional, String) Specifies the boot mode. The value can be `bios` or `uefi`.
 
 ## Attributes Reference
 
-The following attributes are exported:
+In additin to the arguments defined above, the following attributes are exported:
 
 * `id` - A unique ID assigned by IMS.
-
-* `name` - See Argument Reference above.
-
-* `description` - See Argument Reference above.
-
-* `min_ram` - See Argument Reference above.
-
-* `max_ram` - See Argument Reference above.
-
-* `tags` - See Argument Reference above.
-
-* `instance_id` - See Argument Reference above.
-
-* `image_url` - See Argument Reference above.
-
-* `min_disk` - See Argument Reference above.
-
-* `os_version` - See Argument Reference above.
-
-* `is_config` - See Argument Reference above.
-
-* `cmk_id` - See Argument Reference above.
-
-* `type` - See Argument Reference above.
 
 * `visibility` - Whether the image is visible to other tenants.
 

--- a/opentelekomcloud/acceptance/ims/resource_opentelekomcloud_ims_image_v2_test.go
+++ b/opentelekomcloud/acceptance/ims/resource_opentelekomcloud_ims_image_v2_test.go
@@ -177,9 +177,9 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
 }
 
 resource "opentelekomcloud_ims_image_v2" "image_1" {
-  name        = "TFTest_image"
-  instance_id = opentelekomcloud_compute_instance_v2.instance_1.id
-  description = "created by TerraformAccTest"
+  name             = "TFTest_image"
+  instance_id      = opentelekomcloud_compute_instance_v2.instance_1.id
+  description      = "created by TerraformAccTest"
   hw_firmware_type = "uefi"
   tags = {
     foo = "bar"
@@ -205,9 +205,9 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
 }
 
 resource "opentelekomcloud_ims_image_v2" "image_1" {
-  name        = "TFTest_image_update"
-  instance_id = opentelekomcloud_compute_instance_v2.instance_1.id
-  description = "created by TerraformAccTest"
+  name             = "TFTest_image_update"
+  instance_id      = opentelekomcloud_compute_instance_v2.instance_1.id
+  description      = "created by TerraformAccTest"
   hw_firmware_type = "bios"
   tags = {
     foo  = "bar"

--- a/opentelekomcloud/acceptance/ims/resource_opentelekomcloud_ims_image_v2_test.go
+++ b/opentelekomcloud/acceptance/ims/resource_opentelekomcloud_ims_image_v2_test.go
@@ -33,6 +33,7 @@ func TestAccImsImageV2_basic(t *testing.T) {
 					testAccCheckImsImageV2Tags(resourceImageName, "foo", "bar"),
 					testAccCheckImsImageV2Tags(resourceImageName, "key", "value"),
 					resource.TestCheckResourceAttr(resourceImageName, "name", "TFTest_image"),
+					resource.TestCheckResourceAttr(resourceImageName, "hw_firmware_type", "uefi"),
 				),
 			},
 			{
@@ -43,6 +44,7 @@ func TestAccImsImageV2_basic(t *testing.T) {
 					testAccCheckImsImageV2Tags(resourceImageName, "key", "value1"),
 					testAccCheckImsImageV2Tags(resourceImageName, "key2", "value2"),
 					resource.TestCheckResourceAttr(resourceImageName, "name", "TFTest_image_update"),
+					resource.TestCheckResourceAttr(resourceImageName, "hw_firmware_type", "bios"),
 				),
 			},
 		},
@@ -178,6 +180,7 @@ resource "opentelekomcloud_ims_image_v2" "image_1" {
   name        = "TFTest_image"
   instance_id = opentelekomcloud_compute_instance_v2.instance_1.id
   description = "created by TerraformAccTest"
+  hw_firmware_type = "uefi"
   tags = {
     foo = "bar"
     key = "value"
@@ -205,6 +208,7 @@ resource "opentelekomcloud_ims_image_v2" "image_1" {
   name        = "TFTest_image_update"
   instance_id = opentelekomcloud_compute_instance_v2.instance_1.id
   description = "created by TerraformAccTest"
+  hw_firmware_type = "bios"
   tags = {
     foo  = "bar"
     key  = "value1"

--- a/releasenotes/notes/ims-image-v2-new-field-32482a3ca49f386d.yaml
+++ b/releasenotes/notes/ims-image-v2-new-field-32482a3ca49f386d.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    **[IMS]** Added `hw_firmware_type` as argument in ``resource/opentelekomcloud_ims_image_v2`` (`#2830 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2830>`_)

--- a/releasenotes/notes/ims-images-image-v2-new-field-7a93d2229cb5bb30.yaml
+++ b/releasenotes/notes/ims-images-image-v2-new-field-7a93d2229cb5bb30.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   - |
-    **[IMS]** Added `hw_firmware_type` as argument in ``resource/opentelekomcloud_ims_image_v2`` and as attribute in ``datasource/opentelekomcloud_ims_image_v2`` (`#2816 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2816>`_)
+    **[IMS]** Added `hw_firmware_type` as argument in ``resource/opentelekomcloud_images_image_v2`` and as attribute in ``datasource/opentelekomcloud_images_image_v2`` (`#2816 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2816>`_)


### PR DESCRIPTION
## Summary of the Pull Request

**resource/opentelekomcloud_ims_image_v2**
Users can now define the fields:
- hw_firmware_type

## PR Checklist

* [x] Refers to: #2799 
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccImsImageV2_basic
--- PASS: TestAccImsImageV2_basic (290.91s)
PASS
```
