### PR TITLE
[Feat.] ER: route tables data source

### DIFF
--- a/docs/data-sources/er_route_tables_v3.md
+++ b/docs/data-sources/er_route_tables_v3.md
@@ -1,0 +1,115 @@
+---
+subcategory: "Enterprise Router (ER)"
+layout: "opentelekomcloud"
+page_title: "OpenTelekomCloud: opentelekomcloud_er_route_tables_v3"
+sidebar_current: "docs-opentelekomcloud-datasource-er-route-tables-v3"
+description: |-
+  Query Route tables for enterprise router within OpenTelekomCloud
+---
+
+# opentelekomcloud_er_route_tables_v3
+
+Use this data source to query the route tables under the ER instance within OpenTelekomCloud.
+
+## Example Usage
+
+### Querying specified route tables under ER instance using name
+
+```hcl
+variable "instance_id" {}
+variable "route_table_name" {}
+
+data "opentelekomcloud_er_route_tables_v3" "test" {
+  instance_id = var.instance_id
+  name        = var.route_table_name
+}
+```
+
+### Querying specified route tables under ER instance using tags
+
+```hcl
+variable "instance_id" {}
+
+data "opentelekomcloud_er_route_tables_v3" "test" {
+  instance_id = var.instance_id
+
+  tags = {
+    foo = "bar"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `instance_id` - (Required, String) Specifies the ID of the ER instance to which the route tables belongs.
+
+* `route_table_id` - (Optional, String) Specifies the route table ID used to query specified route table.
+
+* `name` - (Optional, String) Specifies the name used to filter the route tables.
+  The name can contain `1` to `64` characters, only English letters, digits, underscore (_),
+  hyphens (-) and dots (.) allowed.
+
+* `tags` - (Optional, Map) Specifies the key/value pairs used to filter the route tables.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `route_tables` - All route tables that match the filter parameters.
+  The [object](#route_tables) structure is documented below.
+
+<a name="route_tables"></a>
+The `route_tables` block supports:
+
+* `id` - The route table ID.
+
+* `name` - The name of the route table.
+
+* `description` - The description of the route table.
+
+* `associations` - The association configurations of the route table.
+  The [object](#route_table_relationship) structure is documented below.
+
+* `propagations` - The propagation configurations of the route table.
+  The [object](#route_table_relationship) structure is documented below.
+
+* `routes` - The route details of the route table.
+  The [object](#route_table_routes) structure is documented below.
+
+* `created_at` - The creation time.
+
+* `updated_at` - The latest update time.
+
+<a name="route_table_relationship"></a>
+The `associations` or `propagations` block supports:
+
+* `id` - The ID of the association/propagation.
+
+* `attachment_id` - The attachment ID corresponding to the routing association/propagation.
+
+* `attachment_type` - The attachment type corresponding to the routing association/propagation.
+
+<a name="route_table_routes"></a>
+The `routes` block supports:
+
+* `id` - The route ID.
+
+* `destination` - The destination address (CIDR) of the route.
+
+* `is_blackhole` - Whether route is the black hole route.
+
+* `attachments` - The details of the attachment corresponding to the route.
+  The [object](#route_table_route_attachments) structure is documented below.
+
+<a name="route_table_route_attachments"></a>
+The `attachments` block supports:
+
+* `attachment_id` - The ID of the nexthop attachment.
+
+* `attachment_type` - The type of the nexthop attachment.
+
+* `resource_id` - The ID of the resource associated with the attachment.

--- a/opentelekomcloud/acceptance/er/data_source_opentelekomcloud_er_route_tables_v3_test.go
+++ b/opentelekomcloud/acceptance/er/data_source_opentelekomcloud_er_route_tables_v3_test.go
@@ -1,0 +1,243 @@
+package er
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+)
+
+func TestAccDataSourceRouteTables_basic(t *testing.T) {
+	var (
+		all = "data.opentelekomcloud_er_route_tables_v3.test"
+		dc  = common.InitDataSourceCheck(all)
+
+		byRouteTableId   = "data.opentelekomcloud_er_route_tables_v3.filter_by_route_table_id"
+		dcByRouteTableId = common.InitDataSourceCheck(byRouteTableId)
+
+		byName   = "data.opentelekomcloud_er_route_tables_v3.filter_by_name"
+		dcByName = common.InitDataSourceCheck(byName)
+
+		byTags   = "data.opentelekomcloud_er_route_tables_v3.filter_by_tags"
+		dcByTags = common.InitDataSourceCheck(byTags)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+		},
+		ProviderFactories: common.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceRouteTables_basic_step1(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "route_tables.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					dcByRouteTableId.CheckResourceExists(),
+					resource.TestCheckResourceAttr(byRouteTableId, "route_tables.#", "1"),
+					resource.TestCheckResourceAttrPair(byRouteTableId, "route_tables.0.id",
+						"opentelekomcloud_er_route_table_v3.test", "id"),
+					resource.TestCheckResourceAttrPair(byRouteTableId, "route_tables.0.name",
+						"opentelekomcloud_er_route_table_v3.test", "name"),
+					resource.TestCheckResourceAttrPair(byRouteTableId, "route_tables.0.description",
+						"opentelekomcloud_er_route_table_v3.test", "description"),
+					resource.TestCheckResourceAttr(byRouteTableId, "route_tables.0.associations.#", "1"),
+					resource.TestCheckResourceAttrPair(byRouteTableId, "route_tables.0.associations.0.id",
+						"opentelekomcloud_er_association_v3.test", "id"),
+					resource.TestCheckResourceAttrPair(byRouteTableId, "route_tables.0.associations.0.attachment_id",
+						"opentelekomcloud_er_vpc_attachment_v3.test", "id"),
+					resource.TestCheckResourceAttr(byRouteTableId, "route_tables.0.associations.0.attachment_type", "vpc"),
+					resource.TestCheckResourceAttr(byRouteTableId, "route_tables.0.propagations.#", "1"),
+					resource.TestCheckResourceAttrPair(byRouteTableId, "route_tables.0.propagations.0.id",
+						"opentelekomcloud_er_propagation_v3.test", "id"),
+					resource.TestCheckResourceAttrPair(byRouteTableId, "route_tables.0.propagations.0.attachment_id",
+						"opentelekomcloud_er_vpc_attachment_v3.test", "id"),
+					resource.TestCheckResourceAttr(byRouteTableId, "route_tables.0.propagations.0.attachment_type", "vpc"),
+					resource.TestCheckResourceAttr(byRouteTableId, "route_tables.0.routes.#", "1"),
+					resource.TestCheckResourceAttrPair(byRouteTableId, "route_tables.0.routes.0.id",
+						"opentelekomcloud_er_static_route_v3.test", "id"),
+					resource.TestCheckResourceAttrPair(byRouteTableId, "route_tables.0.routes.0.destination",
+						"opentelekomcloud_er_static_route_v3.test", "destination"),
+					resource.TestCheckResourceAttr(byRouteTableId, "route_tables.0.routes.0.is_blackhole", "false"),
+					resource.TestCheckResourceAttr(byRouteTableId, "route_tables.0.routes.0.attachments.#", "1"),
+					resource.TestCheckResourceAttrPair(byRouteTableId, "route_tables.0.routes.0.attachments.0.attachment_id",
+						"opentelekomcloud_er_vpc_attachment_v3.test", "id"),
+					resource.TestCheckResourceAttr(byRouteTableId, "route_tables.0.routes.0.attachments.0.attachment_type", "vpc"),
+					resource.TestCheckResourceAttrPair(byRouteTableId, "route_tables.0.routes.0.attachments.0.resource_id",
+						"opentelekomcloud_vpc_v1.test", "id"),
+					resource.TestCheckResourceAttr(byRouteTableId, "route_tables.0.tags.%", "2"),
+					resource.TestCheckResourceAttr(byRouteTableId, "route_tables.0.tags.foo", "bar"),
+					resource.TestCheckResourceAttr(byRouteTableId, "route_tables.0.tags.key", "value"),
+					resource.TestCheckOutput("is_route_table_id_filter_useful", "true"),
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					dcByTags.CheckResourceExists(),
+					resource.TestCheckOutput("is_tags_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceRouteTables_base() string {
+	var (
+		name     = fmt.Sprintf("er-acc-api%s", acctest.RandString(5))
+		bgpAsNum = acctest.RandIntRange(64512, 65534)
+	)
+
+	return fmt.Sprintf(`
+resource "opentelekomcloud_vpc_v1" "test" {
+  name = "%[1]s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "opentelekomcloud_vpc_subnet_v1" "test" {
+  vpc_id = opentelekomcloud_vpc_v1.test.id
+
+  name       = "%[1]s"
+  cidr       = cidrsubnet(opentelekomcloud_vpc_v1.test.cidr, 4, 1)
+  gateway_ip = cidrhost(cidrsubnet(opentelekomcloud_vpc_v1.test.cidr, 4, 1), 1)
+}
+
+resource "opentelekomcloud_er_instance_v3" "test" {
+  availability_zones = ["eu-de-02"]
+
+  name = "%[2]s"
+  asn  = %[3]d
+}
+
+resource "opentelekomcloud_er_route_table_v3" "test" {
+  instance_id = opentelekomcloud_er_instance_v3.test.id
+  name        = "%[2]s"
+  description = "Created by script"
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+
+resource "opentelekomcloud_er_vpc_attachment_v3" "test" {
+  instance_id = opentelekomcloud_er_instance_v3.test.id
+  vpc_id      = opentelekomcloud_vpc_v1.test.id
+  subnet_id   = opentelekomcloud_vpc_subnet_v1.test.id
+  name        = "%[2]s"
+}
+
+resource "opentelekomcloud_er_static_route_v3" "test" {
+  route_table_id = opentelekomcloud_er_route_table_v3.test.id
+  destination    = opentelekomcloud_vpc_v1.test.cidr
+  attachment_id  = opentelekomcloud_er_vpc_attachment_v3.test.id
+}
+
+resource "opentelekomcloud_er_association_v3" "test" {
+  instance_id    = opentelekomcloud_er_instance_v3.test.id
+  route_table_id = opentelekomcloud_er_route_table_v3.test.id
+  attachment_id  = opentelekomcloud_er_vpc_attachment_v3.test.id
+}
+
+resource "opentelekomcloud_er_propagation_v3" "test" {
+  instance_id    = opentelekomcloud_er_instance_v3.test.id
+  route_table_id = opentelekomcloud_er_route_table_v3.test.id
+  attachment_id  = opentelekomcloud_er_vpc_attachment_v3.test.id
+}
+`, name, name, bgpAsNum)
+}
+
+func testAccDataSourceRouteTables_basic_step1() string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "opentelekomcloud_er_route_tables_v3" "test" {
+  depends_on = [
+    opentelekomcloud_er_static_route_v3.test,
+    opentelekomcloud_er_association_v3.test,
+    opentelekomcloud_er_propagation_v3.test,
+  ]
+
+  instance_id = opentelekomcloud_er_instance_v3.test.id
+}
+
+# Filter by route table ID
+locals {
+  route_table_id = opentelekomcloud_er_route_table_v3.test.id
+}
+
+data "opentelekomcloud_er_route_tables_v3" "filter_by_route_table_id" {
+  depends_on = [
+    opentelekomcloud_er_static_route_v3.test,
+    opentelekomcloud_er_association_v3.test,
+    opentelekomcloud_er_propagation_v3.test,
+  ]
+
+  instance_id    = opentelekomcloud_er_instance_v3.test.id
+  route_table_id = local.route_table_id
+}
+
+locals {
+  route_table_id_filter_result = [
+    for v in data.opentelekomcloud_er_route_tables_v3.filter_by_route_table_id.route_tables[*].id : v == local.route_table_id
+  ]
+}
+
+output "is_route_table_id_filter_useful" {
+  value = length(local.route_table_id_filter_result) > 0 && alltrue(local.route_table_id_filter_result)
+}
+
+# Filter by name
+locals {
+  route_table_name = opentelekomcloud_er_route_table_v3.test.name
+}
+
+data "opentelekomcloud_er_route_tables_v3" "filter_by_name" {
+  depends_on = [
+    opentelekomcloud_er_static_route_v3.test,
+    opentelekomcloud_er_association_v3.test,
+    opentelekomcloud_er_propagation_v3.test,
+  ]
+
+  instance_id = opentelekomcloud_er_instance_v3.test.id
+  name        = local.route_table_name
+}
+
+locals {
+  name_filter_result = [
+    for v in data.opentelekomcloud_er_route_tables_v3.filter_by_route_table_id.route_tables[*].name : v == local.route_table_name
+  ]
+}
+
+output "is_name_filter_useful" {
+  value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)
+}
+
+# Filter by tags
+locals {
+  route_table_tags = opentelekomcloud_er_route_table_v3.test.tags
+}
+
+data "opentelekomcloud_er_route_tables_v3" "filter_by_tags" {
+  depends_on = [
+    opentelekomcloud_er_static_route_v3.test,
+    opentelekomcloud_er_association_v3.test,
+    opentelekomcloud_er_propagation_v3.test,
+  ]
+
+  instance_id = opentelekomcloud_er_instance_v3.test.id
+  tags        = local.route_table_tags
+}
+
+locals {
+  tags_filter_result = [
+    for v in data.opentelekomcloud_er_route_tables_v3.filter_by_tags.route_tables[*].tags : length(v) == length(local.route_table_tags) &&
+    length(v) == length(merge(v, local.route_table_tags))
+  ]
+}
+
+output "is_tags_filter_useful" {
+  value = length(local.tags_filter_result) > 0 && alltrue(local.tags_filter_result)
+}
+`, testAccDataSourceRouteTables_base())
+}

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -317,6 +317,7 @@ func Provider() *schema.Provider {
 			"opentelekomcloud_er_availability_zones_v3":           er.DataSourceErAvailabilityZonesV3(),
 			"opentelekomcloud_er_quotas_v3":                       er.DataSourceErQuotasV3(),
 			"opentelekomcloud_er_flow_logs_v3":                    er.DataSourceErFlowLogsV3(),
+			"opentelekomcloud_er_route_tables_v3":                 er.DataSourceRouteTablesV2(),
 			"opentelekomcloud_evs_volumes_v2":                     evs.DataSourceEvsVolumesV2(),
 			"opentelekomcloud_hss_host_groups_v5":                 hss.DataSourceHostGroups(),
 			"opentelekomcloud_hss_quotas_v5":                      hss.DataSourceQuotas(),

--- a/opentelekomcloud/services/er/data_source_opentelekomcloud_er_route_tables_v3.go
+++ b/opentelekomcloud/services/er/data_source_opentelekomcloud_er_route_tables_v3.go
@@ -1,0 +1,316 @@
+package er
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/er/v3/association"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/er/v3/propagation"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/er/v3/route"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/er/v3/route_table"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
+)
+
+func DataSourceRouteTablesV2() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceRouteTablesV3Read,
+
+		Schema: map[string]*schema.Schema{
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"route_table_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"tags": common.TagsSchema(),
+			"route_tables": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"associations": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     routeTableRelationshipSchemaResource(),
+						},
+						"propagations": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     routeTableRelationshipSchemaResource(),
+						},
+						"routes": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"destination": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"is_blackhole": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"attachments": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"attachment_id": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"attachment_type": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"resource_id": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"created_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"updated_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"tags": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func routeTableRelationshipSchemaResource() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"attachment_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"attachment_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func queryRouteTableAssociations(client *golangsdk.ServiceClient, instanceId, routeTableId string) ([]map[string]interface{},
+	error) {
+	resp, err := association.List(client, association.ListOpts{
+		RouterId:     instanceId,
+		RouteTableId: routeTableId,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(resp.Associations) < 1 {
+		return nil, nil
+	}
+
+	result := make([]map[string]interface{}, len(resp.Associations))
+	for i, assoc := range resp.Associations {
+		result[i] = map[string]interface{}{
+			"attachment_id":   assoc.AttachmentID,
+			"id":              assoc.ID,
+			"attachment_type": assoc.ResourceType,
+		}
+	}
+	return result, nil
+}
+
+func queryRouteTablePropagations(client *golangsdk.ServiceClient, instanceId, routeTableId string) ([]map[string]interface{},
+	error) {
+	resp, err := propagation.List(client, propagation.ListOpts{
+		RouterId:     instanceId,
+		RouteTableId: routeTableId,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(resp.Propagations) < 1 {
+		return nil, nil
+	}
+
+	result := make([]map[string]interface{}, len(resp.Propagations))
+	for i, prop := range resp.Propagations {
+		result[i] = map[string]interface{}{
+			"attachment_id":   prop.AttachmentID,
+			"id":              prop.ID,
+			"attachment_type": prop.ResourceType,
+		}
+	}
+	return result, nil
+}
+
+func queryRouteTableRoutes(client *golangsdk.ServiceClient, routeTableId string) ([]map[string]interface{},
+	error) {
+	resp, err := route.List(client, route.ListOpts{
+		RouteTableId: routeTableId,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(resp.Routes) < 1 {
+		return nil, nil
+	}
+
+	result := make([]map[string]interface{}, len(resp.Routes))
+	for i, rt := range resp.Routes {
+		rr := map[string]interface{}{
+			"destination":  rt.Destination,
+			"is_blackhole": rt.IsBlackhole,
+			"id":           rt.RouteId,
+		}
+		if len(rt.NextHops) < 1 {
+			result[i] = rr
+			continue
+		}
+
+		attachments := make([]map[string]interface{}, len(rt.NextHops))
+		for i, attachment := range rt.NextHops {
+			attachments[i] = map[string]interface{}{
+				"attachment_id":   attachment.AttachmentId,
+				"attachment_type": attachment.ResourceType,
+				"resource_id":     attachment.ResourceId,
+			}
+		}
+		rr["attachments"] = attachments
+		result[i] = rr
+	}
+	return result, nil
+}
+
+func filterRouteTablesByTags(d *schema.ResourceData, all []route_table.RouteTable) ([]route_table.RouteTable, error) {
+	filter := map[string]interface{}{
+		"ID":   d.Get("route_table_id"),
+		"Name": d.Get("name"),
+	}
+	filterResult, err := common.FilterSliceWithField(all, filter)
+	if err != nil {
+		return nil, fmt.Errorf("error filting security groups list: %s", err)
+	}
+
+	tagFilter := d.Get("tags").(map[string]interface{})
+	result := make([]route_table.RouteTable, 0, len(filterResult))
+	for _, val := range filterResult {
+		item := val.(route_table.RouteTable)
+		tagmap := common.TagsToMap(item.Tags)
+
+		if !common.MapContains(tagmap, tagFilter) {
+			continue
+		}
+		result = append(result, item)
+	}
+	return result, nil
+}
+
+func flattenRouteTables(client *golangsdk.ServiceClient, instanceId string,
+	all []route_table.RouteTable) []map[string]interface{} {
+	if len(all) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, len(all))
+	for i, routeTable := range all {
+		routeTableId := routeTable.ID
+
+		associationList, _ := queryRouteTableAssociations(client, instanceId, routeTableId)
+		propagationList, _ := queryRouteTablePropagations(client, instanceId, routeTableId)
+		routeList, _ := queryRouteTableRoutes(client, routeTableId)
+
+		result[i] = map[string]interface{}{
+			"id":           routeTableId,
+			"name":         routeTable.Name,
+			"description":  routeTable.Description,
+			"associations": associationList,
+			"propagations": propagationList,
+			"routes":       routeList,
+			"created_at":   routeTable.CreatedAt,
+			"updated_at":   routeTable.UpdatedAt,
+			"tags":         common.TagsToMap(routeTable.Tags),
+		}
+	}
+	return result
+}
+
+func dataSourceRouteTablesV3Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := config.ErV3Client(config.GetRegion(d))
+	if err != nil {
+		return fmterr.Errorf(errCreationV3Client, err)
+	}
+
+	instanceId := d.Get("instance_id").(string)
+	resp, err := route_table.List(client, route_table.ListOpts{
+		RouterId: instanceId,
+	})
+	if err != nil {
+		return diag.Errorf("error retrieving route tables: %s", err)
+	}
+	filterResult, err := filterRouteTablesByTags(d, resp.RouteTables)
+	if err != nil {
+		return diag.Errorf("error retrieving route tables: %s", err)
+	}
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	mErr := multierror.Append(nil,
+		d.Set("route_tables", flattenRouteTables(client, instanceId, filterResult)),
+	)
+
+	if mErr.ErrorOrNil() != nil {
+		return diag.Errorf("error saving route table list field: %s", mErr)
+	}
+	return nil
+}

--- a/releasenotes/notes/er_route_tables-f33e1059f66699aa.yaml
+++ b/releasenotes/notes/er_route_tables-f33e1059f66699aa.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  |
+  **[ER]** Add new ``data_source/opentelekomcloud_er_route_tables_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)

--- a/releasenotes/notes/er_route_tables-f33e1059f66699aa.yaml
+++ b/releasenotes/notes/er_route_tables-f33e1059f66699aa.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   |
-  **[ER]** Add new ``data_source/opentelekomcloud_er_route_tables_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+  **[ER]** Add new ``data_source/opentelekomcloud_er_route_tables_v3`` (`#3068 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3068>`_)


### PR DESCRIPTION
## Summary of the Pull Request
New `data source`  opentelekomcloud_er_route_tables_v3

## PR Checklist

* [x] Refers to: #2992
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccDataSourceRouteTables_basic
=== PAUSE TestAccDataSourceRouteTables_basic
=== CONT  TestAccDataSourceRouteTables_basic
--- PASS: TestAccDataSourceRouteTables_basic (158.50s)
PASS

Process finished with the exit code 0
```
