### PR TITLE
[Feat.] SMN: new `data_source/opentelekomcloud_smn_message_templates_v2`

### DIFF
--- a/docs/data-sources/smn_message_templates_v2.md
+++ b/docs/data-sources/smn_message_templates_v2.md
@@ -1,0 +1,57 @@
+---
+subcategory: "Simple Message Notification (SMN)"
+layout: "opentelekomcloud"
+page_title: "OpenTelekomCloud: opentelekomcloud_smn_message_templates_v2"
+sidebar_current: "docs-opentelekomcloud-datasource-smn-message-templates-v2"
+description: |-
+  Get details about an SMN Message templates resources within OpenTelekomCloud.
+---
+
+# opentelekomcloud_smn_message_templates_v2
+
+Use this data source to get the list of SMN message templates.
+
+## Example Usage
+
+```hcl
+variable "name" {}
+
+data "opentelekomcloud_smn_message_templates_v2" "test" {
+  name = var.name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Optional, String) Specifies the name of the message template.
+
+* `protocol` - (Optional, String) Specifies the protocol of the message template.
+
+* `template_id` - (Optional, String) Specifies the message template ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `templates` - The list of message templates.
+  The [templates](#SmnMessageTemplate_MessageTemplate) structure is documented below.
+
+<a name="SmnMessageTemplate_MessageTemplate"></a>
+The `templates` block supports:
+
+* `id` - Indicates the message template ID.
+
+* `name` - Indicates the message template name.
+
+* `protocol` - Indicates the protocol supported by the template.
+
+* `tag_names` - Indicates the variable list. The variable name will be quoted in braces ({}) in the template.
+  When you use a template to send messages, you can replace the variable with any content.
+
+* `created_at` - Indicates the create time.
+
+* `updated_at` - Indicates the update time.

--- a/opentelekomcloud/acceptance/smn/data_source_opentelekomcloud_smn_message_templates_v2_test.go
+++ b/opentelekomcloud/acceptance/smn/data_source_opentelekomcloud_smn_message_templates_v2_test.go
@@ -1,0 +1,43 @@
+package acceptance
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+)
+
+func TestAccDataSourceSmnMessageTemplates_basic(t *testing.T) {
+	dataSource := "data.opentelekomcloud_smn_message_templates_v2.test"
+	dc := common.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+		},
+		ProviderFactories: common.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceSmnMessageTemplates_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSource, "templates.0.protocol", "default"),
+					resource.TestCheckResourceAttr(dataSource, "templates.0.name", "test-message-template"),
+				),
+			},
+		},
+	})
+}
+
+var testDataSourceSmnMessageTemplates_basic = `
+data "opentelekomcloud_smn_message_templates_v2" "test" {
+  name     = opentelekomcloud_smn_message_template_v2.test.name
+  protocol = "default"
+}
+
+resource "opentelekomcloud_smn_message_template_v2" "test" {
+  name     = "test-message-template"
+  protocol = "default"
+  content  = "Test content, contains {content1} and {content2}"
+}
+`

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -371,6 +371,7 @@ func Provider() *schema.Provider {
 			"opentelekomcloud_sfs_file_system_v2":                 sfs.DataSourceSFSFileSystemV2(),
 			"opentelekomcloud_sfs_turbo_share_v1":                 sfs.DataSourceSFSTurboShareV1(),
 			"opentelekomcloud_sdrs_domain_v1":                     sdrs.DataSourceSdrsDomainV1(),
+			"opentelekomcloud_smn_message_templates_v2":           smn.DataSourceSmnMessageTemplatesV2(),
 			"opentelekomcloud_smn_topic_v2":                       smn.DataSourceTopic(),
 			"opentelekomcloud_smn_subscription_v2":                smn.DataSourceSmnSubscriptionV2(),
 			"opentelekomcloud_smn_topic_subscription_v2":          smn.DataSourceSmnTopicSubscriptionV2(),

--- a/opentelekomcloud/services/smn/data_source_opentelekomcloud_smn_message_templates_v2.go
+++ b/opentelekomcloud/services/smn/data_source_opentelekomcloud_smn_message_templates_v2.go
@@ -1,0 +1,127 @@
+package smn
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/smn/v2/templates"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
+)
+
+func DataSourceSmnMessageTemplatesV2() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceSmnMessageTemplateRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"protocol": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"template_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"templates": {
+				Type:     schema.TypeList,
+				Elem:     smnMessageTemplateMessageTemplateSchema(),
+				Computed: true,
+			},
+		},
+	}
+}
+
+func smnMessageTemplateMessageTemplateSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"protocol": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tag_names": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+	return &sc
+}
+
+func dataSourceSmnMessageTemplateRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, keyClientV2, func() (*golangsdk.ServiceClient, error) {
+		return config.SmnV2Client(config.GetProjectName(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationClient, err)
+	}
+
+	var mErr *multierror.Error
+
+	listSmnMessageTemplate, err := templates.List(client, templates.ListOpts{
+		Name:     d.Get("name").(string),
+		Protocol: d.Get("protocol").(string),
+	})
+
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving OpenTelekomCloud Smn Message Template")
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	if listSmnMessageTemplate == nil || listSmnMessageTemplate.MessageTemplates == nil {
+		mErr = multierror.Append(mErr, d.Set("templates", []interface{}{}))
+		return diag.FromErr(mErr.ErrorOrNil())
+	}
+
+	templateID, hasTemplateID := d.GetOk("template_id")
+
+	rst := make([]interface{}, 0, len(listSmnMessageTemplate.MessageTemplates))
+	for _, v := range listSmnMessageTemplate.MessageTemplates {
+		if hasTemplateID && templateID.(string) != v.MessageTemplateID {
+			continue
+		}
+
+		rst = append(rst, map[string]interface{}{
+			"id":         v.MessageTemplateID,
+			"name":       v.Name,
+			"protocol":   v.Protocol,
+			"tag_names":  v.TagNames,
+			"created_at": v.CreateTime,
+			"updated_at": v.UpdateTime,
+		})
+	}
+
+	mErr = multierror.Append(mErr, d.Set("templates", rst))
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}

--- a/releasenotes/notes/sms_message_template_datasource-c82e0c3342bf92f6.yaml
+++ b/releasenotes/notes/sms_message_template_datasource-c82e0c3342bf92f6.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   - |
-    **New Data Source:** ``data_source/opentelekomcloud_smn_message_templates_v2`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **New Data Source:** ``data_source/opentelekomcloud_smn_message_templates_v2`` (`#3050 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3050>`_)

--- a/releasenotes/notes/sms_message_template_datasource-c82e0c3342bf92f6.yaml
+++ b/releasenotes/notes/sms_message_template_datasource-c82e0c3342bf92f6.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    **New Data Source:** ``data_source/opentelekomcloud_smn_message_templates_v2`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)


### PR DESCRIPTION
## Summary of the Pull Request
New data source to query info about smn message templates

## PR Checklist

* [x] Closes: #2980
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccDataSourceSmnMessageTemplates_basic
=== PAUSE TestAccDataSourceSmnMessageTemplates_basic
=== CONT  TestAccDataSourceSmnMessageTemplates_basic
--- PASS: TestAccDataSourceSmnMessageTemplates_basic (27.74s)
PASS

Process finished with the exit code 0
```
