### PR TITLE
[Feat.] TaurusDB: concurrency

### DIFF
--- a/docs/resources/taurusdb_mysql_sql_control_rule_v3.md
+++ b/docs/resources/taurusdb_mysql_sql_control_rule_v3.md
@@ -1,0 +1,74 @@
+---
+subcategory: "TaurusDB(for MySQL)"
+layout: "opentelekomcloud"
+page_title: "OpenTelekomCloud: opentelekomcloud_taurusdb_mysql_sql_control_rule_v3"
+sidebar_current: "docs-opentelekomcloud-resource-taurusdb-mysql-sql-control-rule-v3"
+description: |-
+  Manages a TaurusDB MySQL SQL concurrency control rule resource within OpenTelekomCloud.
+---
+
+# opentelekomcloud_taurusdb_mysql_sql_control_rule_v3
+
+Manages a TaurusDB MySQL SQL concurrency control rule resource within OpenTelekomCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "node_id" {}
+
+resource "opentelekomcloud_taurusdb_mysql_sql_control_rule_v3" "test" {
+  instance_id     = var.instance_id
+  node_id         = var.node_id
+  sql_type        = "SELECT"
+  pattern         = "select~from~t1"
+  max_concurrency = 20
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `instance_id` - (Required, String, ForceNew) Specifies the ID of the TaurusDB MySQL instance.
+  Changing this parameter will create a new resource.
+
+* `node_id` - (Required, String, ForceNew) Specifies the ID of the TaurusDB MySQL node.
+  Changing this parameter will create a new resource.
+
+* `sql_type` - (Required, String, ForceNew) Specifies the SQL statement type.
+  Value options: **SELECT**, **UPDATE**, **DELETE**.
+  Changing this parameter will create a new resource.
+
+* `pattern` - (Required, String, ForceNew) Specifies the concurrency control rule of SQL statements. A rule can consist
+  of up to 128 keywords. The keywords are separated by tildes (~), for example, select~from~t1. The rule cannot contain
+  backslashes (\), commas (,), or double tildes (~~). It cannot end with tildes (~).
+  Changing this parameter will create a new resource.
+
+* `max_concurrency` - (Required, Int) Specifies the maximum number of concurrent SQL statements.
+  Value: a non-negative integer.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Indicates the resource ID which is formatted `<instance_id>/<node_id>/<sql_type>/<pattern>`.
+
+* `region` - Indicates the region in which to create the resource.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `update` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
+
+## Import
+
+The TaurusDB MySQL SQL concurrency control rule can be imported using the `instance_id`, `node_id`, `sql_type` and
+`pattern` separated by slashes, e.g.
+
+```bash
+$ terraform import opentelekomcloud_taurusdb_mysql_sql_control_rule_v3.test <instance_id>/<node_id>/<sql_type>/<pattern>
+```

--- a/opentelekomcloud/acceptance/taurusdb/resource_opentelekomcloud_taurusdb_mysql_sql_control_rule_v3_test.go
+++ b/opentelekomcloud/acceptance/taurusdb/resource_opentelekomcloud_taurusdb_mysql_sql_control_rule_v3_test.go
@@ -1,0 +1,144 @@
+package acceptance
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/taurus/v3/sqlfilter"
+
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+)
+
+const sqlControlRuleResourceName = "opentelekomcloud_taurusdb_mysql_sql_control_rule_v3.test"
+
+func getTaurusDbMysqlSqlControlRuleResourceFunc(conf *cfg.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.TaurusDBV3Client(env.OS_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating TaurusDB client: %s", err)
+	}
+
+	parts := strings.SplitN(state.Primary.ID, "/", 4)
+	if len(parts) != 4 {
+		return nil, fmt.Errorf("invalid id format")
+	}
+
+	instanceID := parts[0]
+	nodeID := parts[1]
+	sqlType := parts[2]
+	pattern := parts[3]
+
+	opts := sqlfilter.GetSqlFilterRulesOpts{
+		NodeId: nodeID,
+	}
+
+	resp, err := sqlfilter.GetSqlFilterRules(client, instanceID, opts)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving SQL control rule: %s", err)
+	}
+
+	for _, rule := range resp.SqlFilterRules {
+		if rule.SqlType == sqlType {
+			for _, p := range rule.Patterns {
+				if p.Pattern == pattern {
+					return p, nil
+				}
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("TaurusDB MySQL SQL control rule not found")
+}
+
+func TestAccTaurusDBMySQLSqlControlRule_basic(t *testing.T) {
+	var obj interface{}
+
+	name := "tf_taurusdb_" + acctest.RandString(3)
+
+	rc := common.InitResourceCheck(
+		sqlControlRuleResourceName,
+		&obj,
+		getTaurusDbMysqlSqlControlRuleResourceFunc,
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTaurusDBMySQLSqlControlRuleBasic(name, 20),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(sqlControlRuleResourceName, "instance_id",
+						"opentelekomcloud_taurusdb_mysql_instance_v3.test", "id"),
+					resource.TestCheckResourceAttrPair(sqlControlRuleResourceName, "node_id",
+						"opentelekomcloud_taurusdb_mysql_instance_v3.test", "nodes.0.id"),
+					resource.TestCheckResourceAttr(sqlControlRuleResourceName, "sql_type", "SELECT"),
+					resource.TestCheckResourceAttr(sqlControlRuleResourceName, "pattern", "select~from~t1"),
+					resource.TestCheckResourceAttr(sqlControlRuleResourceName, "max_concurrency", "20"),
+				),
+			},
+			{
+				Config: testAccTaurusDBMySQLSqlControlRuleBasic(name, 30),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(sqlControlRuleResourceName, "max_concurrency", "30"),
+				),
+			},
+			{
+				ResourceName:      sqlControlRuleResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccTaurusDBMySQLSqlControlRuleBasic(name string, maxConcurrency int) string {
+	return fmt.Sprintf(`
+%s
+
+resource "opentelekomcloud_taurusdb_mysql_sql_control_rule_v3" "test" {
+  instance_id     = opentelekomcloud_taurusdb_mysql_instance_v3.test.id
+  node_id         = opentelekomcloud_taurusdb_mysql_instance_v3.test.nodes[0].id
+  sql_type        = "SELECT"
+  pattern         = "select~from~t1"
+  max_concurrency = %d
+}
+`, testAccTaurusDBMySqlInstanceForSqlControl(name), maxConcurrency)
+}
+
+func testAccTaurusDBMySqlInstanceForSqlControl(name string) string {
+	return fmt.Sprintf(`
+%s
+%s
+
+resource "opentelekomcloud_taurusdb_mysql_instance_v3" "test" {
+  name                     = "%s"
+  vpc_id                   = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  subnet_id                = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
+  security_group_id        = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
+  flavor                   = "gaussdb.mysql.xlarge.x86.8"
+  password                 = "Test123!@#"
+  availability_zone_mode   = "multi"
+  master_availability_zone = "eu-de-01"
+  read_replicas            = 1
+
+  datastore {
+    engine  = "gaussdb-mysql"
+    version = "8.0"
+  }
+
+  backup_strategy {
+    start_time = "03:00-04:00"
+    keep_days  = 7
+  }
+}
+`, common.DataSourceSubnet, common.DataSourceSecGroupDefault, name)
+}

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -664,6 +664,7 @@ func Provider() *schema.Provider {
 			"opentelekomcloud_swr_repository_v2":                         swr.ResourceSwrRepositoryV2(),
 			"opentelekomcloud_taurusdb_mysql_backup_v3":                  taurusdb.ResourceTaurusDbMysqlBackup(),
 			"opentelekomcloud_taurusdb_mysql_instance_v3":                taurusdb.ResourceTaurusDbV3Instance(),
+			"opentelekomcloud_taurusdb_mysql_sql_control_rule_v3":        taurusdb.ResourceTaurusDbV3MySQLSqlControlRule(),
 			"opentelekomcloud_taurusdb_mysql_proxy_v3":                   taurusdb.ResourceTaurusDbV3Proxy(),
 			"opentelekomcloud_tms_tags_v1":                               tms.ResourceTmsTagV1(),
 			"opentelekomcloud_tms_resource_tags_v1":                      tms.ResourceTmsResourceTagsV1(),

--- a/opentelekomcloud/services/taurusdb/resource_opentelekomcloud_taurusdb_mysql_sql_control_rule_v3.go
+++ b/opentelekomcloud/services/taurusdb/resource_opentelekomcloud_taurusdb_mysql_sql_control_rule_v3.go
@@ -1,0 +1,264 @@
+package taurusdb
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/taurus/v3/sqlfilter"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+)
+
+func ResourceTaurusDbV3MySQLSqlControlRule() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceTaurusDbV3MySQLSqlControlRuleCreate,
+		ReadContext:   resourceTaurusDbV3MySQLSqlControlRuleRead,
+		UpdateContext: resourceTaurusDbV3MySQLSqlControlRuleUpdate,
+		DeleteContext: resourceTaurusDbV3MySQLSqlControlRuleDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"node_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"sql_type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"pattern": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"max_concurrency": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"region": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceTaurusDbV3MySQLSqlControlRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := config.TaurusDBV3Client(config.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating TaurusDb client: %s ", err)
+	}
+
+	instanceID := d.Get("instance_id").(string)
+	nodeID := d.Get("node_id").(string)
+	sqlType := d.Get("sql_type").(string)
+	pattern := d.Get("pattern").(string)
+	maxConcurrency := d.Get("max_concurrency").(int)
+
+	opts := sqlfilter.UpdateSqlFilterRulesOpts{
+		SqlFilterRules: []sqlfilter.NodeSqlFilterRuleInfo{
+			{
+				NodeId: nodeID,
+				Rules: []sqlfilter.NodeSqlFilterRule{
+					{
+						SqlType: sqlType,
+						Patterns: []sqlfilter.NodeSqlFilterRulePattern{
+							{
+								Pattern:        pattern,
+								MaxConcurrency: maxConcurrency,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	jobID, err := sqlfilter.UpdateSqlFilterRules(client, instanceID, opts)
+	if err != nil {
+		return diag.Errorf("error creating TaurusDB MySQL SQL control rule: %s", err)
+	}
+
+	if jobID == nil || *jobID == "" {
+		return diag.Errorf("unable to find the job ID from the API response")
+	}
+
+	if err := waitForJobComplete(ctx, client, *jobID, d.Timeout(schema.TimeoutCreate)); err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s/%s/%s", instanceID, nodeID, sqlType, pattern))
+
+	return resourceTaurusDbV3MySQLSqlControlRuleRead(ctx, d, meta)
+}
+
+func resourceTaurusDbV3MySQLSqlControlRuleRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := config.TaurusDBV3Client(config.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating TaurusDb client: %s ", err)
+	}
+
+	parts := strings.SplitN(d.Id(), "/", 4)
+	if len(parts) != 4 {
+		return diag.Errorf("invalid id format, must be <instance_id>/<node_id>/<sql_type>/<pattern>")
+	}
+
+	instanceID := parts[0]
+	nodeID := parts[1]
+	sqlType := parts[2]
+	pattern := parts[3]
+
+	opts := sqlfilter.GetSqlFilterRulesOpts{
+		NodeId: nodeID,
+	}
+
+	resp, err := sqlfilter.GetSqlFilterRules(client, instanceID, opts)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving TaurusDb MySQL SQL control rule")
+	}
+
+	var maxConcurrency *int
+	for _, rule := range resp.SqlFilterRules {
+		if rule.SqlType == sqlType {
+			for _, p := range rule.Patterns {
+				if p.Pattern == pattern {
+					maxConcurrency = &p.MaxConcurrency
+					break
+				}
+			}
+		}
+		if maxConcurrency != nil {
+			break
+		}
+	}
+
+	if maxConcurrency == nil {
+		return common.CheckDeletedDiag(d, fmt.Errorf("not found"), "")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", config.GetRegion(d)),
+		d.Set("instance_id", instanceID),
+		d.Set("node_id", nodeID),
+		d.Set("sql_type", sqlType),
+		d.Set("pattern", pattern),
+		d.Set("max_concurrency", *maxConcurrency),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceTaurusDbV3MySQLSqlControlRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := config.TaurusDBV3Client(config.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating TaurusDb client: %s ", err)
+	}
+
+	if d.HasChange("max_concurrency") {
+		instanceID := d.Get("instance_id").(string)
+		nodeID := d.Get("node_id").(string)
+		sqlType := d.Get("sql_type").(string)
+		pattern := d.Get("pattern").(string)
+		maxConcurrency := d.Get("max_concurrency").(int)
+
+		opts := sqlfilter.UpdateSqlFilterRulesOpts{
+			SqlFilterRules: []sqlfilter.NodeSqlFilterRuleInfo{
+				{
+					NodeId: nodeID,
+					Rules: []sqlfilter.NodeSqlFilterRule{
+						{
+							SqlType: sqlType,
+							Patterns: []sqlfilter.NodeSqlFilterRulePattern{
+								{
+									Pattern:        pattern,
+									MaxConcurrency: maxConcurrency,
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		jobID, err := sqlfilter.UpdateSqlFilterRules(client, instanceID, opts)
+		if err != nil {
+			return diag.Errorf("error updating TaurusDb MySQL SQL control rule: %s", err)
+		}
+
+		if jobID == nil || *jobID == "" {
+			return diag.Errorf("unable to find the job ID from the API response")
+		}
+
+		if err := waitForJobComplete(ctx, client, *jobID, d.Timeout(schema.TimeoutUpdate)); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	return resourceTaurusDbV3MySQLSqlControlRuleRead(ctx, d, meta)
+}
+
+func resourceTaurusDbV3MySQLSqlControlRuleDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := config.TaurusDBV3Client(config.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating TaurusDb client: %s ", err)
+	}
+
+	instanceID := d.Get("instance_id").(string)
+	nodeID := d.Get("node_id").(string)
+	sqlType := d.Get("sql_type").(string)
+	pattern := d.Get("pattern").(string)
+
+	opts := sqlfilter.DeleteSqlFilterRulesOpts{
+		SqlFilterRules: []sqlfilter.DeleteNodeSqlFilterRuleInfo{
+			{
+				NodeId: nodeID,
+				Rules: []sqlfilter.DeleteNodeSqlFilterRule{
+					{
+						SqlType:  sqlType,
+						Patterns: []string{pattern},
+					},
+				},
+			},
+		},
+	}
+
+	jobID, err := sqlfilter.DeleteSqlFilterRules(client, instanceID, opts)
+	if err != nil {
+		return diag.Errorf("error deleting TaurusDB MySQL SQL control rule: %s", err)
+	}
+
+	if jobID == nil || *jobID == "" {
+		return diag.Errorf("unable to find the job ID from the API response")
+	}
+
+	if err := waitForJobComplete(ctx, client, *jobID, d.Timeout(schema.TimeoutDelete)); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}

--- a/releasenotes/notes/taurusdb_sql_control-96e23d58e5a92fb6.yaml
+++ b/releasenotes/notes/taurusdb_sql_control-96e23d58e5a92fb6.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   - |
-    **New Resource:** ``opentelekomcloud_taurusdb_mysql_sql_control_rule_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **New Resource:** ``opentelekomcloud_taurusdb_mysql_sql_control_rule_v3`` (`#3153 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3153>`_)

--- a/releasenotes/notes/taurusdb_sql_control-96e23d58e5a92fb6.yaml
+++ b/releasenotes/notes/taurusdb_sql_control-96e23d58e5a92fb6.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    **New Resource:** ``opentelekomcloud_taurusdb_mysql_sql_control_rule_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)


### PR DESCRIPTION
## Summary of the Pull Request
New resource for taurusdb mysql concurrency management

## PR Checklist

* [x] Refers to: #3065
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccTaurusDBMySQLSqlControlRule_basic
--- PASS: TestAccTaurusDBMySQLSqlControlRule_basic (716.98s)
PASS

Process finished with the exit code 0
```
