### PR TITLE
[Fix.] FGS: `max_instance_num` fix during `custom_image` update

### DIFF
--- a/opentelekomcloud/services/fgs/resource_opentelekomcloud_fgs_function_v2.go
+++ b/opentelekomcloud/services/fgs/resource_opentelekomcloud_fgs_function_v2.go
@@ -1112,6 +1112,10 @@ func resourceFgsFunctionMetadataUpdate(fgsClient *golangsdk.ServiceClient, urn s
 		strategyConfig := function.StrategyConfig{
 			ConcurrentNum: v.(int),
 		}
+		if v, ok := d.GetOk("max_instance_num"); ok && v.(string) != "" {
+			maxInstanceNum, _ := strconv.Atoi(v.(string))
+			strategyConfig.Concurrency = maxInstanceNum
+		}
 		updateMetadateOpts.StrategyConfig = &strategyConfig
 	}
 

--- a/releasenotes/notes/fgs_func_max_concur-635f6bfb7d7c8561.yaml
+++ b/releasenotes/notes/fgs_func_max_concur-635f6bfb7d7c8561.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[FGS]** Fix `max_instance_num` update for ``resource/opentelekomcloud_fgs_function_v2`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)

--- a/releasenotes/notes/fgs_func_max_concur-635f6bfb7d7c8561.yaml
+++ b/releasenotes/notes/fgs_func_max_concur-635f6bfb7d7c8561.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    **[FGS]** Fix `max_instance_num` update for ``resource/opentelekomcloud_fgs_function_v2`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[FGS]** Fix `max_instance_num` update for ``resource/opentelekomcloud_fgs_function_v2`` (`#2956 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2956>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Fix issue when `max_instance_num` resets if `custom_image` part is updated.

## PR Checklist

* [x] Refers to: #2936
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccFgsV2Function_createByImage
=== PAUSE TestAccFgsV2Function_createByImage
=== CONT  TestAccFgsV2Function_createByImage
--- PASS: TestAccFgsV2Function_createByImage (98.75s)
PASS

Process finished with the exit code 0
```
