### PR TITLE
[Fix] read fix for all LTS resources

### DIFF
--- a/opentelekomcloud/acceptance/lts/resource_opentelekomcloud_lts_cce_access_v3_test.go
+++ b/opentelekomcloud/acceptance/lts/resource_opentelekomcloud_lts_cce_access_v3_test.go
@@ -23,7 +23,7 @@ func TestAccCceAccessConfig_containerFile(t *testing.T) {
 		rc     = common.InitResourceCheck(rName, &access, getHostAccessConfigResourceFunc)
 	)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			common.TestAccPreCheck(t)
 		},
@@ -111,7 +111,7 @@ func TestAccCceAccessConfig_containerStdout(t *testing.T) {
 		rc     = common.InitResourceCheck(rName, &access, getHostAccessConfigResourceFunc)
 	)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			common.TestAccPreCheck(t)
 		},
@@ -192,7 +192,7 @@ func TestAccCceAccessConfig_hostFile(t *testing.T) {
 		rc     = common.InitResourceCheck(rName, &access, getHostAccessConfigResourceFunc)
 	)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			common.TestAccPreCheck(t)
 		},

--- a/opentelekomcloud/acceptance/lts/resource_opentelekomcloud_lts_host_access_v3_test.go
+++ b/opentelekomcloud/acceptance/lts/resource_opentelekomcloud_lts_host_access_v3_test.go
@@ -47,7 +47,7 @@ func TestAccHostAccessConfigV3_basic(t *testing.T) {
 		rc     = common.InitResourceCheck(rName, &access, getHostAccessConfigResourceFunc)
 	)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
@@ -98,7 +98,7 @@ func TestAccHostAccessConfigV3_windows(t *testing.T) {
 		rc     = common.InitResourceCheck(rName, &access, getHostAccessConfigResourceFunc)
 	)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),

--- a/opentelekomcloud/acceptance/lts/resource_opentelekomcloud_lts_host_access_v3_test.go
+++ b/opentelekomcloud/acceptance/lts/resource_opentelekomcloud_lts_host_access_v3_test.go
@@ -27,13 +27,13 @@ func getHostAccessConfigResourceFunc(config *cfg.Config, state *terraform.Resour
 	if len(requestResp.Result) < 1 {
 		return nil, golangsdk.ErrDefault404{}
 	}
-	var accessResult *ac.AccessConfigInfo
+	var accessResult ac.AccessConfigInfo
 	for _, acc := range requestResp.Result {
 		if acc.ID == state.Primary.ID {
-			accessResult = &acc
+			accessResult = acc
 		}
 	}
-	if accessResult == nil {
+	if accessResult.ID == "" {
 		return nil, golangsdk.ErrDefault404{}
 	}
 	return accessResult, nil

--- a/opentelekomcloud/acceptance/lts/resource_opentelekomcloud_lts_host_group_v3_test.go
+++ b/opentelekomcloud/acceptance/lts/resource_opentelekomcloud_lts_host_group_v3_test.go
@@ -27,13 +27,13 @@ func getHostGroupResourceFunc(config *cfg.Config, state *terraform.ResourceState
 	if len(requestResp.Result) < 1 {
 		return nil, golangsdk.ErrDefault404{}
 	}
-	var groupResult *hg.HostGroupResponse
+	var groupResult hg.HostGroupResponse
 	for _, group := range requestResp.Result {
 		if group.ID == state.Primary.ID {
-			groupResult = &group
+			groupResult = group
 		}
 	}
-	if groupResult == nil {
+	if groupResult.ID == "" {
 		return nil, golangsdk.ErrDefault404{}
 	}
 	return groupResult, nil

--- a/opentelekomcloud/acceptance/lts/resource_opentelekomcloud_lts_loggroup_test.go
+++ b/opentelekomcloud/acceptance/lts/resource_opentelekomcloud_lts_loggroup_test.go
@@ -28,13 +28,13 @@ func getLtsGroupResourceFunc(config *cfg.Config, state *terraform.ResourceState)
 	if len(requestResp) < 1 {
 		return nil, golangsdk.ErrDefault404{}
 	}
-	var groupResult *groups.LogGroup
+	var groupResult groups.LogGroup
 	for _, group := range requestResp {
 		if group.LogGroupId == state.Primary.ID {
-			groupResult = &group
+			groupResult = group
 		}
 	}
-	if groupResult == nil {
+	if groupResult.LogGroupId == "" {
 		return nil, golangsdk.ErrDefault404{}
 	}
 	return groupResult, nil

--- a/opentelekomcloud/acceptance/lts/resource_opentelekomcloud_lts_logtopic_test.go
+++ b/opentelekomcloud/acceptance/lts/resource_opentelekomcloud_lts_logtopic_test.go
@@ -28,13 +28,13 @@ func getLtsStreamResourceFunc(config *cfg.Config, state *terraform.ResourceState
 	if len(requestResp) < 1 {
 		return nil, golangsdk.ErrDefault404{}
 	}
-	var streamResult *streams.LogStream
+	var streamResult streams.LogStream
 	for _, stream := range requestResp {
 		if stream.LogStreamId == state.Primary.ID {
-			streamResult = &stream
+			streamResult = stream
 		}
 	}
-	if streamResult == nil {
+	if streamResult.LogStreamId == "" {
 		return nil, golangsdk.ErrDefault404{}
 	}
 	return streamResult, nil

--- a/opentelekomcloud/acceptance/lts/resource_opentelekomcloud_lts_logtransfer_test.go
+++ b/opentelekomcloud/acceptance/lts/resource_opentelekomcloud_lts_logtransfer_test.go
@@ -26,13 +26,13 @@ func getLtsTransferResourceFunc(config *cfg.Config, state *terraform.ResourceSta
 	if len(requestResp) < 1 {
 		return nil, golangsdk.ErrDefault404{}
 	}
-	var transferResult *transfers.Transfer
+	var transferResult transfers.Transfer
 	for _, transfer := range requestResp {
 		if transfer.LogTransferId == state.Primary.ID {
-			transferResult = &transfer
+			transferResult = transfer
 		}
 	}
-	if transferResult == nil {
+	if transferResult.LogTransferId == "" {
 		return nil, golangsdk.ErrDefault404{}
 	}
 	return transferResult, nil

--- a/opentelekomcloud/services/lts/resource_opentelekomcloud_lts_cce_access_v3.go
+++ b/opentelekomcloud/services/lts/resource_opentelekomcloud_lts_cce_access_v3.go
@@ -286,13 +286,13 @@ func resourceCceAccessConfigV3Read(ctx context.Context, d *schema.ResourceData, 
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	var configResult *ac.AccessConfigInfo
+	var configResult ac.AccessConfigInfo
 	for _, acc := range requestResp.Result {
 		if acc.ID == d.Id() {
-			configResult = &acc
+			configResult = acc
 		}
 	}
-	if configResult == nil {
+	if configResult.ID == "" {
 		return common.CheckDeletedDiag(d, err, fmt.Sprintf("unable to find OpenTelekomCloud LTS v2 cce access config by its ID (%s)", d.Id()))
 	}
 	tagsMap := make(map[string]string)

--- a/opentelekomcloud/services/lts/resource_opentelekomcloud_lts_cce_access_v3.go
+++ b/opentelekomcloud/services/lts/resource_opentelekomcloud_lts_cce_access_v3.go
@@ -290,6 +290,7 @@ func resourceCceAccessConfigV3Read(ctx context.Context, d *schema.ResourceData, 
 	for _, acc := range requestResp.Result {
 		if acc.ID == d.Id() {
 			configResult = acc
+			break
 		}
 	}
 	if configResult.ID == "" {

--- a/opentelekomcloud/services/lts/resource_opentelekomcloud_lts_group_v2.go
+++ b/opentelekomcloud/services/lts/resource_opentelekomcloud_lts_group_v2.go
@@ -95,13 +95,13 @@ func resourceLtsGroupV2Read(ctx context.Context, d *schema.ResourceData, meta in
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	var groupResult *groups.LogGroup
+	var groupResult groups.LogGroup
 	for _, gr := range requestResp {
 		if gr.LogGroupId == d.Id() {
-			groupResult = &gr
+			groupResult = gr
 		}
 	}
-	if groupResult == nil {
+	if groupResult.LogGroupId == "" {
 		return common.CheckDeletedDiag(d, err, fmt.Sprintf("unable to find OpenTelekomCloud LTS v2 log group by its ID (%s)", d.Id()))
 	}
 

--- a/opentelekomcloud/services/lts/resource_opentelekomcloud_lts_group_v2.go
+++ b/opentelekomcloud/services/lts/resource_opentelekomcloud_lts_group_v2.go
@@ -99,6 +99,7 @@ func resourceLtsGroupV2Read(ctx context.Context, d *schema.ResourceData, meta in
 	for _, gr := range requestResp {
 		if gr.LogGroupId == d.Id() {
 			groupResult = gr
+			break
 		}
 	}
 	if groupResult.LogGroupId == "" {

--- a/opentelekomcloud/services/lts/resource_opentelekomcloud_lts_host_access_v3.go
+++ b/opentelekomcloud/services/lts/resource_opentelekomcloud_lts_host_access_v3.go
@@ -327,13 +327,13 @@ func resourceHostAccessConfigV3Read(ctx context.Context, d *schema.ResourceData,
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	var configResult *ac.AccessConfigInfo
+	var configResult ac.AccessConfigInfo
 	for _, acc := range requestResp.Result {
 		if acc.ID == d.Id() {
-			configResult = &acc
+			configResult = acc
 		}
 	}
-	if configResult == nil {
+	if configResult.ID == "" {
 		return common.CheckDeletedDiag(d, err, fmt.Sprintf("unable to find OpenTelekomCloud LTS v2 host access config by its ID (%s)", d.Id()))
 	}
 	tagsMap := make(map[string]string)

--- a/opentelekomcloud/services/lts/resource_opentelekomcloud_lts_host_access_v3.go
+++ b/opentelekomcloud/services/lts/resource_opentelekomcloud_lts_host_access_v3.go
@@ -331,6 +331,7 @@ func resourceHostAccessConfigV3Read(ctx context.Context, d *schema.ResourceData,
 	for _, acc := range requestResp.Result {
 		if acc.ID == d.Id() {
 			configResult = acc
+			break
 		}
 	}
 	if configResult.ID == "" {

--- a/opentelekomcloud/services/lts/resource_opentelekomcloud_lts_host_group_v3.go
+++ b/opentelekomcloud/services/lts/resource_opentelekomcloud_lts_host_group_v3.go
@@ -154,13 +154,14 @@ func resourceHostGroupV3Read(ctx context.Context, d *schema.ResourceData, meta i
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	var groupResult *hg.HostGroupResponse
+	var groupResult hg.HostGroupResponse
+
 	for _, gr := range requestResp.Result {
 		if gr.ID == d.Id() {
-			groupResult = &gr
+			groupResult = gr
 		}
 	}
-	if groupResult == nil {
+	if groupResult.ID == "" {
 		return common.CheckDeletedDiag(d, err, fmt.Sprintf("unable to find OpenTelekomCloud LTS v2 host group by its ID (%s)", d.Id()))
 	}
 	tagsMap := make(map[string]string)

--- a/opentelekomcloud/services/lts/resource_opentelekomcloud_lts_host_group_v3.go
+++ b/opentelekomcloud/services/lts/resource_opentelekomcloud_lts_host_group_v3.go
@@ -159,6 +159,7 @@ func resourceHostGroupV3Read(ctx context.Context, d *schema.ResourceData, meta i
 	for _, gr := range requestResp.Result {
 		if gr.ID == d.Id() {
 			groupResult = gr
+			break
 		}
 	}
 	if groupResult.ID == "" {

--- a/opentelekomcloud/services/lts/resource_opentelekomcloud_lts_stream_v2.go
+++ b/opentelekomcloud/services/lts/resource_opentelekomcloud_lts_stream_v2.go
@@ -123,6 +123,7 @@ func resourceStreamV2Read(ctx context.Context, d *schema.ResourceData, meta inte
 	for _, stream := range requestResp {
 		if stream.LogStreamId == d.Id() {
 			streamResult = stream
+			break
 		}
 	}
 	if streamResult.LogStreamId == "" {

--- a/opentelekomcloud/services/lts/resource_opentelekomcloud_lts_stream_v2.go
+++ b/opentelekomcloud/services/lts/resource_opentelekomcloud_lts_stream_v2.go
@@ -118,13 +118,14 @@ func resourceStreamV2Read(ctx context.Context, d *schema.ResourceData, meta inte
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	var streamResult *streams.LogStream
+	var streamResult streams.LogStream
+
 	for _, stream := range requestResp {
 		if stream.LogStreamId == d.Id() {
-			streamResult = &stream
+			streamResult = stream
 		}
 	}
-	if streamResult == nil {
+	if streamResult.LogStreamId == "" {
 		return common.CheckDeletedDiag(d, err, fmt.Sprintf("unable to find OpenTelekomCloud LTS v2 log stream by its ID (%s)", d.Id()))
 	}
 

--- a/opentelekomcloud/services/lts/resource_opentelekomcloud_lts_transfer_v2.go
+++ b/opentelekomcloud/services/lts/resource_opentelekomcloud_lts_transfer_v2.go
@@ -330,13 +330,14 @@ func resourceLtsTransferV2Read(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	requestResp, err := transfers.List(client, transfers.ListTransfersOpts{})
-	var transferResult *transfers.Transfer
+	var transferResult transfers.Transfer
+
 	for _, tr := range requestResp {
 		if tr.LogTransferId == d.Id() {
-			transferResult = &tr
+			transferResult = tr
 		}
 	}
-	if transferResult == nil {
+	if transferResult.LogTransferId == "" {
 		return common.CheckDeletedDiag(d, err, fmt.Sprintf("unable to find OpenTelekomCloud LTS v2 log transfer by its ID (%s)", d.Id()))
 	}
 	mErr := multierror.Append(nil,

--- a/opentelekomcloud/services/lts/resource_opentelekomcloud_lts_transfer_v2.go
+++ b/opentelekomcloud/services/lts/resource_opentelekomcloud_lts_transfer_v2.go
@@ -335,6 +335,7 @@ func resourceLtsTransferV2Read(ctx context.Context, d *schema.ResourceData, meta
 	for _, tr := range requestResp {
 		if tr.LogTransferId == d.Id() {
 			transferResult = tr
+			break
 		}
 	}
 	if transferResult.LogTransferId == "" {

--- a/releasenotes/notes/lts-read-fix-be6e3c54b219293c.yaml
+++ b/releasenotes/notes/lts-read-fix-be6e3c54b219293c.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[LTS]** Fix id check in read for all resources (`#2886 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2886>`_)


### PR DESCRIPTION
## Summary of the Pull Request
pointer to structure leads to wrongly setting of resource ids

## PR Checklist

* [x] Refers to: #2884
* [x] Tests added/passed.
* [ ] Documentation updated.
* [x] Schema updated.
* [ ] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccLtsV2Group_basic
=== PAUSE TestAccLtsV2Group_basic
=== CONT  TestAccLtsV2Group_basic
--- PASS: TestAccLtsV2Group_basic (83.35s)
=== RUN   TestAccLtsV2Group_ctsIssue
=== PAUSE TestAccLtsV2Group_ctsIssue
=== CONT  TestAccLtsV2Group_ctsIssue
--- PASS: TestAccLtsV2Group_ctsIssue (31.37s)
=== RUN   TestAccHostAccessConfigV3_basic
=== PAUSE TestAccHostAccessConfigV3_basic
=== CONT  TestAccHostAccessConfigV3_basic
--- PASS: TestAccHostAccessConfigV3_basic (51.92s)
=== RUN   TestAccHostAccessConfigV3_windows
=== PAUSE TestAccHostAccessConfigV3_windows
=== CONT  TestAccHostAccessConfigV3_windows
--- PASS: TestAccHostAccessConfigV3_windows (32.56s)
=== RUN   TestAccLogTankGroupV2_basic
--- PASS: TestAccLogTankGroupV2_basic (40.02s)
=== RUN   TestAccLogTankTopicV2_basic
--- PASS: TestAccLogTankTopicV2_basic (24.87s)
=== RUN   TestAccLogTankTransferV2_basic
--- PASS: TestAccLogTankTransferV2_basic (51.66s)
=== RUN   TestAccLogTankTransferV2_encryptedBucket
--- PASS: TestAccLogTankTransferV2_encryptedBucket (28.83s)
=== RUN   TestAccLtsStream_basic
=== PAUSE TestAccLtsStream_basic
=== CONT  TestAccLtsStream_basic
--- PASS: TestAccLtsStream_basic (50.47s)
=== RUN   TestAccLtsV2Transfer_basic
=== PAUSE TestAccLtsV2Transfer_basic
=== CONT  TestAccLtsV2Transfer_basic
--- PASS: TestAccLtsV2Transfer_basic (54.88s)
PASS
ok  	github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/lts	229.900s

Process finished with the exit code 0

```
