### PR TITLE
[Fix.] APIG: fix parameter set for `apigw_vpc_channel_v2`

### DIFF
--- a/opentelekomcloud/services/apigw/resource_opentelekomcloud_apigw_vpc_channel_v2.go
+++ b/opentelekomcloud/services/apigw/resource_opentelekomcloud_apigw_vpc_channel_v2.go
@@ -561,7 +561,7 @@ func flattenChannelMemberGroups(groups []channel.MemberGroupsResp) []map[string]
 			"weight":               v.Weight,
 			"microservice_version": v.MicroserviceVersion,
 			"microservice_port":    v.MicroservicePort,
-			"microservice_tagss":   flattenMicroserviceLabels(v.MicroserviceTags),
+			"microservice_tags":   flattenMicroserviceLabels(v.MicroserviceTags),
 		}
 	}
 	return result

--- a/opentelekomcloud/services/apigw/resource_opentelekomcloud_apigw_vpc_channel_v2.go
+++ b/opentelekomcloud/services/apigw/resource_opentelekomcloud_apigw_vpc_channel_v2.go
@@ -561,7 +561,7 @@ func flattenChannelMemberGroups(groups []channel.MemberGroupsResp) []map[string]
 			"weight":               v.Weight,
 			"microservice_version": v.MicroserviceVersion,
 			"microservice_port":    v.MicroservicePort,
-			"microservice_tags":   flattenMicroserviceLabels(v.MicroserviceTags),
+			"microservice_tags":    flattenMicroserviceLabels(v.MicroserviceTags),
 		}
 	}
 	return result

--- a/releasenotes/notes/apigw_vpc_channel_fix-d58b24ad643cbbe6.yaml
+++ b/releasenotes/notes/apigw_vpc_channel_fix-d58b24ad643cbbe6.yaml
@@ -1,4 +1,4 @@
 ---
 fix:
   |
-  **[APIGW]** Fix typo for ``resource/opentelekomcloud_apigw_vpc_channel_v2`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+  **[APIGW]** Fix `microservice_tags` parameter set for ``resource/opentelekomcloud_apigw_vpc_channel_v2`` (`#3174 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3174>`_)

--- a/releasenotes/notes/apigw_vpc_channel_fix-d58b24ad643cbbe6.yaml
+++ b/releasenotes/notes/apigw_vpc_channel_fix-d58b24ad643cbbe6.yaml
@@ -1,0 +1,4 @@
+---
+fix:
+  |
+  **[APIGW]** Fix typo for ``resource/opentelekomcloud_apigw_vpc_channel_v2`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Fix `microservice_tags` parameter set for `opentelekomcloud_apigw_vpc_channel_v2`

## PR Checklist

* [x] Refers to: #3171
* [x] Tests passed.
* [ ] Documentation updated.
* [ ] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccChannel_basic
=== PAUSE TestAccChannel_basic
=== CONT  TestAccChannel_basic
--- PASS: TestAccChannel_basic (565.08s)
PASS

Process finished with the exit code 0
```
