### PR TITLE
[Fix.] OBS: `kms_project_id` parameter set fix for `data_source/opentelekomcloud_obs_bucket` 

### DIFF
--- a/opentelekomcloud/services/obs/data_source_opentelekomcloud_obs_bucket.go
+++ b/opentelekomcloud/services/obs/data_source_opentelekomcloud_obs_bucket.go
@@ -202,6 +202,10 @@ func DataSourceObsBucket() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"kms_project_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 					},
 				},
 			},

--- a/releasenotes/notes/obs_bucket_data_fix-11c98af3d941b844.yaml
+++ b/releasenotes/notes/obs_bucket_data_fix-11c98af3d941b844.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    **[OBS]** Fix `kms_project_id` set for ``data_source/opentelekomcloud_obs_bucket`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[OBS]** Fix `kms_project_id` set for ``data_source/opentelekomcloud_obs_bucket`` (`#3040 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3040>`_)

--- a/releasenotes/notes/obs_bucket_data_fix-11c98af3d941b844.yaml
+++ b/releasenotes/notes/obs_bucket_data_fix-11c98af3d941b844.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[OBS]** Fix `kms_project_id` set for ``data_source/opentelekomcloud_obs_bucket`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Fix setting of `kms_project_id` parameter.

## PR Checklist

* [x] Refers to: #3039
* [x] Tests passed.
* [ ] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccDataSourceObsBucket_basic
=== PAUSE TestAccDataSourceObsBucket_basic
=== CONT  TestAccDataSourceObsBucket_basic
--- PASS: TestAccDataSourceObsBucket_basic (48.49s)
PASS

Process finished with the exit code 0
```
