### PR TITLE
[Feat.] KMS: introduce `kms_project_id` to encrypt buckets via side project keys

### DIFF
--- a/docs/resources/obs_bucket.md
+++ b/docs/resources/obs_bucket.md
@@ -540,6 +540,8 @@ The `server_side_encryption` object supports the following
 
 * `kms_key_id` - (Required) The ID of KMS key used for the encryption.
 
+* `kms_project_id` - (Optional) The ID of the project where the KMS master key belongs.
+
 ~> Only base project (e.g. `eu-de`) KMS keys can be used for the encryption
 
 The `event_notifications` object supports the following

--- a/opentelekomcloud/services/obs/resource_opentelekomcloud_obs_bucket.go
+++ b/opentelekomcloud/services/obs/resource_opentelekomcloud_obs_bucket.go
@@ -305,6 +305,10 @@ func ResourceObsBucket() *schema.Resource {
 								validation.StringInSlice([]string{"kms"}, false),
 							),
 						},
+						"kms_project_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 					},
 				},
 			},
@@ -1448,6 +1452,7 @@ func resourceObsBucketEncryptionUpdate(client *obs.ObsClient, d *schema.Resource
 		BucketEncryptionConfiguration: obs.BucketEncryptionConfiguration{
 			SSEAlgorithm:   d.Get("server_side_encryption.0.algorithm").(string),
 			KMSMasterKeyID: d.Get("server_side_encryption.0.kms_key_id").(string),
+			ProjectID:      d.Get("server_side_encryption.0.kms_project_id").(string),
 		},
 	})
 	if err != nil {
@@ -1469,8 +1474,9 @@ func setObsBucketEncryption(client *obs.ObsClient, d *schema.ResourceData) error
 		return fmt.Errorf("error reading bucket encryption: %w", err)
 	}
 	value = []map[string]interface{}{{
-		"kms_key_id": config.KMSMasterKeyID,
-		"algorithm":  config.SSEAlgorithm,
+		"kms_key_id":     config.KMSMasterKeyID,
+		"algorithm":      config.SSEAlgorithm,
+		"kms_project_id": config.ProjectID,
 	}}
 	return d.Set("server_side_encryption", value)
 }

--- a/releasenotes/notes/obs_encryption-56f51eb775280615.yaml
+++ b/releasenotes/notes/obs_encryption-56f51eb775280615.yaml
@@ -1,4 +1,4 @@
 ---
 enhancements:
   - |
-    **[OBS]** Added new encryption parameter `kms_project_id` for ``resource/opentelekomcloud_obs_bucket`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[OBS]** Added new encryption parameter `kms_project_id` for ``resource/opentelekomcloud_obs_bucket`` (`#2946 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2946>`_)

--- a/releasenotes/notes/obs_encryption-56f51eb775280615.yaml
+++ b/releasenotes/notes/obs_encryption-56f51eb775280615.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[OBS]** Added new encryption parameter `kms_project_id` for ``resource/opentelekomcloud_obs_bucket`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)


### PR DESCRIPTION
## Summary of the Pull Request
New parameter introduced for bucket encryption.

## PR Checklist

* [x] Refers to: #2945
* [x] Tests passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccObsBucket_basic
=== PAUSE TestAccObsBucket_basic
=== CONT  TestAccObsBucket_basic
--- PASS: TestAccObsBucket_basic (190.77s)
PASS

Process finished with the exit code 0
```
