### PR TITLE
[Feat.] RDS: add `period` setting for `backup_strategy`

### DIFF
--- a/docs/resources/rds_instance_v3.md
+++ b/docs/resources/rds_instance_v3.md
@@ -48,6 +48,7 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
   backup_strategy {
     start_time = "08:00-09:00"
     keep_days  = 1
+    period     = "1,2,3,4,5"
   }
 
   tags = {
@@ -458,6 +459,11 @@ The `backup_strategy` block supports:
   be 1 greater than the hh value. The values of mm and MM must be
   the same and must be set to any of the following: 00, 15, 30, or
   45. Example value: 08:15-09:15 23:00-00:00.
+
+* `period` - (Optional) Specifies the backup cycle configuration. Data will be automatically backed up on the selected days every week.
+  This parameter is mandatory except that the automated backup policy is disabled.
+  Value range: The value is digits separated by commas (,), indicating the day of the week and starting from Monday.
+  For example, the value `1,2,3,4` indicates that the backup period is Monday, Tuesday, Wednesday, and Thursday.
 
 The `restore_point` block supports:
 

--- a/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
+++ b/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
@@ -52,6 +52,8 @@ func TestAccRdsInstanceV3Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(instanceV3ResourceName, "name", "tf_rds_instance_updated_"+postfix),
 					resource.TestCheckResourceAttr(instanceV3ResourceName, "db.0.port", "8636"),
 					resource.TestCheckResourceAttr(instanceV3ResourceName, "lower_case_table_names", "0"),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "backup_strategy.0.keep_days", "2"),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "backup_strategy.0.period", "1,2,3,4"),
 				),
 			},
 		},
@@ -225,6 +227,7 @@ func TestAccRdsInstanceV3Backup(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRdsInstanceV3Exists(instanceV3ResourceName, &rdsInstance),
 					resource.TestCheckResourceAttr(instanceV3ResourceName, "name", "tf_rds_instance_"+postfix),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "backup_strategy.0.period", "1,2"),
 				),
 			},
 		},
@@ -456,6 +459,7 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
   backup_strategy {
     start_time = "08:00-09:00"
     keep_days  = 0
+    period     = "1,2,3"
   }
   tags = {
     muh = "value-create"
@@ -494,7 +498,8 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
   flavor = "rds.pg.n1.large.4"
   backup_strategy {
     start_time = "08:00-09:00"
-    keep_days  = 1
+    keep_days  = 2
+    period     = "1,2,3,4"
   }
   tags = {
     muh = "value-update"
@@ -611,13 +616,14 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
   subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
   volume {
-    type = "ULTRAHIGH"
+    type = "CLOUDSSD"
     size = 100
   }
-  flavor = "rds.pg.c2.large"
+  flavor = "rds.pg.n1.large.4"
   backup_strategy {
     start_time = "10:00-11:00"
     keep_days  = 5
+    period     = "1,2"
   }
 }
 `, common.DataSourceSecGroupDefault, common.DataSourceSubnet, postfix, env.OS_AVAILABILITY_ZONE)

--- a/releasenotes/notes/rds_backup_period-31ab340181ab843c.yaml
+++ b/releasenotes/notes/rds_backup_period-31ab340181ab843c.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[RDS]** Implement `period` option for `backup_strategy` for ``resource/opentelekomcloud_rds_instance_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)

--- a/releasenotes/notes/rds_backup_period-31ab340181ab843c.yaml
+++ b/releasenotes/notes/rds_backup_period-31ab340181ab843c.yaml
@@ -1,4 +1,4 @@
 ---
 enhancements:
   - |
-    **[RDS]** Implement `period` option for `backup_strategy` for ``resource/opentelekomcloud_rds_instance_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[RDS]** Implement `period` option for `backup_strategy` for ``resource/opentelekomcloud_rds_instance_v3`` (`#2882 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2882>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Added `period` option for `backup_strategy` for RDS instance v3 resource

## PR Checklist

* [x] Refers to: #2834
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccRdsInstanceV3Backup
--- PASS: TestAccRdsInstanceV3Backup (409.96s)
PASS

Process finished with the exit code 0


=== RUN   TestAccRdsInstanceV3Basic
--- PASS: TestAccRdsInstanceV3Basic (736.09s)
PASS

Process finished with the exit code 0
```
