### PR TITLE
[Fix] DDM: Add wait to ddm_schema_v1 delete context

### DIFF
--- a/opentelekomcloud/acceptance/ddm/resource_opentelekomcloud_ddm_schema_v1_test.go
+++ b/opentelekomcloud/acceptance/ddm/resource_opentelekomcloud_ddm_schema_v1_test.go
@@ -49,6 +49,15 @@ func TestAccDdmSchemasV1_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(ddmSchemaResourceName, "name", "ddm_schema"),
 				),
 			},
+			// Update test to check forceNew does not throw error and new resource is created.
+			{
+				Config: testAccDdmSchemaV1Update,
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(ddmSchemaResourceName, "name", "ddm_schema"),
+					resource.TestCheckResourceAttr(ddmSchemaResourceName, "shard_unit", "16"),
+				),
+			},
 			{
 				ResourceName:      ddmSchemaResourceName,
 				ImportState:       true,
@@ -70,6 +79,22 @@ resource "opentelekomcloud_ddm_schema_v1" "schema_1" {
   shard_mode   = "cluster"
   shard_number = 8
   shard_unit   = 8
+  rds {
+    id             = "%s"
+    admin_username = "root"
+    admin_password = "test-acc-password-1"
+  }
+  purge_rds_on_delete = true
+}
+`, env.OS_DDM_ID, env.OS_RDS_ID)
+
+var testAccDdmSchemaV1Update = fmt.Sprintf(`
+resource "opentelekomcloud_ddm_schema_v1" "schema_1" {
+  name         = "ddm_schema"
+  instance_id  = "%s"
+  shard_mode   = "cluster"
+  shard_number = 16
+  shard_unit   = 16
   rds {
     id             = "%s"
     admin_username = "root"

--- a/opentelekomcloud/services/ddm/resource_opentelekomcloud_ddm_schema_v1.go
+++ b/opentelekomcloud/services/ddm/resource_opentelekomcloud_ddm_schema_v1.go
@@ -205,7 +205,7 @@ func resourceDdmSchemaV1Create(ctx context.Context, d *schema.ResourceData, meta
 	instanceId := d.Get("instance_id").(string)
 	ddmSchema, err := schemas.CreateSchema(client, instanceId, createOpts)
 	if err != nil {
-		return fmterr.Errorf("error getting OpenTelekomCloud DDM instance from result: %w", err)
+		return fmterr.Errorf("error getting OpenTelekomCloud DDM schema from result: %w", err)
 	}
 	schemaName := ddmSchema.Databases[0].Name
 	id := fmt.Sprintf("%s/%s", instanceId, schemaName)
@@ -243,10 +243,10 @@ func resourceDdmSchemaV1Read(ctx context.Context, d *schema.ResourceData, meta i
 	ddmInstanceId := d.Get("instance_id").(string)
 	sc, err := schemas.QuerySchemaDetails(client, ddmInstanceId, schemaName)
 	if err != nil {
-		return fmterr.Errorf("error fetching DDM instance: %w", err)
+		return fmterr.Errorf("error fetching DDM schema: %w", err)
 	}
 
-	log.Printf("[DEBUG] Retrieved instance %s: %#v", schemaName, sc.Database)
+	log.Printf("[DEBUG] Retrieved schema %s: %#v", schemaName, sc.Database)
 
 	mErr := multierror.Append(nil,
 		d.Set("region", config.GetRegion(d)),
@@ -321,6 +321,11 @@ func resourceDdmSchemaV1Delete(ctx context.Context, d *schema.ResourceData, meta
 		return fmterr.Errorf("error deleting OpenTelekomCloud DDM schema: %s", err)
 	}
 
+	err = WaitForDeleteSchema(client, 600, 5, ddmInstanceId, schemaName)
+	if err != nil {
+		return fmterr.Errorf("error waiting for OpenTelekomCloudDDM schema (%s) to be deleted: %w", schemaName, err)
+	}
+
 	d.SetId("")
 	return nil
 }
@@ -340,4 +345,31 @@ func resourceDDMSchemaRDSV1(d *schema.ResourceData) []schemas.DatabaseInstancesP
 		rdsInstances = append(rdsInstances, rdsInstance)
 	}
 	return rdsInstances
+}
+
+func WaitForDeleteSchema(client *golangsdk.ServiceClient, waitTime int, interval time.Duration, ddmInstanceId, schemaName string) error {
+	jobClient := *client
+	jobClient.ResourceBase = jobClient.Endpoint
+
+	return golangsdk.WaitFor(waitTime, func() (bool, error) {
+		schemasList, err := schemas.QuerySchemas(client, ddmInstanceId, schemas.QuerySchemasOpts{
+			Limit: 128,
+		})
+		if err != nil {
+			return false, err
+		}
+		found := false
+
+		for _, schema := range schemasList {
+			if schema.Name == schemaName {
+				found = true
+			}
+		}
+		if !found {
+			return true, nil
+		}
+
+		time.Sleep(interval * time.Second)
+		return false, nil
+	})
 }

--- a/releasenotes/notes/ddm-fix-schema-delete-context-08126aa6b980ca9c.yaml
+++ b/releasenotes/notes/ddm-fix-schema-delete-context-08126aa6b980ca9c.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[DDM]** Check delete completed for ``resource/opentelekomcloud_ddm_schema_v1`` (`#2965 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2965>`_)


### PR DESCRIPTION
## Summary of the Pull Request

ForceNew calls for delete context followed by Create context. Delete API is called but execution takes time in cloud. Need to add wait so that delete is ensured.

## PR Checklist

* [x] Refers to: #2957 
* [x] Tests added/passed.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccDdmSchemasV1_basic
--- PASS: TestAccDdmSchemasV1_basic (150.18s)
PASS
```
