### PR TITLE
[Fix.] CCE: remove redundant node errorchecks

### DIFF
--- a/docs/resources/cce_node_v3.md
+++ b/docs/resources/cce_node_v3.md
@@ -36,12 +36,12 @@ resource "opentelekomcloud_cce_node_v3" "node_1" {
 
   root_volume {
     size       = 40
-    volumetype = "SATA"
+    volumetype = "SAS"
   }
 
   data_volumes {
     size       = 100
-    volumetype = "SATA"
+    volumetype = "SAS"
   }
   data_volumes {
     size       = 100

--- a/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_node_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_node_v3_test.go
@@ -554,12 +554,12 @@ resource "opentelekomcloud_cce_node_v3" "node_2" {
 
   root_volume {
     size       = 40
-    volumetype = "SATA"
+    volumetype = "SAS"
   }
 
   data_volumes {
     size       = 100
-    volumetype = "SATA"
+    volumetype = "SAS"
   }
 }
 
@@ -574,12 +574,12 @@ resource "opentelekomcloud_cce_node_v3" "node_3" {
 
   root_volume {
     size       = 40
-    volumetype = "SATA"
+    volumetype = "SAS"
   }
 
   data_volumes {
     size       = 100
-    volumetype = "SATA"
+    volumetype = "SAS"
   }
 }
 `, shared.DataSourceCluster, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME)
@@ -600,7 +600,7 @@ resource "opentelekomcloud_cce_node_v3" "node_1" {
 
   root_volume {
     size       = 40
-    volumetype = "SATA"
+    volumetype = "SAS"
   }
 
   data_volumes {
@@ -630,7 +630,7 @@ resource "opentelekomcloud_cce_node_v3" "node_1" {
 
   root_volume {
     size       = 40
-    volumetype = "SATA"
+    volumetype = "SAS"
   }
   data_volumes {
     size       = 100
@@ -659,12 +659,12 @@ resource "opentelekomcloud_cce_node_v3" "node_1" {
 
   root_volume {
     size       = 40
-    volumetype = "SATA"
+    volumetype = "SAS"
   }
 
   data_volumes {
     size       = 100
-    volumetype = "SATA"
+    volumetype = "SAS"
   }
 }
 `, shared.DataSourceCluster, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME)
@@ -681,11 +681,11 @@ resource "opentelekomcloud_cce_node_v3" "node_1" {
 
   root_volume {
     size       = 40
-    volumetype = "SATA"
+    volumetype = "SAS"
   }
   data_volumes {
     size       = 100
-    volumetype = "SATA"
+    volumetype = "SAS"
   }
   timeouts {
     create = "10m"
@@ -705,14 +705,14 @@ resource "opentelekomcloud_cce_node_v3" "node_1" {
   key_pair          = "%s"
   root_volume {
     size       = 40
-    volumetype = "SATA"
+    volumetype = "SAS"
   }
 
   bandwidth_size = 100
 
   data_volumes {
     size       = 100
-    volumetype = "SATA"
+    volumetype = "SAS"
   }
 }
 `, shared.DataSourceCluster, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME)
@@ -728,14 +728,14 @@ resource "opentelekomcloud_cce_node_v3" "node_1" {
   key_pair          = "%s"
   root_volume {
     size       = 40
-    volumetype = "SATA"
+    volumetype = "SAS"
   }
 
   bandwidth_size = 10
 
   data_volumes {
     size       = 100
-    volumetype = "SATA"
+    volumetype = "SAS"
   }
 }
 `, shared.DataSourceCluster, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME)
@@ -751,12 +751,12 @@ resource "opentelekomcloud_cce_node_v3" "node_1" {
   key_pair          = "%s"
   root_volume {
     size       = 40
-    volumetype = "SATA"
+    volumetype = "SAS"
   }
 
   data_volumes {
     size       = 100
-    volumetype = "SATA"
+    volumetype = "SAS"
   }
 }
 `, shared.DataSourceCluster, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME)
@@ -772,7 +772,7 @@ resource "opentelekomcloud_cce_node_v3" "node_1" {
   key_pair          = "%s"
   root_volume {
     size       = 40
-    volumetype = "SATA"
+    volumetype = "SAS"
   }
 
   bandwidth_size = 100
@@ -781,7 +781,7 @@ resource "opentelekomcloud_cce_node_v3" "node_1" {
 
   data_volumes {
     size       = 100
-    volumetype = "SATA"
+    volumetype = "SAS"
   }
 }
 `, shared.DataSourceCluster, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME)
@@ -797,7 +797,7 @@ resource "opentelekomcloud_cce_node_v3" "node_1" {
   key_pair          = "%s"
   root_volume {
     size       = 40
-    volumetype = "SATA"
+    volumetype = "SAS"
   }
 
   bandwidth_size = null
@@ -806,7 +806,7 @@ resource "opentelekomcloud_cce_node_v3" "node_1" {
 
   data_volumes {
     size       = 100
-    volumetype = "SATA"
+    volumetype = "SAS"
   }
 }
 `, shared.DataSourceCluster, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME)
@@ -825,14 +825,14 @@ resource "opentelekomcloud_cce_node_v3" "node_1" {
   key_pair          = "%s"
   root_volume {
     size       = 40
-    volumetype = "SATA"
+    volumetype = "SAS"
   }
 
   eip_ids = [opentelekomcloud_networking_floatingip_v2.fip_1.id]
 
   data_volumes {
     size       = 100
-    volumetype = "SATA"
+    volumetype = "SAS"
   }
 }
 `, shared.DataSourceCluster, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME)
@@ -850,14 +850,14 @@ resource "opentelekomcloud_cce_node_v3" "node_1" {
   key_pair          = "%s"
   root_volume {
     size       = 40
-    volumetype = "SATA"
+    volumetype = "SAS"
   }
 
   eip_ids = [opentelekomcloud_networking_floatingip_v2.fip_2.id]
 
   data_volumes {
     size       = 100
-    volumetype = "SATA"
+    volumetype = "SAS"
   }
 }
 `, shared.DataSourceCluster, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME)
@@ -873,13 +873,13 @@ resource "opentelekomcloud_cce_node_v3" "node_1" {
 
   root_volume {
     size       = 40
-    volumetype = "SATA"
+    volumetype = "SAS"
     kms_id     = "%s"
   }
 
   data_volumes {
     size       = 100
-    volumetype = "SATA"
+    volumetype = "SAS"
     kms_id     = "%s"
   }
 }
@@ -897,11 +897,11 @@ resource "opentelekomcloud_cce_node_v3" "node_1" {
   key_pair          = "%s"
   root_volume {
     size       = 40
-    volumetype = "SATA"
+    volumetype = "SAS"
   }
   data_volumes {
     size       = 100
-    volumetype = "SATA"
+    volumetype = "SAS"
   }
   taints {
     key    = "dedicated"
@@ -930,12 +930,12 @@ resource "opentelekomcloud_cce_node_v3" "node_1" {
 
   root_volume {
     size       = 40
-    volumetype = "SATA"
+    volumetype = "SAS"
   }
 
   data_volumes {
     size       = 100
-    volumetype = "SATA"
+    volumetype = "SAS"
   }
 
   max_pods         = 16
@@ -970,7 +970,7 @@ resource "opentelekomcloud_cce_node_v3" "node_1" {
 
   root_volume {
     size       = 40
-    volumetype = "SATA"
+    volumetype = "SAS"
   }
 
   data_volumes {

--- a/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_v3.go
+++ b/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_v3.go
@@ -603,16 +603,7 @@ func resourceCCENodeV3Create(ctx context.Context, d *schema.ResourceData, meta i
 
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)
 	node, err := nodes.Create(client, clusterID, createOpts)
-	switch err.(type) {
-	case golangsdk.ErrDefault403:
-		retryNode, err := recursiveCreate(ctx, client, createOpts, clusterID)
-		if err == "fail" {
-			return fmterr.Errorf("error creating OpenTelekomCloud Node")
-		}
-		node = retryNode
-	case nil:
-		break
-	default:
+	if err != nil {
 		return fmterr.Errorf("error creating OpenTelekomCloud Node: %s", err)
 	}
 
@@ -1166,28 +1157,6 @@ func waitForClusterAvailable(cceClient *golangsdk.ServiceClient, clusterId strin
 
 		return n, n.Status.Phase, nil
 	}
-}
-
-func recursiveCreate(ctx context.Context, client *golangsdk.ServiceClient, opts nodes.CreateOpts, clusterID string) (*nodes.Nodes, string) {
-	stateCluster := &resource.StateChangeConf{
-		Target:     []string{"Available"},
-		Refresh:    waitForClusterAvailable(client, clusterID),
-		Timeout:    15 * time.Minute,
-		Delay:      15 * time.Second,
-		MinTimeout: 3 * time.Second,
-	}
-	_, stateErr := stateCluster.WaitForStateContext(ctx)
-	if stateErr != nil {
-		log.Printf("[INFO] Cluster Unavailable %s.\n", stateErr)
-	}
-	node, err := nodes.Create(client, clusterID, opts)
-	if err != nil {
-		if _, ok := err.(golangsdk.ErrDefault403); ok {
-			return recursiveCreate(ctx, client, opts, clusterID)
-		}
-		return node, "fail"
-	}
-	return node, "success"
 }
 
 func resourceNodeImport(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {

--- a/releasenotes/notes/cce_node_change-9a2d3755dd8cd149.yaml
+++ b/releasenotes/notes/cce_node_change-9a2d3755dd8cd149.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[CCE]** Remove redundant error switch for ``resource/opentelekomcloud_cce_node_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)

--- a/releasenotes/notes/cce_node_change-9a2d3755dd8cd149.yaml
+++ b/releasenotes/notes/cce_node_change-9a2d3755dd8cd149.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    **[CCE]** Remove redundant error switch for ``resource/opentelekomcloud_cce_node_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[CCE]** Remove redundant error switch for ``resource/opentelekomcloud_cce_node_v3`` (`#3091 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3091>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Remove redundant error checks after node creation

## PR Checklist

* [ ] Refers to: #xxx
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccResourceCCENodesV3OS
=== PAUSE TestAccResourceCCENodesV3OS
=== CONT  TestAccResourceCCENodesV3OS
    resource_opentelekomcloud_cce_node_v3_test.go:191: Cluster is required by the test. 1 test(s) are using cluster.
    cluster.go:121: starting creating shared cluster
2025/08/12 11:39:46 [DEBUG] Waiting for state to become: [Available]
......
2025/08/12 11:43:25 [TRACE] Waiting 10s before next try
2025/08/12 11:43:36 [TRACE] Waiting 10s before next try
2025/08/12 11:43:46 [TRACE] Waiting 10s before next try
    cluster.go:117: Cluster usage is 0 now, ready to delete the cluster
    cluster.go:80: starting deleting shared cluster
--- PASS: TestAccResourceCCENodesV3OS (672.63s)
PASS

Process finished with the exit code 0
```
