### PR TITLE
[Fix] Add missing argument `server` when importing existing `opentelekomcloud_waf_domain_v1`

### DIFF
--- a/opentelekomcloud/services/waf/resource_domain_v1.go
+++ b/opentelekomcloud/services/waf/resource_domain_v1.go
@@ -344,6 +344,7 @@ func resourceWafDomainV1Read(_ context.Context, d *schema.ResourceData, meta int
 	}
 
 	mErr = multierror.Append(mErr,
+		d.Set("server", servers),
 		d.Set("block_page", blockPage),
 	)
 	if err := mErr.ErrorOrNil(); err != nil {


### PR DESCRIPTION
## Summary of the Pull Request

When Terraform imports the existing WAF domain into the `opentelekomcloud_waf_domain_v1` resource, it receives all servers attached to the given WAF domain in the API response but does not add them to the generated resource configuration.

## PR Checklist

* [ ] Refers to: #2999
