### PR TITLE
[Fix] DDM: Fix param_group_id validation in ddm_instance_v1

### DIFF
--- a/opentelekomcloud/services/ddm/resource_opentelekomcloud_ddm_instance_v1.go
+++ b/opentelekomcloud/services/ddm/resource_opentelekomcloud_ddm_instance_v1.go
@@ -86,9 +86,8 @@ func ResourceDdmInstanceV1() *schema.Resource {
 				ValidateFunc: validation.IsUUID,
 			},
 			"param_group_id": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.IsUUID,
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 			"time_zone": {
 				Type:         schema.TypeString,

--- a/releasenotes/notes/ddm-fix-instance-v1-arg-fae0640b50c83202.yaml
+++ b/releasenotes/notes/ddm-fix-instance-v1-arg-fae0640b50c83202.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[DDM]** Remove validation in ``param_group_id`` schema parameter in ``resource/opentelekomcloud_ddm_schema_v1`` (`#2966 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2966>`_)


### PR DESCRIPTION
## Summary of the Pull Request

Fix param_group_id validation in ddm_instance_v1

## PR Checklist

* [x] Refers to: #2964 
* [x] Tests added/passed.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccDdmInstancesV1_basic
--- PASS: TestAccDdmInstancesV1_basic (369.84s)
PASS
```

> [!NOTE]
tested using the id of default parameter template as `param_group_id`. 