### PR TITLE
[Depr.] GAUSSDB: `opentelekomcloud_gaussdb_mysql_instance_v3` deprecation

### DIFF
--- a/docs/resources/gaussdb_mysql_instance_v3.md
+++ b/docs/resources/gaussdb_mysql_instance_v3.md
@@ -14,6 +14,9 @@ Up-to-date reference of API arguments for GaussDB for MySql you can get at
 
 GaussDB MySql instance management within OpenTelekomCloud.
 
+~>
+Deprecated, use `opentelekomcloud_taurusdb_mysql_instance_v3.go` resource instead.
+
 ## Example Usage
 
 ### Create a basic instance

--- a/docs/resources/gaussdb_mysql_instance_v3.md
+++ b/docs/resources/gaussdb_mysql_instance_v3.md
@@ -15,7 +15,7 @@ Up-to-date reference of API arguments for GaussDB for MySql you can get at
 GaussDB MySql instance management within OpenTelekomCloud.
 
 ~>
-Deprecated, use `opentelekomcloud_taurusdb_mysql_instance_v3.go` resource instead.
+Deprecated, use `opentelekomcloud_taurusdb_mysql_instance_v3` resource instead.
 
 ## Example Usage
 

--- a/opentelekomcloud/services/gaussdb/resource_opentelekomcloud_gaussdb_mysql_instance_v3.go
+++ b/opentelekomcloud/services/gaussdb/resource_opentelekomcloud_gaussdb_mysql_instance_v3.go
@@ -34,6 +34,8 @@ func ResourceGaussDBInstanceV3() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
+		DeprecationMessage: "The `opentelekomcloud_gaussdb_mysql_instance_v3` resource is deprecated. Starting from release 1.36.47, use taurusdb instead.",
+
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(60 * time.Minute),
 			Update: schema.DefaultTimeout(60 * time.Minute),

--- a/releasenotes/notes/taurusdb_deprecation-8fd4fb7610093f6b.yaml
+++ b/releasenotes/notes/taurusdb_deprecation-8fd4fb7610093f6b.yaml
@@ -1,0 +1,4 @@
+---
+deprecations:
+  - |
+    **[GAUSSDB]** Resource ``opentelekomcloud_gaussdb_mysql_instance_v3`` will be deprecated after provider v1.36.46 (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)

--- a/releasenotes/notes/taurusdb_deprecation-8fd4fb7610093f6b.yaml
+++ b/releasenotes/notes/taurusdb_deprecation-8fd4fb7610093f6b.yaml
@@ -1,4 +1,4 @@
 ---
 deprecations:
   - |
-    **[GAUSSDB]** Resource ``opentelekomcloud_gaussdb_mysql_instance_v3`` will be deprecated after provider v1.36.46 (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[GAUSSDB]** Resource ``opentelekomcloud_gaussdb_mysql_instance_v3`` will be deprecated after provider v1.36.46 (`#3111 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3111>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Deprecation message about `opentelekomcloud_gaussdb_mysql_instance_v3` since provider v1.36.47

## PR Checklist

* [ ] Refers to: #xxx
* [ ] Tests added/passed.
* [ ] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.
