### PR TITLE
[Feat.] OBS: bucket lifecycle rules `tag` filter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,8 +22,6 @@ linters:
     - typecheck
     - unused
     - unconvert
-    - vet
-    - vetshadow
     - whitespace
 
 linters-settings:

--- a/docs/resources/obs_bucket.md
+++ b/docs/resources/obs_bucket.md
@@ -278,6 +278,14 @@ resource "opentelekomcloud_obs_bucket" "bucket" {
     prefix  = "tmp/"
     enabled = true
 
+    tag {
+      key   = "key1"
+      value = "value1"
+    }
+    tag {
+      key   = "key2"
+      value = "value2"
+    }
     noncurrent_version_expiration {
       days = 180
     }
@@ -496,6 +504,8 @@ The `lifecycle_rule` object supports the following:
   or end with a slash (/), cannot have consecutive slashes (/), and cannot contain the following
   special characters: \:*?"<>|.
 
+* `tag` - (Optional) A list of tags to filter objects. Maximum 10 tags per rule with unique keys (documented below).
+
 * `expiration` - (Optional) Specifies a period when objects that have been last updated are automatically
   deleted. (documented below).
 
@@ -510,6 +520,12 @@ The `lifecycle_rule` object supports the following:
 
 -> At least one of `expiration`, `transition`, `noncurrent_version_expiration`, `noncurrent_version_transition`
 must be specified.
+
+The `tag` object supports the following:
+
+* `key` - (Required) The tag key. Must be unique within the rule, cannot be blank, maximum 128 characters. Cannot contain: =*<>\,|/?!;
+
+* `value` - (Required) The tag value. Can be blank, maximum 255 characters. Cannot contain: =*<>\,|?!;
 
 The `expiration` object supports the following
 

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20250708094148-5a80a893b91b
+	github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20250709111330-64176d138ab5
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.31.0
 	golang.org/x/sync v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -158,8 +158,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k+Mg7cowZ8yv4Trqw9UsJby758=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20250708094148-5a80a893b91b h1:Agp1tVT0D9XSrijaNvw/EHfUk0rk2EzQvAIXRCKlIyY=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20250708094148-5a80a893b91b/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20250709111330-64176d138ab5 h1:K45kEB1SxZnrWlYurBRpNfQuawlbS2mjZslEpFLk49I=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20250709111330-64176d138ab5/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/opentelekomcloud/acceptance/obs/resource_opentelekomcloud_obs_bucket_test.go
+++ b/opentelekomcloud/acceptance/obs/resource_opentelekomcloud_obs_bucket_test.go
@@ -162,6 +162,33 @@ func TestAccObsBucket_lifecycle(t *testing.T) {
 	})
 }
 
+func TestAccObsBucket_lifecycleFilter(t *testing.T) {
+	rInt := acctest.RandInt()
+	resourceName := "opentelekomcloud_obs_bucket.bucket"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckObsBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccObsBucketConfigWithLifecycleFilter(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "lifecycle_rule.0.name", "rule1"),
+					resource.TestCheckResourceAttr(resourceName, "lifecycle_rule.0.prefix", "path1/"),
+					resource.TestCheckResourceAttr(resourceName, "lifecycle_rule.1.name", "rule2"),
+					resource.TestCheckResourceAttr(resourceName, "lifecycle_rule.1.prefix", "path2/"),
+					resource.TestCheckResourceAttr(resourceName, "lifecycle_rule.1.tag.0.key", "key1"),
+					resource.TestCheckResourceAttr(resourceName, "lifecycle_rule.1.tag.0.value", "value1"),
+					resource.TestCheckResourceAttr(resourceName, "lifecycle_rule.1.tag.1.key", "key2"),
+					resource.TestCheckResourceAttr(resourceName, "lifecycle_rule.1.tag.1.value", "value2"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccObsBucket_website(t *testing.T) {
 	rInt := acctest.RandInt()
 	resourceName := "opentelekomcloud_obs_bucket.bucket"
@@ -567,6 +594,47 @@ resource "opentelekomcloud_obs_bucket" "bucket" {
     noncurrent_version_transition {
       days          = 180
       storage_class = "COLD"
+    }
+  }
+}
+`, randInt)
+}
+
+func testAccObsBucketConfigWithLifecycleFilter(randInt int) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_obs_bucket" "bucket" {
+  bucket     = "tf-test-bucket-%d"
+  acl        = "private"
+  versioning = true
+
+  lifecycle_rule {
+    name    = "rule1"
+    prefix  = "path1/"
+    enabled = true
+
+    expiration {
+      days = 365
+    }
+  }
+  lifecycle_rule {
+    name    = "rule2"
+    prefix  = "path2/"
+    enabled = true
+    tag {
+      key   = "key1"
+      value = "value1"
+    }
+    tag {
+      key   = "key2"
+      value = "value2"
+    }
+    noncurrent_version_expiration {
+      days = 365
+    }
+
+    noncurrent_version_transition {
+      days          = 60
+      storage_class = "WARM"
     }
   }
 }

--- a/opentelekomcloud/services/obs/resource_opentelekomcloud_obs_bucket.go
+++ b/opentelekomcloud/services/obs/resource_opentelekomcloud_obs_bucket.go
@@ -196,6 +196,22 @@ func ResourceObsBucket() *schema.Resource {
 								},
 							},
 						},
+						"tag": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"value": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -777,8 +793,29 @@ func mapToRule(src map[string]interface{}) (rule obs.LifecycleRule) {
 		rule.Status = obs.RuleStatusDisabled
 	}
 
-	// Prefix
-	rule.Prefix = src["prefix"].(string)
+	prefix := src["prefix"].(string)
+
+	tags := src["tag"].([]interface{})
+
+	// Filter
+	if len(tags) > 0 {
+		filter := obs.LifecycleFilter{
+			Prefix: prefix,
+		}
+		tagList := make([]obs.Tag, len(tags))
+		for i, tag := range tags {
+			tagMap := tag.(map[string]interface{})
+			tagList[i] = obs.Tag{
+				Key:   tagMap["key"].(string),
+				Value: tagMap["value"].(string),
+			}
+		}
+		filter.Tags = tagList
+		rule.Filter = filter
+	} else {
+		// Prefix
+		rule.Prefix = prefix
+	}
 
 	// Expiration
 	expiration := src["expiration"].(*schema.Set).List()
@@ -1103,6 +1140,16 @@ func ruleToMap(src obs.LifecycleRule) map[string]interface{} {
 
 	if src.Prefix != "" {
 		rule["prefix"] = src.Prefix
+	} else if src.Filter.Prefix != "" {
+		rule["prefix"] = src.Filter.Prefix
+		tags := make([]interface{}, len(src.Filter.Tags))
+		for i, v := range src.Filter.Tags {
+			tag := make(map[string]interface{})
+			tag["key"] = v.Key
+			tag["value"] = v.Value
+			tags[i] = tag
+		}
+		rule["tag"] = tags
 	}
 
 	// expiration

--- a/releasenotes/notes/obs_lifecycle_tags-c76e3fb69e3cc4aa.yaml
+++ b/releasenotes/notes/obs_lifecycle_tags-c76e3fb69e3cc4aa.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[OBS]** Add tag filters for lifecycle rules for ``opentelekomcloud_obs_bucket`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)

--- a/releasenotes/notes/obs_lifecycle_tags-c76e3fb69e3cc4aa.yaml
+++ b/releasenotes/notes/obs_lifecycle_tags-c76e3fb69e3cc4aa.yaml
@@ -1,4 +1,4 @@
 ---
 enhancements:
   - |
-    **[OBS]** Add tag filters for lifecycle rules for ``opentelekomcloud_obs_bucket`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[OBS]** Add tag filters for lifecycle rules for ``opentelekomcloud_obs_bucket`` (`#3030 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3030>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Add a new `tag` filter for bucket lifecycle rules.

## PR Checklist

* [x] Refers to: #2839, #3011
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccObsBucket_lifecycleFilter
=== PAUSE TestAccObsBucket_lifecycleFilter
=== CONT  TestAccObsBucket_lifecycleFilter
--- PASS: TestAccObsBucket_lifecycleFilter (26.32s)
PASS

Process finished with the exit code 0

=== RUN   TestAccObsBucket_lifecycle
=== PAUSE TestAccObsBucket_lifecycle
=== CONT  TestAccObsBucket_lifecycle
--- PASS: TestAccObsBucket_lifecycle (27.03s)
PASS

Process finished with the exit code 0

=== RUN   TestAccObsBucket_basic
=== PAUSE TestAccObsBucket_basic
=== CONT  TestAccObsBucket_basic
--- PASS: TestAccObsBucket_basic (86.47s)
PASS

Process finished with the exit code 0
```
