### PR TITLE
[Feat.] TaurusDB: proxies data source

### DIFF
--- a/docs/data-sources/taurusdb_mysql_proxies_v3.md
+++ b/docs/data-sources/taurusdb_mysql_proxies_v3.md
@@ -1,0 +1,110 @@
+---
+subcategory: "TaurusDB(for MySQL)"
+layout: "opentelekomcloud"
+page_title: "OpenTelekomCloud: opentelekomcloud_taurusdb_mysql_proxies_v3"
+sidebar_current: "docs-opentelekomcloud-datasource-taurusdb-mysql-proxies-v3"
+description: |-
+  Get the list of TaurusDB MySQL proxies from OpenTelekomCloud
+---
+
+# opentelekomcloud_taurusdb_mysql_proxies_v3
+
+Use this data source to get the list of TaurusDB MySQL proxies.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+data "opentelekomcloud_taurusdb_mysql_proxies_v3" "test" {
+  instance_id = var.instance_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `instance_id` - (Required, String) Specifies the ID of the TaurusDB MySQL instance.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `region` - The region in which to query the resource.
+
+* `proxy_list` - Indicates the list of proxies.
+  The [proxy_list](#proxy_list) structure is documented below.
+
+<a name="proxy_list"></a>
+The `proxy_list` block supports:
+
+* `id` - Indicates the proxy ID.
+
+* `name` - Indicates the proxy name.
+
+* `flavor` - Indicates the flavor of the proxy.
+
+* `port` - Indicates the proxy port.
+
+* `status` - Indicates the status of the proxy instance.
+
+* `delay_threshold_in_seconds` - Indicates the delay threshold in seconds.
+
+* `node_num` - Indicates the number of proxy nodes.
+
+* `ram` - Indicates the memory size of the proxy.
+
+* `mode` - Indicates the proxy mode.
+
+* `elb_vip` - Indicates the virtual IP address in ELB mode.
+
+* `vcpus` - Indicates the number of vCPUs of the proxy.
+
+* `transaction_split` - Indicates whether the proxy transaction splitting is enabled.
+
+* `address` - Indicates the address of the proxy.
+
+* `nodes` - Indicates the node information of the proxy.
+  The [nodes](#proxy_nodes) structure is documented below.
+
+* `master_node_weight` - Indicates the read weight of the master node.
+  The [master_node_weight](#master_node_weight) structure is documented below.
+
+* `readonly_nodes_weight` - Indicates the read weight of the read-only node.
+  The [readonly_nodes_weight](#readonly_nodes_weight) structure is documented below.
+
+<a name="proxy_nodes"></a>
+The `nodes` block supports:
+
+* `id` - Indicates the proxy node ID.
+
+* `name` - Indicates the proxy node name.
+
+* `role` - Indicates the proxy node role.
+
+* `az_code` - Indicates the proxy node AZ.
+
+* `status` - Indicates the proxy node status.
+
+* `frozen_flag` - Indicates whether the proxy node is frozen.
+
+<a name="master_node_weight"></a>
+The `master_node_weight` block supports:
+
+* `id` - Indicates the node ID.
+
+* `name` - Indicates the node name.
+
+* `weight` - Indicates the weight assigned to the node.
+
+<a name="readonly_nodes_weight"></a>
+The `readonly_nodes_weight` block supports:
+
+* `id` - Indicates the node ID.
+
+* `name` - Indicates the node name.
+
+* `weight` - Indicates the weight assigned to the node.

--- a/opentelekomcloud/acceptance/taurusdb/data_source_opentelekomcloud_taurusdb_mysql_proxies_v3_test.go
+++ b/opentelekomcloud/acceptance/taurusdb/data_source_opentelekomcloud_taurusdb_mysql_proxies_v3_test.go
@@ -1,0 +1,120 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+)
+
+const dataSourceName = "data.opentelekomcloud_taurusdb_mysql_proxies_v3.test"
+
+func TestAccDataSourceTaurusDBMysqlProxies_basic(t *testing.T) {
+	name := "tf_taurusdb_proxy_" + acctest.RandString(3)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceTaurusDBMysqlProxiesBasic(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "proxy_list.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "proxy_list.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "proxy_list.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "proxy_list.0.flavor"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "proxy_list.0.port"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "proxy_list.0.status"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "proxy_list.0.delay_threshold_in_seconds"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "proxy_list.0.node_num"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "proxy_list.0.ram"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "proxy_list.0.mode"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "proxy_list.0.elb_vip"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "proxy_list.0.vcpus"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "proxy_list.0.transaction_split"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "proxy_list.0.address"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "proxy_list.0.master_node_weight.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "proxy_list.0.master_node_weight.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "proxy_list.0.master_node_weight.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "proxy_list.0.master_node_weight.0.weight"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "proxy_list.0.readonly_nodes_weight.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "proxy_list.0.readonly_nodes_weight.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "proxy_list.0.readonly_nodes_weight.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "proxy_list.0.readonly_nodes_weight.0.weight"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "proxy_list.0.nodes.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "proxy_list.0.nodes.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "proxy_list.0.nodes.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "proxy_list.0.nodes.0.role"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "proxy_list.0.nodes.0.az_code"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "proxy_list.0.nodes.0.status"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "proxy_list.0.nodes.0.frozen_flag"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceTaurusDBMysqlProxiesBase(name string) string {
+	return fmt.Sprintf(`
+%s
+
+%s
+
+resource "opentelekomcloud_taurusdb_mysql_instance_v3" "instance" {
+  name                     = "%s"
+  password                 = "Test@12345678"
+  flavor                   = "gaussdb.mysql.xlarge.x86.8"
+  vpc_id                   = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  subnet_id                = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.id
+  security_group_id        = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
+  availability_zone_mode   = "multi"
+  master_availability_zone = "eu-de-01"
+  read_replicas            = 2
+}
+
+locals {
+  sorted_nodes = [
+    for node in opentelekomcloud_taurusdb_mysql_instance_v3.instance.nodes :
+    node if node.type == "master"
+  ]
+
+  readonly_nodes = [
+    for node in opentelekomcloud_taurusdb_mysql_instance_v3.instance.nodes :
+    node if node.type == "slave"
+  ]
+}
+
+resource "opentelekomcloud_taurusdb_mysql_proxy_v3" "test" {
+  instance_id = opentelekomcloud_taurusdb_mysql_instance_v3.instance.id
+  flavor      = "gaussdb.proxy.large.x86.2"
+  node_num    = 2
+  proxy_name  = "%[3]s"
+  proxy_mode  = "readwrite"
+
+  master_node_weight {
+    id     = local.sorted_nodes[0].id
+    weight = 50
+  }
+
+  readonly_nodes_weight {
+    id     = local.readonly_nodes[0].id
+    weight = 50
+  }
+}
+`, common.DataSourceSubnet, common.DataSourceSecGroupDefault, name)
+}
+
+func testAccDataSourceTaurusDBMysqlProxiesBasic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "opentelekomcloud_taurusdb_mysql_proxies_v3" "test" {
+  depends_on = [opentelekomcloud_taurusdb_mysql_proxy_v3.test]
+
+  instance_id = opentelekomcloud_taurusdb_mysql_instance_v3.instance.id
+}
+`, testAccDataSourceTaurusDBMysqlProxiesBase(name))
+}

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -405,6 +405,7 @@ func Provider() *schema.Provider {
 			"opentelekomcloud_taurusdb_mysql_engine_versions_v3":  taurusdb.DataSourceTaurusDBV3MysqlEngineVersions(),
 			"opentelekomcloud_taurusdb_mysql_flavors_v3":          taurusdb.DataSourceTaurusDBV3MysqlFlavors(),
 			"opentelekomcloud_taurusdb_mysql_instance_v3":         taurusdb.DataSourceTaurusDBV3Instance(),
+			"opentelekomcloud_taurusdb_mysql_proxies_v3":          taurusdb.DataSourceTaurusDBV3MysqlProxies(),
 			"opentelekomcloud_tms_quotas_v1":                      tms.DataSourceTmsQuotasV1(),
 			"opentelekomcloud_tms_resource_instances_v1":          tms.DataSourceTmsResourceInstancesV1(),
 			"opentelekomcloud_tms_resource_tag_keys_v1":           tms.DataSourceTmsTagKeysV1(),

--- a/opentelekomcloud/services/taurusdb/data_source_opentelekomcloud_taurusdb_mysql_proxies_v3.go
+++ b/opentelekomcloud/services/taurusdb/data_source_opentelekomcloud_taurusdb_mysql_proxies_v3.go
@@ -1,0 +1,256 @@
+package taurusdb
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/taurus/v3/proxy"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+)
+
+func DataSourceTaurusDBV3MysqlProxies() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceTaurusDBMysqlProxiesRead,
+
+		Schema: map[string]*schema.Schema{
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"proxy_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"flavor": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"port": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"delay_threshold_in_seconds": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"node_num": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"ram": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"mode": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"elb_vip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"vcpus": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"transaction_split": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"address": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"nodes": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     nodesElem(),
+						},
+						"master_node_weight": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"weight": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"readonly_nodes_weight": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"weight": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"region": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func nodesElem() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"role": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"az_code": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"frozen_flag": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceTaurusDBMysqlProxiesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := config.TaurusDBV3Client(config.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating TaurusDb client: %s ", err)
+	}
+
+	instanceId := d.Get("instance_id").(string)
+
+	proxies, err := proxy.List(client, instanceId, proxy.ListOpts{})
+	if err != nil {
+		return diag.Errorf("error retrieving TaurusDB MySQL proxies: %s", err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(id)
+
+	proxyList := make([]map[string]interface{}, len(proxies))
+	for i, p := range proxies {
+		proxyList[i] = map[string]interface{}{
+			"id":                         p.Proxy.PoolId,
+			"name":                       p.Proxy.Name,
+			"flavor":                     p.Proxy.FlavorRef,
+			"port":                       p.Proxy.Port,
+			"status":                     p.Proxy.Status,
+			"delay_threshold_in_seconds": p.Proxy.DelayThresholdInSeconds,
+			"node_num":                   p.Proxy.NodeNum,
+			"ram":                        p.Proxy.Ram,
+			"mode":                       p.Proxy.Mode,
+			"elb_vip":                    p.Proxy.ElbVip,
+			"vcpus":                      p.Proxy.Vcpus,
+			"transaction_split":          convertTransactionSplit(p.Proxy.TransactionSplit),
+			"address":                    p.Proxy.Address,
+			"nodes":                      flattenProxyNodes(p.Proxy.Nodes),
+			"master_node_weight":         flattenMasterNode(p.MasterNode),
+			"readonly_nodes_weight":      flattenReadonlyNodes(p.ReadonlyNodes),
+		}
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", config.GetRegion(d)),
+		d.Set("proxy_list", proxyList),
+	)
+
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error setting TaurusDB MySQL proxies fields: %s", err)
+	}
+
+	return nil
+}
+
+func convertTransactionSplit(value string) string {
+	if value == "true" {
+		return "ON"
+	}
+	return "OFF"
+}
+
+func flattenMasterNode(node proxy.MysqlProxyNodeV3) []map[string]interface{} {
+	if node.Id == "" {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"id":     node.Id,
+			"name":   node.Name,
+			"weight": node.Weight,
+		},
+	}
+}
+
+func flattenReadonlyNodes(nodes []proxy.MysqlProxyNodeV3) []map[string]interface{} {
+	if len(nodes) == 0 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, len(nodes))
+	for i, node := range nodes {
+		result[i] = map[string]interface{}{
+			"id":     node.Id,
+			"name":   node.Name,
+			"weight": node.Weight,
+		}
+	}
+	return result
+}

--- a/releasenotes/notes/taurusdb_proxies_data-5619afb44867f1f0.yaml
+++ b/releasenotes/notes/taurusdb_proxies_data-5619afb44867f1f0.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   - |
-    **New Data Source:** ``data_source/opentelekomcloud_taurusdb_mysql_proxies_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **New Data Source:** ``data_source/opentelekomcloud_taurusdb_mysql_proxies_v3`` (`#3180 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3180>`_)

--- a/releasenotes/notes/taurusdb_proxies_data-5619afb44867f1f0.yaml
+++ b/releasenotes/notes/taurusdb_proxies_data-5619afb44867f1f0.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    **New Data Source:** ``data_source/opentelekomcloud_taurusdb_mysql_proxies_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)


### PR DESCRIPTION
## Summary of the Pull Request
New `data_source/opentelekomcloud_taurusdb_mysql_proxies_v3`.

## PR Checklist

* [x] Refers to: #3065
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccDataSourceTaurusDBMysqlProxies_basic
--- PASS: TestAccDataSourceTaurusDBMysqlProxies_basic (1405.48s)
PASS

Process finished with the exit code 0

```
