### PR TITLE
[Feat.] RDS: Add `private_ip` parameter for `opentelekomcloud_rds_instance_v3`

### DIFF
--- a/docs/resources/rds_instance_v3.md
+++ b/docs/resources/rds_instance_v3.md
@@ -342,6 +342,8 @@ The following arguments are supported:
 
 * `vpc_id` - (Required, ForceNew) Specifies the VPC ID. Changing this parameter will create a new resource.
 
+* `private_ip` - (Optional, ForceNew) Specifies the private IP address of a DB instance.
+
 * `backup_strategy` - (Optional) Specifies the advanced backup policy. Structure is documented below.
 
 * `ha_replication_mode` - (Optional, ForceNew) Specifies the replication mode for the standby DB instance. For MySQL, the value

--- a/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
+++ b/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
@@ -2,6 +2,7 @@ package acceptance
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"testing"
 
@@ -384,6 +385,27 @@ func TestAccRdsInstanceV3_SSLEnable(t *testing.T) {
 	})
 }
 
+func TestAccRdsInstanceV3_PrivateIp(t *testing.T) {
+	postfix := acctest.RandString(3)
+	var rdsInstance instances.InstanceResponse
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckRdsInstanceV3Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRdsInstanceV3PrivateIp(postfix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRdsInstanceV3Exists(instanceV3ResourceName, &rdsInstance),
+					resource.TestCheckResourceAttrPair(instanceV3ResourceName, "private_ips.0", instanceV3ResourceName, "private_ip"),
+					testAccCheckRdsInstanceV3PrivateIp(),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckRdsInstanceV3Destroy(s *terraform.State) error {
 	config := common.TestAccProvider.Meta().(*cfg.Config)
 	client, err := config.RdsV3Client(env.OS_REGION_NAME)
@@ -429,6 +451,36 @@ func testAccCheckRdsInstanceV3Exists(n string, rdsInstance *instances.InstanceRe
 		}
 
 		*rdsInstance = *found
+
+		return nil
+	}
+}
+
+func testAccCheckRdsInstanceV3PrivateIp() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		subnet, ok := s.RootModule().Resources["data.opentelekomcloud_vpc_subnet_v1.shared_subnet"]
+		if !ok {
+			return fmt.Errorf("subnet not found in state")
+		}
+
+		subnetCIDR := subnet.Primary.Attributes["cidr"]
+
+		rs, ok := s.RootModule().Resources[instanceV3ResourceName]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", instanceV3ResourceName)
+		}
+
+		actualIP := rs.Primary.Attributes["private_ip"]
+
+		_, network, _ := net.ParseCIDR(subnetCIDR)
+		ip := make(net.IP, len(network.IP))
+		copy(ip, network.IP)
+
+		ip[len(ip)-1] += byte(10)
+
+		if actualIP != ip.String() {
+			return fmt.Errorf("expected private_ip %s (from CIDR %s + 10), got %s", ip.String(), subnetCIDR, actualIP)
+		}
 
 		return nil
 	}
@@ -1162,6 +1214,33 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
   parameters = {
     require_secure_transport = "ON"
   }
+}
+`, common.DataSourceSecGroupDefault, common.DataSourceSubnet, postfix, env.OS_AVAILABILITY_ZONE)
+}
+
+func testAccRdsInstanceV3PrivateIp(postfix string) string {
+	return fmt.Sprintf(`
+%s
+%s
+
+resource "opentelekomcloud_rds_instance_v3" "instance" {
+  name              = "tf_rds_instance_%s"
+  availability_zone = ["%s"]
+  db {
+    password = "Postgres!120521"
+    type     = "PostgreSQL"
+    version  = "15"
+    port     = "8635"
+  }
+  security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
+  subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  private_ip        = cidrhost(data.opentelekomcloud_vpc_subnet_v1.shared_subnet.cidr, 10)
+  volume {
+    type = "CLOUDSSD"
+    size = 40
+  }
+  flavor = "rds.pg.n1.large.4"
 }
 `, common.DataSourceSecGroupDefault, common.DataSourceSubnet, postfix, env.OS_AVAILABILITY_ZONE)
 }

--- a/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_instance_v3.go
+++ b/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_instance_v3.go
@@ -207,6 +207,11 @@ func ResourceRdsInstanceV3() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"private_ip": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 			"backup_strategy": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -443,6 +448,7 @@ func resourceRdsInstanceV3Create(ctx context.Context, d *schema.ResourceData, me
 			AvailabilityZone: resourceRDSAvailabilityZones(d),
 			VpcId:            d.Get("vpc_id").(string),
 			SubnetId:         d.Get("subnet_id").(string),
+			DataVip:          d.Get("private_ip").(string),
 			SecurityGroupId:  d.Get("security_group_id").(string),
 			RestorePoint:     resourceRestorePoint(d),
 		}
@@ -473,6 +479,7 @@ func resourceRdsInstanceV3Create(ctx context.Context, d *schema.ResourceData, me
 			AvailabilityZone: resourceRDSAvailabilityZones(d),
 			VpcId:            d.Get("vpc_id").(string),
 			SubnetId:         d.Get("subnet_id").(string),
+			DataVip:          d.Get("private_ip").(string),
 			SecurityGroupId:  d.Get("security_group_id").(string),
 			ChargeInfo:       resourceRDSChangeMode(),
 		}

--- a/releasenotes/notes/rds_instance_private_ip-921ecc5716c6f7f1.yaml
+++ b/releasenotes/notes/rds_instance_private_ip-921ecc5716c6f7f1.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    **[RDS]** Added new parameter `private_ip` for ``opentelekomcloud_rds_instance_v3``
+    (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)

--- a/releasenotes/notes/rds_instance_private_ip-921ecc5716c6f7f1.yaml
+++ b/releasenotes/notes/rds_instance_private_ip-921ecc5716c6f7f1.yaml
@@ -2,4 +2,4 @@
 enhancements:
   - |
     **[RDS]** Added new parameter `private_ip` for ``opentelekomcloud_rds_instance_v3``
-    (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    (`#3019 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3019>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Add possibility to customize `private_ip` for `opentelekomcloud_rds_instance_v3` on instance creation.

## PR Checklist

* [x] Refers to: #2994
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccRdsInstanceV3_PrivateIp
--- PASS: TestAccRdsInstanceV3_PrivateIp (350.77s)
PASS

Process finished with the exit code 0

=== RUN   TestAccRdsInstanceV3Basic
--- PASS: TestAccRdsInstanceV3Basic (780.31s)
PASS

Process finished with the exit code 0
```
