### PR TITLE
[Feat.] TaurusDB: configuration data source

### DIFF
--- a/docs/data-sources/taurusdb_mysql_configuration_v3.md
+++ b/docs/data-sources/taurusdb_mysql_configuration_v3.md
@@ -1,0 +1,40 @@
+---
+subcategory: "TaurusDB(for MySQL)"
+layout: "opentelekomcloud"
+page_title: "OpenTelekomCloud: opentelekomcloud_taurusdb_mysql_configuration_v3"
+sidebar_current: "docs-opentelekomcloud-datasource-taurusdb-mysql-configuration-v3"
+description: |-
+  Get available TaurusDB MySQL configuration from OpenTelekomCloud
+---
+
+# opentelekomcloud_taurusdb_mysql_configuration_v3
+
+Use this data source to get available OpenTelekomCloud TaurusDB MySQL configuration.
+
+## Example Usage
+
+```hcl
+data "opentelekomcloud_taurusdb_mysql_configuration_v3" "this" {
+  name = "Default-TaurusDB V2.0"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Optional) Specifies the name of the parameter template.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Indicates the ID of the configuration.
+
+* `region` - Indicates the region of the configuration.
+
+* `description` - Indicates the description of the configuration.
+
+* `datastore_name` - Indicates the datastore name of the configuration.
+
+* `datastore_version` - Indicates the datastore version of the configuration.

--- a/opentelekomcloud/acceptance/taurusdb/data_source_opentelekomcloud_taurusdb_mysql_configuration_v3_test.go
+++ b/opentelekomcloud/acceptance/taurusdb/data_source_opentelekomcloud_taurusdb_mysql_configuration_v3_test.go
@@ -1,0 +1,62 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+)
+
+func TestAccOpenTelekomCloudTaurusDBMysqlConfigurationDataSource_basic(t *testing.T) {
+	dataSource := "data.opentelekomcloud_taurusdb_mysql_configuration_v3.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOpenTelekomCloudTaurusDBMysqlConfigurationDataSource_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTaurusDBMysqlConfigurationDataSourceID(dataSource),
+					resource.TestCheckResourceAttr(
+						dataSource,
+						"name",
+						"Default-TaurusDB V2.0"),
+					resource.TestCheckResourceAttrSet(
+						dataSource,
+						"description"),
+					resource.TestCheckResourceAttrSet(
+						dataSource,
+						"datastore_version"),
+					resource.TestCheckResourceAttrSet(
+						dataSource,
+						"datastore_name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckTaurusDBMysqlConfigurationDataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("can't find TaurusDB MySQL configuration data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("the TaurusDB MySQL configuration data source ID not set")
+		}
+
+		return nil
+	}
+}
+
+const testAccOpenTelekomCloudTaurusDBMysqlConfigurationDataSource_basic = `
+data "opentelekomcloud_taurusdb_mysql_configuration_v3" "test" {
+  name = "Default-TaurusDB V2.0"
+}
+`

--- a/opentelekomcloud/acceptance/taurusdb/data_source_opentelekomcloud_taurusdb_mysql_configuration_v3_test.go
+++ b/opentelekomcloud/acceptance/taurusdb/data_source_opentelekomcloud_taurusdb_mysql_configuration_v3_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
 )
 
-func TestAccOpenTelekomCloudTaurusDBMysqlConfigurationDataSource_basic(t *testing.T) {
+func TestAccTaurusDBMysqlConfigurationDataSource_basic(t *testing.T) {
 	dataSource := "data.opentelekomcloud_taurusdb_mysql_configuration_v3.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -18,7 +18,7 @@ func TestAccOpenTelekomCloudTaurusDBMysqlConfigurationDataSource_basic(t *testin
 		ProviderFactories: common.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccOpenTelekomCloudTaurusDBMysqlConfigurationDataSource_basic,
+				Config: testAccTaurusDBMysqlConfigurationDataSource_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTaurusDBMysqlConfigurationDataSourceID(dataSource),
 					resource.TestCheckResourceAttr(
@@ -55,7 +55,7 @@ func testAccCheckTaurusDBMysqlConfigurationDataSourceID(n string) resource.TestC
 	}
 }
 
-const testAccOpenTelekomCloudTaurusDBMysqlConfigurationDataSource_basic = `
+const testAccTaurusDBMysqlConfigurationDataSource_basic = `
 data "opentelekomcloud_taurusdb_mysql_configuration_v3" "test" {
   name = "Default-TaurusDB V2.0"
 }

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -400,6 +400,7 @@ func Provider() *schema.Provider {
 			"opentelekomcloud_smn_subscription_v2":                smn.DataSourceSmnSubscriptionV2(),
 			"opentelekomcloud_smn_topic_subscription_v2":          smn.DataSourceSmnTopicSubscriptionV2(),
 			"opentelekomcloud_taurusdb_mysql_backups_v3":          taurusdb.DataSourceTaurusDBV3MysqlBackups(),
+			"opentelekomcloud_taurusdb_mysql_configuration_v3":    taurusdb.DataSourceTaurusDBV3MysqlConfiguration(),
 			"opentelekomcloud_taurusdb_mysql_engine_versions_v3":  taurusdb.DataSourceTaurusDBV3MysqlEngineVersions(),
 			"opentelekomcloud_taurusdb_mysql_flavors_v3":          taurusdb.DataSourceTaurusDBV3MysqlFlavors(),
 			"opentelekomcloud_taurusdb_mysql_instance_v3":         taurusdb.DataSourceTaurusDBV3Instance(),

--- a/opentelekomcloud/services/taurusdb/data_source_opentelekomcloud_taurusdb_mysql_configuration_v3.go
+++ b/opentelekomcloud/services/taurusdb/data_source_opentelekomcloud_taurusdb_mysql_configuration_v3.go
@@ -1,0 +1,91 @@
+package taurusdb
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/taurus/v3/template"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+)
+
+func DataSourceTaurusDBV3MysqlConfiguration() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceTaurusDBMysqlConfigurationRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"datastore_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"datastore_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"region": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceTaurusDBMysqlConfigurationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := config.TaurusDBV3Client(config.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating TaurusDb client: %s ", err)
+	}
+
+	opts := template.ListConfigurationsOpts{
+		Limit: 100,
+	}
+
+	configsList, err := template.ListConfigurations(client, opts)
+	if err != nil {
+		return diag.Errorf("unable to retrieve configurations: %s", err)
+	}
+
+	if len(configsList) < 1 {
+		return diag.Errorf("your query returned no results. " +
+			"please change your search criteria and try again.")
+	}
+
+	if name, ok := d.GetOk("name"); ok {
+		var filteredConfigs []template.ConfigurationSummary
+		for _, conf := range configsList {
+			if conf.Name == name.(string) {
+				filteredConfigs = append(filteredConfigs, conf)
+			}
+		}
+		configsList = filteredConfigs
+	}
+
+	if len(configsList) < 1 {
+		return diag.Errorf("your query returned no results. " +
+			"please change your search criteria and try again.")
+	}
+
+	configuration := configsList[0]
+	d.SetId(configuration.Id)
+
+	mErr := multierror.Append(
+		d.Set("name", configuration.Name),
+		d.Set("description", configuration.Description),
+		d.Set("datastore_version", configuration.DatastoreVersionName),
+		d.Set("datastore_name", configuration.DatastoreName),
+		d.Set("region", config.GetRegion(d)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}

--- a/releasenotes/notes/taurusdb_data_conf-104981296042fb40.yaml
+++ b/releasenotes/notes/taurusdb_data_conf-104981296042fb40.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   - |
-    **New Data Source:** ``data_source/opentelekomcloud_taurusdb_mysql_configuration_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **New Data Source:** ``data_source/opentelekomcloud_taurusdb_mysql_configuration_v3`` (`#3168 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3168>`_)

--- a/releasenotes/notes/taurusdb_data_conf-104981296042fb40.yaml
+++ b/releasenotes/notes/taurusdb_data_conf-104981296042fb40.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    **New Data Source:** ``data_source/opentelekomcloud_taurusdb_mysql_configuration_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Data source to query TaurusDB configuration template.

## PR Checklist

* [x] Refers to: #3065
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccTaurusDBMysqlConfigurationDataSource_basic
=== PAUSE TestAccTaurusDBMysqlConfigurationDataSource_basic
=== CONT  TestAccTaurusDBMysqlConfigurationDataSource_basic
--- PASS: TestAccTaurusDBMysqlConfigurationDataSource_basic (22.72s)
PASS

Process finished with the exit code 0
```
