### PR TITLE
[Feat.] Add attribute for `default_group_id` in `opentelekomcloud_apigw_gateway_v2`

### DIFF
--- a/docs/resources/apigw_gateway_v2.md
+++ b/docs/resources/apigw_gateway_v2.md
@@ -92,6 +92,8 @@ All above argument parameters can be exported as attribute parameters along with
 * `maintain_end` - End time of the maintenance time window. It must be in the format "xx:00:00".
   There is a 4-hour difference between the start time and end time.
 
+* `default_group_id` - The ID of `DEFAULT` group.
+
 * `vpc_ingress_address` - VPC ingress address.
 
 * `public_egress_address` - IP address for public outbound access.

--- a/opentelekomcloud/acceptance/apigw/resource_opentelekomcloud_apigw_gateway_v2_test.go
+++ b/opentelekomcloud/acceptance/apigw/resource_opentelekomcloud_apigw_gateway_v2_test.go
@@ -48,6 +48,7 @@ func TestAccAPIGWv2Gateway_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceGwName, "spec_id", "BASIC"),
 					resource.TestCheckResourceAttr(resourceGwName, "description", "test gateway"),
 					resource.TestCheckResourceAttr(resourceGwName, "maintain_begin", "22:00:00"),
+					resource.TestCheckResourceAttrSet(resourceGwName, "default_group_id"),
 				),
 			},
 			{

--- a/opentelekomcloud/services/apigw/resource_opentelekomcloud_apigw_gateway_v2.go
+++ b/opentelekomcloud/services/apigw/resource_opentelekomcloud_apigw_gateway_v2.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/apigw/v2/gateway"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/apigw/v2/group"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/pointerto"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
@@ -164,6 +165,10 @@ func ResourceAPIGWv2() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"default_group_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"private_egress_addresses": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -290,6 +295,15 @@ func resourceGatewayRead(_ context.Context, d *schema.ResourceData, meta interfa
 	if err != nil {
 		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error getting instance (%s) details form server", instanceId))
 	}
+
+	groups, err := group.List(client, group.ListOpts{
+		GatewayID: instanceId,
+		Name:      "DEFAULT",
+	})
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	log.Printf("[DEBUG] Retrieved the dedicated instance (%s): %#v", instanceId, resp)
 
 	mErr := multierror.Append(nil,
@@ -323,6 +337,11 @@ func resourceGatewayRead(_ context.Context, d *schema.ResourceData, meta interfa
 	if len(resp.NodeIps.Shubao) > 0 {
 		mErr = multierror.Append(mErr, d.Set("private_egress_addresses", resp.NodeIps.Shubao))
 	}
+
+	if len(groups) > 0 {
+		mErr = multierror.Append(mErr, d.Set("default_group_id", groups[0].ID))
+	}
+
 	if mErr.ErrorOrNil() != nil {
 		return diag.Errorf("error saving resource fields of the dedicated instance: %s", mErr)
 	}

--- a/releasenotes/notes/apigw-gw-default-group-id-446bc7935056cefb.yaml
+++ b/releasenotes/notes/apigw-gw-default-group-id-446bc7935056cefb.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    **[APIGW]** Add attribute ``default_group_id`` in ``resource/opentelekomcloud_apigw_gateway_v2``
+    (`#3093 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3093>`_)


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [x] Refers to: #3088
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccAPIGWv2Gateway_basic
=== PAUSE TestAccAPIGWv2Gateway_basic
=== CONT  TestAccAPIGWv2Gateway_basic
--- PASS: TestAccAPIGWv2Gateway_basic (534.86s)
PASS

Process finished with the exit code 0
```
