### PR TITLE
[Fix] RDS: fix required restart after `parameters` update

### DIFF
--- a/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_instance_v3.go
+++ b/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_instance_v3.go
@@ -1478,11 +1478,11 @@ func updateInstanceParameters(d *schema.ResourceData, client *golangsdk.ServiceC
 		Values:     d.Get("parameters").(map[string]interface{}),
 		InstanceId: d.Id(),
 	}
-	_, err := configurations.UpdateInstanceConfiguration(client, opts)
+	rawConf, err := configurations.UpdateInstanceConfiguration(client, opts)
 	if err != nil {
 		return false, err
 	}
-	return true, err
+	return rawConf.RestartRequired, err
 }
 
 func rdsInstanceStateRefreshFunc(client *golangsdk.ServiceClient, instanceID string) resource.StateRefreshFunc {

--- a/releasenotes/notes/rds_params_update-b594574343657ef8.yaml
+++ b/releasenotes/notes/rds_params_update-b594574343657ef8.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[RDS]** Change required restart option for ``resource/opentelekomcloud_rds_instance_v3`` after `parameters` update depending on API response (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)

--- a/releasenotes/notes/rds_params_update-b594574343657ef8.yaml
+++ b/releasenotes/notes/rds_params_update-b594574343657ef8.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    **[RDS]** Change required restart option for ``resource/opentelekomcloud_rds_instance_v3`` after `parameters` update depending on API response (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[RDS]** Change required restart option for ``resource/opentelekomcloud_rds_instance_v3`` after `parameters` update depending on API response (`#2973 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2973>`_)


### PR DESCRIPTION
## Summary of the Pull Request
RDS instances now only restart when necessary after `parameters` changes, reducing unnecessary downtime.

## PR Checklist

* [x] Refers to: #2970
* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccRdsPostgre13V3ParamsBasic
--- PASS: TestAccRdsPostgre13V3ParamsBasic (558.81s)
PASS

Process finished with the exit code 0
```
