### PR TITLE
[Feat.] TaurusDB: flavors and engine data source

### DIFF
--- a/docs/data-sources/taurusdb_mysql_engine_versions_v3.md
+++ b/docs/data-sources/taurusdb_mysql_engine_versions_v3.md
@@ -1,0 +1,44 @@
+---
+subcategory: "TaurusDB(for MySQL)"
+layout: "opentelekomcloud"
+page_title: "OpenTelekomCloud: opentelekomcloud_taurusdb_mysql_engine_versions_v3"
+sidebar_current: "docs-opentelekomcloud-datasource-taurusdb-mysql-engine-versions_v3"
+description: |-
+  Get database specifications of a specified DB engine from OpenTelekomCloud
+---
+
+# opentelekomcloud_taurusdb_mysql_engine_versions_v3
+
+Use this data source to get the database specifications of a specified DB engine.
+
+## Example Usage
+
+```hcl
+data "opentelekomcloud_taurusdb_mysql_engine_versions_v3" "test" {
+  database_name = "gaussdb-mysql"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `database_name` - (Required) Specifies the DB engine.
+  Value options: **gaussdb-mysql**.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `datastores` - Indicates the DB version list.
+  The [datastores](#datastores) structure is documented below.
+
+<a name="datastores"></a>
+The `datastores` block supports:
+
+* `id` - Indicates the DB version ID.
+
+* `name` - Indicates the DB version number.
+  Only the major version number with two digits is returned.

--- a/docs/data-sources/taurusdb_mysql_flavors_v3.md
+++ b/docs/data-sources/taurusdb_mysql_flavors_v3.md
@@ -1,0 +1,57 @@
+---
+subcategory: "TaurusDB(for MySQL)"
+layout: "opentelekomcloud"
+page_title: "OpenTelekomCloud: opentelekomcloud_taurusdb_mysql_flavors_v3"
+sidebar_current: "docs-opentelekomcloud-datasource-taurusdb-mysql-flavors-v3"
+description: |-
+  Get available TaurusDB MySQL flavors from OpenTelekomCloud
+---
+
+# opentelekomcloud_taurusdb_mysql_flavors_v3
+
+Use this data source to get available OpenTelekomCloud TaurusDB MySQL flavors.
+
+## Example Usage
+
+```hcl
+data "opentelekomcloud_taurusdb_mysql_flavors_v3" "flavors" {
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `engine` - (Optional) Specifies the database engine. Only **gaussdb-mysql** is supported now.
+
+* `version` - (Optional) Specifies the database version. Only **8.0** is supported now.
+
+* `availability_zone_mode` - (Optional) Specifies the availability zone mode. Currently supports **single** and **multi**. Defaults to **single**.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `region` - The region in which flavors are obtained.
+
+* `flavors` - Indicates the flavors information.
+  The [flavors](#flavors) structure is documented below.
+
+<a name="flavors"></a>
+The `flavors` block supports:
+
+* `name` - Indicates the name of the TaurusDB MySQL flavor.
+
+* `vcpus` - Indicates the CPU size.
+
+* `memory` - Indicates the memory size in GB.
+
+* `type` - Indicates the arch type of the flavor.
+
+* `mode` - Indicates the database mode.
+
+* `version` - Indicates the database version.
+
+* `az_status` - Indicates the flavor status in each availability zone.

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20251008110717-de5bd5f57971
+	github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20251009082428-277e7d430734
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.43.0
 	golang.org/x/sync v0.17.0

--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20251008110717-de5bd5f57971 h1:wwbzVmuUD0roDaeAMYgGni5gEPCSvWszRpjm1eJTWqk=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20251008110717-de5bd5f57971/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20251009082428-277e7d430734 h1:wgepjqXjnDkaL/y0Fs3+43raG7KaKuKK8JvlbTU5q1Y=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20251009082428-277e7d430734/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/opentelekomcloud/acceptance/taurusdb/data_source_opentelekomcloud_taurusdb_mysql_engine_versions_v3_test.go
+++ b/opentelekomcloud/acceptance/taurusdb/data_source_opentelekomcloud_taurusdb_mysql_engine_versions_v3_test.go
@@ -1,0 +1,39 @@
+package acceptance
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+)
+
+func TestAccDataSourceGaussdbMysqlEngineVersions_basic(t *testing.T) {
+	dataSource := "data.opentelekomcloud_taurusdb_mysql_engine_versions_v3.test"
+	dc := common.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+		},
+		ProviderFactories: common.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceGaussdbMysqlEngineVersions_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "datastores.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "datastores.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "datastores.0.name"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceGaussdbMysqlEngineVersions_basic() string {
+	return `
+data "opentelekomcloud_taurusdb_mysql_engine_versions_v3" "test" {
+  database_name = "gaussdb-mysql"
+}
+`
+}

--- a/opentelekomcloud/acceptance/taurusdb/data_source_opentelekomcloud_taurusdb_mysql_flavors_v3_test.go
+++ b/opentelekomcloud/acceptance/taurusdb/data_source_opentelekomcloud_taurusdb_mysql_flavors_v3_test.go
@@ -1,0 +1,49 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+)
+
+func TestAccOpenTelekomCloudTaurusDBMysqlFlavorsDataSource_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOpenTelekomCloudTaurusDBMysqlFlavorsDataSource_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTaurusDBMysqlFlavorsDataSourceID("data.opentelekomcloud_taurusdb_mysql_flavors_v3.flavor"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckTaurusDBMysqlFlavorsDataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("can't find TaurusDB MySQL data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("the TaurusDB MySQL data source ID not set")
+		}
+
+		return nil
+	}
+}
+
+const testAccOpenTelekomCloudTaurusDBMysqlFlavorsDataSource_basic = `
+data "opentelekomcloud_taurusdb_mysql_flavors_v3" "flavor" {
+  engine                 = "gaussdb-mysql"
+  version                = "8.0"
+  availability_zone_mode = "multi"
+}
+`

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -398,6 +398,8 @@ func Provider() *schema.Provider {
 			"opentelekomcloud_smn_topic_v2":                       smn.DataSourceTopic(),
 			"opentelekomcloud_smn_subscription_v2":                smn.DataSourceSmnSubscriptionV2(),
 			"opentelekomcloud_smn_topic_subscription_v2":          smn.DataSourceSmnTopicSubscriptionV2(),
+			"opentelekomcloud_taurusdb_mysql_engine_versions_v3":  taurusdb.DataSourceTaurusDBV33MysqlEngineVersions(),
+			"opentelekomcloud_taurusdb_mysql_flavors_v3":          taurusdb.DataSourceTaurusDBV3MysqlFlavors(),
 			"opentelekomcloud_tms_quotas_v1":                      tms.DataSourceTmsQuotasV1(),
 			"opentelekomcloud_tms_resource_instances_v1":          tms.DataSourceTmsResourceInstancesV1(),
 			"opentelekomcloud_tms_resource_tag_keys_v1":           tms.DataSourceTmsTagKeysV1(),

--- a/opentelekomcloud/services/taurusdb/data_source_opentelekomcloud_taurusdb_mysql_engine_versions_v3.go
+++ b/opentelekomcloud/services/taurusdb/data_source_opentelekomcloud_taurusdb_mysql_engine_versions_v3.go
@@ -1,0 +1,83 @@
+package taurusdb
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/taurus/v3/instance"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+)
+
+func DataSourceTaurusDBV33MysqlEngineVersions() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceTausurDBV3MysqlEngineVersionsRead,
+
+		Schema: map[string]*schema.Schema{
+			"database_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"datastores": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"region": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceTausurDBV3MysqlEngineVersionsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := config.TaurusDBV3Client(config.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating TaurusDb client: %s ", err)
+	}
+
+	databaseName := d.Get("database_name").(string)
+
+	resp, err := instance.ListDatastores(client, databaseName)
+	if err != nil {
+		return diag.Errorf("error retrieving TaurusDB MySQL engine versions: %s", err)
+	}
+
+	datastores := make([]map[string]interface{}, len(resp.Datastores))
+	for i, ds := range resp.Datastores {
+		datastores[i] = map[string]interface{}{
+			"id":   ds.Id,
+			"name": ds.Name,
+		}
+	}
+
+	if err := d.Set("datastores", datastores); err != nil {
+		return diag.Errorf("error setting datastores: %s", err)
+	}
+
+	if err := d.Set("region", config.GetRegion(d)); err != nil {
+		return diag.Errorf("error setting region: %s", err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(id)
+
+	return nil
+}

--- a/opentelekomcloud/services/taurusdb/data_source_opentelekomcloud_taurusdb_mysql_flavors_v3.go
+++ b/opentelekomcloud/services/taurusdb/data_source_opentelekomcloud_taurusdb_mysql_flavors_v3.go
@@ -1,0 +1,120 @@
+package taurusdb
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/taurus/v3/instance"
+
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+)
+
+func DataSourceTaurusDBV3MysqlFlavors() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceTaurusDBV3MysqlFlavorsRead,
+
+		Schema: map[string]*schema.Schema{
+			"engine": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "gaussdb-mysql",
+			},
+			"version": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "8.0",
+			},
+			"availability_zone_mode": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "single",
+			},
+			"flavors": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"vcpus": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"memory": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"mode": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"az_status": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+			"region": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceTaurusDBV3MysqlFlavorsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := config.TaurusDBV3Client(config.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating TaurusDb client: %s ", err)
+	}
+
+	opts := instance.ListFlavorsOpts{
+		DatabaseName:         d.Get("engine").(string),
+		VersionName:          d.Get("version").(string),
+		AvailabilityZoneMode: d.Get("availability_zone_mode").(string),
+	}
+
+	flavorList, err := instance.ListFlavors(client, opts)
+	if err != nil {
+		return diag.Errorf("error fetching flavors for TaurusDB MySQL: %s", err)
+	}
+
+	flavors := make([]interface{}, 0, len(flavorList))
+	for _, flavor := range flavorList {
+		flavors = append(flavors, map[string]interface{}{
+			"name":      flavor.SpecCode,
+			"vcpus":     flavor.Vcpus,
+			"memory":    flavor.Ram,
+			"type":      flavor.Type,
+			"mode":      flavor.InstanceMode,
+			"version":   flavor.VersionName,
+			"az_status": flavor.AzStatus,
+		})
+	}
+
+	d.SetId("flavors")
+
+	var mErr *multierror.Error
+	mErr = multierror.Append(mErr,
+		d.Set("region", config.GetRegion(d)),
+		d.Set("flavors", flavors),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}

--- a/releasenotes/notes/taurusdb_flavors-ceaed34850c0b212.yaml
+++ b/releasenotes/notes/taurusdb_flavors-ceaed34850c0b212.yaml
@@ -1,6 +1,6 @@
 ---
 features:
   - |
-    **New Data Source:** ``data_source/opentelekomcloud_taurusdb_engine_versions_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **New Data Source:** ``data_source/opentelekomcloud_taurusdb_engine_versions_v3`` (`#3160 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3160>`_)
   - |
-    **New Data Source:** ``data_source/opentelekomcloud_taurusdb_flavors_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **New Data Source:** ``data_source/opentelekomcloud_taurusdb_flavors_v3`` (`#3160 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3160>`_)

--- a/releasenotes/notes/taurusdb_flavors-ceaed34850c0b212.yaml
+++ b/releasenotes/notes/taurusdb_flavors-ceaed34850c0b212.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    **New Data Source:** ``data_source/opentelekomcloud_taurusdb_engine_versions_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+  - |
+    **New Data Source:** ``data_source/opentelekomcloud_taurusdb_flavors_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)


### PR DESCRIPTION
## Summary of the Pull Request
New data sources:

- ``data_source/opentelekomcloud_taurusdb_engine_versions_v3``
- ``data_source/opentelekomcloud_taurusdb_flavors_v3``

## PR Checklist

* [x] Refers to: #3065
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccOpenTelekomCloudTaurusDBMysqlFlavorsDataSource_basic
=== PAUSE TestAccOpenTelekomCloudTaurusDBMysqlFlavorsDataSource_basic
=== CONT  TestAccOpenTelekomCloudTaurusDBMysqlFlavorsDataSource_basic
--- PASS: TestAccOpenTelekomCloudTaurusDBMysqlFlavorsDataSource_basic (23.34s)
PASS

Process finished with the exit code 0

=== RUN   TestAccDataSourceGaussdbMysqlEngineVersions_basic
=== PAUSE TestAccDataSourceGaussdbMysqlEngineVersions_basic
=== CONT  TestAccDataSourceGaussdbMysqlEngineVersions_basic
--- PASS: TestAccDataSourceGaussdbMysqlEngineVersions_basic (26.43s)
PASS

Process finished with the exit code 0
```
