### PR TITLE
[Fix] data_store and backup_strategy settings for `opentelekomcloud_gaussdb_mysql_instance_v3`

### DIFF
--- a/docs/resources/gaussdb_mysql_instance_v3.md
+++ b/docs/resources/gaussdb_mysql_instance_v3.md
@@ -112,8 +112,7 @@ The `backup_strategy` block supports:
   HH value must be 1 greater than the hh value. The values of mm and MM must be the same and must be set to 00. Example
   value: 08:00-09:00, 03:00-04:00.
 
-* `keep_days` - (Optional, String
-* ) Specifies the number of days to retain the generated backup files. The value ranges from
+* `keep_days` - (Optional, String) Specifies the number of days to retain the generated backup files. The value ranges from
   0 to 35. If this parameter is set to 0, the automated backup policy is not set. If this parameter is not transferred,
   the automated backup policy is enabled by default. Backup files are stored for seven days by default.
 

--- a/docs/resources/gaussdb_mysql_instance_v3.md
+++ b/docs/resources/gaussdb_mysql_instance_v3.md
@@ -112,7 +112,8 @@ The `backup_strategy` block supports:
   HH value must be 1 greater than the hh value. The values of mm and MM must be the same and must be set to 00. Example
   value: 08:00-09:00, 03:00-04:00.
 
-* `keep_days` - (Optional, Int) Specifies the number of days to retain the generated backup files. The value ranges from
+* `keep_days` - (Optional, String
+* ) Specifies the number of days to retain the generated backup files. The value ranges from
   0 to 35. If this parameter is set to 0, the automated backup policy is not set. If this parameter is not transferred,
   the automated backup policy is enabled by default. Backup files are stored for seven days by default.
 

--- a/opentelekomcloud/acceptance/gaussdb/resource_opentelekomcloud_gaussdb_mysql_instance_v3_test.go
+++ b/opentelekomcloud/acceptance/gaussdb/resource_opentelekomcloud_gaussdb_mysql_instance_v3_test.go
@@ -76,6 +76,14 @@ resource "opentelekomcloud_gaussdb_mysql_instance_v3" "instance" {
   availability_zone_mode   = "multi"
   master_availability_zone = "eu-de-01"
   read_replicas            = 1
+  datastore {
+    engine  = "gaussdb-mysql"
+    version = "8.0"
+  }
+  backup_strategy {
+    start_time = "03:00-04:00"
+    keep_days  = 7
+  }
 }
 `, common.DataSourceSubnet, common.DataSourceSecGroupDefault, postfix)
 }
@@ -94,6 +102,14 @@ resource "opentelekomcloud_gaussdb_mysql_instance_v3" "instance" {
   availability_zone_mode   = "multi"
   master_availability_zone = "eu-de-01"
   read_replicas            = 1
+  datastore {
+    engine  = "gaussdb-mysql"
+    version = "8.0"
+  }
+  backup_strategy {
+    start_time = "03:00-04:00"
+    keep_days  = 8
+  }
 }
 `, common.DataSourceSubnet, common.DataSourceSecGroupDefault, postfix)
 }

--- a/opentelekomcloud/services/gaussdb/resource_opentelekomcloud_gaussdb_mysql_instance_v3.go
+++ b/opentelekomcloud/services/gaussdb/resource_opentelekomcloud_gaussdb_mysql_instance_v3.go
@@ -137,13 +137,11 @@ func ResourceGaussDBInstanceV3() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 							ForceNew: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								"gaussdb-mysql",
-							}, true),
 						},
 						"version": {
 							Type:     schema.TypeString,
-							Required: true,
+							Optional: true,
+							Computed: true,
 							ForceNew: true,
 						},
 					},
@@ -161,7 +159,7 @@ func ResourceGaussDBInstanceV3() *schema.Resource {
 							Required: true,
 						},
 						"keep_days": {
-							Type:     schema.TypeInt,
+							Type:     schema.TypeString,
 							Optional: true,
 						},
 					},
@@ -408,13 +406,12 @@ func resourceGaussDBInstanceV3Read(_ context.Context, d *schema.ResourceData, me
 
 	log.Printf("[DEBUG] Retrieved instance %s: %#v", d.Id(), inst)
 
-	// set data store
-	dbList := make([]map[string]interface{}, 1)
-	db := map[string]interface{}{
-		"version": inst.Datastore.Version,
-		"engine":  inst.Datastore.Type,
+	ds := []interface{}{
+		map[string]interface{}{
+			"engine":  inst.Datastore.Type,
+			"version": normalizeVersion(inst.Datastore.Version),
+		},
 	}
-	dbList = append(dbList, db)
 
 	port, err := strconv.Atoi(inst.Port)
 	if err != nil {
@@ -440,7 +437,7 @@ func resourceGaussDBInstanceV3Read(_ context.Context, d *schema.ResourceData, me
 		d.Set("availability_zone_mode", inst.AzMode),
 		d.Set("master_availability_zone", inst.MasterAzCode),
 		d.Set("port", port),
-		d.Set("datastore", dbList),
+		d.Set("datastore", ds),
 		d.Set("alias", inst.Alias),
 		d.Set("charging_mode", inst.ChargeInfo.ChargeMode),
 		d.Set("node_count", inst.NodeCount),
@@ -504,9 +501,7 @@ func resourceGaussDBInstanceV3Read(_ context.Context, d *schema.ResourceData, me
 	backupStrategyList := make([]map[string]interface{}, 1)
 	backupStrategy := map[string]interface{}{
 		"start_time": inst.BackupStrategy.StartTime,
-	}
-	if days, err := strconv.Atoi(inst.BackupStrategy.KeepDays); err == nil {
-		backupStrategy["keep_days"] = days
+		"keep_days":  inst.BackupStrategy.KeepDays,
 	}
 	backupStrategyList[0] = backupStrategy
 	mErr = multierror.Append(d.Set("backup_strategy", backupStrategyList))
@@ -652,8 +647,8 @@ func resourceGaussDBInstanceV3Update(ctx context.Context, d *schema.ResourceData
 		}
 		backupRaw := d.Get("backup_strategy").([]interface{})
 		rawMap := backupRaw[0].(map[string]interface{})
-		keepDays := rawMap["keep_days"].(int)
-		updateOpts.BackupPolicy.KeepDays = keepDays
+		keepDays := rawMap["keep_days"].(string)
+		updateOpts.BackupPolicy.KeepDays, _ = strconv.Atoi(keepDays)
 		updateOpts.BackupPolicy.StartTime = rawMap["start_time"].(string)
 		// Fixed to "1,2,3,4,5,6,7"
 		updateOpts.BackupPolicy.Period = "1,2,3,4,5,6,7"
@@ -718,4 +713,12 @@ func waitForGaussJob(client *golangsdk.ServiceClient, jobId string, timeout int)
 	})
 
 	return false, err
+}
+
+func normalizeVersion(v string) string {
+	parts := strings.Split(v, ".")
+	if len(parts) >= 2 {
+		return fmt.Sprintf("%s.%s", parts[0], parts[1])
+	}
+	return v
 }

--- a/releasenotes/notes/gaussdb-fix-01c0bfe431cb4b8b.yaml
+++ b/releasenotes/notes/gaussdb-fix-01c0bfe431cb4b8b.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[GAUSSDB]** Fix resource parameters setting ``backup_strategy`` and ``datastore`` for ``resource/opentelekomcloud_gaussdb_mysql_instance_v3`` (`#3084 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3084>`_)


### PR DESCRIPTION
## Summary of the Pull Request

## PR Checklist

* [x] Refers to: #3062
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccMysqlGaussdbInstanceV3Basic
--- PASS: TestAccMysqlGaussdbInstanceV3Basic (1166.90s)
PASS

Debugger finished with the exit code 0
```
