### PR TITLE
[Feat] TMS: Add new data source tms_resource_instances_v1

### DIFF
--- a/docs/data-sources/tms_resource_instances_v1.md
+++ b/docs/data-sources/tms_resource_instances_v1.md
@@ -1,0 +1,60 @@
+---
+subcategory: "Tag Management Service (TMS)"
+layout: "opentelekomcloud"
+page_title: "OpenTelekomCloud: opentelekomcloud_tms_resource_instances_v1"
+sidebar_current: "docs-opentelekomcloud-datasource-tms-resource-instances-v1"
+description: |-
+  Get TMS resource instances resource, used to query resources by tag, within OpenTelekomCloud.
+---
+
+Up-to-date reference of API arguments for TMS resource instances you can get at
+[documentation portal](https://docs.otc.t-systems.com/tag-management-service/api-ref/api_description/resource_tags/querying_resources_by_tag.html)
+
+# opentelekomcloud_tms_resource_instances_v1
+
+Use this data source to get the list of resource instances filtered by tag within OpenTelekomCloud.
+
+## Example Usage
+
+```hcl
+variable "project_id" {}
+
+data "opentelekomcloud_tms_resource_instances_v1" "tags_ds_1" {
+  resource_types = ["disk", "ecs"]
+  tags {
+    key    = "test"
+    values = ["test-tf-acc"]
+  }
+  project_id = var.project_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `resource_types` - (Required, List[String]) Specifies the resource type. This parameter is case-sensitive. Supported resource types can be provided as ecs,scaling_group, images, disk,vpcs,security-groups, shared_bandwidth,eip, cdn.
+
+* `project_id` - (Optional, String) Specifies the Project ID. This parameter is mandatory when resource_type is a region-specific service.
+
+* `without_any_tag` - (Optional, Boolean) Specifies whether to query only untagged resources. If this parameter is set to `true`, only untagged resources are queried.
+
+* `tags` - (Required, List) Specifies the list of tags. The structure is documented below.
+    * `key` - (Required, String) Specifies the key. It can contain up to 36 characters. The key cannot be empty. Only digits, letters, hyphens (-), at signs (@), and underscores (_) are allowed.
+    * `values` - (Required, List[String]) Specifies tag values. Each value contains a maximum of 43 Unicode characters and can be an empty string. Only digits, letters, hyphens (-), at signs (@), and underscores (_) are allowed.
+
+
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `resources` - Indicates the list of resources. The structure is documented below.
+    * `project_id` - Indicates the project ID.
+    * `project_name` - Indicates the  project name.
+    * `resource_id` - Indicates the resource ID.
+    * `resource_name` - Indicates the resource name.
+    * `resource_type` - Indicates the resource type.
+    * `tags` - Indicates the resource tags.

--- a/opentelekomcloud/acceptance/tms/data_source_opentelekomicloud_tms_resource_instances_test.go
+++ b/opentelekomcloud/acceptance/tms/data_source_opentelekomicloud_tms_resource_instances_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestAccTmsResourceInstancesDS_basic(t *testing.T) {
-	dataSourceName := "data.opentelekomcloud_tms_resource_instances_v1.tags.ds_1"
+	dataSourceName := "data.opentelekomcloud_tms_resource_instances_v1.ds_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -76,7 +76,7 @@ resource "opentelekomcloud_tms_resource_tags_v1" "tags_1" {
   }
 }
 
-data "opentelekomcloud_tms_resource_instances_v1" "tags_ds_1" {
+data "opentelekomcloud_tms_resource_instances_v1" "ds_1" {
   depends_on     = ["opentelekomcloud_tms_resource_tags_v1.tags_1"]
   resource_types = ["disk", "ecs"]
   tags {

--- a/opentelekomcloud/acceptance/tms/data_source_opentelekomicloud_tms_resource_instances_test.go
+++ b/opentelekomcloud/acceptance/tms/data_source_opentelekomicloud_tms_resource_instances_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestAccTmsResourceInstancesDS_basic(t *testing.T) {
-	dataSourceName := "data.opentelekomcloud_tms_resource_tags_v1.tags.ds_1"
+	dataSourceName := "data.opentelekomcloud_tms_resource_instances_v1.tags.ds_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -76,9 +76,9 @@ resource "opentelekomcloud_tms_resource_tags_v1" "tags_1" {
   }
 }
 
-data "opentelekomcloud_tms_resource_tags_v1" "tags_ds_1" {
-  depends_on = ["opentelekomcloud_tms_resource_tags_v1.tags_1"]
-  resources  = ["disk", "ecs"]
+data "opentelekomcloud_tms_resource_instances_v1" "tags_ds_1" {
+  depends_on     = ["opentelekomcloud_tms_resource_tags_v1.tags_1"]
+  resource_types = ["disk", "ecs"]
   tags {
     key    = "test"
     values = ["test-tf-acc"]

--- a/opentelekomcloud/acceptance/tms/data_source_opentelekomicloud_tms_resource_instances_test.go
+++ b/opentelekomcloud/acceptance/tms/data_source_opentelekomicloud_tms_resource_instances_test.go
@@ -1,0 +1,89 @@
+package tms
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+)
+
+func TestAccTmsResourceInstancesDS_basic(t *testing.T) {
+	dataSourceName := "data.opentelekomcloud_tms_resource_tags_v1.tags.ds_1"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceTagsDS_basic(tools.RandomString("tms-rt-acc-test-", 4)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTMSResourceInstancesV1DsId(dataSourceName),
+					resource.TestCheckResourceAttr(dataSourceName, "resources.0.resource_type", "disk"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckTMSResourceInstancesV1DsId(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("can't find TMS resource instances v1 data source: %s ", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("TMS resource instances v1 data source ID not set")
+		}
+
+		return nil
+	}
+}
+
+func testAccResourceTagsDS_basic(volName string) string {
+	return fmt.Sprintf(`
+data "opentelekomcloud_identity_project_v3" "project_1" {}
+
+resource "opentelekomcloud_evs_volume_v3" "volume" {
+  name              = "%s"
+  description       = "tms test volume"
+  availability_zone = "eu-de-01"
+  volume_type       = "SSD"
+  size              = 20
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
+
+}
+
+resource "opentelekomcloud_tms_resource_tags_v1" "tags_1" {
+  depends_on = ["opentelekomcloud_evs_volume_v3.volume"]
+  project_id = data.opentelekomcloud_identity_project_v3.project_1.id
+
+  resources {
+    resource_type = "disk"
+    resource_id   = opentelekomcloud_evs_volume_v3.volume.id
+  }
+
+  tags = {
+    test = "test-tf-acc"
+  }
+}
+
+data "opentelekomcloud_tms_resource_tags_v1" "tags_ds_1" {
+  depends_on = ["opentelekomcloud_tms_resource_tags_v1.tags_1"]
+  resources  = ["disk", "ecs"]
+  tags {
+    key    = "test"
+    values = ["test-tf-acc"]
+  }
+  project_id = data.opentelekomcloud_identity_project_v3.project_1.id
+}
+`, volName)
+}

--- a/opentelekomcloud/common/utils.go
+++ b/opentelekomcloud/common/utils.go
@@ -636,3 +636,11 @@ func StringSliceIgnoreEmpty(e string) []string {
 	}
 	return nil
 }
+
+// Convert String Pointer to string
+func StringPtrToString(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return *p
+}

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -383,6 +383,7 @@ func Provider() *schema.Provider {
 			"opentelekomcloud_smn_subscription_v2":                smn.DataSourceSmnSubscriptionV2(),
 			"opentelekomcloud_smn_topic_subscription_v2":          smn.DataSourceSmnTopicSubscriptionV2(),
 			"opentelekomcloud_tms_quotas_v1":                      tms.DataSourceTmsQuotasV1(),
+			"opentelekomcloud_tms_resource_instances_v1":          tms.DataSourceTmsResourceInstancesV1(),
 			"opentelekomcloud_tms_tags_v1":                        tms.DataSourceTmsTagV1(),
 			"opentelekomcloud_vpc_eip_v1":                         vpc.DataSourceVPCEipV1(),
 			"opentelekomcloud_vpc_v1":                             vpc.DataSourceVirtualPrivateCloudVpcV1(),

--- a/opentelekomcloud/services/tms/data_source_opentelekomcloud_tms_resource_instances_v1.go
+++ b/opentelekomcloud/services/tms/data_source_opentelekomcloud_tms_resource_instances_v1.go
@@ -1,0 +1,157 @@
+package tms
+
+import (
+	"context"
+
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/pointerto"
+	rt "github.com/opentelekomcloud/gophertelekomcloud/openstack/tms/v1/resource-tags"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
+)
+
+func DataSourceTmsResourceInstancesV1() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceTmsResourceInstancesV1Read,
+
+		Schema: map[string]*schema.Schema{
+			"resource_types": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"tags": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"values": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+			"without_any_tag": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"resources": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"project_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"project_name": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"resource_id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"resource_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"resource_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"tags": {
+							Type:     schema.TypeMap,
+							Required: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceTmsResourceInstancesV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, tmsClientV1, func() (*golangsdk.ServiceClient, error) {
+		return config.TmsV1Client()
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationClient, err)
+	}
+
+	listOpts := rt.ListResourceOpts{
+		ResourceTypes: common.ExpandToStringList(d.Get("resource_types").([]interface{})),
+		ProjectId:     d.Get("project_id").(string),
+		Tags:          getTMSTags(d),
+		WithoutAnyTag: pointerto.Bool(d.Get("without_any_tag").(bool)),
+	}
+
+	allResourceInstances, err := rt.ListResources(client, listOpts)
+	if err != nil {
+		return fmterr.Errorf("Error listing Resources: %s", err)
+	}
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(id)
+
+	var resourceList []map[string]interface{}
+	for _, t := range allResourceInstances {
+		resource := map[string]interface{}{
+			"project_id":    t.ProjectId,
+			"project_name":  t.ProjectName,
+			"resource_id":   t.ResourceId,
+			"resource_name": t.ResourceName,
+			"resource_type": t.ResourceType,
+			"tags":          setTMSResourceTags(t.Tags),
+		}
+		resourceList = append(resourceList, resource)
+	}
+
+	if err = d.Set("resources", resourceList); err != nil {
+		return fmterr.Errorf("Error setting TMS tagged resources: %s", err)
+	}
+	return nil
+}
+
+func getTMSTags(d *schema.ResourceData) []rt.ListResourceTag {
+	tagsRaw := d.Get("tags").([]interface{})
+
+	var tags []rt.ListResourceTag
+	for _, v := range tagsRaw {
+		tagRaw := v.(map[string]interface{})
+		tags = append(tags, rt.ListResourceTag{
+			Key:    tagRaw["key"].(string),
+			Values: common.ExpandToStringList(tagRaw["values"].([]interface{})),
+		})
+	}
+	return tags
+}
+func setTMSResourceTags(tags []rt.ResourceTag) map[string]string {
+	result := make(map[string]string)
+	for _, val := range tags {
+		result[val.Key] = common.StringPtrToString(val.Value)
+	}
+
+	return result
+}

--- a/opentelekomcloud/services/tms/data_source_opentelekomcloud_tms_resource_instances_v1.go
+++ b/opentelekomcloud/services/tms/data_source_opentelekomcloud_tms_resource_instances_v1.go
@@ -60,11 +60,11 @@ func DataSourceTmsResourceInstancesV1() *schema.Resource {
 							Computed: true,
 						},
 						"project_name": {
-							Type:     schema.TypeInt,
+							Type:     schema.TypeString,
 							Computed: true,
 						},
 						"resource_id": {
-							Type:     schema.TypeInt,
+							Type:     schema.TypeString,
 							Computed: true,
 						},
 						"resource_name": {

--- a/releasenotes/notes/tms-add-ds-resource-instances-v1-7544abf0c73ed932.yaml
+++ b/releasenotes/notes/tms-add-ds-resource-instances-v1-7544abf0c73ed932.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    **[TMS]** New Data Source ``opentelekomcloud_tms_resource_instances_v1`` (`#3096 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3096>`_)


### PR DESCRIPTION
## Summary of the Pull Request

New data source `opentelekomcloud_tms_resource_instances_v1`

## PR Checklist

* [x] Refers to: #2981 
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccTmsResourceInstancesDS_basic
--- PASS: TestAccTmsResourceInstancesDS_basic (46.67s)
PASS

Process finished with the exit code 0
```
