### PR TITLE
[Feat.] ER: associations data source

### DIFF
--- a/docs/data-sources/er_associations_v3.md
+++ b/docs/data-sources/er_associations_v3.md
@@ -1,0 +1,68 @@
+---
+subcategory: "Enterprise Router (ER)"
+layout: "opentelekomcloud"
+page_title: "OpenTelekomCloud: opentelekomcloud_er_associations_v3"
+sidebar_current: "docs-opentelekomcloud-datasource-er-associations-v3"
+description: |-
+  Get the list of ER associations from OpenTelekomCloud
+---
+# opentelekomcloud_er_associations_v3
+
+Use this data source to get the list of associations.
+
+## Example Usage
+
+```hcl
+variable instance_id {}
+variable route_table_id {}
+
+data "opentelekomcloud_er_associations_v3" "test" {
+  instance_id    = var.instance_id
+  route_table_id = var.route_table_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `instance_id` - (Required, String) Specifies the ER instance ID to which the association belongs.
+
+* `route_table_id` - (Required, String) Specifies the route table ID to which the association belongs.
+
+* `attachment_id` - (Optional, String) Specifies the attachment ID corresponding to the association.
+
+* `attachment_type` - (Optional, String) Specifies the attachment type corresponding to the association.
+
+* `status` - (Optional, String) Specifies the status of the association. Default value is `available`.
+  The valid values are as follows:
+  + **available**
+  + **failed**
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `associations` - All associations that match the filter parameters.
+  The [associations](#route_associations) structure is documented below.
+
+<a name="route_associations"></a>
+The `associations` block supports:
+
+* `id` - The association ID.
+
+* `attachment_id` -The attachment ID corresponding to the association.
+
+* `attachment_type` -The type of the attachment corresponding to the association.
+
+* `resource_id` - The resource ID of the attachment corresponding to the association.
+
+* `route_policy_id` - The route policy ID of the egress IPv4 protocol.
+
+* `status` - The current status of the association.
+
+* `created_at` - The creation time.
+
+* `updated_at` - The latest update time.

--- a/opentelekomcloud/acceptance/er/data_source_opentelekomcloud_er_associations_v3_test.go
+++ b/opentelekomcloud/acceptance/er/data_source_opentelekomcloud_er_associations_v3_test.go
@@ -1,0 +1,181 @@
+package er
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+)
+
+func TestAccDataSourceAssociations_basic(t *testing.T) {
+	var (
+		name       = fmt.Sprintf("er-acc-api%s", acctest.RandString(5))
+		baseConfig = testAccDataSourceAssociations_base(name)
+
+		all = "data.opentelekomcloud_er_associations_v3.test"
+		dc  = common.InitDataSourceCheck(all)
+
+		byAttachmentId   = "data.opentelekomcloud_er_associations_v3.filter_by_attachment_id"
+		dcByAttachmentId = common.InitDataSourceCheck(byAttachmentId)
+
+		byAttachmentType   = "data.opentelekomcloud_er_associations_v3.filter_by_attachment_type"
+		dcByAttachmentType = common.InitDataSourceCheck(byAttachmentType)
+
+		byStatus   = "data.opentelekomcloud_er_associations_v3.filter_by_status"
+		dcByStatus = common.InitDataSourceCheck(byStatus)
+
+		byNotFoundInstanceId   = "data.opentelekomcloud_er_associations_v3.instance_id_not_found"
+		dcByNotFoundInstanceId = common.InitDataSourceCheck(byNotFoundInstanceId)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+		},
+		ProviderFactories: common.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAssociations_basic_step1(baseConfig),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(all, "associations.#"),
+					resource.TestCheckResourceAttrSet(all, "associations.0.resource_id"),
+					dcByAttachmentId.CheckResourceExists(),
+					resource.TestCheckOutput("is_attachment_id_filter_useful", "true"),
+					dcByAttachmentType.CheckResourceExists(),
+					resource.TestCheckOutput("is_attachment_type_filter_useful", "true"),
+					dcByStatus.CheckResourceExists(),
+					resource.TestCheckOutput("is_status_filter_useful", "true"),
+				),
+			},
+			{
+				Config: testAccDataSourceAssociations_basic_step2(baseConfig),
+				Check: resource.ComposeTestCheckFunc(
+					dcByNotFoundInstanceId.CheckResourceExists(),
+					resource.TestCheckResourceAttr(byNotFoundInstanceId, "associations.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAssociations_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "opentelekomcloud_er_association_v3" "test" {
+  instance_id    = opentelekomcloud_er_instance_v3.test.id
+  route_table_id = opentelekomcloud_er_route_table_v3.test.id
+  attachment_id  = opentelekomcloud_er_vpc_attachment_v3.test.id
+}
+`, testAccAssociation_base(name))
+}
+
+func testAccDataSourceAssociations_basic_step1(baseConfig string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "opentelekomcloud_er_associations_v3" "test" {
+  depends_on = [
+    opentelekomcloud_er_association_v3.test,
+  ]
+
+  instance_id    = opentelekomcloud_er_instance_v3.test.id
+  route_table_id = opentelekomcloud_er_route_table_v3.test.id
+}
+
+locals {
+  attachment_id = data.opentelekomcloud_er_associations_v3.test.associations[0].attachment_id
+}
+
+data "opentelekomcloud_er_associations_v3" "filter_by_attachment_id" {
+  depends_on = [
+    opentelekomcloud_er_association_v3.test,
+  ]
+
+  instance_id    = opentelekomcloud_er_instance_v3.test.id
+  route_table_id = opentelekomcloud_er_route_table_v3.test.id
+  attachment_id  = local.attachment_id
+}
+
+locals {
+  attachment_id_filter_result = [
+    for v in data.opentelekomcloud_er_associations_v3.filter_by_attachment_id.associations[*].attachment_id :
+    v == local.attachment_id
+  ]
+}
+
+output "is_attachment_id_filter_useful" {
+  value = alltrue(local.attachment_id_filter_result) && length(local.attachment_id_filter_result) > 0
+}
+
+locals {
+  attachment_type = data.opentelekomcloud_er_associations_v3.test.associations[0].attachment_type
+}
+
+data "opentelekomcloud_er_associations_v3" "filter_by_attachment_type" {
+  depends_on = [
+    opentelekomcloud_er_association_v3.test,
+  ]
+
+  instance_id     = opentelekomcloud_er_instance_v3.test.id
+  route_table_id  = opentelekomcloud_er_route_table_v3.test.id
+  attachment_type = local.attachment_type
+}
+
+locals {
+  attachment_type_filter_result = [
+    for v in data.opentelekomcloud_er_associations_v3.filter_by_attachment_type.associations[*].attachment_type :
+    v == local.attachment_type
+  ]
+}
+
+output "is_attachment_type_filter_useful" {
+  value = alltrue(local.attachment_type_filter_result) && length(local.attachment_type_filter_result) > 0
+}
+
+locals {
+  status = data.opentelekomcloud_er_associations_v3.test.associations[0].status
+}
+
+data "opentelekomcloud_er_associations_v3" "filter_by_status" {
+  depends_on = [
+    opentelekomcloud_er_association_v3.test,
+  ]
+
+  instance_id    = opentelekomcloud_er_instance_v3.test.id
+  route_table_id = opentelekomcloud_er_route_table_v3.test.id
+  status         = local.status
+}
+
+locals {
+  status_filter_result = [
+    for v in data.opentelekomcloud_er_associations_v3.filter_by_status.associations[*].status : v == local.status
+  ]
+}
+
+output "is_status_filter_useful" {
+  value = alltrue(local.status_filter_result) && length(local.status_filter_result) > 0
+}
+`, baseConfig)
+}
+
+func testAccDataSourceAssociations_basic_step2(baseConfig string) string {
+	randUUID, _ := uuid.GenerateUUID()
+
+	return fmt.Sprintf(`
+%[1]s
+
+data "opentelekomcloud_er_associations_v3" "instance_id_not_found" {
+  depends_on = [
+    opentelekomcloud_er_association_v3.test,
+  ]
+
+  instance_id    = "%[2]s"
+  route_table_id = opentelekomcloud_er_route_table_v3.test.id
+}
+`, baseConfig, randUUID)
+}

--- a/opentelekomcloud/acceptance/er/resource_opentelekomcloud_er_association_v3_test.go
+++ b/opentelekomcloud/acceptance/er/resource_opentelekomcloud_er_association_v3_test.go
@@ -92,6 +92,9 @@ func testAccAssociation_base(name string) string {
 	bgpAsNum := acctest.RandIntRange(64512, 65534)
 
 	return fmt.Sprintf(`
+
+data "opentelekomcloud_er_availability_zones_v3" "test" {}
+
 resource "opentelekomcloud_vpc_v1" "test" {
   name = "%[1]s"
   cidr = "192.168.0.0/16"
@@ -106,7 +109,7 @@ resource "opentelekomcloud_vpc_subnet_v1" "test" {
 }
 
 resource "opentelekomcloud_er_instance_v3" "test" {
-  availability_zones = ["eu-de-01", "eu-de-02"]
+  availability_zones = slice(data.opentelekomcloud_er_availability_zones_v3.test.names, 0, 1)
 
   name = "%[1]s"
   asn  = %[2]d

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -313,6 +313,7 @@ func Provider() *schema.Provider {
 			"opentelekomcloud_dns_nameservers_v2":                 dns.DataSourceDNSNameserversV2(),
 			"opentelekomcloud_dns_zone_v2":                        dns.DataSourceDNSZoneV2(),
 			"opentelekomcloud_dws_flavors_v2":                     dws.DataSourceDwsFlavorsV2(),
+			"opentelekomcloud_er_associations_v3":                 er.DataSourceAssociationsV3(),
 			"opentelekomcloud_er_instances_v3":                    er.DataSourceErInstancesV3(),
 			"opentelekomcloud_er_availability_zones_v3":           er.DataSourceErAvailabilityZonesV3(),
 			"opentelekomcloud_er_quotas_v3":                       er.DataSourceErQuotasV3(),

--- a/opentelekomcloud/services/er/data_source_opentelekomcloud_er_associations_v3.go
+++ b/opentelekomcloud/services/er/data_source_opentelekomcloud_er_associations_v3.go
@@ -1,0 +1,153 @@
+package er
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/er/v3/association"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
+)
+
+func DataSourceAssociationsV3() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAssociationsRead,
+
+		Schema: map[string]*schema.Schema{
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"route_table_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"attachment_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"attachment_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"associations": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     associationsSchema(),
+			},
+		},
+	}
+}
+
+func associationsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"route_table_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"attachment_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"attachment_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"resource_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildAssociationsistOpts(d *schema.ResourceData) association.ListOpts {
+	opts := association.ListOpts{
+		RouterId:     d.Get("instance_id").(string),
+		RouteTableId: d.Get("route_table_id").(string),
+	}
+	if attachmentId, ok := d.GetOk("attachment_id"); ok {
+		opts.AttachmentId = []string{attachmentId.(string)}
+	}
+
+	if attachmentType, ok := d.GetOk("attachment_type"); ok {
+		opts.ResourceType = []string{attachmentType.(string)}
+	}
+
+	if status, ok := d.GetOk("status"); ok {
+		opts.State = []string{status.(string)}
+	}
+
+	return opts
+}
+
+func flattenAssociations(all []association.Association) []map[string]interface{} {
+	if len(all) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, len(all))
+	for i, assoc := range all {
+		result[i] = map[string]interface{}{
+			"id":              assoc.ID,
+			"route_table_id":  assoc.RouteTableID,
+			"attachment_id":   assoc.AttachmentID,
+			"attachment_type": assoc.ResourceType,
+			"resource_id":     assoc.ResourceID,
+			"status":          assoc.State,
+			"created_at":      assoc.CreatedAt,
+			"updated_at":      assoc.UpdatedAt,
+		}
+	}
+	return result
+}
+
+func dataSourceAssociationsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := config.ErV3Client(config.GetRegion(d))
+	if err != nil {
+		return fmterr.Errorf(errCreationV3Client, err)
+	}
+
+	opts := buildAssociationsistOpts(d)
+	resp, err := association.List(client, opts)
+	if err != nil {
+		return diag.Errorf("error retrieving associations: %s", err)
+	}
+
+	randUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("associations", flattenAssociations(resp.Associations)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}

--- a/releasenotes/notes/er_associations-afcaffab9a2bc520.yaml
+++ b/releasenotes/notes/er_associations-afcaffab9a2bc520.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  |
+  **[ER]** Add new ``data_source/opentelekomcloud_er_associations_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)

--- a/releasenotes/notes/er_associations-afcaffab9a2bc520.yaml
+++ b/releasenotes/notes/er_associations-afcaffab9a2bc520.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   |
-  **[ER]** Add new ``data_source/opentelekomcloud_er_associations_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+  **[ER]** Add new ``data_source/opentelekomcloud_er_associations_v3`` (`#3078 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3078>`_)


### PR DESCRIPTION
## Summary of the Pull Request
New ``data_source/opentelekomcloud_er_associations_v3``

## PR Checklist

* [x] Refers to: #2992
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccDataSourceAssociations_basic
=== PAUSE TestAccDataSourceAssociations_basic
=== CONT  TestAccDataSourceAssociations_basic
--- PASS: TestAccDataSourceAssociations_basic (161.59s)
PASS

Process finished with the exit code 0
```
