### PR TITLE
[Feat.] CES: Add data source ces_events_v1

### DIFF
--- a/docs/data-sources/ces_events_v1.md
+++ b/docs/data-sources/ces_events_v1.md
@@ -1,0 +1,56 @@
+---
+subcategory: "Cloud Eye (CES)"
+layout: "opentelekomcloud"
+page_title: "OpenTelekomCloud: opentelekomcloud_ces_events_v1"
+sidebar_current: "docs-opentelekomcloud-datasource-ces-events-v1"
+description: |-
+  Get details about CES events within OpenTelekomCloud.
+---
+
+Up-to-date reference of API arguments for CES events v1 you can get at
+[documentation portal](https://docs.otc.t-systems.com/cloud-eye/api-ref/api_description/event_monitoring/index.html)
+
+# opentelekomcloud_ces_events_v1
+
+Get details about CES events within OpenTelekomCloud.
+
+## Example Usage
+
+```hcl
+data "opentelekomcloud_ces_events_v1" "events_1" {
+  event_type = "EVENT.CUSTOM"
+  from       = 1257893000000
+  to         = 1257895000000
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `event_name` - (Optional, String) Specifies the event name.
+
+* `event_type` - (Optional, String) Specifies the event type. The value can be `EVENT.SYS` (system event) or `EVENT.CUSTOM` (custom event).
+
+* `from` - (Optional, Int) Specifies the start time of the query, which is a UNIX timestamp (ms). 
+
+* `to` - (Optional, Int) Specifies the end time of the query, which is a UNIX timestamp (ms). 
+
+* `limit` - (Optional, Int) Specifies the maximum number of records that can be queried at a time. Supported range: `1` to `100` (default)
+
+## Attributes Reference
+
+In addition to the arguments mentioned above, the following attributes are exported:
+
+* `events` - Specifies one or more pieces of event data. The structure is described below. 
+* `meta_data` - Specifies the number of metadata records in the query result. The structure is described below.
+    * `total` - Specifies the total number of events.
+
+
+The `events` block supports:
+
+* `event_name` - Specifies the event name.
+* `event_type` - Specifies the event type.
+* `event_count` - Specifies the number of occurrences of this event within the specified query time range.
+* `latest_occur_time` - Specifies when the event occurred, which is a UNIX timestamp (ms).
+* `latest_event_source` - Specifies the event source. If the event is a system event, the source is the namespace of each service. If the event is a custom event, the event source is defined by the user.

--- a/opentelekomcloud/acceptance/ces/data_source_opentelekomcloud_ces_events_v1_test.go
+++ b/opentelekomcloud/acceptance/ces/data_source_opentelekomcloud_ces_events_v1_test.go
@@ -64,8 +64,8 @@ resource "opentelekomcloud_ces_event_report_v1" "event_report_1" {
 data "opentelekomcloud_ces_events_v1" "events_1" {
   depends_on = [opentelekomcloud_ces_event_report_v1.event_report_1]
   event_type = "EVENT.CUSTOM"
-  from  = %d
-  to    = %d
-  limit = 1
+  from       = %d
+  to         = %d
+  limit      = 1
 }
 `, time.Now().Unix()*1000, time.Now().Unix()*1000-100000, time.Now().Unix()*1000+10000)

--- a/opentelekomcloud/acceptance/ces/data_source_opentelekomcloud_ces_events_v1_test.go
+++ b/opentelekomcloud/acceptance/ces/data_source_opentelekomcloud_ces_events_v1_test.go
@@ -1,0 +1,71 @@
+package acceptance
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+)
+
+const eventsdataSourceName = "data.opentelekomcloud_ces_events_v1.events_1"
+
+func TestAccCESEventsV1DataSource_basic(t *testing.T) {
+	if os.Getenv("RUN_CES_EVENTS") == "" {
+		t.Skip("CES tests are not suitable for CI runner unless specifically flagged")
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testCESEventsBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCESEventsV1DataSourceID(eventsdataSourceName),
+					resource.TestCheckResourceAttr(eventsdataSourceName, "meta_data.0.total", "1"),
+					resource.TestCheckResourceAttr(eventsdataSourceName, "events.0.latest_event_source", "SYS.ECS"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCESEventsV1DataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("can't find CES Events data source: %s ", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("CES events data source ID not set")
+		}
+
+		return nil
+	}
+}
+
+var testCESEventsBasic = fmt.Sprintf(`
+resource "opentelekomcloud_ces_event_report_v1" "event_report_1" {
+  event_name   = "Test_Acc_tf_event"
+  event_source = "SYS.ECS"
+  time         = %d
+  detail {
+    content     = "This is a test event run by TF tests"
+    event_state = "normal"
+    event_level = "Info"
+  }
+}
+
+data "opentelekomcloud_ces_events_v1" "events_1" {
+  depends_on = [opentelekomcloud_ces_event_report_v1.event_report_1]
+  event_type = "EVENT.CUSTOM"
+  from  = %d
+  to    = %d
+  limit = 1
+}
+`, time.Now().Unix()*1000, time.Now().Unix()*1000-100000, time.Now().Unix()*1000+10000)

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -274,6 +274,7 @@ func Provider() *schema.Provider {
 			"opentelekomcloud_cce_node_ids_v3":                    cce.DataSourceCceNodeIdsV3(),
 			"opentelekomcloud_cce_node_v3":                        cce.DataSourceCceNodesV3(),
 			"opentelekomcloud_ces_event_details_v1":               ces.DataSourceCesEventDetailsV1(),
+			"opentelekomcloud_ces_events_v1":                      ces.DataSourceCesEventsV1(),
 			"opentelekomcloud_cfw_firewall_v1":                    cfw.DataSourceCfwFirewallV1(),
 			"opentelekomcloud_compute_availability_zones_v2":      ecs.DataSourceComputeAvailabilityZonesV2(),
 			"opentelekomcloud_compute_bms_flavors_v2":             bms.DataSourceBMSFlavorV2(),

--- a/opentelekomcloud/services/ces/data_source_opentelekomcloud_ces_events_v1.go
+++ b/opentelekomcloud/services/ces/data_source_opentelekomcloud_ces_events_v1.go
@@ -1,0 +1,150 @@
+package ces
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/ces/v1/events"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
+)
+
+func DataSourceCesEventsV1() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceCesEventsRead,
+
+		Schema: map[string]*schema.Schema{
+			"event_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"event_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"EVENT.SYS", "EVENT.CUSTOM",
+				}, false),
+			},
+			"from": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"to": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"limit": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      100,
+				ValidateFunc: validation.IntBetween(1, 100),
+			},
+			"events": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"event_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"event_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"event_count": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"latest_occur_time": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"latest_event_source": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"meta_data": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"total": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceCesEventsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, cesClientV1, func() (*golangsdk.ServiceClient, error) {
+		return config.CesV1Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationClient, err)
+	}
+
+	listOpts := events.ListEventsOpts{
+		EventName: d.Get("event_name").(string),
+		EventType: d.Get("event_type").(string),
+		From:      InterfaceToInt64(d.Get("from")),
+		To:        InterfaceToInt64(d.Get("to")),
+		Limit:     d.Get("limit").(int),
+	}
+
+	listEvents, err := events.ListEvents(client, listOpts)
+	if err != nil {
+		return fmterr.Errorf("error fetching event : %w", err)
+	}
+
+	d.SetId(tools.RandomString("events_", 10))
+
+	log.Printf("[DEBUG] Retrieved events list %s: %#v", d.Id(), listEvents)
+
+	metadata := []map[string]interface{}{
+		{
+			"total": listEvents.MetaData.Total,
+		},
+	}
+
+	mErr := multierror.Append(
+		d.Set("events", setEvents(listEvents.Events)),
+		d.Set("meta_data", metadata),
+	)
+
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func setEvents(eventInfoListInResp []events.EventInfo) []map[string]interface{} {
+	var eventInfoList []map[string]interface{}
+	for _, eventInfoInResp := range eventInfoListInResp {
+		eventInfo := map[string]interface{}{
+			"event_name":          eventInfoInResp.EventName,
+			"event_type":          eventInfoInResp.EventType,
+			"event_count":         eventInfoInResp.EventCount,
+			"latest_occur_time":   eventInfoInResp.LatestOccurTime,
+			"latest_event_source": eventInfoInResp.LatestEventSource,
+		}
+		eventInfoList = append(eventInfoList, eventInfo)
+	}
+	return eventInfoList
+}

--- a/releasenotes/notes/ces-add-data-source-events-v1-10b4510209880572.yaml
+++ b/releasenotes/notes/ces-add-data-source-events-v1-10b4510209880572.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    **[CES]** Add new data source ``opentelekomcloud_ces_events_v1`` (`#3005 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3005>`_).


### PR DESCRIPTION
## Summary of the Pull Request

Add data source `opentelekomcloud_ces_events_v1`

## PR Checklist

* [x] Refers to: #2982 
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccCESEventsV1DataSource_basic
--- PASS: TestAccCESEventsV1DataSource_basic (25.45s)
PASS
```
