### PR TITLE
[DCS]: v3 engine version deprecation

### DIFF
--- a/docs/resources/dcs_instance_v1.md
+++ b/docs/resources/dcs_instance_v1.md
@@ -16,51 +16,6 @@ Manages a DCSv1 instance in the OpenTelekomCloud DCS Service.
 
 ## Example Usage
 
-### Engine version 3.0 (`security_group_id` is required):
-
-```hcl
-variable "network_id" {}
-variable "vpc_id" {}
-
-resource "opentelekomcloud_networking_secgroup_v2" "secgroup_1" {
-  name        = "secgroup_1"
-  description = "secgroup_1"
-}
-
-data "opentelekomcloud_dcs_az_v1" "az_1" {
-  name = "eu-de-01"
-}
-
-data "opentelekomcloud_dcs_product_v1" "product_1" {
-  spec_code = "dcs.master_standby"
-}
-
-resource "opentelekomcloud_dcs_instance_v1" "instance_1" {
-  name           = "test_dcs_instance"
-  engine_version = "3.0"
-  password       = "0TCTestP@ssw0rd"
-  engine         = "Redis"
-  capacity       = 2
-  vpc_id         = var.vpc_id
-
-  security_group_id = opentelekomcloud_networking_secgroup_v2.secgroup_1.id
-  subnet_id         = var.network_id
-  available_zones   = [data.opentelekomcloud_dcs_az_v1.az_1.id]
-  product_id        = data.opentelekomcloud_dcs_product_v1.product_1.id
-  backup_policy {
-    save_days   = 1
-    backup_type = "manual"
-    begin_at    = "00:00-01:00"
-    period_type = "weekly"
-    backup_at   = [1, 2, 4, 6]
-  }
-  tags = {
-    environment = "basic"
-    managed_by  = "terraform"
-  }
-}
-```
-
 ### Engine version 5.0 (please pay attention of proper selection of the spec_code):
 
 ```hcl
@@ -110,7 +65,7 @@ The following arguments are supported:
 * `engine` - (Required, ForceNew, String) Indicates a cache engine. Only `Redis` is supported. Changing this
   creates a new instance.
 
-* `engine_version` - (Required, ForceNew, String) Indicates the version of a cache engine, which can be `3.0`/`4.0`/`5.0`/`6.0`.
+* `engine_version` - (Required, ForceNew, String) Indicates the version of a cache engine, which can be `4.0`/`5.0`/`6.0`.
   Changing this creates a new instance.
 
 * `capacity` - (Required, ForceNew, Float) Indicates the Cache capacity. Unit: GB.
@@ -118,8 +73,6 @@ The following arguments are supported:
     `0.5`, `1`, `2`, `4`, `8`, `16`, `32` and `64`.
     Cluster instance specifications support `4`,`8`,`16`, `24`, `32`, `48`, `64`, `96`, `128`, `192`, `256`,
     `384`, `512`, `768` and `1024`.
-  + **Redis3.0**: Stand-alone and active/standby type instance values: `2`, `4`, `8`, `16`, `32` and `64`.
-    Proxy cluster instance specifications support `64`, `128`, `256`, `512`, and `1024`.
   + **Memcached**: Stand-alone and active/standby type instance values: `2`, `4`, `8`, `16`, `32` and `64`.
 
 * `password` - (Optional, ForceNew, String) Indicates the password of an instance. An instance password

--- a/docs/resources/dcs_instance_v2.md
+++ b/docs/resources/dcs_instance_v2.md
@@ -16,47 +16,6 @@ Manages a DCSv2 instance in the OpenTelekomCloud DCS Service.
 
 ## Example Usage
 
-### Engine version 3.0 (`security_group_id` is required):
-
-```hcl
-variable "network_id" {}
-variable "vpc_id" {}
-
-resource "opentelekomcloud_networking_secgroup_v2" "secgroup_1" {
-  name        = "secgroup_1"
-  description = "secgroup_1"
-}
-
-data "opentelekomcloud_dcs_az_v1" "az_1" {
-  name = "eu-de-01"
-}
-
-resource "opentelekomcloud_dcs_instance_v2" "instance_1" {
-  name               = "test_dcs_instance"
-  engine_version     = "3.0"
-  password           = "0TCTestP@ssw0rd"
-  engine             = "Redis"
-  capacity           = 2
-  vpc_id             = var.vpc_id
-  security_group_id  = opentelekomcloud_networking_secgroup_v2.secgroup_1.id
-  subnet_id          = var.network_id
-  availability_zones = ["eu-de-01"]
-  flavor             = "dcs.master_standby"
-
-  backup_policy {
-    save_days   = 1
-    backup_type = "manual"
-    begin_at    = "00:00-01:00"
-    period_type = "weekly"
-    backup_at   = [1, 2, 4, 6]
-  }
-  tags = {
-    environment = "basic"
-    managed_by  = "terraform"
-  }
-}
-```
-
 ### Engine version 5.0 (please pay attention of proper selection of flavor):
 
 ```hcl
@@ -97,7 +56,7 @@ The following arguments are supported:
   Changing this creates a new instance.
 
 * `engine_version` - (Optional, String, ForceNew) Specifies the version of a cache engine.
-  It is mandatory when the engine is *Redis*, the value can be 3.0, 4.0, 5.0 or 6.0.
+  It is mandatory when the engine is *Redis*, the value can be 4.0, 5.0 or 6.0.
   Changing this creates a new instance.
 
 * `capacity` - (Required, Float) Specifies the cache capacity. Unit: GB.

--- a/opentelekomcloud/common/customize_diffs.go
+++ b/opentelekomcloud/common/customize_diffs.go
@@ -176,3 +176,16 @@ func ValidateVpnRegion(v interface{}, path cty.Path) diag.Diagnostics {
 		AttributePath: path,
 	}}
 }
+
+func ValidateDcsEngineVersion(v interface{}, path cty.Path) diag.Diagnostics {
+	engine := v.(string)
+	if engine != "3.0" {
+		return nil
+	}
+	return diag.Diagnostics{diag.Diagnostic{
+		Severity:      diag.Warning,
+		Summary:       "[DEPRECATION WARNING]",
+		Detail:        "Redis 3.x versions in DCS have reached their End of Sale status on 21st June 2024.",
+		AttributePath: path,
+	}}
+}

--- a/opentelekomcloud/services/dcs/resource_opentelekomcloud_dcs_instance_v1.go
+++ b/opentelekomcloud/services/dcs/resource_opentelekomcloud_dcs_instance_v1.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/tags"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/dcs/v1/configs"
@@ -59,12 +58,10 @@ func ResourceDcsInstanceV1() *schema.Resource {
 				ForceNew: true,
 			},
 			"engine_version": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					"3.0", "4.0", "5.0", "6.0",
-				}, false),
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: common.ValidateDcsEngineVersion,
 			},
 			"capacity": {
 				Type:     schema.TypeFloat,

--- a/opentelekomcloud/services/dcs/resource_opentelekomcloud_dcs_instance_v2.go
+++ b/opentelekomcloud/services/dcs/resource_opentelekomcloud_dcs_instance_v2.go
@@ -63,9 +63,10 @@ func ResourceDcsInstanceV2() *schema.Resource {
 				}, true),
 			},
 			"engine_version": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:             schema.TypeString,
+				Optional:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: common.ValidateDcsEngineVersion,
 			},
 			"capacity": {
 				Type:     schema.TypeFloat,

--- a/releasenotes/notes/dcs_deprecation-5239058003db5619.yaml
+++ b/releasenotes/notes/dcs_deprecation-5239058003db5619.yaml
@@ -1,0 +1,6 @@
+---
+deprecations:
+  - |
+    **[DCS]** Engine version v3 deprecation for ``resource/opentelekomcloud_dcs_instance_v1`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+  - |
+    **[DCS]** Engine version v3 deprecation for ``resource/opentelekomcloud_dcs_instance_v2`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)

--- a/releasenotes/notes/dcs_deprecation-5239058003db5619.yaml
+++ b/releasenotes/notes/dcs_deprecation-5239058003db5619.yaml
@@ -1,6 +1,6 @@
 ---
 deprecations:
   - |
-    **[DCS]** Engine version v3 deprecation for ``resource/opentelekomcloud_dcs_instance_v1`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[DCS]** Engine version v3 deprecation for ``resource/opentelekomcloud_dcs_instance_v1`` (`#2928 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2928>`_)
   - |
-    **[DCS]** Engine version v3 deprecation for ``resource/opentelekomcloud_dcs_instance_v2`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[DCS]** Engine version v3 deprecation for ``resource/opentelekomcloud_dcs_instance_v2`` (`#2928 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2928>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Redis v3.x has reached end of life.

## PR Checklist

* [x] Refers to: #2851
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.
