### PR TITLE
[Feat.] ER: new `data_source/opentelekomcloud_er_propagations_v3`

### DIFF
--- a/docs/data-sources/er_propagations_v3.md
+++ b/docs/data-sources/er_propagations_v3.md
@@ -1,0 +1,80 @@
+---
+subcategory: "Enterprise Router (ER)"
+layout: "opentelekomcloud"
+page_title: "OpenTelekomCloud: opentelekomcloud_er_propagations_v3"
+sidebar_current: "docs-opentelekomcloud-datasource-er-propagations-v3"
+description: |-
+  Get the list of ER propagations from OpenTelekomCloud
+---
+# opentelekomcloud_er_propagations_v3
+
+Use this data source to get the list of propagations.
+
+## Example Usage
+
+```hcl
+variable instance_id {}
+variable route_table_id {}
+variable attachment_id {}
+
+data "opentelekomcloud_er_propagations_v3" "test" {
+  instance_id    = var.instance_id
+  route_table_id = var.route_table_id
+  attachment_id  = var.attachment_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `instance_id` - (Required, String) Specifies the ER instance ID to which the propagation belongs.
+
+* `route_table_id` - (Required, String) Specifies the route table ID to which the propagation belongs.
+
+* `attachment_id` - (Optional, String) Specifies the attachment ID to which the propagation belongs.
+
+* `attachment_type` - (Optional, String) Specifies the attachment type of corresponding to the propagation.
+  The valid values are as follows:
+  + **vpc**: Virtual private cloud.
+  + **vpn**: VPN gateway.
+  + **vgw**: Virtual gateway of cloud private line.
+  + **peering**: Peering connection, through the cloud connection (CC) to load ERs in different regions to create a
+    peering connection.
+  + **enc**: Enterprise connect network in EC.
+  + **cfw**: VPC border firewall.
+
+* `status` - (Optional, String) Specifies the status of the propagation. Default value is `available`.
+  The valid values are as follows:
+  + **available**
+  + **failed**
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `propagations` - All propagations that match the filter parameters.
+  The [propagations](#route_propagations) structure is documented below.
+
+<a name="route_propagations"></a>
+The `propagations` block supports:
+
+* `id` - The propagation ID.
+
+* `instance_id` - The ER instance ID to which the propagation belongs.
+
+* `route_table_id` - The route table ID of corresponding to the propagation.
+
+* `attachment_id` - The attachment ID corresponding to the propagation.
+
+* `attachment_type` - The attachment type corresponding to the propagation.
+
+* `resource_id` - The resource ID of the attachment associated with the propagation.
+
+* `status` - The current status of the propagation.
+
+* `created_at` - The creation time of the propagation.
+
+* `updated_at` - The latest update time of the propagation.

--- a/opentelekomcloud/acceptance/er/data_source_opentelekomcloud_er_propagations_v3_test.go
+++ b/opentelekomcloud/acceptance/er/data_source_opentelekomcloud_er_propagations_v3_test.go
@@ -1,0 +1,181 @@
+package er
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+)
+
+func TestAccDataSourcePropagations_basic(t *testing.T) {
+	var (
+		name       = fmt.Sprintf("er-acc-api%s", acctest.RandString(5))
+		baseConfig = testAccDataSourcePropagations_base(name)
+
+		all = "data.opentelekomcloud_er_propagations_v3.test"
+		dc  = common.InitDataSourceCheck(all)
+
+		byAttachmentId   = "data.opentelekomcloud_er_propagations_v3.filter_by_attachment_id"
+		dcByAttachmentId = common.InitDataSourceCheck(byAttachmentId)
+
+		byAttachmentType   = "data.opentelekomcloud_er_propagations_v3.filter_by_attachment_type"
+		dcByAttachmentType = common.InitDataSourceCheck(byAttachmentType)
+
+		byStatus   = "data.opentelekomcloud_er_propagations_v3.filter_by_status"
+		dcByStatus = common.InitDataSourceCheck(byStatus)
+
+		byNotFoundInstanceId   = "data.opentelekomcloud_er_propagations_v3.instance_id_not_found"
+		dcByNotFoundInstanceId = common.InitDataSourceCheck(byNotFoundInstanceId)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+		},
+		ProviderFactories: common.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourcePropagations_basic_step1(baseConfig),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(all, "propagations.#"),
+					resource.TestCheckResourceAttrSet(all, "propagations.0.resource_id"),
+					dcByAttachmentId.CheckResourceExists(),
+					resource.TestCheckOutput("is_attachment_id_filter_useful", "true"),
+					dcByAttachmentType.CheckResourceExists(),
+					resource.TestCheckOutput("is_attachment_type_filter_useful", "true"),
+					dcByStatus.CheckResourceExists(),
+					resource.TestCheckOutput("is_status_filter_useful", "true"),
+				),
+			},
+			{
+				Config: testAccDataSourcePropagations_basic_step2(baseConfig),
+				Check: resource.ComposeTestCheckFunc(
+					dcByNotFoundInstanceId.CheckResourceExists(),
+					resource.TestCheckResourceAttr(byNotFoundInstanceId, "propagations.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourcePropagations_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "opentelekomcloud_er_propagation_v3" "test" {
+  instance_id    = opentelekomcloud_er_instance_v3.test.id
+  route_table_id = opentelekomcloud_er_route_table_v3.test.id
+  attachment_id  = opentelekomcloud_er_vpc_attachment_v3.test.id
+}
+`, testAccPropagation_base(name))
+}
+
+func testAccDataSourcePropagations_basic_step1(baseConfig string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "opentelekomcloud_er_propagations_v3" "test" {
+  depends_on = [
+    opentelekomcloud_er_propagation_v3.test,
+  ]
+
+  instance_id    = opentelekomcloud_er_instance_v3.test.id
+  route_table_id = opentelekomcloud_er_route_table_v3.test.id
+}
+
+locals {
+  attachment_id = data.opentelekomcloud_er_propagations_v3.test.propagations[0].attachment_id
+}
+
+data "opentelekomcloud_er_propagations_v3" "filter_by_attachment_id" {
+  depends_on = [
+    opentelekomcloud_er_propagation_v3.test,
+  ]
+
+  instance_id    = opentelekomcloud_er_instance_v3.test.id
+  route_table_id = opentelekomcloud_er_route_table_v3.test.id
+  attachment_id  = local.attachment_id
+}
+
+locals {
+  attachment_id_filter_result = [
+    for v in data.opentelekomcloud_er_propagations_v3.filter_by_attachment_id.propagations[*].attachment_id :
+    v == local.attachment_id
+  ]
+}
+
+output "is_attachment_id_filter_useful" {
+  value = alltrue(local.attachment_id_filter_result) && length(local.attachment_id_filter_result) > 0
+}
+
+locals {
+  attachment_type = data.opentelekomcloud_er_propagations_v3.test.propagations[0].attachment_type
+}
+
+data "opentelekomcloud_er_propagations_v3" "filter_by_attachment_type" {
+  depends_on = [
+    opentelekomcloud_er_propagation_v3.test,
+  ]
+
+  instance_id     = opentelekomcloud_er_instance_v3.test.id
+  route_table_id  = opentelekomcloud_er_route_table_v3.test.id
+  attachment_type = local.attachment_type
+}
+
+locals {
+  attachment_type_filter_result = [
+    for v in data.opentelekomcloud_er_propagations_v3.filter_by_attachment_type.propagations[*].attachment_type :
+    v == local.attachment_type
+  ]
+}
+
+output "is_attachment_type_filter_useful" {
+  value = alltrue(local.attachment_type_filter_result) && length(local.attachment_type_filter_result) > 0
+}
+
+locals {
+  status = data.opentelekomcloud_er_propagations_v3.test.propagations[0].status
+}
+
+data "opentelekomcloud_er_propagations_v3" "filter_by_status" {
+  depends_on = [
+    opentelekomcloud_er_propagation_v3.test,
+  ]
+
+  instance_id    = opentelekomcloud_er_instance_v3.test.id
+  route_table_id = opentelekomcloud_er_route_table_v3.test.id
+  status         = local.status
+}
+
+locals {
+  status_filter_result = [
+    for v in data.opentelekomcloud_er_propagations_v3.filter_by_status.propagations[*].status : v == local.status
+  ]
+}
+
+output "is_status_filter_useful" {
+  value = alltrue(local.status_filter_result) && length(local.status_filter_result) > 0
+}
+`, baseConfig)
+}
+
+func testAccDataSourcePropagations_basic_step2(baseConfig string) string {
+	randUUID, _ := uuid.GenerateUUID()
+
+	return fmt.Sprintf(`
+%[1]s
+
+data "opentelekomcloud_er_propagations_v3" "instance_id_not_found" {
+  depends_on = [
+    opentelekomcloud_er_propagation_v3.test,
+  ]
+
+  instance_id    = "%[2]s"
+  route_table_id = opentelekomcloud_er_route_table_v3.test.id
+}
+`, baseConfig, randUUID)
+}

--- a/opentelekomcloud/acceptance/er/resource_opentelekomcloud_er_propagation_v3_test.go
+++ b/opentelekomcloud/acceptance/er/resource_opentelekomcloud_er_propagation_v3_test.go
@@ -92,6 +92,8 @@ func testAccPropagation_base(name string) string {
 	bgpAsNum := acctest.RandIntRange(64512, 65534)
 
 	return fmt.Sprintf(`
+data "opentelekomcloud_er_availability_zones_v3" "test" {}
+
 resource "opentelekomcloud_vpc_v1" "test" {
   name = "%[1]s"
   cidr = "192.168.0.0/16"
@@ -106,7 +108,7 @@ resource "opentelekomcloud_vpc_subnet_v1" "test" {
 }
 
 resource "opentelekomcloud_er_instance_v3" "test" {
-  availability_zones = ["eu-de-02"]
+  availability_zones = slice(data.opentelekomcloud_er_availability_zones_v3.test.names, 0, 1)
 
   name = "%[1]s"
   asn  = %[2]d

--- a/opentelekomcloud/acceptance/er/resource_opentelekomcloud_er_propagation_v3_test.go
+++ b/opentelekomcloud/acceptance/er/resource_opentelekomcloud_er_propagation_v3_test.go
@@ -106,7 +106,7 @@ resource "opentelekomcloud_vpc_subnet_v1" "test" {
 }
 
 resource "opentelekomcloud_er_instance_v3" "test" {
-  availability_zones = ["eu-de-01", "eu-de-02"]
+  availability_zones = ["eu-de-02"]
 
   name = "%[1]s"
   asn  = %[2]d

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -317,6 +317,7 @@ func Provider() *schema.Provider {
 			"opentelekomcloud_er_availability_zones_v3":           er.DataSourceErAvailabilityZonesV3(),
 			"opentelekomcloud_er_quotas_v3":                       er.DataSourceErQuotasV3(),
 			"opentelekomcloud_er_flow_logs_v3":                    er.DataSourceErFlowLogsV3(),
+			"opentelekomcloud_er_propagations_v3":                 er.DataSourcePropagationsV3(),
 			"opentelekomcloud_er_route_tables_v3":                 er.DataSourceRouteTablesV2(),
 			"opentelekomcloud_evs_volumes_v2":                     evs.DataSourceEvsVolumesV2(),
 			"opentelekomcloud_hss_host_groups_v5":                 hss.DataSourceHostGroups(),

--- a/opentelekomcloud/services/er/data_source_opentelekomcloud_er_propagations_v3.go
+++ b/opentelekomcloud/services/er/data_source_opentelekomcloud_er_propagations_v3.go
@@ -1,0 +1,162 @@
+package er
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/er/v3/propagation"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
+)
+
+func DataSourcePropagationsV3() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourcePropagationsRead,
+
+		Schema: map[string]*schema.Schema{
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"route_table_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"attachment_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"attachment_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"propagations": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     propagationSchema(),
+			},
+		},
+	}
+}
+
+func propagationSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"route_table_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"attachment_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"attachment_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"resource_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildPropagationListOpts(d *schema.ResourceData) propagation.ListOpts {
+	opts := propagation.ListOpts{}
+	if attachmentId, ok := d.GetOk("attachment_id"); ok {
+		opts.AttachmentId = []string{attachmentId.(string)}
+	}
+
+	if attachmentType, ok := d.GetOk("attachment_type"); ok {
+		opts.ResourceType = []string{attachmentType.(string)}
+	}
+
+	if status, ok := d.GetOk("status"); ok {
+		opts.State = []string{status.(string)}
+	}
+
+	opts.RouterId = d.Get("instance_id").(string)
+	opts.RouteTableId = d.Get("route_table_id").(string)
+
+	return opts
+}
+
+func flattenPropagations(all []propagation.Propagation) []map[string]interface{} {
+	if len(all) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, len(all))
+	for i, prop := range all {
+		result[i] = map[string]interface{}{
+			"id":              prop.ID,
+			"instance_id":     prop.ErID,
+			"route_table_id":  prop.RouteTableID,
+			"attachment_id":   prop.AttachmentID,
+			"attachment_type": prop.ResourceType,
+			"resource_id":     prop.ResourceID,
+			"status":          prop.State,
+			"created_at":      prop.CreatedAt,
+			"updated_at":      prop.UpdatedAt,
+		}
+	}
+	return result
+}
+
+func dataSourcePropagationsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := config.ErV3Client(config.GetRegion(d))
+	if err != nil {
+		return fmterr.Errorf(errCreationV3Client, err)
+	}
+
+	opts := buildPropagationListOpts(d)
+
+	resp, err := propagation.List(client, opts)
+	if err != nil {
+		return diag.Errorf("error retrieving propagations: %s", err)
+	}
+
+	randUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("propagations", flattenPropagations(resp.Propagations)),
+	)
+
+	if mErr.ErrorOrNil() != nil {
+		return diag.Errorf("error saving data source fields of ER propagations: %s", mErr)
+	}
+	return nil
+}

--- a/releasenotes/notes/er_propagations-f7580dfbeb1592ae.yaml
+++ b/releasenotes/notes/er_propagations-f7580dfbeb1592ae.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  |
+  **[ER]** Add new ``data_source/opentelekomcloud_er_propagations_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)

--- a/releasenotes/notes/er_propagations-f7580dfbeb1592ae.yaml
+++ b/releasenotes/notes/er_propagations-f7580dfbeb1592ae.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   |
-  **[ER]** Add new ``data_source/opentelekomcloud_er_propagations_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+  **[ER]** Add new ``data_source/opentelekomcloud_er_propagations_v3`` (`#3074 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3074>`_)


### PR DESCRIPTION
## Summary of the Pull Request
New data source `opentelekomcloud_er_propagations_v3` implemented.

## PR Checklist

* [x] Refers to: #2992
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccDataSourcePropagations_basic
=== PAUSE TestAccDataSourcePropagations_basic
=== CONT  TestAccDataSourcePropagations_basic
--- PASS: TestAccDataSourcePropagations_basic (168.78s)
PASS

Process finished with the exit code 0
```
