### PR TITLE
[Fix] rm default SATA in system_disk_type from ecs_instance_v1

### DIFF
--- a/docs/resources/ecs_instance_v1.md
+++ b/docs/resources/ecs_instance_v1.md
@@ -268,15 +268,11 @@ The following arguments are supported:
 * `metadata` - (Optional, Map) Metadata key/value pairs to associate with the instance.
 
 * `system_disk_type` - (Optional, String, ForceNew) The system disk type of the server.
-  Changing this creates a new server. Options are limited depending on AZ. Available options are:
-  * `SATA`: common I/O disk type. Available for all AZs.
+  Changing this creates a new server. Options are limited depending on AZ. Default: `SSD`. Available options are:
   * `SAS`: high I/O disk type. Available for all AZs.
   * `SSD`: ultra-high I/O disk type. Available for all AZs.
   * `GPSSD`: the general purpose SSD type
   * `ESSD`: extreme SSD disk type.
-
-  -> **NOTE:** 
-  Common I/O (SATA) will reach end of life, end of 2025.
 
 * `system_disk_size` - (Optional, Integer, ForceNew) The system disk size in GB, The value range is 1 to 1024.
   Changing this creates a new server.
@@ -316,7 +312,7 @@ The `nics` block supports:
   network. Changing this creates a new server.
 
 * `ipv6_enable` - (Optional, Bool, ForceNew) Specifies whether to support IPv6 addresses. If this parameter is set to true, the NIC supports IPv6 addresses.
-  
+
   -> **NOTE:**
   IPV6 enable requires the subnet to have IPV6 enabled as well.
 

--- a/opentelekomcloud/services/ecs/resource_opentelekomcloud_ecs_instance_v1.go
+++ b/opentelekomcloud/services/ecs/resource_opentelekomcloud_ecs_instance_v1.go
@@ -690,7 +690,7 @@ func resourceInstanceNicsV1(d *schema.ResourceData) []cloudservers.Nic {
 func resourceInstanceRootVolumeV1(d *schema.ResourceData) cloudservers.RootVolume {
 	diskType := d.Get("system_disk_type").(string)
 	if diskType == "" {
-		diskType = "SATA"
+		diskType = "SSD"
 	}
 	volRequest := cloudservers.RootVolume{
 		VolumeType: diskType,

--- a/releasenotes/notes/ecs-sata-rm-92944f934c8d01d1.yaml
+++ b/releasenotes/notes/ecs-sata-rm-92944f934c8d01d1.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[ECS]** Change dafault ``system_disk_type`` from ``SATA`` to ``SSD`` in ``resource/opentelekomcloud_compute_instances_v2`` (`#3130 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3130>`_)


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [ ] Refers to: #xxx
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccEcsV1InstanceBasic
=== PAUSE TestAccEcsV1InstanceBasic
=== CONT  TestAccEcsV1InstanceBasic
--- PASS: TestAccEcsV1InstanceBasic (153.37s)
=== RUN   TestAccEcsV1InstanceIp
=== PAUSE TestAccEcsV1InstanceIp
=== CONT  TestAccEcsV1InstanceIp
--- PASS: TestAccEcsV1InstanceIp (105.98s)
=== RUN   TestAccEcsV1InstanceIpv6
    resource_opentelekomcloud_ecs_instance_v1_test.go:116: TestAccEcsV1InstanceIpv6 required OS_IPV6_ENABLED_NETWORK_ID to continue.
--- SKIP: TestAccEcsV1InstanceIpv6 (0.00s)

Test ignored.
=== RUN   TestAccEcsV1InstanceDeleted
=== PAUSE TestAccEcsV1InstanceDeleted
=== CONT  TestAccEcsV1InstanceDeleted
--- PASS: TestAccEcsV1InstanceDeleted (205.68s)
=== RUN   TestAccEcsV1InstanceDiskTypeValidation
=== PAUSE TestAccEcsV1InstanceDiskTypeValidation
=== CONT  TestAccEcsV1InstanceDiskTypeValidation
--- PASS: TestAccEcsV1InstanceDiskTypeValidation (12.80s)
=== RUN   TestAccEcsV1InstanceVPCValidation
=== PAUSE TestAccEcsV1InstanceVPCValidation
=== CONT  TestAccEcsV1InstanceVPCValidation
--- PASS: TestAccEcsV1InstanceVPCValidation (125.87s)
=== RUN   TestAccEcsV1InstanceEncryption
=== PAUSE TestAccEcsV1InstanceEncryption
=== CONT  TestAccEcsV1InstanceEncryption
    resource_opentelekomcloud_ecs_instance_v1_test.go:249: OS_KMS_ID is not set
--- SKIP: TestAccEcsV1InstanceEncryption (0.00s)

Test ignored.
=== RUN   TestAccEcsV1InstanceVolumeAttach
=== PAUSE TestAccEcsV1InstanceVolumeAttach
=== CONT  TestAccEcsV1InstanceVolumeAttach
--- PASS: TestAccEcsV1InstanceVolumeAttach (178.20s)
=== RUN   TestAccEcsV1InstanceWithoutAZ
=== PAUSE TestAccEcsV1InstanceWithoutAZ
=== CONT  TestAccEcsV1InstanceWithoutAZ
--- PASS: TestAccEcsV1InstanceWithoutAZ (105.80s)
PASS

Process finished with the exit code 0
```
