### PR TITLE
[Feat.] multiple policy support in `resource/opentelekomcloud_cbr_vault_v3`

### DIFF
--- a/docs/resources/cbr_vault_v3.md
+++ b/docs/resources/cbr_vault_v3.md
@@ -189,6 +189,29 @@ resource "opentelekomcloud_cbr_vault_v3" "vault" {
 }
 ```
 
+### Vault with backup and replication policies
+```hcl
+resource "opentelekomcloud_cbr_vault_v3" "policies" {
+  name            = "multipolicy"
+
+  billing {
+    size          = 100
+    object_type   = "server"
+    protect_type  = "backup"
+    charging_mode = "post_paid"
+    period_type   = "month"
+    period_num    = 2
+  }
+
+  policy {
+    id = opentelekomcloud_cbr_policy_v3.backup[1].id
+  }
+  policy {
+    id                   = var.replication_policy_id
+    destination_vault_id = var.destination_vault
+  }
+}
+```
 ### Vault with auto bind and bind rule
 
 ```hcl

--- a/docs/resources/cbr_vault_v3.md
+++ b/docs/resources/cbr_vault_v3.md
@@ -192,7 +192,7 @@ resource "opentelekomcloud_cbr_vault_v3" "vault" {
 ### Vault with backup and replication policies
 ```hcl
 resource "opentelekomcloud_cbr_vault_v3" "policies" {
-  name            = "multipolicy"
+  name = "multipolicy"
 
   billing {
     size          = 100

--- a/docs/resources/cbr_vault_v3.md
+++ b/docs/resources/cbr_vault_v3.md
@@ -254,7 +254,7 @@ The following arguments are supported:
     * `include_volumes` - (Optional) List of included volumes.
 
 * `backup_policy_id` - (Optional) Backup policy ID. If the value of this parameter is empty, automatic backup is not
-  performed.
+  performed. Deprecated use `policy` instead.
 
 * `description` - (Optional) User-defined vault description.
 
@@ -272,6 +272,19 @@ The following arguments are supported:
 
 * `locked` - (Optional) Specifies whether the vault is locked. A locked vault cannot be unlocked.
   Defaults to **false**.
+
+* `policy` - (Optional, List) Specifies the policy details to associate with the CBR vault.
+  The [object](#vault_policies) structure is documented below.
+
+<a name="vault_policies"></a>
+The `policy` block supports:
+
+* `id` - (Required, String) Specifies the policy ID.
+
+* `destination_vault_id` - (Optional, String) Specifies the ID of destination vault to which the replication policy
+  will be associated.
+
+-> Only one policy of each type (backup and replication) can be associated.
 
 ## Attributes Reference
 

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20251009082428-277e7d430734
+	github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20251014080911-573919fe7059
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.43.0
 	golang.org/x/sync v0.17.0

--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20251009082428-277e7d430734 h1:wgepjqXjnDkaL/y0Fs3+43raG7KaKuKK8JvlbTU5q1Y=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20251009082428-277e7d430734/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20251014080911-573919fe7059 h1:znuGcZwkcAQtS4afJvClWTxBgG8iIMH/RIDfSd4Jhl8=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20251014080911-573919fe7059/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/opentelekomcloud/acceptance/cbr/resource_opentelekomcloud_cbr_vault_v3_test.go
+++ b/opentelekomcloud/acceptance/cbr/resource_opentelekomcloud_cbr_vault_v3_test.go
@@ -395,8 +395,8 @@ func testAccVault_bindPolicies_base(name string) string {
 resource "opentelekomcloud_cbr_policy_v3" "backup" {
   count = 2
 
-  name            = format("%[1]s_%%d", count.index)
-  operation_type  = "backup"
+  name           = format("%[1]s_%%d", count.index)
+  operation_type = "backup"
 
   operation_definition {
     day_backups   = 1
@@ -455,7 +455,7 @@ resource "opentelekomcloud_cbr_vault_v3" "legacy" {
 }
 
 resource "opentelekomcloud_cbr_vault_v3" "test" {
-  name            = "%[2]s"
+  name = "%[2]s"
 
   billing {
     size          = 100
@@ -496,7 +496,7 @@ resource "opentelekomcloud_cbr_vault_v3" "legacy" {
 }
 
 resource "opentelekomcloud_cbr_vault_v3" "test" {
-  name            = "%[2]s"
+  name = "%[2]s"
 
   billing {
     size          = 100

--- a/opentelekomcloud/acceptance/cbr/resource_opentelekomcloud_cbr_vault_v3_test.go
+++ b/opentelekomcloud/acceptance/cbr/resource_opentelekomcloud_cbr_vault_v3_test.go
@@ -2,6 +2,7 @@ package acceptance
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 	"testing"
 
@@ -324,6 +325,9 @@ func testAccCheckCBRVaultV3Destroy(s *terraform.State) error {
 }
 
 func TestAccVault_bindPolicies(t *testing.T) {
+	if os.Getenv("OS_DEST_VAULT_ID") == "" {
+		t.Skip("OS_DEST_VAULT_ID is not set; skipping OpenTelekomCloud CBR bind policies test.")
+	}
 	var (
 		vault interface{}
 
@@ -350,7 +354,7 @@ func TestAccVault_bindPolicies(t *testing.T) {
 					resource.TestCheckResourceAttr(mainRcName, "name", randName),
 					resource.TestCheckResourceAttr(mainRcName, "policy.#", "2"),
 					legacyRc.CheckResourceExists(),
-					resource.TestCheckResourceAttrPair(legacyRcName, "policy_id",
+					resource.TestCheckResourceAttrPair(legacyRcName, "backup_policy_id",
 						"opentelekomcloud_cbr_policy_v3.backup.0", "id"),
 				),
 			},
@@ -361,7 +365,7 @@ func TestAccVault_bindPolicies(t *testing.T) {
 					resource.TestCheckResourceAttr(mainRcName, "name", randName),
 					resource.TestCheckResourceAttr(mainRcName, "policy.#", "2"),
 					legacyRc.CheckResourceExists(),
-					resource.TestCheckResourceAttrPair(legacyRcName, "policy_id",
+					resource.TestCheckResourceAttrPair(legacyRcName, "backup_policy_id",
 						"opentelekomcloud_cbr_policy_v3.backup.1", "id"),
 				),
 			},
@@ -369,13 +373,17 @@ func TestAccVault_bindPolicies(t *testing.T) {
 				ResourceName:      mainRcName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"billing",
+				},
 			},
 			{
 				ResourceName:      legacyRcName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"policy_id",
+					"billing",
+					"backup_policy_id",
 				},
 			},
 		},
@@ -407,7 +415,7 @@ resource "opentelekomcloud_cbr_policy_v3" "backup" {
 resource "opentelekomcloud_cbr_policy_v3" "replication" {
   count = 2
 
-  name                   = "%[1]s"
+  name                   = format("%[1]s_%%d", count.index)
   operation_type         = "replication"
   destination_region     = "%[2]s"
   destination_project_id = "%[3]s"
@@ -424,20 +432,6 @@ resource "opentelekomcloud_cbr_policy_v3" "replication" {
   trigger_pattern = [
     "FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR,SA,SU;BYHOUR=14;BYMINUTE=00"
   ]
-}
-
-resource "opentelekomcloud_cbr_vault_v3" "destination" {
-  region          = "%[2]s"
-  name            = "%[1]s"
-
-  billing {
-    size          = 100
-    object_type   = "server"
-    protect_type  = "replication"
-    charging_mode = "post_paid"
-    period_type   = "month"
-    period_num    = 2
-  }
 }
 `, name, env.OS_DEST_REGION, env.OS_DEST_PROJECT_ID)
 }
@@ -477,10 +471,10 @@ resource "opentelekomcloud_cbr_vault_v3" "test" {
   }
   policy {
     id                   = opentelekomcloud_cbr_policy_v3.replication[0].id
-    destination_vault_id = opentelekomcloud_cbr_vault_v3.destination.id
+    destination_vault_id = "%[3]s"
   }
 }
-`, testAccVault_bindPolicies_base(name), name)
+`, testAccVault_bindPolicies_base(name), name, env.OS_DEST_VAULT_ID)
 }
 
 func testAccVault_bindPolicies_step2(name string) string {
@@ -489,7 +483,7 @@ func testAccVault_bindPolicies_step2(name string) string {
 
 resource "opentelekomcloud_cbr_vault_v3" "legacy" {
   name             = "%[2]s_legacy"
-  backup_policy_id = opentelekomcloud_cbr_policy_v3.backup[0].id
+  backup_policy_id = opentelekomcloud_cbr_policy_v3.backup[1].id
 
   billing {
     size          = 100
@@ -518,10 +512,10 @@ resource "opentelekomcloud_cbr_vault_v3" "test" {
   }
   policy {
     id                   = opentelekomcloud_cbr_policy_v3.replication[1].id
-    destination_vault_id = opentelekomcloud_cbr_vault_v3.destination.id
+    destination_vault_id = "%[3]s"
   }
 }
-`, testAccVault_bindPolicies_base(name), name)
+`, testAccVault_bindPolicies_base(name), name, env.OS_DEST_VAULT_ID)
 }
 
 var (
@@ -828,7 +822,7 @@ resource "opentelekomcloud_ecs_instance_v1" "instance_1" {
   }
 
   data_disks {
-    type = "SATA"
+    type = "SAS"
     size = "10"
   }
   data_disks {

--- a/opentelekomcloud/acceptance/cbr/resource_opentelekomcloud_cbr_vault_v3_test.go
+++ b/opentelekomcloud/acceptance/cbr/resource_opentelekomcloud_cbr_vault_v3_test.go
@@ -18,6 +18,14 @@ import (
 
 const resourceVaultName = "opentelekomcloud_cbr_vault_v3.vault"
 
+func getVaultResourceFunc(conf *cfg.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.CbrV3Client(env.OS_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating CBR client: %s", err)
+	}
+	return vaults.Get(client, state.Primary.ID)
+}
+
 func TestAccCBRVaultV3_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -313,6 +321,207 @@ func testAccCheckCBRVaultV3Destroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func TestAccVault_bindPolicies(t *testing.T) {
+	var (
+		vault interface{}
+
+		randName     = tools.RandomString("cbr-pol-", 3)
+		mainRcName   = "opentelekomcloud_cbr_vault_v3.test"
+		legacyRcName = "opentelekomcloud_cbr_vault_v3.legacy"
+
+		mainRc   = common.InitResourceCheck(mainRcName, &vault, getVaultResourceFunc)
+		legacyRc = common.InitResourceCheck(legacyRcName, &vault, getVaultResourceFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+			common.TestAccPreCheckReplication(t)
+		},
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      mainRc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVault_bindPolicies_step1(randName),
+				Check: resource.ComposeTestCheckFunc(
+					mainRc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(mainRcName, "name", randName),
+					resource.TestCheckResourceAttr(mainRcName, "policy.#", "2"),
+					legacyRc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(legacyRcName, "policy_id",
+						"opentelekomcloud_cbr_policy_v3.backup.0", "id"),
+				),
+			},
+			{
+				Config: testAccVault_bindPolicies_step2(randName),
+				Check: resource.ComposeTestCheckFunc(
+					mainRc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(mainRcName, "name", randName),
+					resource.TestCheckResourceAttr(mainRcName, "policy.#", "2"),
+					legacyRc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(legacyRcName, "policy_id",
+						"opentelekomcloud_cbr_policy_v3.backup.1", "id"),
+				),
+			},
+			{
+				ResourceName:      mainRcName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      legacyRcName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"policy_id",
+				},
+			},
+		},
+	})
+}
+
+func testAccVault_bindPolicies_base(name string) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_cbr_policy_v3" "backup" {
+  count = 2
+
+  name            = format("%[1]s_%%d", count.index)
+  operation_type  = "backup"
+
+  operation_definition {
+    day_backups   = 1
+    week_backups  = 2
+    year_backups  = 3
+    month_backups = 4
+    max_backups   = 10
+    timezone      = "UTC+03:00"
+  }
+
+  trigger_pattern = [
+    "FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR,SA,SU;BYHOUR=14;BYMINUTE=00"
+  ]
+}
+
+resource "opentelekomcloud_cbr_policy_v3" "replication" {
+  count = 2
+
+  name                   = "%[1]s"
+  operation_type         = "replication"
+  destination_region     = "%[2]s"
+  destination_project_id = "%[3]s"
+
+  operation_definition {
+    day_backups   = 1
+    week_backups  = 2
+    year_backups  = 3
+    month_backups = 4
+    max_backups   = 10
+    timezone      = "UTC+03:00"
+  }
+
+  trigger_pattern = [
+    "FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR,SA,SU;BYHOUR=14;BYMINUTE=00"
+  ]
+}
+
+resource "opentelekomcloud_cbr_vault_v3" "destination" {
+  region          = "%[2]s"
+  name            = "%[1]s"
+
+  billing {
+    size          = 100
+    object_type   = "server"
+    protect_type  = "replication"
+    charging_mode = "post_paid"
+    period_type   = "month"
+    period_num    = 2
+  }
+}
+`, name, env.OS_DEST_REGION, env.OS_DEST_PROJECT_ID)
+}
+
+func testAccVault_bindPolicies_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "opentelekomcloud_cbr_vault_v3" "legacy" {
+  name             = "%[2]s_legacy"
+  backup_policy_id = opentelekomcloud_cbr_policy_v3.backup[0].id
+
+  billing {
+    size          = 100
+    object_type   = "server"
+    protect_type  = "backup"
+    charging_mode = "post_paid"
+    period_type   = "month"
+    period_num    = 2
+  }
+}
+
+resource "opentelekomcloud_cbr_vault_v3" "test" {
+  name            = "%[2]s"
+
+  billing {
+    size          = 100
+    object_type   = "server"
+    protect_type  = "backup"
+    charging_mode = "post_paid"
+    period_type   = "month"
+    period_num    = 2
+  }
+
+  policy {
+    id = opentelekomcloud_cbr_policy_v3.backup[0].id
+  }
+  policy {
+    id                   = opentelekomcloud_cbr_policy_v3.replication[0].id
+    destination_vault_id = opentelekomcloud_cbr_vault_v3.destination.id
+  }
+}
+`, testAccVault_bindPolicies_base(name), name)
+}
+
+func testAccVault_bindPolicies_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "opentelekomcloud_cbr_vault_v3" "legacy" {
+  name             = "%[2]s_legacy"
+  backup_policy_id = opentelekomcloud_cbr_policy_v3.backup[0].id
+
+  billing {
+    size          = 100
+    object_type   = "server"
+    protect_type  = "backup"
+    charging_mode = "post_paid"
+    period_type   = "month"
+    period_num    = 2
+  }
+}
+
+resource "opentelekomcloud_cbr_vault_v3" "test" {
+  name            = "%[2]s"
+
+  billing {
+    size          = 100
+    object_type   = "server"
+    protect_type  = "backup"
+    charging_mode = "post_paid"
+    period_type   = "month"
+    period_num    = 2
+  }
+
+  policy {
+    id = opentelekomcloud_cbr_policy_v3.backup[1].id
+  }
+  policy {
+    id                   = opentelekomcloud_cbr_policy_v3.replication[1].id
+    destination_vault_id = opentelekomcloud_cbr_vault_v3.destination.id
+  }
+}
+`, testAccVault_bindPolicies_base(name), name)
 }
 
 var (

--- a/opentelekomcloud/acceptance/env/vars.go
+++ b/opentelekomcloud/acceptance/env/vars.go
@@ -24,6 +24,7 @@ var (
 	OS_PROJECT_ID              = os.Getenv("OS_PROJECT_ID")
 	OS_DEST_REGION             = os.Getenv("OS_DEST_REGION")
 	OS_DEST_PROJECT_ID         = os.Getenv("OS_DEST_PROJECT_ID")
+	OS_DEST_VAULT_ID           = os.Getenv("OS_DEST_VAULT_ID")
 	OS_DC_HOSTING_ID           = os.Getenv("OS_DC_HOSTING_ID")
 	OS_DDM_ID                  = os.Getenv("OS_DDM_ID")
 	OS_RDS_ID                  = os.Getenv("OS_RDS_ID")

--- a/opentelekomcloud/services/cbr/resource_opentelekomcloud_cbr_policy_v3.go
+++ b/opentelekomcloud/services/cbr/resource_opentelekomcloud_cbr_policy_v3.go
@@ -30,9 +30,7 @@ func ResourceCBRPolicyV3() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
-				ForceNew: true,
 			},
 			"enabled": {
 				Type:     schema.TypeBool,

--- a/opentelekomcloud/services/cbr/resource_opentelekomcloud_cbr_policy_v3.go
+++ b/opentelekomcloud/services/cbr/resource_opentelekomcloud_cbr_policy_v3.go
@@ -30,7 +30,9 @@ func ResourceCBRPolicyV3() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:     schema.TypeString,
+				Optional: true,
 				Computed: true,
+				ForceNew: true,
 			},
 			"enabled": {
 				Type:     schema.TypeBool,

--- a/opentelekomcloud/services/cbr/resource_opentelekomcloud_cbr_vault_v3.go
+++ b/opentelekomcloud/services/cbr/resource_opentelekomcloud_cbr_vault_v3.go
@@ -36,9 +36,7 @@ func ResourceCBRVaultV3() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
-				ForceNew: true,
 			},
 			"description": {
 				Type:         schema.TypeString,
@@ -463,10 +461,8 @@ func updatePoliciesBinding(client *golangsdk.ServiceClient, vaultID string, oPol
 			return fmt.Errorf("unexpected policy type in removal set: %T", item)
 		}
 		policyID, _ := p["id"].(string)
-		destVaultID, _ := p["destination_vault_id"].(string)
 		if _, err := vaults.UnbindPolicy(client, vaultID, vaults.BindPolicyOpts{
-			PolicyID:           policyID,
-			DestinationVaultId: destVaultID,
+			PolicyID: policyID,
 		}); err != nil {
 			return fmt.Errorf("error unbinding policy from vault (%s): %w", vaultID, err)
 		}
@@ -478,8 +474,10 @@ func updatePoliciesBinding(client *golangsdk.ServiceClient, vaultID string, oPol
 			return fmt.Errorf("unexpected policy type in addition set: %T", item)
 		}
 		policyID, _ := p["id"].(string)
+		destVaultID, _ := p["destination_vault_id"].(string)
 		if _, err := vaults.BindPolicy(client, vaultID, vaults.BindPolicyOpts{
-			PolicyID: policyID,
+			PolicyID:           policyID,
+			DestinationVaultId: destVaultID,
 		}); err != nil {
 			return fmt.Errorf("error binding policy to vault (%s): %w", vaultID, err)
 		}

--- a/opentelekomcloud/services/cbr/resource_opentelekomcloud_cbr_vault_v3.go
+++ b/opentelekomcloud/services/cbr/resource_opentelekomcloud_cbr_vault_v3.go
@@ -3,12 +3,14 @@ package cbr
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/cbr/v3/policies"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/cbr/v3/vaults"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/pointerto"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/tags"
@@ -32,6 +34,12 @@ func ResourceCBRVaultV3() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"description": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -212,8 +220,27 @@ func ResourceCBRVaultV3() *schema.Resource {
 				},
 			},
 			"backup_policy_id": {
-				Type:     schema.TypeString,
+				Type:       schema.TypeString,
+				Optional:   true,
+				Deprecated: "Use parameter 'policy' instead.",
+			},
+			"policy": {
+				Type:     schema.TypeSet,
 				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"destination_vault_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+				Description: "The policy details to associate with the CBR vault.",
 			},
 			"tags": common.TagsSchema(),
 			"enterprise_project_id": {
@@ -326,6 +353,7 @@ func resourceCBRVaultV3Read(_ context.Context, d *schema.ResourceData, meta inte
 		d.Set("user_id", vault.UserID),
 		d.Set("created_at", vault.CreatedAt),
 		d.Set("locked", vault.Locked),
+		d.Set("policy", flattenPolicies(client, d.Id())),
 
 		setVaultBilling(d, &vault.Billing),
 	)
@@ -334,6 +362,37 @@ func resourceCBRVaultV3Read(_ context.Context, d *schema.ResourceData, meta inte
 	}
 
 	return nil
+}
+
+func flattenPolicies(client *golangsdk.ServiceClient, vaultID string) []map[string]interface{} {
+	policyList, err := policies.List(client, policies.ListOpts{
+		VaultID: vaultID,
+	})
+	if err != nil {
+		log.Printf("[ERROR] error querying CBR policies by vault ID (%s): %v", vaultID, err)
+		return nil
+	}
+	if len(policyList) < 1 {
+		return nil
+	}
+	results := make([]map[string]interface{}, 0, len(policyList))
+	for _, val := range policyList {
+		policy := map[string]interface{}{
+			"id": val.ID,
+		}
+		var destVaultID string
+		for _, av := range val.AssociatedVaults {
+			if av.VaultID == vaultID {
+				destVaultID = av.DestinationVaultID
+				break
+			}
+		}
+		if destVaultID != "" {
+			policy["destination_vault_id"] = destVaultID
+		}
+		results = append(results, policy)
+	}
+	return results
 }
 
 func resourceCBRVaultV3Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -374,7 +433,58 @@ func resourceCBRVaultV3Create(ctx context.Context, d *schema.ResourceData, meta 
 		}
 	}
 
+	// Bind backup(/replication) policy to the vault, not batch bind.
+	if pol, ok := d.GetOk("policy"); ok {
+		err := updatePoliciesBinding(client, d.Id(), schema.NewSet(schema.HashString, nil), pol)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
 	return resourceCBRVaultV3Read(ctx, d, meta)
+}
+
+func updatePoliciesBinding(client *golangsdk.ServiceClient, vaultID string, oPolicies, nPolicies interface{}) error {
+	rmSet, ok := oPolicies.(*schema.Set)
+	if !ok {
+		return fmt.Errorf("oPolicies is not *schema.Set")
+	}
+	newSet, ok := nPolicies.(*schema.Set)
+	if !ok {
+		return fmt.Errorf("nPolicies is not *schema.Set")
+	}
+
+	rmRaw := rmSet.Difference(newSet)
+	newRaw := newSet.Difference(rmSet)
+
+	for _, item := range rmRaw.List() {
+		p, ok := item.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("unexpected policy type in removal set: %T", item)
+		}
+		policyID, _ := p["id"].(string)
+		destVaultID, _ := p["destination_vault_id"].(string)
+		if _, err := vaults.UnbindPolicy(client, vaultID, vaults.BindPolicyOpts{
+			PolicyID:           policyID,
+			DestinationVaultId: destVaultID,
+		}); err != nil {
+			return fmt.Errorf("error unbinding policy from vault (%s): %w", vaultID, err)
+		}
+	}
+
+	for _, item := range newRaw.List() {
+		p, ok := item.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("unexpected policy type in addition set: %T", item)
+		}
+		policyID, _ := p["id"].(string)
+		if _, err := vaults.BindPolicy(client, vaultID, vaults.BindPolicyOpts{
+			PolicyID: policyID,
+		}); err != nil {
+			return fmt.Errorf("error binding policy to vault (%s): %w", vaultID, err)
+		}
+	}
+	return nil
 }
 
 func resourceExtraMapToExtra(src map[string]interface{}) (*vaults.ResourceExtraInfo, error) {
@@ -643,6 +753,13 @@ func resourceCBRVaultV3Update(ctx context.Context, d *schema.ResourceData, meta 
 
 	if d.HasChange("backup_policy_id") {
 		if err := updatePolicy(d, client); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if d.HasChange("policy") {
+		oPolicies, nPolicies := d.GetChange("policy")
+		if err := updatePoliciesBinding(client, d.Id(), oPolicies, nPolicies); err != nil {
 			return diag.FromErr(err)
 		}
 	}

--- a/releasenotes/notes/cbr-vault-policies-d68df53a92c8c031.yaml
+++ b/releasenotes/notes/cbr-vault-policies-d68df53a92c8c031.yaml
@@ -1,0 +1,7 @@
+---
+enhancements:
+  - |
+    **[CBR]** Add ``policy`` attribute to assign multiple policies for ``resource/opentelekomcloud_cbr_vault_v3`` (`#3163 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3163>`_)
+deprecations:
+  - |
+    **[CBR]** ``backup_policy_id`` are marked as deprecated in ``resource/opentelekomcloud_cbr_vault_v3`` (`#3163 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3163>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Now possible to assign replication policy to vault

## PR Checklist

* [x] Refers to: #3161
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccCBRVaultV3_basic
=== PAUSE TestAccCBRVaultV3_basic
=== CONT  TestAccCBRVaultV3_basic
--- PASS: TestAccCBRVaultV3_basic (109.77s)
=== RUN   TestAccCBRVaultV3_unAssign
=== PAUSE TestAccCBRVaultV3_unAssign
=== CONT  TestAccCBRVaultV3_unAssign
--- PASS: TestAccCBRVaultV3_unAssign (96.60s)
=== RUN   TestAccCBRVaultV3_instance
=== PAUSE TestAccCBRVaultV3_instance
=== CONT  TestAccCBRVaultV3_instance
--- PASS: TestAccCBRVaultV3_instance (105.11s)
=== RUN   TestAccCBRVaultV3_extraInfoExclude
=== PAUSE TestAccCBRVaultV3_extraInfoExclude
=== CONT  TestAccCBRVaultV3_extraInfoExclude
=== RUN   TestAccCBRVaultV3_bind_rules
=== PAUSE TestAccCBRVaultV3_bind_rules
=== CONT  TestAccCBRVaultV3_bind_rules
--- PASS: TestAccCBRVaultV3_bind_rules (23.03s)
=== RUN   TestAccVault_locked
=== PAUSE TestAccVault_locked
=== CONT  TestAccVault_locked
--- PASS: TestAccVault_locked (30.17s)
=== RUN   TestAccVault_bindPolicies
=== PAUSE TestAccVault_bindPolicies
=== CONT  TestAccVault_bindPolicies
--- PASS: TestAccVault_bindPolicies (61.23s)
PASS

Process finished with the exit code 0
```
