### PR TITLE
[Refactor] FGS: enable_class_isolation set as argument in fgs_function_v2

### DIFF
--- a/docs/resources/fgs_function_v2.md
+++ b/docs/resources/fgs_function_v2.md
@@ -321,6 +321,8 @@ The following arguments are supported:
 
 * `enable_dynamic_memory` - (Optional, Boolean) Specifies whether to enable dynamic memory allocation.
 
+* `enable_class_isolation` - (Optional, Boolean) Specifies whether to enable class isolation.
+
 The `func_mounts` block supports:
 
 * `mount_type` - (Required, String) Specifies the mount type.
@@ -445,8 +447,6 @@ In addition to all arguments above, the following attributes are exported:
 * `apig_route_enable` - Whether to configure gateway routing rules.
 
 * `heartbeat_handler` - Entry of the heartbeat function in the format of "xx.xx".
-
-* `enable_class_isolation` - Indicates whether to enable class isolation.
 
 * `allow_ephemeral_storage` - Indicates whether ephemeral storage can be configured.
 

--- a/opentelekomcloud/acceptance/fgs/resource_opentelekomcloud_fgs_function_v2_test.go
+++ b/opentelekomcloud/acceptance/fgs/resource_opentelekomcloud_fgs_function_v2_test.go
@@ -1109,6 +1109,7 @@ func TestAccFgsV2Function_EnableDynamicMemory(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "enable_dynamic_memory", "true"),
+					resource.TestCheckResourceAttr(resourceName, "enable_class_isolation", "true"),
 				),
 			},
 		},
@@ -1118,16 +1119,17 @@ func TestAccFgsV2Function_EnableDynamicMemory(t *testing.T) {
 func testAccFunction_EnableDynamicMemory(name string) string {
 	return fmt.Sprintf(`
 resource "opentelekomcloud_fgs_function_v2" "test" {
-  functiongraph_version = "v2"
-  name                  = "%[1]s"
-  app                   = "default"
-  handler               = "index.handler"
-  memory_size           = 128
-  timeout               = 3
-  runtime               = "Python2.7"
-  code_type             = "inline"
-  func_code             = "dCA9ICdIZWxsbyBtZXNzYWdlOiAnICsganN="
-  enable_dynamic_memory = true
+  functiongraph_version  = "v2"
+  name                   = "%[1]s"
+  app                    = "default"
+  handler                = "index.handler"
+  memory_size            = 128
+  timeout                = 3
+  runtime                = "Python2.7"
+  code_type              = "inline"
+  func_code              = "dCA9ICdIZWxsbyBtZXNzYWdlOiAnICsganN="
+  enable_dynamic_memory  = true
+  enable_class_isolation = true
 }
 `, name)
 }

--- a/opentelekomcloud/services/fgs/resource_opentelekomcloud_fgs_function_v2.go
+++ b/opentelekomcloud/services/fgs/resource_opentelekomcloud_fgs_function_v2.go
@@ -356,6 +356,10 @@ func ResourceFgsFunctionV2() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
+			"enable_class_isolation": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 			"extend_config": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -370,10 +374,6 @@ func ResourceFgsFunctionV2() *schema.Resource {
 			},
 			"heartbeat_handler": {
 				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"enable_class_isolation": {
-				Type:     schema.TypeBool,
 				Computed: true,
 			},
 			"gpu_type": {
@@ -586,7 +586,7 @@ func resourceFgsFunctionV2Create(ctx context.Context, d *schema.ResourceData, me
 	d.SetId(f.FuncURN)
 	urn := resourceFgsFunctionUrn(d.Id())
 	if d.HasChanges("vpc_id", "network_id", "peering_cidr", "func_mounts", "app_agency", "initializer_handler",
-		"initializer_timeout", "concurrency_num") {
+		"initializer_timeout", "concurrency_num", "enable_class_isolation") {
 		err := resourceFgsFunctionMetadataUpdate(fgsClient, urn, d)
 		if err != nil {
 			return diag.FromErr(err)
@@ -1254,25 +1254,26 @@ func resourceFgsFunctionMetadataUpdate(fgsClient *golangsdk.ServiceClient, urn s
 	}
 
 	updateMetadateOpts := function.UpdateFuncMetadataOpts{
-		Name:                d.Get("name").(string),
-		Handler:             d.Get("handler").(string),
-		MemorySize:          d.Get("memory_size").(int),
-		Timeout:             d.Get("timeout").(int),
-		Runtime:             d.Get("runtime").(string),
-		Package:             packV,
-		Description:         d.Get("description").(string),
-		UserData:            d.Get("user_data").(string),
-		EncryptedUserData:   d.Get("encrypted_user_data").(string),
-		Xrole:               agencyV,
-		AppXrole:            d.Get("app_agency").(string),
-		InitHandler:         d.Get("initializer_handler").(string),
-		InitTimeout:         pointerto.Int(d.Get("initializer_timeout").(int)),
-		CustomImage:         buildCustomImage(d.Get("custom_image").([]interface{})),
-		GpuMemory:           pointerto.Int(d.Get("gpu_memory").(int)),
-		PreStopHandler:      d.Get("pre_stop_handler").(string),
-		PreStopTimeout:      pointerto.Int(d.Get("pre_stop_timeout").(int)),
-		PeeringCIDR:         d.Get("peering_cidr").(string),
-		EnableDynamicMemory: pointerto.Bool(d.Get("enable_dynamic_memory").(bool)),
+		Name:                 d.Get("name").(string),
+		Handler:              d.Get("handler").(string),
+		MemorySize:           d.Get("memory_size").(int),
+		Timeout:              d.Get("timeout").(int),
+		Runtime:              d.Get("runtime").(string),
+		Package:              packV,
+		Description:          d.Get("description").(string),
+		UserData:             d.Get("user_data").(string),
+		EncryptedUserData:    d.Get("encrypted_user_data").(string),
+		Xrole:                agencyV,
+		AppXrole:             d.Get("app_agency").(string),
+		InitHandler:          d.Get("initializer_handler").(string),
+		InitTimeout:          pointerto.Int(d.Get("initializer_timeout").(int)),
+		CustomImage:          buildCustomImage(d.Get("custom_image").([]interface{})),
+		GpuMemory:            pointerto.Int(d.Get("gpu_memory").(int)),
+		PreStopHandler:       d.Get("pre_stop_handler").(string),
+		PreStopTimeout:       pointerto.Int(d.Get("pre_stop_timeout").(int)),
+		PeeringCIDR:          d.Get("peering_cidr").(string),
+		EnableDynamicMemory:  pointerto.Bool(d.Get("enable_dynamic_memory").(bool)),
+		EnableClassIsolation: pointerto.Bool(d.Get("enable_class_isolation").(bool)),
 	}
 
 	if _, ok := d.GetOk("vpc_id"); ok {

--- a/releasenotes/notes/fgs-new-argument-function-v2-6a4b5058fdafccee.yaml
+++ b/releasenotes/notes/fgs-new-argument-function-v2-6a4b5058fdafccee.yaml
@@ -1,0 +1,4 @@
+---
+upgrade:
+  - |
+    **[FGS]** Change `enable_class_isolation` from an attribute to argument in ``resource/opentelekomcloud_fgs_function_v2`` (`#3080 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3080>`_)


### PR DESCRIPTION
## Summary of the Pull Request

The parameter `enable_class_isolation` is now an argument in resource `opentelekomcloud_fgs_function_v2`

## PR Checklist

* [x] Refers to: #3079 
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccFgsV2Function_EnableDynamicMemory
=== PAUSE TestAccFgsV2Function_EnableDynamicMemory
=== CONT  TestAccFgsV2Function_EnableDynamicMemory
--- PASS: TestAccFgsV2Function_EnableDynamicMemory (29.94s)
PASS
```
