### PR TITLE
[Fix] FGS: Remove attribute is_bridge_function from fgs_function_v2

### DIFF
--- a/docs/resources/fgs_function_v2.md
+++ b/docs/resources/fgs_function_v2.md
@@ -442,8 +442,6 @@ In addition to all arguments above, the following attributes are exported:
 
 * `is_stateful_function` - Whether stateful functions are supported.
 
-* `is_bridge_function` - Whether this is a bridge function.
-
 * `apig_route_enable` - Whether to configure gateway routing rules.
 
 * `heartbeat_handler` - Entry of the heartbeat function in the format of "xx.xx".

--- a/opentelekomcloud/services/fgs/resource_opentelekomcloud_fgs_function_v2.go
+++ b/opentelekomcloud/services/fgs/resource_opentelekomcloud_fgs_function_v2.go
@@ -364,10 +364,6 @@ func ResourceFgsFunctionV2() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
-			"is_bridge_function": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
 			"apig_route_enable": {
 				Type:     schema.TypeBool,
 				Computed: true,
@@ -924,7 +920,6 @@ func resourceFgsFunctionV2Read(ctx context.Context, d *schema.ResourceData, meta
 		d.Set("enable_dynamic_memory", f.EnableDynamicMemory),
 		d.Set("extend_config", f.ExtendConfig),
 		d.Set("is_stateful_function", f.IsStatefulFunction),
-		d.Set("is_bridge_function", f.IsBridgeFunction),
 		d.Set("apig_route_enable", f.ApigRouteEnable),
 		d.Set("heartbeat_handler", f.HeartbeatHandler),
 		d.Set("enable_class_isolation", f.EnableClassIsolation),

--- a/releasenotes/notes/fgs-fix-remove-attribute-function-v2-474677b5558bb60e.yaml
+++ b/releasenotes/notes/fgs-fix-remove-attribute-function-v2-474677b5558bb60e.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[FGS]** Remove attribute `is_bridge_function` from resource ``resource/opentelekomcloud_fgs_function_v2`` (`#3072 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3072>`_)


### PR DESCRIPTION
## Summary of the Pull Request

Remove attribute `is_bridge_function` from resource `opentelekomcloud_fgs_function_v2`

## PR Checklist

* [x] Refers to: #3069 
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.
