### PR TITLE
[Doc.] CCE: add eni network type

### DIFF
--- a/docs/resources/cce_cluster_v3.md
+++ b/docs/resources/cce_cluster_v3.md
@@ -197,9 +197,10 @@ The following arguments are supported:
 * `highway_subnet_id` - (Optional) The ID of the high speed network used to create bare metal nodes. Changing this parameter will create a new cluster resource.
 
 * `container_network_type` - (Required) Container network type.
-  * `overlay_l2` - An overlay_l2 network built for containers by using Open vSwitch(OVS)
+  * `overlay_l2` - An overlay_l2 network built for containers by using Open vSwitch(OVS).
+  * `vpc-router` - A vpc-router network built for containers by using ipvlan and custom VPC routes.
+  * `eni` - Cloud native 2.0 network model which integrates the native ENI capability of VPC.
   * `underlay_ipvlan` - An underlay_ipvlan network built for bare metal servers by using ipvlan.
-  * `vpc-router` - An vpc-router network built for containers by using ipvlan and custom VPC routes.
 
 * `container_network_cidr` - (Optional) Container network segment. Changing this parameter will create a new cluster resource.
 

--- a/releasenotes/notes/cce-doc-network-types-d468b118ecd9050a.yaml
+++ b/releasenotes/notes/cce-doc-network-types-d468b118ecd9050a.yaml
@@ -1,0 +1,4 @@
+---
+other:
+  - |
+    **[CCE]** Update ``container_network_type`` description for ``resource/opentelekomcloud_cce_cluster_v3`` documentation (`#2872 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2872>`_)


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [X] Refers to: https://docs.otc.t-systems.com/cloud-container-engine/api-ref/apis/cluster_management/creating_a_cluster.html
* [X] Tests added/passed.
* [X] Documentation updated.
* [ ] Schema updated.
* [ ] Release notes added.

## Acceptance Steps Performed

```
  # opentelekomcloud_cce_cluster_v3.cluster will be created
  + resource "opentelekomcloud_cce_cluster_v3" "cluster" {
      + authentication_mode      = "rbac"
      + billing_mode             = 0
      + certificate_clusters     = (known after apply)
      + certificate_users        = (known after apply)
      + cluster_type             = "VirtualMachine"
      + cluster_version          = "v1.30"
      + container_network_cidr   = (known after apply)
      + container_network_type   = "eni"
...
$ curl -sS -X GET -H "$AUTH_TOKEN" https://$CCE/api/v3/projects/$OS_PROJECT_ID/clusters | jq  | grep \"eni\"
          "mode": "eni"
```
