### PR TITLE
[Doc] DCS: Update argument engine_version in dcs_instance_v2

### DIFF
--- a/docs/resources/dcs_instance_v2.md
+++ b/docs/resources/dcs_instance_v2.md
@@ -56,7 +56,7 @@ The following arguments are supported:
   Changing this creates a new instance.
 
 * `engine_version` - (Optional, String, ForceNew) Specifies the version of a cache engine.
-  It is mandatory when the engine is *Redis*, the value can be 4.0, 5.0 or 6.0.
+  It is mandatory when the engine is *Redis*, the value can be 4.0, 5.0, 6.0 or 7.0.
   Changing this creates a new instance.
 
 * `capacity` - (Required, Float) Specifies the cache capacity. Unit: GB.

--- a/releasenotes/notes/dcs-update-docs-instance-engine-version-1174affbbfc16d58.yaml
+++ b/releasenotes/notes/dcs-update-docs-instance-engine-version-1174affbbfc16d58.yaml
@@ -1,0 +1,4 @@
+---
+doc:
+  - |
+    **[DCS]** Update argument `engine_version` in doc for resource `dcs_incstance_v2` (`#2943 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2943>`_)


### PR DESCRIPTION
## Summary of the Pull Request

Add 7.0 to argument `engine_version` definition in `opentelekomcloud_dcs_instance_v2` resource doc

## PR Checklist

* [x] Refers to: #2941 
* [x] Documentation updated.
* [x] Release notes added.

