### PR TITLE
[Feat] PrivateNAT: Add resource private_nat_transit_ip_v3 and doc fix

### DIFF
--- a/docs/resources/private_nat_gateway_v3.md
+++ b/docs/resources/private_nat_gateway_v3.md
@@ -10,7 +10,7 @@ description: |-
 Up-to-date reference of API arguments for Private NAT gateway you can get at
 [documentation portal](https://docs.otc.t-systems.com/nat-gateway/api-ref/apis_for_private_nat_gateways_v3.0/private_nat_gateways/index.html)
 
-# opentelekomcloud_nat_gateway_v2
+# opentelekomcloud_private_nat_gateway_v3
 
 Manages a V3 Private NAT Gateway resource within OpenTelekomCloud.
 

--- a/docs/resources/private_nat_transit_ip_v3.md
+++ b/docs/resources/private_nat_transit_ip_v3.md
@@ -1,0 +1,68 @@
+---
+subcategory: "Private NAT"
+layout: "opentelekomcloud"
+page_title: "OpenTelekomCloud: opentelekomcloud_private_nat_transit_ip_v3"
+sidebar_current: "docs-opentelekomcloud-resource-private-nat-transit-ip-v3"
+description: |-
+  Manages a Private NAT Transit IP resource within OpenTelekomCloud.
+---
+
+Up-to-date reference of API arguments for Private NAT Transit IP you can get at
+[documentation portal](https://docs.otc.t-systems.com/nat-gateway/api-ref/apis_for_private_nat_gateways_v3.0/transit_ip_addresses/index.html)
+
+# opentelekomcloud_private_nat_transit_ip_v3
+
+Manages a V3 Private NAT Transit IP resource within OpenTelekomCloud.
+
+## Example Usage
+
+```hcl
+variable "network_id" {}
+
+resource "opentelekomcloud_private_nat_transit_ip_v3" "transit_ip_1" {
+  virsubnet_id = var.network_id
+  tags = {
+    kuh = "muh"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `virsubnet_id` - (Required, String, ForceNew) Specifies the subnet ID of the current project.
+
+* `ip_address` - (Optional, String, ForceNew) Specifies the transit IP address.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the ID of the enterprise project that is associated with the transit IP address when the transit IP address is being assigned. Default: `0`.
+
+* `tags` - (Optional, Map, ForceNew) Specifies the tag list in key/value format.
+
+
+## Attributes Reference
+
+In addition to the arguments mentioned above, the following attributes are exported:
+
+* `id` - Private NAT Transit IP ID.
+
+* `project_id` - Indicates the project ID.
+
+* `network_interface_id` - Indicates the network interface ID of the transit IP address.
+
+* `created_at` - Indicates the time when the private NAT Transit IP was created. It is a UTC time in yyyy-mm-ddThh:mm:ssZ format.
+
+* `updated_at` - Indicates the time when the private NAT Transit IP was updated. It is a UTC time in yyyy-mm-ddThh:mm:ssZ format.
+
+* `gateway_id` - Indicates the ID of the private NAT gateway associated with the transit IP address.
+
+* `status` - Indicates the private NAT transit IP status. The value can be: `ACTIVE` (The Transit IP is running properly) or `FROZEN` (The Transit IP is frozen).
+
+
+## Import
+
+Private NAT Transit IP V3 resource can be imported using the Transit IP ID, `id`.
+
+```sh
+terraform import opentelekomcloud_private_nat_transit_ip_v3.ip_1 <id>
+```

--- a/opentelekomcloud/acceptance/privatenat/resource_opentelekomcloud_private_nat_transit_ip_v3_test.go
+++ b/opentelekomcloud/acceptance/privatenat/resource_opentelekomcloud_private_nat_transit_ip_v3_test.go
@@ -1,0 +1,68 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v3/privatenat/transitip"
+
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+)
+
+const transitIpResourceName = "opentelekomcloud_private_nat_transit_ip_v3.transit_ip_1"
+
+func getTransitIp(cfg *cfg.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NatV3Client(env.OS_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating NAT v3 Client: %s", err)
+	}
+	getResp, err := transitip.Get(client, state.Primary.ID)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching Transit IP: %s", err)
+	}
+	return getResp.TransitIp, nil
+}
+
+func TestAccPrivateTransitIpV3_basic(t *testing.T) {
+	var gateway transitip.TransitIP
+	rc := common.InitResourceCheck(
+		transitIpResourceName,
+		&gateway,
+		getTransitIp,
+	)
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPrivateTransitIpV3Basic,
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(transitIpResourceName, "tags.kuh", "muh"),
+				),
+			},
+			{
+				ResourceName:      transitIpResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+var testAccPrivateTransitIpV3Basic = fmt.Sprintf(`
+%s
+
+resource "opentelekomcloud_private_nat_transit_ip_v3" "transit_ip_1" {
+  virsubnet_id = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  tags = {
+    kuh = "muh"
+  }
+}
+`, common.DataSourceSubnet)

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -619,6 +619,7 @@ func Provider() *schema.Provider {
 			"opentelekomcloud_obs_bucket_policy":                         obs.ResourceObsBucketPolicy(),
 			"opentelekomcloud_obs_bucket_replication":                    obs.ResourceObsBucketReplication(),
 			"opentelekomcloud_private_nat_gateway_v3":                    privatenat.ResourcePrivateNatGatewayV3(),
+			"opentelekomcloud_private_nat_transit_ip_v3":                 privatenat.ResourcePrivateNatTransitIpV3(),
 			"opentelekomcloud_rds_backup_v3":                             rds.ResourceRdsBackupV3(),
 			"opentelekomcloud_rds_public_ip_associate_v3":                rds.ResourceRdsPublicIpAssociateV3(),
 			"opentelekomcloud_rds_instance_v1":                           rds.ResourceRdsInstance(),

--- a/opentelekomcloud/services/privatenat/resource_opentelekomcloud_private_nat_transit_ip_v3.go
+++ b/opentelekomcloud/services/privatenat/resource_opentelekomcloud_private_nat_transit_ip_v3.go
@@ -1,0 +1,192 @@
+package privatenat
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v3/privatenat/transitip"
+
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
+)
+
+func ResourcePrivateNatTransitIpV3() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourcePrivateNatTransitIpV3Create,
+		ReadContext:   resourcePrivateNatTransitIpV3Read,
+		DeleteContext: resourcePrivateNatTransitIpV3Delete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+			Delete: schema.DefaultTimeout(20 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"virsubnet_id": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+			"ip_address": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+				Computed: true,
+			},
+			"tags": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+				Computed: true,
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"project_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"network_interface_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"gateway_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourcePrivateNatTransitIpV3Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, keyClientV3, func() (*golangsdk.ServiceClient, error) {
+		return config.NatV3Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV3Client, err)
+	}
+
+	createOpts := transitip.CreateTransitIpOpts{
+		VirSubnetID:         d.Get("virsubnet_id").(string),
+		IpAddress:           d.Get("ip_address").(string),
+		Tags:                getTransitIpTags(d),
+		EnterpriseProjectID: d.Get("enterprise_project_id").(string),
+	}
+
+	createResp, err := transitip.Create(client, createOpts)
+	if err != nil {
+		return fmterr.Errorf("error creating Private NAT Transit IP: %w", err)
+	}
+	d.SetId(createResp.TransitIp.Id)
+	log.Printf("Created Private NAT TransitIp %s: %#v", d.Id(), createResp.TransitIp)
+
+	return resourcePrivateNatTransitIpV3Read(ctx, d, meta)
+}
+
+func resourcePrivateNatTransitIpV3Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, keyClientV3, func() (*golangsdk.ServiceClient, error) {
+		return config.NatV3Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV3Client, err)
+	}
+
+	getResp, err := transitip.Get(client, d.Id())
+	if err != nil {
+		return fmterr.Errorf("error fetching private NAT Transit IP : %w", err)
+	}
+
+	natTransitIp := getResp.TransitIp
+
+	mErr := multierror.Append(
+		d.Set("id", d.Id()),
+		d.Set("virsubnet_id", natTransitIp.VirSubnetID),
+		d.Set("ip_address", natTransitIp.IpAddress),
+		d.Set("tags", setTransitIpTags(natTransitIp.Tags)),
+		d.Set("enterprise_project_id", natTransitIp.EnterpriseProjectID),
+		d.Set("project_id", natTransitIp.ProjectId),
+		d.Set("status", natTransitIp.Status),
+		d.Set("created_at", natTransitIp.CreatedAt),
+		d.Set("updated_at", natTransitIp.UpdatedAt),
+		d.Set("network_interface_id", natTransitIp.NetworkInterfaceId),
+		d.Set("gateway_id", natTransitIp.GatewayId),
+	)
+
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func resourcePrivateNatTransitIpV3Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, keyClientV3, func() (*golangsdk.ServiceClient, error) {
+		return config.NatV3Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV3Client, err)
+	}
+
+	err = transitip.Delete(client, d.Id())
+	if err != nil {
+		return fmterr.Errorf("error deleting Private NAT Transit Ip: %w", err)
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func getTransitIpTags(d *schema.ResourceData) []transitip.TagOptions {
+	tagsInput := d.Get("tags").(map[string]interface{})
+	result := make([]transitip.TagOptions, 0, len(tagsInput))
+
+	for key, value := range tagsInput {
+		result = append(result, transitip.TagOptions{
+			Key:   key,
+			Value: value.(string),
+		})
+	}
+	return result
+}
+
+func setTransitIpTags(tagsOutput []transitip.Tag) map[string]interface{} {
+	result := make(map[string]interface{})
+	for _, tag := range tagsOutput {
+		result[tag.Key] = tag.Value
+	}
+	return result
+}

--- a/releasenotes/notes/privatenat-add-resource-transit-ip-v3-73480f77256356d9.yaml
+++ b/releasenotes/notes/privatenat-add-resource-transit-ip-v3-73480f77256356d9.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    **[PrivateNAT]** Add new resource ``resource/opentelekomcloud_private_nat_transit_ip_v3`` (`#3109 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3109>`_).


### PR DESCRIPTION
## Summary of the Pull Request

Add resource `opentelekomcloud_private_nat_transit_ip_v3`

Minor doc fix

## PR Checklist

* [x] Refers to: #3066 
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccPrivateTransitIpV3_basic
--- PASS: TestAccPrivateTransitIpV3_basic (40.93s)
PASS
```
