### PR TITLE
[Feat.] FGS: `fgs_function_v2` new parameters

### DIFF
--- a/docs/resources/fgs_function_v2.md
+++ b/docs/resources/fgs_function_v2.md
@@ -302,6 +302,10 @@ The following arguments are supported:
 * `reserved_instances` - (Optional, List) Specifies the reserved instance policies of the function.
   The `reserved_instances` structure is documented below.
 
+* `gpu_memory` - (Optional, Int) Specifies the GPU memory size allocated to the function, in MByte (MB).
+  The valid value ranges form `1,024` to `16,384`, the value must be a multiple of `1,024`.
+  If not specified, the GPU function is disabled.
+
 * `pre_stop_handler` - (Optional, String) Specifies the pre-stop handler of a function. The value must contain a period (.)
  in the format of xx.xx. For example, for Node.js function myfunction.pre_stop_handler, the file name is myfunction.js,
  and the initialization function is pre_stop_handler.

--- a/docs/resources/fgs_function_v2.md
+++ b/docs/resources/fgs_function_v2.md
@@ -145,6 +145,43 @@ resource "opentelekomcloud_fgs_function_v2" "test" {
 }
 ```
 
+### Create function with advanced configuration
+
+```hcl
+variable "function_name" {}
+variable "function_codes" {}
+variable "agency_name" {}
+variable "trigger_access_vpc_ids" {
+  type = list(string)
+}
+
+resource "opentelekomcloud_fgs_function_v2" "test" {
+  name                  = var.function_name
+  app                   = "default"
+  agency                = var.agency_name
+  description           = "fuction test"
+  handler               = "test.handler"
+  memory_size           = 128
+  timeout               = 3
+  runtime               = "Python2.7"
+  code_type             = "inline"
+  func_code             = base64encode(var.function_codes)
+  functiongraph_version = "v2"
+
+  network_controller {
+    disable_public_network = true
+
+    dynamic "trigger_access_vpcs" {
+      for_each = var.trigger_access_vpc_ids
+
+      content {
+        vpc_id = trigger_access_vpcs.value
+      }
+    }
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -265,9 +302,18 @@ The following arguments are supported:
 * `reserved_instances` - (Optional, List) Specifies the reserved instance policies of the function.
   The `reserved_instances` structure is documented below.
 
-* `gpu_memory` - (Optional, Int) Specifies the GPU memory size allocated to the function, in MByte (MB).
-  The valid value ranges form `1,024` to `16,384`, the value must be a multiple of `1,024`.
-  If not specified, the GPU function is disabled.
+* `pre_stop_handler` - (Optional, String) Specifies the pre-stop handler of a function. The value must contain a period (.)
+ in the format of xx.xx. For example, for Node.js function myfunction.pre_stop_handler, the file name is myfunction.js,
+ and the initialization function is pre_stop_handler.
+
+* `pre_stop_timeout` - (Optional, Int) Specifies the maximum duration the function can be initialized. Value range: 1s-90s.
+
+* `network_controller` - (Optional, List) Specifies the network configuration of the function.
+  The [network_controller](#function_network_controller) structure is documented below.
+
+* `peering_cidr` - (Optional, String) Specifies the VPC cidr blocks used in the function code to detect whether it
+  conflicts with the VPC cidr blocks used by the service.
+  The cidr blocks are separated by semicolons and cannot exceed `5`.
 
 The `func_mounts` block supports:
 
@@ -362,6 +408,21 @@ The `cron_configs` block supports:
 * `start_time` - (Required, Int) Specifies the effective timestamp of policy. The unit is `s`, e.g. **1740560074**.
 
 * `expired_time` - (Required, Int) Specifies the expiration timestamp of the policy. The unit is `s`, e.g. **1740560074**.
+
+<a name="function_network_controller"></a>
+The `network_controller` block supports:
+
+* `trigger_access_vpcs` - (Optional, List) Specifies the configuration of the VPCs that can trigger the function.
+  The [trigger_access_vpcs](#function_network_controller_trigger_access_vpcs) structure is documented below.
+
+* `disable_public_network` - (Optional, Bool) Specifies whether to disable the public network access.
+
+<a name="function_network_controller_trigger_access_vpcs"></a>
+The `trigger_access_vpcs` block supports:
+
+* `vpc_id` - (Optional, String) Specifies the ID of the VPC that can trigger the function.
+
+* `vpc_name` - (Optional, String) Specifies the name of the VPC that can trigger the function.
 
 ## Attribute Reference
 

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20250709111330-64176d138ab5
+	github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20250714130502-df17d32e643e
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.31.0
 	golang.org/x/sync v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -158,8 +158,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k+Mg7cowZ8yv4Trqw9UsJby758=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20250709111330-64176d138ab5 h1:K45kEB1SxZnrWlYurBRpNfQuawlbS2mjZslEpFLk49I=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20250709111330-64176d138ab5/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20250714130502-df17d32e643e h1:+OFyKTz5bxsXDKTtvqmMU3uBFDnIAWG/3ZmQSUn4lew=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.4-0.20250714130502-df17d32e643e/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/opentelekomcloud/acceptance/fgs/resource_opentelekomcloud_fgs_function_v2_test.go
+++ b/opentelekomcloud/acceptance/fgs/resource_opentelekomcloud_fgs_function_v2_test.go
@@ -52,6 +52,9 @@ func TestAccFgsV2Function_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "urn"),
 					resource.TestCheckResourceAttrSet(resourceName, "version"),
 					resource.TestCheckResourceAttr(resourceName, "code_type", "inline"),
+					resource.TestCheckResourceAttr(resourceName, "network_controller.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "network_controller.0.trigger_access_vpcs.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "network_controller.0.disable_public_network", "true"),
 				),
 			},
 			{
@@ -63,6 +66,9 @@ func TestAccFgsV2Function_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.newkey", "value"),
 					resource.TestCheckResourceAttrSet(resourceName, "urn"),
 					resource.TestCheckResourceAttrSet(resourceName, "version"),
+					resource.TestCheckResourceAttr(resourceName, "network_controller.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "network_controller.0.trigger_access_vpcs.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "network_controller.0.disable_public_network", "false"),
 				),
 			},
 			{
@@ -70,6 +76,7 @@ func TestAccFgsV2Function_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "code_type", "obs"),
+					resource.TestCheckResourceAttr(resourceName, "network_controller.0.trigger_access_vpcs.#", "0"),
 				),
 			},
 			{
@@ -158,6 +165,9 @@ func TestAccFgsV2Function_createByImage(t *testing.T) {
 					resource.TestCheckResourceAttr(rName1, "runtime", "Custom Image"),
 					resource.TestCheckResourceAttr(rName1, "handler", "-"),
 					resource.TestCheckResourceAttr(rName1, "custom_image.0.url", common.OTC_BUILD_IMAGE_URL),
+					resource.TestCheckResourceAttrSet(rName1, "vpc_id"),
+					resource.TestCheckResourceAttrSet(rName1, "network_id"),
+					resource.TestCheckResourceAttrSet(rName1, "peering_cidr"),
 					rc2.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName2, "name", randName+"_2"),
 					resource.TestCheckResourceAttr(rName2, "agency", "functiongraph_swr_trust"),
@@ -179,6 +189,9 @@ func TestAccFgsV2Function_createByImage(t *testing.T) {
 					rc2.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName2, "handler", "-"),
 					resource.TestCheckResourceAttr(rName2, "custom_image.0.url", common.OTC_BUILD_IMAGE_URL_UPDATED),
+					resource.TestCheckResourceAttrSet(rName2, "vpc_id"),
+					resource.TestCheckResourceAttrSet(rName2, "network_id"),
+					resource.TestCheckResourceAttrSet(rName2, "peering_cidr"),
 				),
 			},
 			{
@@ -281,8 +294,19 @@ resource "opentelekomcloud_obs_bucket_object" "test" {
 func testAccFgsV2Function_basic_step1(rName string) string {
 	//nolint:revive
 	return fmt.Sprintf(`
+
+resource "opentelekomcloud_vpc_v1" "trigger_access_1" {
+  name = "%[1]s-trigger-1"
+  cidr = "192.168.0.0/16"
+}
+
+resource "opentelekomcloud_vpc_v1" "trigger_access_2" {
+  name = "%[1]s-trigger-2"
+  cidr = "192.168.0.0/16"
+}
+
 resource "opentelekomcloud_fgs_function_v2" "test" {
-  name        = "%s"
+  name        = "%[1]s"
   app         = "default"
   description = "function test"
   handler     = "index.handler"
@@ -291,6 +315,18 @@ resource "opentelekomcloud_fgs_function_v2" "test" {
   runtime     = "Python2.7"
   code_type   = "inline"
   func_code   = "aW1wb3J0IGpzb24KZGVmIGhhbmRsZXIgKGV2ZW50LCBjb250ZXh0KToKICAgIG91dHB1dCA9ICdIZWxsbyBtZXNzYWdlOiAnICsganNvbi5kdW1wcyhldmVudCkKICAgIHJldHVybiBvdXRwdXQ="
+
+  network_controller {
+    disable_public_network = true
+
+    trigger_access_vpcs {
+      vpc_id = opentelekomcloud_vpc_v1.trigger_access_1.id
+    }
+
+    trigger_access_vpcs {
+      vpc_id = opentelekomcloud_vpc_v1.trigger_access_2.id
+    }
+  }
 
   tags = {
     foo = "bar"
@@ -303,6 +339,16 @@ resource "opentelekomcloud_fgs_function_v2" "test" {
 func testAccFgsV2Function_basic_step2(rName string) string {
 	return fmt.Sprintf(`
 %[1]s
+
+resource "opentelekomcloud_vpc_v1" "trigger_access_1" {
+  name = "%[2]s-trigger-1"
+  cidr = "192.168.0.0/16"
+}
+
+resource "opentelekomcloud_vpc_v1" "trigger_access_2" {
+  name = "%[2]s-trigger-2"
+  cidr = "192.168.0.0/16"
+}
 
 resource "opentelekomcloud_fgs_function_v2" "test" {
   name        = "%[2]s"
@@ -317,6 +363,18 @@ resource "opentelekomcloud_fgs_function_v2" "test" {
   agency      = "functiongraph_swr_trust"
   vpc_id      = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
   network_id  = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+
+  network_controller {
+    disable_public_network = false
+
+    trigger_access_vpcs {
+      vpc_id = opentelekomcloud_vpc_v1.trigger_access_1.id
+    }
+
+    trigger_access_vpcs {
+      vpc_id = opentelekomcloud_vpc_v1.trigger_access_2.id
+    }
+  }
 
   tags = {
     foo    = "baar"
@@ -401,8 +459,9 @@ resource "opentelekomcloud_fgs_function_v2" "create_with_vpc_access" {
     url = "%[3]s"
   }
 
-  vpc_id     = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
-  network_id = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  vpc_id       = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  network_id   = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  peering_cidr = "10.0.1.0/24"
 }
 
 resource "opentelekomcloud_fgs_function_v2" "create_without_vpc_access" {
@@ -464,8 +523,9 @@ resource "opentelekomcloud_fgs_function_v2" "create_without_vpc_access" {
     working_dir = "/"
   }
 
-  vpc_id     = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
-  network_id = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  vpc_id       = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  network_id   = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  peering_cidr = "10.0.1.0/24"
 }
 `, common.DataSourceSubnet, rName, common.OTC_BUILD_IMAGE_URL_UPDATED)
 }

--- a/opentelekomcloud/services/fgs/resource_opentelekomcloud_fgs_function_v2.go
+++ b/opentelekomcloud/services/fgs/resource_opentelekomcloud_fgs_function_v2.go
@@ -133,6 +133,38 @@ func ResourceFgsFunctionV2() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"network_controller": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"trigger_access_vpcs": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"vpc_id": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+									"vpc_name": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"disable_public_network": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+					},
+				},
+			},
 			"vpc_id": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -142,6 +174,10 @@ func ResourceFgsFunctionV2() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				RequiredWith: []string{"vpc_id"},
+			},
+			"peering_cidr": {
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 			"mount_user_id": {
 				Type:     schema.TypeInt,
@@ -308,6 +344,14 @@ func ResourceFgsFunctionV2() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
+			"pre_stop_handler": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"pre_stop_timeout": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
 			"gpu_type": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -412,6 +456,8 @@ func buildFgsFunctionParameters(d *schema.ResourceData) (function.CreateOpts, er
 		Timeout:           d.Get("timeout").(int),
 		UserData:          d.Get("user_data").(string),
 		EncryptedUserData: d.Get("encrypted_user_data").(string),
+		PreStopHandler:    d.Get("pre_stop_handler").(string),
+		PreStopTimeout:    pointerto.Int(d.Get("pre_stop_timeout").(int)),
 		Xrole:             agencyV,
 		CustomImage:       buildCustomImage(d.Get("custom_image").([]interface{})),
 		GpuMemory:         pointerto.Int(d.Get("gpu_memory").(int)),
@@ -431,7 +477,53 @@ func buildFgsFunctionParameters(d *schema.ResourceData) (function.CreateOpts, er
 		}
 		result.LogConfig = &logConfig
 	}
+	if v, ok := d.GetOk("network_controller"); ok && len(v.([]interface{})) > 0 {
+		result.NetworkController = buildNetworkControlConfig(d)
+	}
+
 	return result, nil
+}
+
+func buildNetworkControlConfig(d *schema.ResourceData) *function.NetworkControlConfig {
+	v := d.Get("network_controller").([]interface{})
+	if len(v) < 1 || v[0] == nil {
+		return nil
+	}
+
+	networkController := v[0].(map[string]interface{})
+	config := &function.NetworkControlConfig{}
+
+	if disablePublic, ok := networkController["disable_public_network"].(bool); ok {
+		config.DisablePublicNetwork = &disablePublic
+	}
+
+	if vpcsSet, ok := networkController["trigger_access_vpcs"].(*schema.Set); ok && vpcsSet.Len() > 0 {
+		config.TriggerAccessVpcs = buildTriggerAccessVpcs(vpcsSet.List())
+	}
+
+	return config
+}
+
+func buildTriggerAccessVpcs(vpcs []interface{}) []function.VpcConfig {
+	result := make([]function.VpcConfig, 0, len(vpcs))
+
+	for _, vpc := range vpcs {
+		if vpcMap, ok := vpc.(map[string]interface{}); ok {
+			vpcConfig := function.VpcConfig{}
+
+			if vpcID, ok := vpcMap["vpc_id"].(string); ok {
+				vpcConfig.VpcID = vpcID
+			}
+
+			if vpcName, ok := vpcMap["vpc_name"].(string); ok {
+				vpcConfig.VpcName = vpcName
+			}
+
+			result = append(result, vpcConfig)
+		}
+	}
+
+	return result
 }
 
 func resourceFgsFunctionV2Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -455,7 +547,8 @@ func resourceFgsFunctionV2Create(ctx context.Context, d *schema.ResourceData, me
 
 	d.SetId(f.FuncURN)
 	urn := resourceFgsFunctionUrn(d.Id())
-	if d.HasChanges("vpc_id", "func_mounts", "app_agency", "initializer_handler", "initializer_timeout", "concurrency_num") {
+	if d.HasChanges("vpc_id", "network_id", "peering_cidr", "func_mounts", "app_agency", "initializer_handler",
+		"initializer_timeout", "concurrency_num") {
 		err := resourceFgsFunctionMetadataUpdate(fgsClient, urn, d)
 		if err != nil {
 			return diag.FromErr(err)
@@ -584,6 +677,43 @@ func flattenFgsCustomImage(imageConfig function.CustomImage) []map[string]interf
 		}
 	}
 	return nil
+}
+
+func flattenFunctionNetworkController(networkController *function.NetworkControlConfig) []map[string]interface{} {
+	if networkController == nil {
+		return nil
+	}
+
+	if len(networkController.TriggerAccessVpcs) == 0 &&
+		(networkController.DisablePublicNetwork == nil || !*networkController.DisablePublicNetwork) {
+		return nil
+	}
+
+	result := map[string]interface{}{
+		"trigger_access_vpcs": flattenNetworkControllerTriggerAccessVpcs(networkController.TriggerAccessVpcs),
+	}
+
+	if networkController.DisablePublicNetwork != nil {
+		result["disable_public_network"] = *networkController.DisablePublicNetwork
+	}
+
+	return []map[string]interface{}{result}
+}
+
+func flattenNetworkControllerTriggerAccessVpcs(vpcs []function.VpcConfig) []map[string]interface{} {
+	if len(vpcs) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(vpcs))
+	for _, vpc := range vpcs {
+		result = append(result, map[string]interface{}{
+			"vpc_id":   vpc.VpcID,
+			"vpc_name": vpc.VpcName,
+		})
+	}
+
+	return result
 }
 
 func queryFunctionVersions(client *golangsdk.ServiceClient, functionUrn string) ([]string, error) {
@@ -734,6 +864,10 @@ func resourceFgsFunctionV2Read(ctx context.Context, d *schema.ResourceData, meta
 		d.Set("initializer_timeout", f.InitTimeout),
 		d.Set("functiongraph_version", f.Type),
 		d.Set("custom_image", flattenFgsCustomImage(f.CustomImage)),
+		d.Set("network_controller", flattenFunctionNetworkController(&f.NetworkController)),
+		d.Set("peering_cidr", f.PeeringCIDR),
+		d.Set("pre_stop_handler", f.PreStopHandler),
+		d.Set("pre_stop_timeout", f.PreStopTimeout),
 		d.Set("max_instance_num", strconv.Itoa(f.StrategyConfig.Concurrency)),
 		d.Set("dns_list", f.DomainNames),
 		d.Set("log_group_id", f.LogGroupID),
@@ -995,8 +1129,9 @@ func resourceFgsFunctionV2Update(ctx context.Context, d *schema.ResourceData, me
 	// lintignore:R019
 	if d.HasChanges("app", "handler", "memory_size", "timeout", "encrypted_user_data",
 		"user_data", "agency", "app_agency", "description", "initializer_handler", "initializer_timeout",
-		"vpc_id", "network_id", "mount_user_id", "mount_user_group_id", "func_mounts", "custom_image",
-		"log_group_id", "log_topic_id", "log_group_name", "log_topic_name", "concurrency_num", "gpu_memory", "gpu_type") {
+		"vpc_id", "network_controller", "network_id", "mount_user_id", "mount_user_group_id", "func_mounts", "custom_image",
+		"log_group_id", "log_topic_id", "log_group_name", "log_topic_name", "concurrency_num", "gpu_memory", "gpu_type",
+		"pre_stop_handler", "pre_stop_timeout") {
 		err := resourceFgsFunctionMetadataUpdate(fgsClient, urn, d)
 		if err != nil {
 			return diag.FromErr(err)
@@ -1087,6 +1222,9 @@ func resourceFgsFunctionMetadataUpdate(fgsClient *golangsdk.ServiceClient, urn s
 		InitTimeout:       pointerto.Int(d.Get("initializer_timeout").(int)),
 		CustomImage:       buildCustomImage(d.Get("custom_image").([]interface{})),
 		GpuMemory:         pointerto.Int(d.Get("gpu_memory").(int)),
+		PreStopHandler:    d.Get("pre_stop_handler").(string),
+		PreStopTimeout:    pointerto.Int(d.Get("pre_stop_timeout").(int)),
+		PeeringCIDR:       d.Get("peering_cidr").(string),
 	}
 
 	if _, ok := d.GetOk("vpc_id"); ok {
@@ -1107,6 +1245,8 @@ func resourceFgsFunctionMetadataUpdate(fgsClient *golangsdk.ServiceClient, urn s
 		}
 		updateMetadateOpts.LogConfig = &logConfig
 	}
+
+	updateMetadateOpts.NetworkController = buildNetworkControlConfig(d)
 
 	if v, ok := d.GetOk("concurrency_num"); ok {
 		strategyConfig := function.StrategyConfig{

--- a/releasenotes/notes/fgs_func_new-0be136fc351da9f5.yaml
+++ b/releasenotes/notes/fgs_func_new-0be136fc351da9f5.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[FGS]** Added `network_controller`, `peering_cidr` and `pre_stop_handler` parameters for ``resource/opentelekomcloud_fgs_function_v2`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)

--- a/releasenotes/notes/fgs_func_new-0be136fc351da9f5.yaml
+++ b/releasenotes/notes/fgs_func_new-0be136fc351da9f5.yaml
@@ -1,4 +1,4 @@
 ---
 enhancements:
   - |
-    **[FGS]** Added `network_controller`, `peering_cidr` and `pre_stop_handler` parameters for ``resource/opentelekomcloud_fgs_function_v2`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[FGS]** Added `network_controller`, `peering_cidr` and `pre_stop_handler` parameters for ``resource/opentelekomcloud_fgs_function_v2`` (`#3037 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3037>`_)


### PR DESCRIPTION
## Summary of the Pull Request
New parameters introduced for `opentelekomcloud_fgs_function_v2`:
- network_controller
- peering_cidr
- pre_stop_handler
- pre_stop_timeout

## PR Checklist

* [x] Refers to: #3021
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccFgsV2Function_basic
=== PAUSE TestAccFgsV2Function_basic
=== CONT  TestAccFgsV2Function_basic
--- PASS: TestAccFgsV2Function_basic (99.81s)
PASS
ok      github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/fgs 100.507s

=== RUN   TestAccFgsV2Function_logConfig
=== PAUSE TestAccFgsV2Function_logConfig
=== CONT  TestAccFgsV2Function_logConfig
--- PASS: TestAccFgsV2Function_logConfig (49.15s)
PASS

Process finished with the exit code 0

=== RUN   TestAccFgsV2Function_text
=== PAUSE TestAccFgsV2Function_text
=== CONT  TestAccFgsV2Function_text
--- PASS: TestAccFgsV2Function_text (32.64s)
PASS

Process finished with the exit code 0

=== RUN   TestAccFgsV2Function_createByImage
=== PAUSE TestAccFgsV2Function_createByImage
=== CONT  TestAccFgsV2Function_createByImage
--- PASS: TestAccFgsV2Function_createByImage (66.05s)
PASS

Process finished with the exit code 0
```
