### PR TITLE
[IAM] Add validation of group name length

### DIFF
--- a/opentelekomcloud/services/iam/resource_opentelekomcloud_identity_group_v3.go
+++ b/opentelekomcloud/services/iam/resource_opentelekomcloud_identity_group_v3.go
@@ -33,8 +33,9 @@ func ResourceIdentityGroupV3() *schema.Resource {
 			},
 
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: common.ValidateName,
 			},
 
 			"description": {

--- a/opentelekomcloud/services/iam/resource_opentelekomcloud_identity_group_v3.go
+++ b/opentelekomcloud/services/iam/resource_opentelekomcloud_identity_group_v3.go
@@ -35,7 +35,9 @@ func ResourceIdentityGroupV3() *schema.Resource {
 			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: common.ValidateName,
+				ValidateFunc: validation.StringLenBetween(1, 64),
+
+,
 			},
 
 			"description": {

--- a/opentelekomcloud/services/iam/resource_opentelekomcloud_identity_group_v3.go
+++ b/opentelekomcloud/services/iam/resource_opentelekomcloud_identity_group_v3.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/identity/v3/groups"
 
@@ -36,8 +37,6 @@ func ResourceIdentityGroupV3() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ValidateFunc: validation.StringLenBetween(1, 64),
-
-,
 			},
 
 			"description": {

--- a/releasenotes/notes/iam_groups_validation-364ae592ff9f8c0a.yaml
+++ b/releasenotes/notes/iam_groups_validation-364ae592ff9f8c0a.yaml
@@ -1,4 +1,4 @@
 ---
 enhancements:
   - |
-    **[IAM]** Added validation of group name length to `opentelekomcloud_identity_group_v3`
+    **[IAM]** Added validation of group name length to `opentelekomcloud_identity_group_v3` (`#3148 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3148>`_)

--- a/releasenotes/notes/iam_groups_validation-364ae592ff9f8c0a.yaml
+++ b/releasenotes/notes/iam_groups_validation-364ae592ff9f8c0a.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[IAM]** Added validation of group name length to `opentelekomcloud_identity_group_v3`


### PR DESCRIPTION
## Summary of the Pull Request
Adding the common validation function to ensure, that the documented length of a maximum of 64 characters isn't exceeded. Ensures a clearer error message.

Previously:
```
│ Error: error updating OpenTelekomCloud group: Bad request with: [PATCH https://iam.eu-de.otc.t-systems.com/v3/groups/dd00760560594feaac182ba4c28dbdcd], error message: {"error":{"message":"Invalid input for field 'group.name'. The value is 'test123-test123-test123-test123-test123-test123-test123-test123-test123-test123-test123-test123-test123'.","code":400,"title":"Bad Request","error_msg":"Request body is invalid.","error_code":"IAM.0011"}}
```

Afterwards:
```
│ Error: "name" must contain more than 1 and less than 64 characters
│ 
│   with module.cert_manager_user.opentelekomcloud_identity_group_v3.this[0],
│   on ../../../modules/otc-iam-permissions/otc_iam.tf line 22, in resource "opentelekomcloud_identity_group_v3" "this":
│   22:   name        = var.name
```

## PR Checklist

* [x] Refers to: #3146
* [x] Tests passed.
* [ ] Documentation updated. -> already documented
* [x] Schema updated.
* [x] Release notes added.

