### PR TITLE
[Feat.] EVPN: add `delete_eip` option

### DIFF
--- a/docs/resources/vpn_gateway_v5.md
+++ b/docs/resources/vpn_gateway_v5.md
@@ -147,6 +147,9 @@ The following arguments are supported:
   `active-standby`. The default value is `active-active`.
   Changing this parameter will create a new resource.
 
+* `delete_eip` - (Optional, Bool) Specifies whether to delete eips on resource deletion when`network_type` is `public`.
+  Default: `false`.
+
 * `eip1` - (Optional, List) The master 1 IP in active-active VPN gateway or the master IP
   in active-standby VPN gateway. This parameter is mandatory when `network_type` is `public` or left empty.
   The [object](#GwCreateRequestEip) structure is documented below.
@@ -255,4 +258,22 @@ The gateway can be imported using the `id`, e.g.
 
 ```bash
 $ terraform import opentelekomcloud_enterprise_vpn_gateway_v5.test <id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to `delete_eip` attribute missing from the
+API response.
+It is generally recommended running `terraform plan` after importing an instance.
+You can then decide if changes should be applied to the instance, or the resource definition should be updated to
+align with the instance. Also, you can ignore changes as below.
+
+```
+resource "opentelekomcloud_enterprise_vpn_gateway_v5" "test" {
+    ...
+
+  lifecycle {
+    ignore_changes = [
+      delete_eip
+    ]
+  }
+}
 ```

--- a/releasenotes/notes/vpn_gateway_eip-1c15fb66c1646af6.yaml
+++ b/releasenotes/notes/vpn_gateway_eip-1c15fb66c1646af6.yaml
@@ -1,4 +1,4 @@
 ---
 enhancements:
   - |
-    **[EVPN]** Add `delete_eip` option to specify whether to delete EIP during resource deletion for ``resource/opentelekomcloud_enterprise_vpn_gateway_v5`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[EVPN]** Add `delete_eip` option to specify whether to delete EIP during resource deletion for ``resource/opentelekomcloud_enterprise_vpn_gateway_v5`` (`#2846 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2846>`_)

--- a/releasenotes/notes/vpn_gateway_eip-1c15fb66c1646af6.yaml
+++ b/releasenotes/notes/vpn_gateway_eip-1c15fb66c1646af6.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[EVPN]** Add `delete_eip` option to specify whether to delete EIP during resource deletion for ``resource/opentelekomcloud_enterprise_vpn_gateway_v5`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Added `delete_eip` option for `opentelekomcloud_enterprise_vpn_gateway_v5` resource to choose whether to release eip on deletion or not.

## PR Checklist

* [x] Refers to: #2845
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccGateway_basic
=== PAUSE TestAccGateway_basic
=== CONT  TestAccGateway_basic
--- PASS: TestAccGateway_basic (281.15s)
PASS

Process finished with the exit code 0

=== RUN   TestAccGateway_DeleteEip
=== PAUSE TestAccGateway_DeleteEip
=== CONT  TestAccGateway_DeleteEip
--- PASS: TestAccGateway_DeleteEip (269.52s)
PASS

Process finished with the exit code 0

```
