### PR TITLE
[Feat.] TaurusDb: backup resource

### DIFF
--- a/docs/resources/taurusdb_mysql_backup_v3.md
+++ b/docs/resources/taurusdb_mysql_backup_v3.md
@@ -1,0 +1,76 @@
+---
+subcategory: "TaurusDB(for MySQL)"
+layout: "opentelekomcloud"
+page_title: "OpenTelekomCloud: opentelekomcloud_taurusdb_mysql_backup_v3"
+sidebar_current: "docs-opentelekomcloud-resource-taurusdb-mysql-backup-v3"
+description: |-
+  Manages an TaurusDb mysql backup resource within OpenTelekomCloud.
+---
+
+# opentelekomcloud_taurusdb_mysql_backup_v3
+
+Manages a TaurusDb MySQL backup resource within OpenTelekomCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+resource "opentelekomcloud_taurusdb_mysql_backup_v3" "test" {
+  instance_id = var.instance_id
+  name        = "test_backup_name"
+  description = "test description"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `instance_id` - (Required, String, ForceNew) Specifies the ID of the TaurusDb MySQL instance.
+
+* `name` - (Required, String, ForceNew) Specifies the name of the backup. It must start with a letter and consist of
+  `4` to `64` characters. Only letters (case-sensitive), digits, hyphens (-), and underscores (_) are allowed.
+
+* `description` - (Optional, String, ForceNew) Specifies the description of the backup.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `region` - The resource region
+
+* `begin_time` - Indicates the backup start time in the **yyyy-mm-ddThh:mm:ssZ** format.
+
+* `end_time` - Indicates the backup end time in the **yyyy-mm-ddThh:mm:ssZ** format.
+
+* `take_up_time` - Indicates the backup duration in minutes.
+
+* `size` - Indicates the backup size in MB.
+
+* `datastore` - Indicates the database information.
+
+  The [datastore](#backup_datastore_struct) structure is documented below.
+
+<a name="backup_datastore_struct"></a>
+The `datastore` block supports:
+
+* `type` - Indicates the database engine.
+
+* `version` - Indicates the database version.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 60 minutes.
+
+## Import
+
+The TaurusDb Mysql backup can be imported using the `id`, e.g.
+
+```bash
+$ terraform import opentelekomcloud_taurusdb_mysql_backup_v3.test <id>
+```

--- a/docs/resources/taurusdb_mysql_instance_v3.md
+++ b/docs/resources/taurusdb_mysql_instance_v3.md
@@ -4,7 +4,7 @@ layout: "opentelekomcloud"
 page_title: "OpenTelekomCloud: opentelekomcloud_taurusdb_mysql_instance_v3"
 sidebar_current: "docs-opentelekomcloud-resource-taurusdb-mysql-instance-v3"
 description: |-
-  Manages an SWR Repository resource within OpenTelekomCloud.
+  Manages an TaurusDb mysql instance resource within OpenTelekomCloud.
 ---
 
 # opentelekomcloud_taurusdb_mysql_instance_v3

--- a/opentelekomcloud/acceptance/taurusdb/resource_opentelekomcloud_taurusdb_mysql_backup_v3_test.go
+++ b/opentelekomcloud/acceptance/taurusdb/resource_opentelekomcloud_taurusdb_mysql_backup_v3_test.go
@@ -1,0 +1,91 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/taurus/v3/backup"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+)
+
+func getTaurusDbMysqlBackupResourceFunc(conf *cfg.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.TaurusDBV3Client(env.OS_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating TaurusDb V3 client: %s", err)
+	}
+
+	getResp, err := backup.List(client, backup.ListOpts{
+		BackupId: state.Primary.ID,
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving TaurusDb MySQL backup: %s", err)
+	}
+
+	if len(getResp) == 0 {
+		return nil, fmt.Errorf("TaurusDb backup doesn't exist")
+	}
+
+	return getResp[0], nil
+}
+
+func TestAccTaurusDbMysqlBackup_basic(t *testing.T) {
+	var obj interface{}
+
+	name := common.RandomAccResourceName()
+	rName := "opentelekomcloud_taurusdb_mysql_backup_v3.test"
+
+	rc := common.InitResourceCheck(
+		rName,
+		&obj,
+		getTaurusDbMysqlBackupResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testBackup_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"opentelekomcloud_taurusdb_mysql_instance_v3.instance", "id"),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "test description"),
+					resource.TestCheckResourceAttrSet(rName, "begin_time"),
+					resource.TestCheckResourceAttrSet(rName, "end_time"),
+					resource.TestCheckResourceAttrSet(rName, "take_up_time"),
+					resource.TestCheckResourceAttrSet(rName, "size"),
+					resource.TestCheckResourceAttrSet(rName, "datastore.0.type"),
+					resource.TestCheckResourceAttrSet(rName, "datastore.0.version"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"end_time",
+				},
+			},
+		},
+	})
+}
+
+func testBackup_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "opentelekomcloud_taurusdb_mysql_backup_v3" "test" {
+  instance_id = opentelekomcloud_taurusdb_mysql_instance_v3.instance.id
+  name        = "%s"
+  description = "test description"
+}
+`, testAccTaurusDBMySqlInstanceV3Basic(name), name)
+}

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -662,6 +662,7 @@ func Provider() *schema.Provider {
 			"opentelekomcloud_swr_organization_permissions_v2":           swr.ResourceSwrOrganizationPermissionsV2(),
 			"opentelekomcloud_swr_organization_v2":                       swr.ResourceSwrOrganizationV2(),
 			"opentelekomcloud_swr_repository_v2":                         swr.ResourceSwrRepositoryV2(),
+			"opentelekomcloud_taurusdb_mysql_backup_v3":                  taurusdb.ResourceTaurusDbMysqlBackup(),
 			"opentelekomcloud_taurusdb_mysql_instance_v3":                taurusdb.ResourceTaurusDbV3Instance(),
 			"opentelekomcloud_tms_tags_v1":                               tms.ResourceTmsTagV1(),
 			"opentelekomcloud_tms_resource_tags_v1":                      tms.ResourceTmsResourceTagsV1(),

--- a/opentelekomcloud/services/taurusdb/resource_opentelekomcloud_taurusdb_mysql_backup_v3.go
+++ b/opentelekomcloud/services/taurusdb/resource_opentelekomcloud_taurusdb_mysql_backup_v3.go
@@ -1,0 +1,226 @@
+package taurusdb
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/taurus/v3/backup"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+)
+
+func ResourceTaurusDbMysqlBackup() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceTaurusDbMysqlBackupCreate,
+		ReadContext:   resourceTaurusDbMysqlBackupRead,
+		DeleteContext: resourceTaurusDbMysqlBackupDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(60 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"begin_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"end_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"take_up_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"size": {
+				Type:     schema.TypeFloat,
+				Computed: true,
+			},
+			"datastore": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"region": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceTaurusDbMysqlBackupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := config.TaurusDBV3Client(config.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating TaurusDb client: %s ", err)
+	}
+
+	createOpts := backup.CreateOpts{
+		InstanceId:  d.Get("instance_id").(string),
+		Name:        d.Get("name").(string),
+		Description: d.Get("description").(string),
+	}
+
+	retryFunc := func() (interface{}, bool, error) {
+		res, err := backup.Create(client, createOpts)
+		retry, err := handleMultiOperationsError(err)
+		return res, retry, err
+	}
+	r, err := common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
+		Ctx:          ctx,
+		RetryFunc:    retryFunc,
+		WaitFunc:     TaurusDbInstanceStateRefreshFunc(client, d.Get("instance_id").(string)),
+		WaitTarget:   []string{"ACTIVE"},
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		DelayTimeout: 10 * time.Second,
+		PollInterval: 10 * time.Second,
+	})
+	if err != nil {
+		return diag.Errorf("error creating TaurusDb MySQL backup: %s", err)
+	}
+
+	createResp := r.(*backup.CreateResponse)
+
+	d.SetId(createResp.Backup.Id)
+
+	err = waitForTaurusDbBackupComplete(ctx, d, client)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return resourceTaurusDbMysqlBackupRead(ctx, d, meta)
+}
+
+func waitForTaurusDbBackupComplete(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"BUILDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      taurusDbBackupStateRefreshFunc(client, d.Id()),
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return fmt.Errorf("error waiting for TaurusDb MySQL backup (%s) to build complete: %s", d.Id(), err)
+	}
+	return nil
+}
+
+func taurusDbBackupStateRefreshFunc(client *golangsdk.ServiceClient, backupID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		backup, err := getTaurusDbBackup(client, backupID)
+		if err != nil {
+			return nil, "", err
+		}
+
+		return backup, backup.Status, nil
+	}
+}
+
+func resourceTaurusDbMysqlBackupRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := config.TaurusDBV3Client(config.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating TaurusDb client: %s ", err)
+	}
+
+	var mErr *multierror.Error
+
+	tbBackup, err := getTaurusDbBackup(client, d.Id())
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving TaurusDb MySQL backup")
+	}
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", config.GetRegion(d)),
+		d.Set("instance_id", tbBackup.InstanceId),
+		d.Set("name", tbBackup.Name),
+		d.Set("description", tbBackup.Description),
+		d.Set("begin_time", tbBackup.BeginTime),
+		d.Set("end_time", tbBackup.EndTime),
+		d.Set("take_up_time", tbBackup.TakeUpTime),
+		d.Set("size", tbBackup.Size),
+		d.Set("datastore", flattenGetTaurusDbBackupResponseBodyDatastore(tbBackup)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenGetTaurusDbBackupResponseBodyDatastore(backup *backup.BackupListInfo) []interface{} {
+	rst := make([]interface{}, 0, 1)
+	rst = append(rst, map[string]interface{}{
+		"type":    backup.Datastore.Type,
+		"version": backup.Datastore.Version,
+	})
+	return rst
+}
+
+func getTaurusDbBackup(client *golangsdk.ServiceClient, backupID string) (*backup.BackupListInfo, error) {
+	getResp, err := backup.List(client,
+		backup.ListOpts{BackupId: backupID},
+	)
+
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving TaurusDb MySQL backup: %s", err)
+	}
+
+	if len(getResp) == 0 {
+		return nil, fmt.Errorf("TaurusDb backup doesn't exist")
+	}
+
+	return &getResp[0], nil
+}
+
+func resourceTaurusDbMysqlBackupDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := config.TaurusDBV3Client(config.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating TaurusDb client: %s ", err)
+	}
+
+	_, err = backup.Delete(client, d.Id())
+
+	if err != nil {
+		return diag.Errorf("error deleting TaurusDb MySQL backup: %s", err)
+	}
+
+	return nil
+}

--- a/opentelekomcloud/services/taurusdb/resource_opentelekomcloud_taurusdb_mysql_instance_v3.go
+++ b/opentelekomcloud/services/taurusdb/resource_opentelekomcloud_taurusdb_mysql_instance_v3.go
@@ -75,6 +75,7 @@ func ResourceTaurusDbV3Instance() *schema.Resource {
 			"enterprise_project_id": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"dedicated_resource_id": {
 				Type:     schema.TypeString,

--- a/releasenotes/notes/taurusdb_backup-d874a0dc297dd17d.yaml
+++ b/releasenotes/notes/taurusdb_backup-d874a0dc297dd17d.yaml
@@ -1,7 +1,7 @@
 ---
 features:
   - |
-    **New Resource:** ``opentelekomcloud_taurusdb_mysql_backup_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **New Resource:** ``opentelekomcloud_taurusdb_mysql_backup_v3`` (`#3150 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3150>`_)
 fix:
   - |
-    **[TaurusDb]** Fix `enterprise_project_id` parameter set for ``opentelekomcloud_taurusdb_mysql_instance_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[TaurusDb]** Fix `enterprise_project_id` parameter set for ``opentelekomcloud_taurusdb_mysql_instance_v3`` (`#3150 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3150>`_)

--- a/releasenotes/notes/taurusdb_backup-d874a0dc297dd17d.yaml
+++ b/releasenotes/notes/taurusdb_backup-d874a0dc297dd17d.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    **New Resource:** ``opentelekomcloud_taurusdb_mysql_backup_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+fix:
+  - |
+    **[TaurusDb]** Fix `enterprise_project_id` parameter set for ``opentelekomcloud_taurusdb_mysql_instance_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)


### PR DESCRIPTION
## Summary of the Pull Request

- New resource `opentelekomcloud_taurusdb_mysql_backup_v3`
- Fix `enterprise_project_id` set for `opentelekomcloud_taurusdb_mysql_instance_v3`

## PR Checklist

* [x] Refers to: #3065
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccTaurusDbMysqlBackup_basic
=== PAUSE TestAccTaurusDbMysqlBackup_basic
=== CONT  TestAccTaurusDbMysqlBackup_basic
--- PASS: TestAccTaurusDbMysqlBackup_basic (826.92s)
PASS

Process finished with the exit code 0
```
