### PR TITLE
[FIX] RDS: fix job tasks completion for `opentelekomcloud_rds_public_ip_associate_v3`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20250211092354-98baf25860f9
+	github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20250304150259-b586a10dd290
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.31.0
 	golang.org/x/sync v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -158,8 +158,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k+Mg7cowZ8yv4Trqw9UsJby758=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20250211092354-98baf25860f9 h1:9IOOVC/Ecx5VVWLVo4rXrFUKD0rtKC5I15TkSBB666U=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20250211092354-98baf25860f9/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20250304150259-b586a10dd290 h1:ymNRRwqu550bNZ3IFYnlHJ9Sa08rLbfB9BPjN0bvSDE=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20250304150259-b586a10dd290/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/releasenotes/notes/rds_eip_fix-65e88a74c8f7831e.yaml
+++ b/releasenotes/notes/rds_eip_fix-65e88a74c8f7831e.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[RDS]** Fix `job_id` tasks for ``resource/opentelekomcloud_rds_public_ip_associate_v3`` after gophertelekomcloud sdk update (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)

--- a/releasenotes/notes/rds_eip_fix-65e88a74c8f7831e.yaml
+++ b/releasenotes/notes/rds_eip_fix-65e88a74c8f7831e.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    **[RDS]** Fix `job_id` tasks for ``resource/opentelekomcloud_rds_public_ip_associate_v3`` after gophertelekomcloud sdk update (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[RDS]** Fix `job_id` tasks for ``resource/opentelekomcloud_rds_public_ip_associate_v3`` after gophertelekomcloud sdk update (`#2850 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2850>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Remove sleeps from resource after sdk update.

## PR Checklist

* [ ] Refers to: #xxx
* [x] Tests passed.
* [ ] Documentation updated.
* [ ] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccRdsPublicIpAssociateV3Basic
--- PASS: TestAccRdsPublicIpAssociateV3Basic (525.11s)
PASS

Process finished with the exit code 0
```
