### PR TITLE
[Feat.] TaurusDB: configurations data source

### DIFF
--- a/docs/data-sources/taurusdb_mysql_configurations_v3.md
+++ b/docs/data-sources/taurusdb_mysql_configurations_v3.md
@@ -1,0 +1,51 @@
+---
+subcategory: "TaurusDB(for MySQL)"
+layout: "opentelekomcloud"
+page_title: "OpenTelekomCloud: opentelekomcloud_taurusdb_mysql_configurations_v3"
+sidebar_current: "docs-opentelekomcloud-datasource-taurusdb-mysql-configurations-v3"
+description: |-
+  Get available TaurusDB MySQL configurations from OpenTelekomCloud
+---
+
+# opentelekomcloud_taurusdb_mysql_configurations_v3
+
+Use this data source to get the list of parameter templates.
+
+## Example Usage
+
+```hcl
+data "opentelekomcloud_taurusdb_mysql_configurations_v3" "test" {}
+```
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `region` - The data source region.
+
+* `configurations` - Indicates the list of parameter templates.
+
+  The [configurations](#configurations_struct) structure is documented below.
+
+<a name="configurations_struct"></a>
+The `configurations` block supports:
+
+* `id` - Indicates the ID of the parameter template.
+
+* `name` - Indicates the name of the parameter template.
+
+* `user_defined` - Indicates whether the parameter template is a custom template.
+    + **false**: default parameter template.
+    + **true**: custom template.
+
+* `description` - Indicates the description of parameter template.
+
+* `datastore_name` - Indicates the engine name.
+
+* `datastore_version` - Indicates the engine version.
+
+* `created_at` - Indicates the creation time in the **yyyy-MM-ddTHH:mm:ssZ** format.
+
+* `updated_at` - Indicates the update time in the **yyyy-MM-ddTHH:mm:ssZ** format.

--- a/opentelekomcloud/acceptance/taurusdb/data_source_opentelekomcloud_taurusdb_mysql_configurations_v3_test.go
+++ b/opentelekomcloud/acceptance/taurusdb/data_source_opentelekomcloud_taurusdb_mysql_configurations_v3_test.go
@@ -1,0 +1,58 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+)
+
+func TestAccDataSourceTaurusdbMysqlConfigurations_basic(t *testing.T) {
+	dataSource := "data.opentelekomcloud_taurusdb_mysql_configurations_v3.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+		},
+		ProviderFactories: common.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceTaurusdbMysqlConfigurations_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTaurusdbMysqlConfigurationsDataSourceID(dataSource),
+					resource.TestCheckResourceAttrSet(dataSource, "configurations.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "configurations.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "configurations.0.name"),
+					resource.TestCheckResourceAttrSet(dataSource, "configurations.0.user_defined"),
+					resource.TestCheckResourceAttrSet(dataSource, "configurations.0.datastore_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "configurations.0.datastore_version_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "configurations.0.created_at"),
+					resource.TestCheckResourceAttrSet(dataSource, "configurations.0.updated_at"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckTaurusdbMysqlConfigurationsDataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("can't find TaurusDB MySQL configurations data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("the TaurusDB MySQL configurations data source ID not set")
+		}
+
+		return nil
+	}
+}
+
+func testDataSourceTaurusdbMysqlConfigurations_basic() string {
+	return `
+data "opentelekomcloud_taurusdb_mysql_configurations_v3" "test" {}
+`
+}

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -401,6 +401,7 @@ func Provider() *schema.Provider {
 			"opentelekomcloud_smn_topic_subscription_v2":          smn.DataSourceSmnTopicSubscriptionV2(),
 			"opentelekomcloud_taurusdb_mysql_backups_v3":          taurusdb.DataSourceTaurusDBV3MysqlBackups(),
 			"opentelekomcloud_taurusdb_mysql_configuration_v3":    taurusdb.DataSourceTaurusDBV3MysqlConfiguration(),
+			"opentelekomcloud_taurusdb_mysql_configurations_v3":   taurusdb.DataSourceTaurusDBV3MysqlConfigurations(),
 			"opentelekomcloud_taurusdb_mysql_engine_versions_v3":  taurusdb.DataSourceTaurusDBV3MysqlEngineVersions(),
 			"opentelekomcloud_taurusdb_mysql_flavors_v3":          taurusdb.DataSourceTaurusDBV3MysqlFlavors(),
 			"opentelekomcloud_taurusdb_mysql_instance_v3":         taurusdb.DataSourceTaurusDBV3Instance(),

--- a/opentelekomcloud/services/taurusdb/data_source_opentelekomcloud_taurusdb_mysql_configurations.go
+++ b/opentelekomcloud/services/taurusdb/data_source_opentelekomcloud_taurusdb_mysql_configurations.go
@@ -1,0 +1,131 @@
+package taurusdb
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/taurus/v3/template"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+)
+
+func DataSourceTaurusDBV3MysqlConfigurations() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceTaurusdbMysqlConfigurationsRead,
+
+		Schema: map[string]*schema.Schema{
+			"configurations": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"user_defined": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"datastore_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"datastore_version_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"created_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"updated_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"region": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceTaurusdbMysqlConfigurationsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := config.TaurusDBV3Client(config.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating TaurusDb client: %s ", err)
+	}
+
+	opts := template.ListConfigurationsOpts{
+		Offset: 0,
+		Limit:  100,
+	}
+
+	allConfigurations := make([]template.ConfigurationSummary, 0)
+	for {
+		configurations, err := template.ListConfigurations(client, opts)
+		if err != nil {
+			return diag.Errorf("error listing TaurusDB MySQL configurations: %s", err)
+		}
+
+		if len(configurations) == 0 {
+			break
+		}
+
+		allConfigurations = append(allConfigurations, configurations...)
+
+		if len(configurations) < opts.Limit {
+			break
+		}
+		opts.Offset += opts.Limit
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(id)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", config.GetRegion(d)),
+		d.Set("configurations", flattenConfigurations(allConfigurations)),
+	)
+
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error setting TaurusDB MySQL configurations attributes: %s", err)
+	}
+
+	return nil
+}
+
+func flattenConfigurations(configurations []template.ConfigurationSummary) []map[string]interface{} {
+	result := make([]map[string]interface{}, len(configurations))
+	for i, conf := range configurations {
+		result[i] = map[string]interface{}{
+			"id":                     conf.Id,
+			"name":                   conf.Name,
+			"user_defined":           conf.UserDefined,
+			"description":            conf.Description,
+			"datastore_name":         conf.DatastoreName,
+			"datastore_version_name": conf.DatastoreVersionName,
+			"created_at":             conf.Created,
+			"updated_at":             conf.Updated,
+		}
+	}
+	return result
+}

--- a/releasenotes/notes/taurusdb_configurations-7b615710f8749492.yaml
+++ b/releasenotes/notes/taurusdb_configurations-7b615710f8749492.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   - |
-    **New Data Source:** ``data_source/opentelekomcloud_taurusdb_mysql_configurations_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **New Data Source:** ``data_source/opentelekomcloud_taurusdb_mysql_configurations_v3`` (`#3172 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3172>`_)

--- a/releasenotes/notes/taurusdb_configurations-7b615710f8749492.yaml
+++ b/releasenotes/notes/taurusdb_configurations-7b615710f8749492.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    **New Data Source:** ``data_source/opentelekomcloud_taurusdb_mysql_configurations_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Data source to query TaurusDB configuration templates

## PR Checklist

* [x] Refers to: #3065
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccDataSourceTaurusdbMysqlConfigurations_basic
=== PAUSE TestAccDataSourceTaurusdbMysqlConfigurations_basic
=== CONT  TestAccDataSourceTaurusdbMysqlConfigurations_basic
--- PASS: TestAccDataSourceTaurusdbMysqlConfigurations_basic (24.06s)
PASS

Process finished with the exit code 0

```
