### PR TITLE
[Refactor] FGS: Remove concurrency_num in fgs_function_v2

### DIFF
--- a/docs/resources/fgs_function_v2.md
+++ b/docs/resources/fgs_function_v2.md
@@ -336,11 +336,6 @@ The `func_mounts` block supports:
 
 * `local_mount_path` - (Required, String) Specifies the function access path.
 
-* `concurrency_num` - (Optional, Int) Specifies the number of concurrent requests of the function.
-  The valid value ranges from `1` to `1,000`, the default value is `1`.
-
-  -> This parameter is only supported by the `v2` version of the function.
-
 The `custom_image` block supports:
 
 * `url` - (Required, String) Specifies the URL of SWR image, the URL must start with `swr.`.

--- a/opentelekomcloud/acceptance/fgs/resource_opentelekomcloud_fgs_function_v2_test.go
+++ b/opentelekomcloud/acceptance/fgs/resource_opentelekomcloud_fgs_function_v2_test.go
@@ -1022,69 +1022,6 @@ resource "opentelekomcloud_fgs_function_v2" "test" {
 `, rName, aliasName)
 }
 
-func TestAccFgsV2Function_concurrencyNum(t *testing.T) {
-	var (
-		f function.FuncGraph
-
-		name         = fmt.Sprintf("fgs-acc-%s", acctest.RandString(5))
-		resourceName = "opentelekomcloud_fgs_function_v2.test"
-	)
-
-	rc := common.InitResourceCheck(
-		resourceName,
-		&f,
-		getResourceObj,
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { common.TestAccPreCheck(t) },
-		ProviderFactories: common.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccFunction_strategy_default(name),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "concurrency_num", "1"),
-				),
-			},
-			{
-				Config: testAccFunction_concurrencyNum(name, 1000),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "concurrency_num", "1000"),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"app",
-					"func_code",
-				},
-			},
-		},
-	})
-}
-
-func testAccFunction_concurrencyNum(name string, concurrencyNum int) string {
-	return fmt.Sprintf(`
-resource "opentelekomcloud_fgs_function_v2" "test" {
-  functiongraph_version = "v2"
-  name                  = "%[1]s"
-  app                   = "default"
-  handler               = "index.handler"
-  memory_size           = 128
-  timeout               = 3
-  runtime               = "Python2.7"
-  code_type             = "inline"
-  func_code             = "dCA9ICdIZWxsbyBtZXNzYWdlOiAnICsganN="
-  concurrency_num       = %[2]d
-}
-`, name, concurrencyNum)
-}
-
 func TestAccFgsV2Function_EnableDynamicMemory(t *testing.T) {
 	var (
 		f function.FuncGraph

--- a/opentelekomcloud/services/fgs/resource_opentelekomcloud_fgs_function_v2.go
+++ b/opentelekomcloud/services/fgs/resource_opentelekomcloud_fgs_function_v2.go
@@ -335,11 +335,6 @@ func ResourceFgsFunctionV2() *schema.Resource {
 					},
 				},
 			},
-			"concurrency_num": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Computed: true,
-			},
 			"gpu_memory": {
 				Type:     schema.TypeInt,
 				Optional: true,
@@ -586,7 +581,7 @@ func resourceFgsFunctionV2Create(ctx context.Context, d *schema.ResourceData, me
 	d.SetId(f.FuncURN)
 	urn := resourceFgsFunctionUrn(d.Id())
 	if d.HasChanges("vpc_id", "network_id", "peering_cidr", "func_mounts", "app_agency", "initializer_handler",
-		"initializer_timeout", "concurrency_num", "enable_class_isolation") {
+		"initializer_timeout", "enable_class_isolation") {
 		err := resourceFgsFunctionMetadataUpdate(fgsClient, urn, d)
 		if err != nil {
 			return diag.FromErr(err)
@@ -857,10 +852,6 @@ func getReservedInstanceConfig(c *golangsdk.ServiceClient, d *schema.ResourceDat
 	return result, nil
 }
 
-func getConcurrencyNum(concurrencyNum *int) int {
-	return *concurrencyNum
-}
-
 func resourceFgsFunctionV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
 	fgsClient, err := common.ClientFromCtx(ctx, fgsClientV2, func() (*golangsdk.ServiceClient, error) {
@@ -914,7 +905,6 @@ func resourceFgsFunctionV2Read(ctx context.Context, d *schema.ResourceData, meta
 		setFgsFunctionApp(d, f.Package),
 		setFgsFunctionVpcAccess(d, f.FuncVpc),
 		setFunctionMountConfig(d, f.MountConfig),
-		d.Set("concurrency_num", getConcurrencyNum(pointerto.Int(f.StrategyConfig.ConcurrentNum))),
 		d.Set("versions", versionConfig),
 		d.Set("gpu_memory", f.GpuMemory),
 		d.Set("enable_dynamic_memory", f.EnableDynamicMemory),
@@ -1177,7 +1167,7 @@ func resourceFgsFunctionV2Update(ctx context.Context, d *schema.ResourceData, me
 	if d.HasChanges("app", "handler", "memory_size", "timeout", "encrypted_user_data",
 		"user_data", "agency", "app_agency", "description", "initializer_handler", "initializer_timeout",
 		"vpc_id", "network_controller", "network_id", "mount_user_id", "mount_user_group_id", "func_mounts", "custom_image",
-		"log_group_id", "log_topic_id", "log_group_name", "log_topic_name", "concurrency_num", "gpu_memory", "gpu_type",
+		"log_group_id", "log_topic_id", "log_group_name", "log_topic_name", "gpu_memory", "gpu_type",
 		"pre_stop_handler", "pre_stop_timeout", "enable_dynamic_memory") {
 		err := resourceFgsFunctionMetadataUpdate(fgsClient, urn, d)
 		if err != nil {
@@ -1296,17 +1286,6 @@ func resourceFgsFunctionMetadataUpdate(fgsClient *golangsdk.ServiceClient, urn s
 	}
 
 	updateMetadateOpts.NetworkController = buildNetworkControlConfig(d)
-
-	if v, ok := d.GetOk("concurrency_num"); ok {
-		strategyConfig := function.StrategyConfig{
-			ConcurrentNum: v.(int),
-		}
-		if v, ok := d.GetOk("max_instance_num"); ok && v.(string) != "" {
-			maxInstanceNum, _ := strconv.Atoi(v.(string))
-			strategyConfig.Concurrency = maxInstanceNum
-		}
-		updateMetadateOpts.StrategyConfig = &strategyConfig
-	}
 
 	log.Printf("[DEBUG] Metaddata Update Options: %#v", updateMetadateOpts)
 	updateMetadateOpts.FuncUrn = urn

--- a/releasenotes/notes/fgs-function-v2-remove-argument-7595550b884cce24.yaml
+++ b/releasenotes/notes/fgs-function-v2-remove-argument-7595550b884cce24.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[FGS]** Remove argument `concurrency_num` from resource ``resource/opentelekomcloud_fgs_function_v2`` (`#3102 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3102>`_)


### PR DESCRIPTION
## Summary of the Pull Request

Remove `concurrency_num` in resource `opentelekomcloud_fgs_function_v2`

## PR Checklist

* [x] Refers to: #3095 
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccFgsV2Function_EnableDynamicMemory
=== PAUSE TestAccFgsV2Function_EnableDynamicMemory
=== CONT  TestAccFgsV2Function_EnableDynamicMemory
--- PASS: TestAccFgsV2Function_EnableDynamicMemory (25.18s)
PASS
```
