### PR TITLE
[Fix] strategy update when max_instance_num already set in `resource/opentelekomcloud_fgs_function_v2`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20251022092258-ea1bf8893707
+	github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20251022130737-7851180f8506
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.43.0
 	golang.org/x/sync v0.17.0

--- a/go.sum
+++ b/go.sum
@@ -161,10 +161,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20251014080911-573919fe7059 h1:znuGcZwkcAQtS4afJvClWTxBgG8iIMH/RIDfSd4Jhl8=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20251014080911-573919fe7059/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20251022092258-ea1bf8893707 h1:pdpILpQ6vEfO/zmjpyi/xGblBQECT0YicaknDRyCR7k=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20251022092258-ea1bf8893707/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20251022130737-7851180f8506 h1:6NTPsfKm+SHaSrItvDjqNYsKv+2LY8i5RzpzarmVg78=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20251022130737-7851180f8506/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/opentelekomcloud/acceptance/fgs/resource_opentelekomcloud_fgs_function_v2_test.go
+++ b/opentelekomcloud/acceptance/fgs/resource_opentelekomcloud_fgs_function_v2_test.go
@@ -563,6 +563,14 @@ func TestAccFgsV2Function_strategy(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "max_instance_num", "1000"),
 				),
 			},
+			{
+				Config: testAccFunction_strategy_update(name, 1000),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "max_instance_num", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "timeout", "60"),
+				),
+			},
 			// UpdateMaxInstances doesn't work when max_instance is set to 0
 			// Response: 400 "no param has changed"
 			// {
@@ -624,6 +632,23 @@ resource "opentelekomcloud_fgs_function_v2" "test" {
   handler               = "index.handler"
   memory_size           = 128
   timeout               = 3
+  runtime               = "Python2.7"
+  code_type             = "inline"
+  func_code             = "dCA9ICdIZWxsbyBtZXNzYWdlOiAnICsganN="
+  max_instance_num      = %[2]d
+}
+`, name, maxInstanceNum)
+}
+
+func testAccFunction_strategy_update(name string, maxInstanceNum int) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_fgs_function_v2" "test" {
+  functiongraph_version = "v2"
+  name                  = "%[1]s"
+  app                   = "default"
+  handler               = "index.handler"
+  memory_size           = 128
+  timeout               = 60
   runtime               = "Python2.7"
   code_type             = "inline"
   func_code             = "dCA9ICdIZWxsbyBtZXNzYWdlOiAnICsganN="

--- a/opentelekomcloud/services/fgs/resource_opentelekomcloud_fgs_function_v2.go
+++ b/opentelekomcloud/services/fgs/resource_opentelekomcloud_fgs_function_v2.go
@@ -989,7 +989,7 @@ func resourceFgsFunctionV2Read(ctx context.Context, d *schema.ResourceData, meta
 		d.Set("peering_cidr", f.PeeringCIDR),
 		d.Set("pre_stop_handler", f.PreStopHandler),
 		d.Set("pre_stop_timeout", f.PreStopTimeout),
-		d.Set("max_instance_num", strconv.Itoa(f.StrategyConfig.Concurrency)),
+		d.Set("max_instance_num", strconv.Itoa(*f.StrategyConfig.Concurrency)),
 		d.Set("dns_list", f.DomainNames),
 		d.Set("log_group_id", f.LogGroupID),
 		d.Set("log_topic_id", f.LogStreamID),
@@ -1265,7 +1265,7 @@ func resourceFgsFunctionV2Update(ctx context.Context, d *schema.ResourceData, me
 		"user_data", "agency", "app_agency", "description", "initializer_handler", "initializer_timeout",
 		"vpc_id", "network_controller", "network_id", "mount_user_id", "mount_user_group_id", "func_mounts", "custom_image",
 		"log_group_id", "log_topic_id", "log_group_name", "log_topic_name", "gpu_memory", "gpu_type",
-		"pre_stop_handler", "pre_stop_timeout", "enable_dynamic_memory", "enable_lts_log") {
+		"pre_stop_handler", "pre_stop_timeout", "enable_dynamic_memory", "enable_lts_log", "concurrency_num") {
 		err := resourceFgsFunctionMetadataUpdate(config, fgsClient, urn, d)
 		if err != nil {
 			return diag.FromErr(err)

--- a/releasenotes/notes/fgs-fix-strategy-update-8fae6b9f6ddf2f9c.yaml
+++ b/releasenotes/notes/fgs-fix-strategy-update-8fae6b9f6ddf2f9c.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[FGS]** Fix update when `max_instance_num` is set in resource ``resource/opentelekomcloud_fgs_function_v2`` (`#3185 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3185>`_)


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [x] Refers to: #3179
* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccFgsV2Function_basic
=== PAUSE TestAccFgsV2Function_basic
=== CONT  TestAccFgsV2Function_basic      
--- PASS: TestAccFgsV2Function_basic (52.70s)

=== RUN   TestAccFgsV2Function_text
=== PAUSE TestAccFgsV2Function_text
=== CONT  TestAccFgsV2Function_text
--- PASS: TestAccFgsV2Function_text (30.89s)
=== RUN   TestAccFgsV2Function_createByImage
=== PAUSE TestAccFgsV2Function_createByImage
=== CONT  TestAccFgsV2Function_createByImage
    common.go:187: SWR image URL configuration is not completed for acceptance test of component deployment.
--- SKIP: TestAccFgsV2Function_createByImage (0.00s)

Test ignored.
=== RUN   TestAccFgsV2Function_logConfig
=== PAUSE TestAccFgsV2Function_logConfig
=== CONT  TestAccFgsV2Function_logConfig
--- PASS: TestAccFgsV2Function_logConfig (49.78s)
=== RUN   TestAccFgsV2Function_strategy
=== PAUSE TestAccFgsV2Function_strategy
=== CONT  TestAccFgsV2Function_strategy
--- PASS: TestAccFgsV2Function_strategy (110.65s)
=== RUN   TestAccFgsV2Function_versions
=== PAUSE TestAccFgsV2Function_versions
=== CONT  TestAccFgsV2Function_versions
--- PASS: TestAccFgsV2Function_versions (72.29s)
=== RUN   TestAccFgsV2Function_reservedInstance_version
=== PAUSE TestAccFgsV2Function_reservedInstance_version
=== CONT  TestAccFgsV2Function_reservedInstance_version
--- PASS: TestAccFgsV2Function_reservedInstance_version (54.47s)
=== RUN   TestAccFgsV2Function_reservedInstance_alias
=== PAUSE TestAccFgsV2Function_reservedInstance_alias
=== CONT  TestAccFgsV2Function_reservedInstance_alias
--- PASS: TestAccFgsV2Function_reservedInstance_alias (52.68s)
=== RUN   TestAccFgsV2Function_EnableDynamicMemory
=== PAUSE TestAccFgsV2Function_EnableDynamicMemory
=== CONT  TestAccFgsV2Function_EnableDynamicMemory
--- PASS: TestAccFgsV2Function_EnableDynamicMemory (24.58s)
PASS

Process finished with the exit code 0
```
