### PR TITLE
[Doc] Update docs fix disk and volume type mismatch

### DIFF
--- a/docs/resources/as_configuration_v1.md
+++ b/docs/resources/as_configuration_v1.md
@@ -188,9 +188,10 @@ The `disk` block supports:
   * `SSD`: ultra-high I/O disk type.
   * `co-p1`: high I/O (performance-optimized I) disk type.
   * `uh-l1`: ultra-high I/O (latency-optimized) disk type.
-  -> **NOTE:** Common I/O (SATA) will reach end of life, end of 2025.
+  * `ESSD`: the extreme SSD type
 
-->For HANA, `HL1`, and `HL2` ECSs, use `co-p1` and `uh-l1` disks. For other ECSs, do not use `co-p1` or `uh-l1` disks.
+  -> **NOTE:**
+  Common I/O (SATA) will reach end of life, end of 2025.
 
 * `disk_type` - (Required) Specifies a disk type. The options are as follows:
   * `DATA`: indicates a data disk.

--- a/docs/resources/blockstorage_volume_v2.md
+++ b/docs/resources/blockstorage_volume_v2.md
@@ -7,6 +7,9 @@ description: |-
   Manages a BlockStorage volume resource within OpenTelekomCloud.
 ---
 
+Up-to-date reference of API arguments for EVS blockstorage volume you can get at
+[documentation portal](https://docs.otc.t-systems.com/elastic-volume-service/api-ref/openstack_cinder_apis_recommended/disk_management/index.html)
+
 # opentelekomcloud_blockstorage_volume_v2
 
 Manages a V2 volume resource within OpenTelekomCloud.
@@ -69,8 +72,15 @@ The following arguments are supported:
 * `source_vol_id` - (Optional) The volume ID from which to create the volume.
   Changing this creates a new volume.
 
-* `volume_type` - (Optional) Currently, the value can be `SSD` (ultra-high I/O disk type), `SAS` (high I/O disk type), `SATA` (common I/O disk type), `co-p1` (Exclusive HPC/ SAP HANA: high I/O, performance optimized), or `uh-l1` (Exclusive HPC/ SAP HANA: ultra-high-I/O, latency optimized). Read **Note** for `uh-l1` and `co-p1`: [OTC-API](https://docs.otc.t-systems.com/en-us/api/ecs/en-us_topic_0065817708.html). Changing this creates a new volume.
-  -> **NOTE:** Common I/O (SATA) will reach end of life, end of 2025.
+* `volume_type` - (Optional) Currently, the value can be 
+  * `SATA`: common I/O disk type.
+  * `SAS`: high I/O disk type.
+  * `SSD`: ultra-high I/O disk type.
+  * `GPSSD`: the general purpose SSD type
+  * `ESSD`: the extreme SSD type
+  
+  -> **NOTE:** 
+  Common I/O (SATA) will reach end of life, end of 2025.
 
 * `device_type` - (Optional) The device type of volume to create. Valid options are VBD and SCSI.
   Defaults to VBD. Changing this creates a new volume.

--- a/docs/resources/ecs_instance_v1.md
+++ b/docs/resources/ecs_instance_v1.md
@@ -267,15 +267,16 @@ The following arguments are supported:
 
 * `metadata` - (Optional, Map) Metadata key/value pairs to associate with the instance.
 
-* `system_disk_type` - (Optional, String, ForceNew) The system disk type of the server. For HANA, HL1, and HL2 ECSs use `co-p1` and `uh-l1` disks.
+* `system_disk_type` - (Optional, String, ForceNew) The system disk type of the server.
   Changing this creates a new server. Options are limited depending on AZ. Available options are:
   * `SATA`: common I/O disk type. Available for all AZs.
   * `SAS`: high I/O disk type. Available for all AZs.
   * `SSD`: ultra-high I/O disk type. Available for all AZs.
-  * `co-p1`: high I/O(performance-optimized) disk type.
-  * `uh-l1`: ultra-high I/O(latency-optimized) disk type.
+  * `GPSSD`: the general purpose SSD type
   * `ESSD`: extreme SSD disk type.
-  -> **NOTE:** Common I/O (SATA) will reach end of life, end of 2025.
+
+  -> **NOTE:** 
+  Common I/O (SATA) will reach end of life, end of 2025.
 
 * `system_disk_size` - (Optional, Integer, ForceNew) The system disk size in GB, The value range is 1 to 1024.
   Changing this creates a new server.
@@ -320,15 +321,16 @@ The `metadata` block supports:
 
 The `data_disks` block supports:
 
-* `type` - (Required, String, ForceNew) The data disk type of the server. For HANA, HL1, and HL2 ECSs use `co-p1` and `uh-l1` disks.
+* `type` - (Required, String, ForceNew) The data disk type of the server.
   Changing this creates a new server. Options are limited depending on AZ. Available options are:
   * `SATA`: common I/O disk type. Available for all AZs.
   * `SAS`: high I/O disk type. Available for all AZs.
   * `SSD`: ultra-high I/O disk type. Available for all AZs.
-  * `co-p1`: high I/O(performance-optimized) disk type.
-  * `uh-l1`: ultra-high I/O(latency-optimized) disk type.
+  * `GPSSD`: the general purpose SSD type
   * `ESSD`: extreme SSD disk type.
-  -> **NOTE:** Common I/O (SATA) will reach end of life, end of 2025.
+
+  -> **NOTE:**
+  Common I/O (SATA) will reach end of life, end of 2025.
 
 * `size` - (Required, String, ForceNew) The size of the data disk in GB. The value range is 10 to 32768.
   Changing this creates a new server.

--- a/docs/resources/evs_volume_v3.md
+++ b/docs/resources/evs_volume_v3.md
@@ -57,9 +57,17 @@ The following arguments are supported:
   Changing this creates a new volume.
 
 * `volume_type` - (Required) The type of volume to create.
-  Currently, the value can be `SSD`, `SAS`, `SATA`, `co-p1`, or `uh-l1`.
+  Currently, the value can be:
+  * `SATA`: common I/O disk type. Available for all AZs.
+  * `SAS`: high I/O disk type. Available for all AZs.
+  * `SSD`: ultra-high I/O disk type. Available for all AZs.
+  * `GPSSD`: the general purpose SSD type
+  * `ESSD`: extreme SSD disk type.
+
+  -> **NOTE:**
+  Common I/O (SATA) will reach end of life, end of 2025.
+
   Changing this creates a new volume.
-  -> **NOTE:** Common I/O (SATA) will reach end of life, end of 2025.
 
 * `name` - (Optional) A unique name for the volume. Changing this updates the volume's name.
 

--- a/opentelekomcloud/acceptance/as/resource_opentelekomcloud_as_configuration_v1_test.go
+++ b/opentelekomcloud/acceptance/as/resource_opentelekomcloud_as_configuration_v1_test.go
@@ -57,7 +57,7 @@ func TestAccASV1Configuration_publicIP(t *testing.T) {
 				Config: testAccASV1ConfigurationPublicIP,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckASV1ConfigurationExists(resourceName, &asConfig),
-					resource.TestCheckResourceAttr(resourceName, "scaling_configuration_name", "as_config"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_configuration_name", "as_config_eip"),
 					resource.TestCheckResourceAttrSet(resourceName, "instance_config.0.image"),
 					resource.TestCheckResourceAttr(resourceName, "instance_config.0.key_name", env.OS_KEYPAIR_NAME),
 				),

--- a/releasenotes/notes/docs-update-disk-volume-type-options-49df4c8d32289cb7.yaml
+++ b/releasenotes/notes/docs-update-disk-volume-type-options-49df4c8d32289cb7.yaml
@@ -1,0 +1,10 @@
+---
+doc:
+  - |
+    **[AS]** Update argument `disk/volume_type` in doc for resource `as_configuration_v1` (`#2944 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2944>`_)
+  - |
+    **[EVS]** Update argument `volume_type` in doc for resource `blockstorage_volume_v2` (`#2944 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2944>`_)
+  - |
+    **[ECS]** Update argument `system_disk_type` and `data_disks/type` in doc for resource `ecs_instance_v1` (`#2944 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2944>`_)
+  - |
+    **[EVS]** Update argument `volume_type` in doc for resource `evs_volume_v3` (`#2944 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2944>`_)


### PR DESCRIPTION
## Summary of the Pull Request

Update docs to fix disk and volume type mismatch with API reference docs. 

`co-p1` and `uh-l1` were replaced by `GPSSD` in most services.

## PR Checklist

* [x] Refers to: #2904 
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccASV1Configuration_publicIP
=== PAUSE TestAccASV1Configuration_publicIP
=== CONT  TestAccASV1Configuration_publicIP
    common.go:155: Service: asv1, Region eu-de
--- PASS: TestAccASV1Configuration_publicIP (39.36s)
PASS
```

> [!IMPORTANT]
AS configuration API reference doc retains `co-p1` and `uh-l1` volume type. During testing, `co-p1`, `uh-l1` and `GPSSD` were all accepted values for `volume_type`.
