### PR TITLE
[Feat.] CCE: timezone parameter for cluster v3

### DIFF
--- a/docs/resources/cce_cluster_v3.md
+++ b/docs/resources/cce_cluster_v3.md
@@ -42,6 +42,7 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   container_network_type = "overlay_l2"
   authentication_mode    = "rbac"
   kube_proxy_mode        = "ipvs"
+  timezone               = "Europe/Madrid"
 }
 ```
 
@@ -122,6 +123,7 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   subnet_id              = var.subnet_id
   container_network_type = "overlay_l2"
   authentication_mode    = "rbac"
+  timezone               = "UTC"
 
   depends_on = [opentelekomcloud_identity_agency_v3.enable_cce_auto_creation]
 }
@@ -161,6 +163,8 @@ The following arguments are supported:
 * `labels` - (Optional) Cluster tag, key/value pair format. Changing this parameter will create a new cluster resource.
 
 * `annotations` - (Optional) Cluster annotation, key/value pair format. Changing this parameter will create a new cluster resource.
+
+* `timezone` - (Optional) Cluster timezone in string format.
 
 * `flavor_id` - (Required) Cluster specifications. Changing this parameter will create a new cluster resource.
   * `cce.s1.small` - small-scale single cluster (up to 50 nodes).

--- a/docs/resources/cce_cluster_v3.md
+++ b/docs/resources/cce_cluster_v3.md
@@ -164,7 +164,7 @@ The following arguments are supported:
 
 * `annotations` - (Optional) Cluster annotation, key/value pair format. Changing this parameter will create a new cluster resource.
 
-* `timezone` - (Optional) Cluster timezone in string format.
+* `timezone` - (Optional) Cluster timezone in string format. Changing this parameter will create a new cluster resource.
 
 * `flavor_id` - (Required) Cluster specifications. Changing this parameter will create a new cluster resource.
   * `cce.s1.small` - small-scale single cluster (up to 50 nodes).

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20250407142249-07f997e1c958
+	github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20250409085714-5ce56c2332fc
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.31.0
 	golang.org/x/sync v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -158,8 +158,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k+Mg7cowZ8yv4Trqw9UsJby758=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20250407142249-07f997e1c958 h1:H4UytW05nBY2GxyHY7xHCDcp1JzXo45SLuB0fFKrFX0=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20250407142249-07f997e1c958/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20250409085714-5ce56c2332fc h1:CC4KheAQmxKmA69GGlDol79tUgZl7TPLQakw7NgQpq4=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20250409085714-5ce56c2332fc/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_cluster_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_cluster_v3_test.go
@@ -63,6 +63,7 @@ func TestAccCCEClusterV3_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceClusterName, "certificate_users.0.name", "user"),
 					resource.TestCheckResourceAttr(resourceClusterName, "enable_volume_encryption", "true"),
 					resource.TestCheckResourceAttr(resourceClusterName, "masters.0.availability_zone", "eu-de-01"),
+					resource.TestCheckResourceAttr(resourceClusterName, "timezone", "Europe/Madrid"),
 				),
 			},
 			{
@@ -72,6 +73,7 @@ func TestAccCCEClusterV3_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceClusterName, "kube_proxy_mode", "ipvs"),
 					resource.TestCheckResourceAttr(resourceClusterName, "enable_volume_encryption", "true"),
 					resource.TestCheckResourceAttr(resourceClusterName, "masters.0.availability_zone", "eu-de-01"),
+					resource.TestCheckResourceAttr(resourceClusterName, "timezone", "Europe/Madrid"),
 				),
 			},
 		},
@@ -330,6 +332,7 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   ignore_addons            = true
   kube_proxy_mode          = "ipvs"
   enable_volume_encryption = true
+  timezone                 = "Europe/Madrid"
   masters {
     availability_zone = "eu-de-01"
   }
@@ -400,6 +403,7 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   delete_all_storage       = "true"
   delete_all_network       = "true"
   enable_volume_encryption = true
+  timezone                 = "Europe/Madrid"
   masters {
     availability_zone = "eu-de-01"
   }

--- a/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_cluster_v3.go
+++ b/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_cluster_v3.go
@@ -85,6 +85,7 @@ func ResourceCCEClusterV3() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				Computed: true,
 			},
 			"flavor_id": {
 				Type:     schema.TypeString,

--- a/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_cluster_v3.go
+++ b/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_cluster_v3.go
@@ -81,6 +81,11 @@ func ResourceCCEClusterV3() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"timezone": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 			"flavor_id": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -456,6 +461,7 @@ func resourceCCEClusterV3Create(ctx context.Context, d *schema.ResourceData, met
 			Name:        d.Get("name").(string),
 			Labels:      resourceClusterLabelsV3(d),
 			Annotations: resourceClusterAnnotationsV3(d),
+			Timezone:    d.Get("timezone").(string),
 		},
 		Spec: clusters.Spec{
 			Type:        d.Get("cluster_type").(string),
@@ -591,6 +597,7 @@ func resourceCCEClusterV3Read(ctx context.Context, d *schema.ResourceData, meta 
 		d.Set("region", config.GetRegion(d)),
 		d.Set("eip", eip),
 		d.Set("enable_volume_encryption", cluster.Spec.EnableMasterVolumeEncryption),
+		d.Set("timezone", cluster.Metadata.Timezone),
 	)
 	if err := mErr.ErrorOrNil(); err != nil {
 		return fmterr.Errorf("error setting cce cluster fields: %w", err)

--- a/releasenotes/notes/cce_timezone-b91ad704f72a2850.yaml
+++ b/releasenotes/notes/cce_timezone-b91ad704f72a2850.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[CCE]** Add `timezone` parameter for ``resource/opentelekomcloud_cce_cluster_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)

--- a/releasenotes/notes/cce_timezone-b91ad704f72a2850.yaml
+++ b/releasenotes/notes/cce_timezone-b91ad704f72a2850.yaml
@@ -1,4 +1,4 @@
 ---
 enhancements:
   - |
-    **[CCE]** Add `timezone` parameter for ``resource/opentelekomcloud_cce_cluster_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[CCE]** Add `timezone` parameter for ``resource/opentelekomcloud_cce_cluster_v3`` (`#2891 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2891>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Add `timezone` parameter for ``opentelekomcloud_cce_cluster_v3``

## PR Checklist

* [x] Refers to: #2838
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccCCEClusterV3_basic
=== PAUSE TestAccCCEClusterV3_basic
=== CONT  TestAccCCEClusterV3_basic
--- PASS: TestAccCCEClusterV3_basic (389.26s)
PASS

Process finished with the exit code 0
```
