### PR TITLE
[Feat] PrivateNAT: Add data source private_nat_transit_ip_v3 and doc fix

### DIFF
--- a/docs/data-sources/private_nat_gateway_v3.md
+++ b/docs/data-sources/private_nat_gateway_v3.md
@@ -50,22 +50,6 @@ The following arguments are supported:
 
 * `id` - (Optional, String) Specifies the private NAT gateway name.
 
-* `spec` - (Optional, String) Specifies the private NAT gateway specifications. The value can be: `Small`, `Medium`, `Large`, `Extra-large`. Default value: `Small`.
-
-* `downlink_vpcs` - (Required, List, ForceNew) Specifies the VPC where the private NAT gateway works. The [downlink_vpcs](#downlink_vpcs) structure is documented below. Default value: `0`.
-
-* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the ID of the enterprise project that is associated with the private NAT gateway when the private NAT gateway is created.
-
-* `tags` - (Optional, Map, ForceNew) Specifies the tag list in key/value format.
-
-<a name="downlink_vpcs"></a>
-The `downlink_vpcs` block supports:
-
-* `virsubnet_id` - (Required, String, ForceNew) Specifies the ID of the enterprise project that is associated with the private NAT gateway when the private NAT gateway is created.
-
-* `ngport_ip_address` - (Optional, String, ForceNew) Specifies the private IP address of the private NAT gateway.
-
-
 ## Attributes Reference
 
 In addition to the arguments mentioned above, the following attributes are exported:

--- a/docs/data-sources/private_nat_transit_ip_v3.md
+++ b/docs/data-sources/private_nat_transit_ip_v3.md
@@ -1,0 +1,94 @@
+---
+subcategory: "Private NAT"
+layout: "opentelekomcloud"
+page_title: "OpenTelekomCloud: opentelekomcloud_private_nat_transit_ip_v3"
+sidebar_current: "docs-opentelekomcloud-data-source-private-nat-transit-ip-v3"
+description: |-
+  Manages a Private NAT Transit IP data source within OpenTelekomCloud.
+---
+
+Up-to-date reference of API arguments for Private NAT Transit IP you can get at
+[documentation portal](https://docs.otc.t-systems.com/nat-gateway/api-ref/apis_for_private_nat_gateways_v3.0/transit_ip_addresses/index.html)
+
+# opentelekomcloud_private_nat_transit_ip_v3
+
+Manages a V3 Private NAT Transit IP data source within OpenTelekomCloud.
+
+## Example Usage
+
+### List all Transit IPs
+
+```hcl
+data "opentelekomcloud_private_nat_transit_ip_v3" "transit_ip_1" {}
+```
+
+### List all Transit IPs in a subnet
+
+```hcl
+variable "network_id" {}
+
+data "opentelekomcloud_private_nat_transit_ip_v3" "transit_ip_1" {
+  virsubnet_id = var.network_id
+}
+```
+
+### Get Transit IP by ID
+
+```hcl
+variable "id" {}
+
+data "opentelekomcloud_private_nat_transit_ip_v3" "transit_ip_1" {
+  id = var.id
+}
+```
+
+### Get Transit IP by IP address
+
+```hcl
+variable "ip_address" {}
+
+data "opentelekomcloud_private_nat_transit_ip_v3" "transit_ip_1" {
+  ip_address = var.ip_address
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `id` - (Optional, String) Specifies the private NAT transit IP ID.
+
+* `virsubnet_id` - (Optional, String) Specifies the subnet ID of the current project.
+
+* `ip_address` - (Optional, String) Specifies the transit IP address.
+
+
+## Attributes Reference
+
+In addition to the arguments mentioned above, the following attributes are exported:
+
+* `transit_ips` - The list of private NAT transit IPs. The structure is defined below.
+
+The `transit_ips` block supports: 
+
+* `id` - Private NAT Transit IP ID.
+
+* `virsubnet_id` - Indicates the subnet ID of the current project.
+
+* `ip_address` - Indicates the transit IP address.
+
+* `enterprise_project_id` - Indicates the ID of the enterprise project that is associated with the transit IP address when the transit IP address is being assigned.
+
+* `tags` - Indicates the tag list in key/value format.
+
+* `project_id` - Indicates the project ID.
+
+* `network_interface_id` - Indicates the network interface ID of the transit IP address.
+
+* `created_at` - Indicates the time when the private NAT Transit IP was created. It is a UTC time in yyyy-mm-ddThh:mm:ssZ format.
+
+* `updated_at` - Indicates the time when the private NAT Transit IP was updated. It is a UTC time in yyyy-mm-ddThh:mm:ssZ format.
+
+* `gateway_id` - Indicates the ID of the private NAT gateway associated with the transit IP address.
+
+* `status` - Indicates the private NAT transit IP status. The value can be: `ACTIVE` (The Transit IP is running properly) or `FROZEN` (The Transit IP is frozen).

--- a/opentelekomcloud/acceptance/privatenat/data_source_opentelekomcloud_private_nat_transit_ip_v3_test.go
+++ b/opentelekomcloud/acceptance/privatenat/data_source_opentelekomcloud_private_nat_transit_ip_v3_test.go
@@ -1,0 +1,149 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+)
+
+const transitIpDataSourceName = "data.opentelekomcloud_private_nat_transit_ip_v3.transit_ip_1"
+
+func TestAccPrivateTransitIpV3DS_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPrivateTransitIpV3DSBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPrivateNatTransitIpV3DataSourceID(transitIpDataSourceName),
+					resource.TestCheckResourceAttrSet(transitIpDataSourceName, "transit_ips.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckPrivateNatTransitIpV3DataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("can't find Private NAT Transit IP data source: %s ", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Private NAT Transit IP data source ID not set")
+		}
+
+		return nil
+	}
+}
+
+var testAccPrivateTransitIpV3DSBasic = fmt.Sprintf(`
+%s
+
+resource "opentelekomcloud_private_nat_transit_ip_v3" "transit_ip_test" {
+  virsubnet_id = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+}
+
+data "opentelekomcloud_private_nat_transit_ip_v3" "transit_ip_1" {
+  depends_on = ["opentelekomcloud_private_nat_transit_ip_v3.transit_ip_test"]
+}
+`, common.DataSourceSubnet)
+
+func TestAccPrivateTransitIpV3DS_id(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPrivateTransitIpV3DS_id,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(transitIpDataSourceName, "transit_ips.0.tags.kuh", "muh"),
+				),
+			},
+		},
+	})
+}
+
+var testAccPrivateTransitIpV3DS_id = fmt.Sprintf(`
+%s
+
+resource "opentelekomcloud_private_nat_transit_ip_v3" "transit_ip_test" {
+  virsubnet_id = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  tags = {
+    kuh = "muh"
+  }
+}
+
+data "opentelekomcloud_private_nat_transit_ip_v3" "transit_ip_1" {
+  depends_on = ["opentelekomcloud_private_nat_transit_ip_v3.transit_ip_test"]
+  id         = opentelekomcloud_private_nat_transit_ip_v3.transit_ip_test.id
+}
+`, common.DataSourceSubnet)
+
+func TestAccPrivateTransitIpV3DS_ipaddr(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPrivateTransitIpV3DS_ipaddr,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(transitIpDataSourceName, "transit_ips.0.tags.kuh", "nuh"),
+				),
+			},
+		},
+	})
+}
+
+var testAccPrivateTransitIpV3DS_ipaddr = fmt.Sprintf(`
+%s
+
+resource "opentelekomcloud_private_nat_transit_ip_v3" "transit_ip_test" {
+  virsubnet_id = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  tags = {
+    kuh = "nuh"
+  }
+}
+
+data "opentelekomcloud_private_nat_transit_ip_v3" "transit_ip_1" {
+  depends_on = ["opentelekomcloud_private_nat_transit_ip_v3.transit_ip_test"]
+  ip_address = opentelekomcloud_private_nat_transit_ip_v3.transit_ip_test.ip_address
+}
+`, common.DataSourceSubnet)
+
+func TestAccPrivateTransitIpV3DS_subnet(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPrivateTransitIpV3DS_subnet,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(transitIpDataSourceName, "transit_ips.0.tags.kuh", "puh"),
+				),
+			},
+		},
+	})
+}
+
+var testAccPrivateTransitIpV3DS_subnet = fmt.Sprintf(`
+%s
+
+resource "opentelekomcloud_private_nat_transit_ip_v3" "transit_ip_test" {
+  virsubnet_id = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  tags = {
+    kuh = "puh"
+  }
+}
+
+data "opentelekomcloud_private_nat_transit_ip_v3" "transit_ip_1" {
+  depends_on   = ["opentelekomcloud_private_nat_transit_ip_v3.transit_ip_test"]
+  virsubnet_id = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+}
+`, common.DataSourceSubnet)

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -359,6 +359,7 @@ func Provider() *schema.Provider {
 			"opentelekomcloud_obs_bucket":                         obs.DataSourceObsBucket(),
 			"opentelekomcloud_obs_bucket_object":                  obs.DataSourceObsBucketObject(),
 			"opentelekomcloud_private_nat_gateway_v3":             privatenat.DataSourcePrivateNatGatewayV3(),
+			"opentelekomcloud_private_nat_transit_ip_v3":          privatenat.DataSourcePrivateNatTransitIpV3(),
 			"opentelekomcloud_rds_instance_v3":                    rds.DataSourceRdsInstanceV3(),
 			"opentelekomcloud_rds_backup_v3":                      rds.DataSourceRDSv3Backup(),
 			"opentelekomcloud_rds_flavors_v1":                     rds.DataSourceRdsFlavorV1(),

--- a/opentelekomcloud/services/privatenat/data_source_opentelekomcloud_private_nat_transit_ip_v3.go
+++ b/opentelekomcloud/services/privatenat/data_source_opentelekomcloud_private_nat_transit_ip_v3.go
@@ -1,0 +1,162 @@
+package privatenat
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v3/privatenat/transitip"
+
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
+)
+
+func DataSourcePrivateNatTransitIpV3() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourcePrivateNatTransitIpV3Read,
+
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"ip_address": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"virsubnet_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"transit_ips": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"virsubnet_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ip_address": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"tags": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"enterprise_project_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"project_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"network_interface_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"created_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"updated_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"gateway_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourcePrivateNatTransitIpV3Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, keyClientV3, func() (*golangsdk.ServiceClient, error) {
+		return config.NatV3Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV3Client, err)
+	}
+
+	var listOpts transitip.ListTransitIpsQueryParams
+	if v, ok := d.GetOk("id"); ok {
+		listOpts.Id = []string{v.(string)}
+		d.SetId(v.(string))
+	}
+	if v, ok := d.GetOk("ip_address"); ok {
+		listOpts.IpAddress = []string{v.(string)}
+		d.SetId(v.(string))
+	}
+	if v, ok := d.GetOk("virsubnet_id"); ok {
+		listOpts.VirSubnetID = []string{v.(string)}
+	}
+
+	getResp, err := transitip.List(client, listOpts)
+	if err != nil {
+		return fmterr.Errorf("error fetching private NAT Transit IPs : %w", err)
+	}
+
+	if d.Id() == "" {
+		id, err := uuid.GenerateUUID()
+		if err != nil {
+			return diag.Errorf("unable to generate ID: %s", err)
+		}
+		d.SetId(id)
+	}
+
+	natTransitIps := getResp.TransitIps
+
+	mErr := multierror.Append(
+		d.Set("id", d.Id()),
+		d.Set("transit_ips", setTransitIps(natTransitIps)),
+	)
+
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func setTransitIps(transitIpsInResp []transitip.TransitIP) []map[string]interface{} {
+	var transitIps []map[string]interface{}
+	for _, transitIpInResp := range transitIpsInResp {
+		transitIp := map[string]interface{}{
+			"id":                    transitIpInResp.Id,
+			"virsubnet_id":          transitIpInResp.VirSubnetID,
+			"ip_address":            transitIpInResp.IpAddress,
+			"tags":                  setTransitIpTags(transitIpInResp.Tags),
+			"enterprise_project_id": transitIpInResp.EnterpriseProjectID,
+			"project_id":            transitIpInResp.ProjectId,
+			"status":                transitIpInResp.Status,
+			"created_at":            transitIpInResp.CreatedAt,
+			"updated_at":            transitIpInResp.UpdatedAt,
+			"network_interface_id":  transitIpInResp.NetworkInterfaceId,
+			"gateway_id":            transitIpInResp.GatewayId,
+		}
+		transitIps = append(transitIps, transitIp)
+	}
+	return transitIps
+}

--- a/releasenotes/notes/privatenat-add-data-source-transit-ip-v3-2c21734fd479d44e.yaml
+++ b/releasenotes/notes/privatenat-add-data-source-transit-ip-v3-2c21734fd479d44e.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    **[PrivateNAT]** Add new data source ``opentelekomcloud_private_nat_transit_ip_v3`` (`#3121 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3121>`_).


### PR DESCRIPTION
## Summary of the Pull Request

New data source `opentelekomcloud_private_nat_transit_ip_v3`
Minor doc fixes

## PR Checklist

* [x] Refers to: #3066 
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccPrivateTransitIpV3DS_basic
--- PASS: TestAccPrivateTransitIpV3DS_basic (38.30s)
=== RUN   TestAccPrivateTransitIpV3DS_id
--- PASS: TestAccPrivateTransitIpV3DS_id (42.06s)
=== RUN   TestAccPrivateTransitIpV3DS_ipaddr
--- PASS: TestAccPrivateTransitIpV3DS_ipaddr (44.01s)
=== RUN   TestAccPrivateTransitIpV3DS_subnet
--- PASS: TestAccPrivateTransitIpV3DS_subnet (49.38s)
PASS
```
