### PR TITLE
[Fix] import opentelekomcloud_evs_volume_v3 (#3176)

### DIFF
--- a/opentelekomcloud/acceptance/evs/resource_opentelekomcloud_evs_volume_v3_test.go
+++ b/opentelekomcloud/acceptance/evs/resource_opentelekomcloud_evs_volume_v3_test.go
@@ -18,42 +18,72 @@ import (
 
 const resourceVolumeV3Name = "opentelekomcloud_evs_volume_v3.volume_1"
 
+func getVolumeResourceFunc(conf *cfg.Config, state *terraform.ResourceState) (interface{}, error) {
+	c, err := conf.BlockStorageV3Client(env.OS_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating OpenTelekomCloud BlockStorage V3 client: %s", err)
+	}
+	return volumes.Get(c, state.Primary.ID).Extract()
+}
+
 func TestAccEvsStorageV3Volume_basic(t *testing.T) {
 	var volume volumes.Volume
+
+	rc := common.InitResourceCheck(
+		resourceVolumeV3Name,
+		&volume,
+		getVolumeResourceFunc,
+	)
+
 	t.Parallel()
 	quotas.BookMany(t, volumeQuotas(12))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
-		CheckDestroy:      testAccCheckEvsStorageV3VolumeDestroy,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEvsStorageV3VolumeBasic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEvsStorageV3VolumeExists(resourceVolumeV3Name, &volume),
+					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceVolumeV3Name, "name", "volume_1"),
 				),
 			},
 			{
 				Config: testAccEvsStorageV3VolumeUpdate,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEvsStorageV3VolumeExists(resourceVolumeV3Name, &volume),
+					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceVolumeV3Name, "name", "volume_1-updated"),
 				),
+			},
+			{
+				ResourceName:      resourceVolumeV3Name,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"cascade",
+				},
 			},
 		},
 	})
 }
 
 func TestAccEvsStorageV3Volume_tags(t *testing.T) {
+	var volume volumes.Volume
+
+	rc := common.InitResourceCheck(
+		resourceVolumeV3Name,
+		&volume,
+		getVolumeResourceFunc,
+	)
 	t.Parallel()
 	quotas.BookMany(t, volumeQuotas(12))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
-		CheckDestroy:      testAccCheckEvsStorageV3VolumeDestroy,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEvsStorageV3VolumeTags,
@@ -73,18 +103,24 @@ func TestAccEvsStorageV3Volume_tags(t *testing.T) {
 
 func TestAccEvsStorageV3Volume_image(t *testing.T) {
 	var volume volumes.Volume
+
+	rc := common.InitResourceCheck(
+		resourceVolumeV3Name,
+		&volume,
+		getVolumeResourceFunc,
+	)
 	t.Parallel()
 	quotas.BookMany(t, volumeQuotas(12))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
-		CheckDestroy:      testAccCheckEvsStorageV3VolumeDestroy,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEvsStorageV3VolumeImage,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEvsStorageV3VolumeExists(resourceVolumeV3Name, &volume),
+					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceVolumeV3Name, "name", "volume_1"),
 				),
 			},
@@ -94,18 +130,24 @@ func TestAccEvsStorageV3Volume_image(t *testing.T) {
 
 func TestAccEvsStorageV3Volume_timeout(t *testing.T) {
 	var volume volumes.Volume
+
+	rc := common.InitResourceCheck(
+		resourceVolumeV3Name,
+		&volume,
+		getVolumeResourceFunc,
+	)
 	t.Parallel()
 	quotas.BookMany(t, volumeQuotas(12))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
-		CheckDestroy:      testAccCheckEvsStorageV3VolumeDestroy,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEvsStorageV3VolumeTimeout,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEvsStorageV3VolumeExists(resourceVolumeV3Name, &volume),
+					rc.CheckResourceExists(),
 				),
 			},
 		},
@@ -113,13 +155,20 @@ func TestAccEvsStorageV3Volume_timeout(t *testing.T) {
 }
 
 func TestAccEvsStorageV3Volume_volumeType(t *testing.T) {
+	var volume volumes.Volume
+
+	rc := common.InitResourceCheck(
+		resourceVolumeV3Name,
+		&volume,
+		getVolumeResourceFunc,
+	)
 	t.Parallel()
 	quotas.BookMany(t, volumeQuotas(12))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
-		CheckDestroy:      testAccCheckEvsStorageV3VolumeDestroy,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccEvsStorageV3VolumeVolumeType,
@@ -132,6 +181,12 @@ func TestAccEvsStorageV3Volume_volumeType(t *testing.T) {
 
 func TestAccEvsStorageV3Volume_resize(t *testing.T) {
 	var volume volumes.Volume
+
+	rc := common.InitResourceCheck(
+		resourceVolumeV3Name,
+		&volume,
+		getVolumeResourceFunc,
+	)
 	var volumeUpScaled volumes.Volume
 	t.Parallel()
 	quotas.BookMany(t, volumeQuotas(20))
@@ -139,12 +194,12 @@ func TestAccEvsStorageV3Volume_resize(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
-		CheckDestroy:      testAccCheckEvsStorageV3VolumeDestroy,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEvsStorageV3VolumeBasic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEvsStorageV3VolumeExists(resourceVolumeV3Name, &volume),
+					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceVolumeV3Name, "name", "volume_1"),
 				),
 			},
@@ -159,58 +214,6 @@ func TestAccEvsStorageV3Volume_resize(t *testing.T) {
 	})
 }
 
-func testAccCheckEvsStorageV3VolumeDestroy(s *terraform.State) error {
-	config := common.TestAccProvider.Meta().(*cfg.Config)
-	client, err := config.BlockStorageV3Client(env.OS_REGION_NAME)
-	if err != nil {
-		return fmt.Errorf("error creating OpenTelekomCloud BlockStorageV3 client: %s", err)
-	}
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "opentelekomcloud_evs_volume_v3" {
-			continue
-		}
-
-		_, err := volumes.Get(client, rs.Primary.ID).Extract()
-		if err == nil {
-			return fmt.Errorf("volume still exists")
-		}
-	}
-
-	return nil
-}
-
-func testAccCheckEvsStorageV3VolumeExists(n string, volume *volumes.Volume) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("not found: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no ID is set")
-		}
-
-		config := common.TestAccProvider.Meta().(*cfg.Config)
-		client, err := config.BlockStorageV3Client(env.OS_REGION_NAME)
-		if err != nil {
-			return fmt.Errorf("error creating OpenTelekomCloud BlockStorageV3 client: %s", err)
-		}
-
-		found, err := volumes.Get(client, rs.Primary.ID).Extract()
-		if err != nil {
-			return err
-		}
-
-		if found.ID != rs.Primary.ID {
-			return fmt.Errorf("volume not found")
-		}
-
-		*volume = *found
-
-		return nil
-	}
-}
 func testAccCheckEvsStorageV3VolumePersists(n string, volume, oldVolume *volumes.Volume) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/opentelekomcloud/services/evs/resource_opentelekomcloud_evs_volume_v3.go
+++ b/opentelekomcloud/services/evs/resource_opentelekomcloud_evs_volume_v3.go
@@ -129,7 +129,6 @@ func ResourceEvsStorageVolumeV3() *schema.Resource {
 			"cascade": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				ForceNew: false,
 				Default:  true,
 			},
 			"wwn": {
@@ -230,9 +229,9 @@ func resourceEvsVolumeV3Read(ctx context.Context, d *schema.ResourceData, meta i
 
 	log.Printf("[DEBUG] Retrieved volume %s: %+v", d.Id(), v)
 
-	var device_type = "VBD"
+	var deviceType = "VBD"
 	if v.Metadata["hw:passthrough"] == "true" {
-		device_type = "SCSI"
+		deviceType = "SCSI"
 	}
 
 	mErr := multierror.Append(
@@ -243,7 +242,7 @@ func resourceEvsVolumeV3Read(ctx context.Context, d *schema.ResourceData, meta i
 		d.Set("snapshot_id", v.SnapshotID),
 		d.Set("volume_type", v.VolumeType),
 		d.Set("multiattach", v.Multiattach),
-		d.Set("device_type", device_type),
+		d.Set("device_type", deviceType),
 		d.Set("wwn", v.WWN),
 	)
 	if err := mErr.ErrorOrNil(); err != nil {

--- a/opentelekomcloud/services/evs/resource_opentelekomcloud_evs_volume_v3.go
+++ b/opentelekomcloud/services/evs/resource_opentelekomcloud_evs_volume_v3.go
@@ -129,7 +129,7 @@ func ResourceEvsStorageVolumeV3() *schema.Resource {
 			"cascade": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				ForceNew: true,
+				ForceNew: false,
 				Default:  true,
 			},
 			"wwn": {
@@ -230,6 +230,11 @@ func resourceEvsVolumeV3Read(ctx context.Context, d *schema.ResourceData, meta i
 
 	log.Printf("[DEBUG] Retrieved volume %s: %+v", d.Id(), v)
 
+	var device_type = "VBD"
+	if v.Metadata["hw:passthrough"] == "true" {
+		device_type = "SCSI"
+	}
+
 	mErr := multierror.Append(
 		d.Set("size", v.Size),
 		d.Set("description", v.Description),
@@ -237,6 +242,8 @@ func resourceEvsVolumeV3Read(ctx context.Context, d *schema.ResourceData, meta i
 		d.Set("name", v.Name),
 		d.Set("snapshot_id", v.SnapshotID),
 		d.Set("volume_type", v.VolumeType),
+		d.Set("multiattach", v.Multiattach),
+		d.Set("device_type", device_type),
 		d.Set("wwn", v.WWN),
 	)
 	if err := mErr.ErrorOrNil(); err != nil {

--- a/releasenotes/notes/evs-attributes-set-fix-1345cc43efd48578.yaml
+++ b/releasenotes/notes/evs-attributes-set-fix-1345cc43efd48578.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[EVS]** Update read with ``multiattach`` and ``device_type`` and ``cascade`` not ForcedNew now in ``resource/opentelekomcloud_evs_volume_v3`` (`#3177 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3177>`_)


### PR DESCRIPTION
## Summary of the Pull Request

Proposal to fix #3176 :

* "cascade" is a delete option, thus not applicable for "ForceNew".
* "multiattach" is now taken from platform.
* "device_type" is inferred from volume metadata "hw:passthrough"

## PR Checklist

* [x] Refers to: #3176
* [x] Tests added/passed.
* [ ] Documentation updated.
* [x] Schema updated.
* [ ] Release notes added.

## Acceptance Steps Performed
Lacking a (cost-incurring) test platform: None! Please test/review before merge.
