### PR TITLE
[Feat.] CCE: nodepool `post/preinstall` remove forcenew

### DIFF
--- a/docs/resources/cce_node_pool_v3.md
+++ b/docs/resources/cce_node_pool_v3.md
@@ -150,7 +150,7 @@ the AZ based on the AZ sequence. For more details see
   This parameter and password are alternative. Changing this parameter will create a new resource.
 
 * `os` - (Optional, ForceNew, String) Node OS. Changing this parameter will create a new resource.
-  
+
   Supported OS depends on kubernetes version of the cluster.
   | OS           | Kubernetes version |
   | :----------- | :----------------- |
@@ -167,10 +167,10 @@ the AZ based on the AZ sequence. For more details see
 
 * `subnet_id` - (Optional, String, ForceNew) The ID of the subnet to which the NIC belongs. Changing this parameter will create a new resource.
 
-* `preinstall` - (Optional, String, ForceNew) Script required before installation. The input value can be a Base64 encoded string or not.
+* `preinstall` - (Optional, String) Script required before installation. The input value can be a Base64 encoded string or not.
   Changing this parameter will create a new resource.
 
-* `postinstall` - (Optional, String, ForceNew) Script required after installation. The input value can be a Base64 encoded string or not.
+* `postinstall` - (Optional, String) Script required after installation. The input value can be a Base64 encoded string or not.
   Changing this parameter will create a new resource.
 
 * `max_pods` - (Optional, Int, ForceNew) The maximum number of instances a node is allowed to create.

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20251022130737-7851180f8506
+	github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20251027073001-e09fd01c6b86
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.43.0
 	golang.org/x/sync v0.17.0

--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20251022130737-7851180f8506 h1:6NTPsfKm+SHaSrItvDjqNYsKv+2LY8i5RzpzarmVg78=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20251022130737-7851180f8506/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20251027073001-e09fd01c6b86 h1:e63GPB7y5deHw6e/gyeOplO5fOhoolgU6+EnrdDbzQI=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20251027073001-e09fd01c6b86/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_node_pool_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_node_pool_v3_test.go
@@ -1,6 +1,7 @@
 package acceptance
 
 import (
+	"encoding/base64"
 	"fmt"
 	"testing"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/cce/shared"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 	ecs "github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/ecs"
+	cmn "github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
@@ -44,18 +46,30 @@ func TestAccCCENodePoolsV3_basic(t *testing.T) {
 	quotas.BookMany(t, qts)
 	shared.BookCluster(t)
 
+	initialPreInstallScript := "#!/bin/bash\necho 'Initial preinstall script'"
+	initialPostInstallScript := "#!/bin/bash\necho 'Initial postinstall script'"
+	updatedPreInstallScript := "#!/bin/bash\necho 'Updated preinstall script'"
+	updatedPostInstallScript := "#!/bin/bash\necho 'Updated postinstall script'"
+
+	initialPreInstall := base64.StdEncoding.EncodeToString([]byte(initialPreInstallScript))
+	initialPostInstall := base64.StdEncoding.EncodeToString([]byte(initialPostInstallScript))
+	updatedPreInstall := base64.StdEncoding.EncodeToString([]byte(updatedPreInstallScript))
+	updatedPostInstall := base64.StdEncoding.EncodeToString([]byte(updatedPostInstallScript))
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccCCEKeyPairPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCCENodePoolV3Basic,
+				Config: testAccCCENodePoolV3Basic(initialPreInstall, initialPostInstall),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(nodePoolResourceName, "name", "opentelekomcloud-cce-node-pool"),
 					resource.TestCheckResourceAttr(nodePoolResourceName, "flavor", "s2.large.2"),
 					resource.TestCheckResourceAttr(nodePoolResourceName, "os", "EulerOS 2.9"),
+					resource.TestCheckResourceAttr(nodePoolResourceName, "preinstall", cmn.GetHashOrEmpty(initialPreInstall)),
+					resource.TestCheckResourceAttr(nodePoolResourceName, "postinstall", cmn.GetHashOrEmpty(initialPostInstall)),
 					resource.TestCheckResourceAttr(nodePoolResourceName, "k8s_tags.kubelet.kubernetes.io/namespace", "muh"),
 					resource.TestCheckResourceAttr(nodePoolResourceName, "data_volumes.0.extend_params.useType", "docker"),
 					resource.TestCheckResourceAttr(nodePoolResourceName, "taints.0.key", "example.com/node"),
@@ -64,9 +78,11 @@ func TestAccCCENodePoolsV3_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCCENodePoolV3Update,
+				Config: testAccCCENodePoolV3Update(updatedPreInstall, updatedPostInstall),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(nodePoolResourceName, "initial_node_count", "2"),
+					resource.TestCheckResourceAttr(nodePoolResourceName, "preinstall", cmn.GetHashOrEmpty(updatedPreInstall)),
+					resource.TestCheckResourceAttr(nodePoolResourceName, "postinstall", cmn.GetHashOrEmpty(updatedPostInstall)),
 					resource.TestCheckResourceAttr(nodePoolResourceName, "k8s_tags.kubelet.kubernetes.io/namespace", "kuh"),
 					resource.TestCheckResourceAttr(nodePoolResourceName, "data_volumes.0.extend_params.useType", "docker"),
 					resource.TestCheckResourceAttr(nodePoolResourceName, "taints.0.key", "example-updated.com/node"),
@@ -305,7 +321,8 @@ func TestAccCCENodePoolsV3StorageJsonEncode(t *testing.T) {
 	})
 }
 
-var testAccCCENodePoolV3Basic = fmt.Sprintf(`
+func testAccCCENodePoolV3Basic(preinstall, postinstall string) string {
+	return fmt.Sprintf(`
 %s
 
 resource "opentelekomcloud_cce_node_pool_v3" "node_pool" {
@@ -317,6 +334,8 @@ resource "opentelekomcloud_cce_node_pool_v3" "node_pool" {
   availability_zone  = "%s"
   key_pair           = "%s"
   runtime            = "containerd"
+  preinstall         = "%s"
+  postinstall        = "%s"
 
   scale_enable             = false
   min_node_count           = 1
@@ -346,9 +365,11 @@ resource "opentelekomcloud_cce_node_pool_v3" "node_pool" {
     value  = "infra"
     effect = "NoSchedule"
   }
-}`, shared.DataSourceCluster, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME)
+}`, shared.DataSourceCluster, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME, preinstall, postinstall)
+}
 
-var testAccCCENodePoolV3Update = fmt.Sprintf(`
+func testAccCCENodePoolV3Update(preinstall, postinstall string) string {
+	return fmt.Sprintf(`
 %s
 
 resource "opentelekomcloud_cce_node_pool_v3" "node_pool" {
@@ -359,6 +380,8 @@ resource "opentelekomcloud_cce_node_pool_v3" "node_pool" {
   initial_node_count = 2
   availability_zone  = "%s"
   key_pair           = "%s"
+  preinstall         = "%s"
+  postinstall        = "%s"
 
   scale_enable             = true
   min_node_count           = 2
@@ -387,7 +410,8 @@ resource "opentelekomcloud_cce_node_pool_v3" "node_pool" {
     value  = "infra"
     effect = "NoExecute"
   }
-}`, shared.DataSourceCluster, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME)
+}`, shared.DataSourceCluster, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME, preinstall, postinstall)
+}
 
 var testAccCCENodePoolV3RandomAZ = fmt.Sprintf(`
 %s

--- a/opentelekomcloud/common/custom_functions.go
+++ b/opentelekomcloud/common/custom_functions.go
@@ -43,6 +43,9 @@ func InstallScriptEncode(script string) string {
 func GetHashOrEmpty(v interface{}) string {
 	switch v := v.(type) {
 	case string:
+		if v == "" {
+			return ""
+		}
 		return InstallScriptHashSum(v)
 	default:
 		return ""

--- a/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_pool_v3.go
+++ b/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_pool_v3.go
@@ -237,13 +237,13 @@ func ResourceCCENodePoolV3() *schema.Resource {
 			"preinstall": {
 				Type:      schema.TypeString,
 				Optional:  true,
-				ForceNew:  true,
+				Computed:  true,
 				StateFunc: common.GetHashOrEmpty,
 			},
 			"postinstall": {
 				Type:      schema.TypeString,
 				Optional:  true,
-				ForceNew:  true,
+				Computed:  true,
 				StateFunc: common.GetHashOrEmpty,
 			},
 			"max_pods": {
@@ -486,6 +486,8 @@ func resourceCCENodePoolV3Read(ctx context.Context, d *schema.ResourceData, meta
 		d.Set("key_pair", s.Spec.NodeTemplate.Login.SshKey),
 		d.Set("scale_enable", s.Spec.Autoscaling.Enable),
 		d.Set("max_pods", s.Spec.NodeTemplate.ExtendParam.MaxPods),
+		d.Set("postinstall", common.GetHashOrEmpty(s.Spec.NodeTemplate.ExtendParam.PostInstall)),
+		d.Set("preinstall", common.GetHashOrEmpty(s.Spec.NodeTemplate.ExtendParam.PreInstall)),
 		d.Set("subnet_id", s.Spec.NodeTemplate.NodeNicSpec.PrimaryNic.SubnetId),
 		d.Set("security_group_ids", s.Spec.CustomSecurityGroupIds),
 		d.Set("root_volume", rootVolume),
@@ -557,6 +559,26 @@ func resourceCCENodePoolV3Update(ctx context.Context, d *schema.ResourceData, me
 		return fmterr.Errorf(cceClientError, err)
 	}
 
+	var base64PreInstall, base64PostInstall string
+	if v, ok := d.GetOk("preinstall"); ok {
+		base64PreInstall = common.InstallScriptEncode(v.(string))
+	}
+	if v, ok := d.GetOk("postinstall"); ok {
+		base64PostInstall = common.InstallScriptEncode(v.(string))
+	}
+	var loginSpec nodes.LoginSpec
+	if common.HasFilledOpt(d, "key_pair") {
+		loginSpec = nodes.LoginSpec{SshKey: d.Get("key_pair").(string)}
+	}
+	if common.HasFilledOpt(d, "password") {
+		loginSpec = nodes.LoginSpec{
+			UserPassword: nodes.UserPassword{
+				Username: "root",
+				Password: d.Get("password").(string),
+			},
+		}
+	}
+
 	updateOpts := nodepools.UpdateOpts{
 		Metadata: nodepools.UpdateMetaData{
 			Name: d.Get("name").(string),
@@ -570,9 +592,30 @@ func resourceCCENodePoolV3Update(ctx context.Context, d *schema.ResourceData, me
 				ScaleDownCooldownTime: d.Get("scale_down_cooldown_time").(int),
 				Priority:              d.Get("priority").(int),
 			},
-			NodeTemplate: nodepools.UpdateNodeTemplate{
-				K8sTags: resourceCCENodeK8sTags(d),
-				Taints:  resourceCCENodeTaints(d),
+			NodeTemplate: nodes.Spec{
+				Flavor:      d.Get("flavor").(string),
+				Az:          d.Get("availability_zone").(string),
+				Os:          d.Get("os").(string),
+				Login:       loginSpec,
+				RootVolume:  resourceCCERootVolume(d),
+				DataVolumes: resourceCCEDataVolume(d),
+				Count:       1,
+				NodeNicSpec: nodes.NodeNicSpec{
+					PrimaryNic: nodes.PrimaryNic{
+						SubnetId: d.Get("subnet_id").(string),
+					},
+				},
+				ExtendParam: nodes.ExtendParam{
+					MaxPods:                 d.Get("max_pods").(int),
+					PreInstall:              base64PreInstall,
+					PostInstall:             base64PostInstall,
+					DockerBaseSize:          d.Get("docker_base_size").(int),
+					DockerLVMConfigOverride: d.Get("docker_lvm_config_override").(string),
+					AgencyName:              d.Get("agency_name").(string),
+				},
+				Taints:   resourceCCENodeTaints(d),
+				K8sTags:  resourceCCENodeK8sTags(d),
+				UserTags: resourceCCENodePoolUserTags(d),
 			},
 		},
 	}

--- a/releasenotes/notes/cce_nodepool_install-e86da573af4212e3.yaml
+++ b/releasenotes/notes/cce_nodepool_install-e86da573af4212e3.yaml
@@ -1,4 +1,4 @@
 ---
 enhancements:
   - |
-    **[CCE]** Enable `preinstall` and `postinstall` update without forcenew for ``resource/opentelekomcloud_cce_node_pool_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[CCE]** Enable `preinstall` and `postinstall` update without forcenew for ``resource/opentelekomcloud_cce_node_pool_v3`` (`#3187 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3187>`_)

--- a/releasenotes/notes/cce_nodepool_install-e86da573af4212e3.yaml
+++ b/releasenotes/notes/cce_nodepool_install-e86da573af4212e3.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[CCE]** Enable `preinstall` and `postinstall` update without forcenew for ``resource/opentelekomcloud_cce_node_pool_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)


### PR DESCRIPTION
## Summary of the Pull Request
`postinstall` and `preinstall` parameters can now be updated for `opentelekomcloud_cce_node_pool_v3`

## PR Checklist

* [x] Refers to: #2937
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccCCENodePoolsV3_basic
=== PAUSE TestAccCCENodePoolsV3_basic
=== CONT  TestAccCCENodePoolsV3_basic
    cluster.go:117: Cluster usage is 0 now, ready to delete the cluster
    cluster.go:80: starting deleting shared cluster
--- PASS: TestAccCCENodePoolsV3_basic (623.03s)
=== RUN   TestAccCCENodePoolsV3_agency
=== PAUSE TestAccCCENodePoolsV3_agency
=== CONT  TestAccCCENodePoolsV3_agency
    resource_opentelekomcloud_cce_node_pool_v3_test.go:123: Cluster is required by the test. 5 test(s) are using cluster.
    cluster.go:117: Cluster is released by the test. 3 test(s) are still using cluster.
--- PASS: TestAccCCENodePoolsV3_agency (514.12s)
=== RUN   TestAccCCENodePoolsV3_SecurityGroupIds
=== PAUSE TestAccCCENodePoolsV3_SecurityGroupIds
=== CONT  TestAccCCENodePoolsV3_SecurityGroupIds
    resource_opentelekomcloud_cce_node_pool_v3_test.go:160: Cluster is required by the test. 4 test(s) are using cluster.
    cluster.go:117: Cluster is released by the test. 2 test(s) are still using cluster.
--- PASS: TestAccCCENodePoolsV3_SecurityGroupIds (516.89s)
=== RUN   TestAccCCENodePoolsV3_randomAZ
=== PAUSE TestAccCCENodePoolsV3_randomAZ
=== CONT  TestAccCCENodePoolsV3_randomAZ
    resource_opentelekomcloud_cce_node_pool_v3_test.go:204: Cluster is required by the test. 3 test(s) are using cluster.
    cluster.go:117: Cluster is released by the test. 6 test(s) are still using cluster.
--- PASS: TestAccCCENodePoolsV3_randomAZ (502.89s)
=== RUN   TestAccCCENodePoolsV3EncryptedVolume
=== PAUSE TestAccCCENodePoolsV3EncryptedVolume
=== CONT  TestAccCCENodePoolsV3EncryptedVolume
    resource_opentelekomcloud_cce_node_pool_v3_test.go:230: Cluster is required by the test. 2 test(s) are using cluster.
    cluster.go:121: starting creating shared cluster
2025/10/27 09:53:09 [DEBUG] Waiting for state to become: [Available]
2025/10/27 09:53:14 [TRACE] Waiting 3s before next try
.......
2025/10/27 09:57:09 [TRACE] Waiting 10s before next try
    cluster.go:117: Cluster is released by the test. 1 test(s) are still using cluster.
--- PASS: TestAccCCENodePoolsV3EncryptedVolume (523.67s)
=== RUN   TestAccCCENodePoolsV3ExtendParams
=== PAUSE TestAccCCENodePoolsV3ExtendParams
=== CONT  TestAccCCENodePoolsV3ExtendParams
    resource_opentelekomcloud_cce_node_pool_v3_test.go:257: Cluster is required by the test. 8 test(s) are using cluster.
    cluster.go:117: Cluster is released by the test. 5 test(s) are still using cluster.
--- PASS: TestAccCCENodePoolsV3ExtendParams (503.75s)
=== RUN   TestAccCCENodePoolsV3Storage
=== PAUSE TestAccCCENodePoolsV3Storage
=== CONT  TestAccCCENodePoolsV3Storage
    resource_opentelekomcloud_cce_node_pool_v3_test.go:282: Cluster is required by the test. 6 test(s) are using cluster.
    cluster.go:117: Cluster is released by the test. 4 test(s) are still using cluster.
--- PASS: TestAccCCENodePoolsV3Storage (503.91s)
=== RUN   TestAccCCENodePoolsV3StorageJsonEncode
=== PAUSE TestAccCCENodePoolsV3StorageJsonEncode
=== CONT  TestAccCCENodePoolsV3StorageJsonEncode
    resource_opentelekomcloud_cce_node_pool_v3_test.go:307: Cluster is required by the test. 7 test(s) are using cluster.
    cluster.go:117: Cluster is released by the test. 7 test(s) are still using cluster.
--- PASS: TestAccCCENodePoolsV3StorageJsonEncode (502.87s)
PASS

Process finished with the exit code 0
```
