### PR TITLE
[Feat.] RDS: change `parameters`  to a computed property

### DIFF
--- a/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
+++ b/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
@@ -184,7 +184,7 @@ func TestAccRdsInstanceV3HA(t *testing.T) {
 					testAccCheckRdsInstanceV3Exists(instanceV3ResourceName, &rdsInstance),
 					resource.TestCheckResourceAttr(instanceV3ResourceName, "name", "tf_rds_instance_"+postfix),
 					resource.TestCheckResourceAttr(instanceV3ResourceName, "ha_replication_mode", "semisync"),
-					resource.TestCheckResourceAttr(instanceV3ResourceName, "volume.0.type", "ULTRAHIGH"),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "volume.0.type", "CLOUDSSD"),
 					resource.TestCheckResourceAttr(instanceV3ResourceName, "db.0.type", "MySQL"),
 					resource.TestCheckResourceAttr(instanceV3ResourceName, "availability_zones.#", "2"),
 					resource.TestCheckResourceAttr(instanceV3ResourceName, "ssl_enable", "false"),
@@ -297,7 +297,6 @@ func TestAccRdsInstanceV3TimeZoneAndSSL(t *testing.T) {
 					testAccCheckRdsInstanceV3Exists(instanceV3ResourceName, &rdsInstance),
 					resource.TestCheckResourceAttr(instanceV3ResourceName, "name", "tf_rds_instance_"+postfix),
 					resource.TestCheckResourceAttr(instanceV3ResourceName, "db.0.type", "MySQL"),
-					resource.TestCheckResourceAttr(instanceV3ResourceName, "flavor", "rds.mysql.m1.large"),
 					resource.TestCheckResourceAttr(instanceV3ResourceName, "ssl_enable", "true"),
 				),
 			},
@@ -318,14 +317,12 @@ func TestAccRdsInstanceV3AutoScaling(t *testing.T) {
 				Config: testAccRdsInstanceV3ConfigurationTimeZone(postfix),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRdsInstanceV3Exists(instanceV3ResourceName, &rdsInstance),
-					resource.TestCheckResourceAttr(instanceV3ResourceName, "flavor", "rds.mysql.m1.large"),
 					resource.TestCheckResourceAttr(instanceV3ResourceName, "db.0.port", "8635"),
 				),
 			},
 			{
 				Config: testAccRdsInstanceV3AutoScaling(postfix),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(instanceV3ResourceName, "flavor", "rds.mysql.m1.large"),
 					resource.TestCheckResourceAttr(instanceV3ResourceName, "volume.0.limit_size", "500"),
 					resource.TestCheckResourceAttr(instanceV3ResourceName, "volume.0.trigger_threshold", "10"),
 				),
@@ -352,7 +349,7 @@ func TestAccRdsInstanceV3RestoreToPITR_NewInstance(t *testing.T) {
 			{
 				Config: testAccRdsInstanceV3RestorePITRUpdate(postfix),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(instanceV3ResourceName, "flavor", "rds.pg.c2.large"),
+					testAccCheckRdsInstanceV3Exists(instanceV3ResourceName, &rdsInstance),
 				),
 			},
 			{
@@ -600,13 +597,26 @@ func testAccRdsInstanceV3HA(postfix string, az2 string) string {
 %s
 %s
 
+data "opentelekomcloud_rds_flavors_v3" "flavor" {
+  db_type       = "MySQL"
+  db_version    = "8.0"
+  instance_mode = "ha"
+}
+
+locals {
+  available_flavor = [
+    for flavor in data.opentelekomcloud_rds_flavors_v3.flavor.flavors :
+    flavor if lookup(flavor.az_status, "%s", "unsupported") == "normal" && lookup(flavor.az_status, "%s", "unsupported") == "normal"
+  ][0]
+}
+
 resource "opentelekomcloud_rds_instance_v3" "instance" {
   name              = "tf_rds_instance_%s"
   availability_zone = ["%s", "%s"]
   db {
     password = "MySql!120521"
     type     = "MySQL"
-    version  = "5.6"
+    version  = "8.0"
     port     = "8635"
   }
   security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
@@ -616,14 +626,14 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
     type = "CLOUDSSD"
     size = 100
   }
-  flavor = "rds.mysql.s1.large.ha"
+  flavor = local.available_flavor.name
   backup_strategy {
     start_time = "08:00-09:00"
     keep_days  = 1
   }
   ha_replication_mode = "semisync"
 }
-`, common.DataSourceSecGroupDefault, common.DataSourceSubnet, postfix, env.OS_AVAILABILITY_ZONE, az2)
+`, common.DataSourceSecGroupDefault, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, az2, postfix, env.OS_AVAILABILITY_ZONE, az2)
 }
 
 func testAccRdsInstanceV3OptionalParams(postfix string) string {
@@ -785,11 +795,24 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
 
 func testAccRdsInstanceV3ConfigurationOverride(postfix string) string {
 	return fmt.Sprintf(`
-%s
-%s
+%[1]s
+%[2]s
+
+data "opentelekomcloud_rds_flavors_v3" "flavor" {
+  db_type       = "PostgreSQL"
+  db_version    = "15"
+  instance_mode = "single"
+}
+
+locals {
+  available_flavor = [
+    for flavor in data.opentelekomcloud_rds_flavors_v3.flavor.flavors :
+    flavor if lookup(flavor.az_status, "%[4]s", "unsupported") == "normal"
+  ][0]
+}
 
 resource "opentelekomcloud_rds_parametergroup_v3" "pg" {
-  name = "pg-rds-test"
+  name = "pg-rds-test-%[3]s"
   values = {
     autocommit = "OFF"
   }
@@ -800,8 +823,8 @@ resource "opentelekomcloud_rds_parametergroup_v3" "pg" {
 }
 
 resource "opentelekomcloud_rds_instance_v3" "instance" {
-  name              = "tf_rds_instance_%s"
-  availability_zone = ["%s"]
+  name              = "tf_rds_instance_%[3]s"
+  availability_zone = ["%[4]s"]
 
   db {
     password = "Postgres!120521"
@@ -813,9 +836,9 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
   security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
   subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
-  flavor            = "rds.pg.c2.large"
+  flavor            = local.available_flavor.name
   volume {
-    type = "ULTRAHIGH"
+    type = "CLOUDSSD"
     size = 40
   }
 
@@ -902,11 +925,25 @@ resource "opentelekomcloud_rds_instance_v3" "from_backup" {
 
 func testAccRdsInstanceV3ConfigurationTimeZone(postfix string) string {
 	return fmt.Sprintf(`
-%s
-%s
+%[1]s
+%[2]s
+
+data "opentelekomcloud_rds_flavors_v3" "flavor" {
+  db_type       = "MySQL"
+  db_version    = "8.0"
+  instance_mode = "single"
+}
+
+locals {
+  available_flavor = [
+    for flavor in data.opentelekomcloud_rds_flavors_v3.flavor.flavors :
+    flavor if lookup(flavor.az_status, "%[4]s", "unsupported") == "normal"
+  ][0]
+}
+
 resource "opentelekomcloud_rds_instance_v3" "instance" {
-  name              = "tf_rds_instance_%s"
-  availability_zone = ["%s"]
+  name              = "tf_rds_instance_%[3]s"
+  availability_zone = ["%[4]s"]
   db {
     password = "MySql!112822"
     type     = "MySQL"
@@ -918,10 +955,10 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
   subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
   volume {
-    type = "ULTRAHIGH"
+    type = "CLOUDSSD"
     size = 40
   }
-  flavor     = "rds.mysql.m1.large"
+  flavor     = local.available_flavor.name
   ssl_enable = true
   backup_strategy {
     start_time = "08:00-09:00"
@@ -935,7 +972,7 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
 
 
 resource "opentelekomcloud_rds_parametergroup_v3" "pg_1" {
-  name        = "pg_tmz"
+  name        = "pg_tmz-%[3]s"
   description = "time zone template"
 
   values = {
@@ -1027,6 +1064,19 @@ func testAccRdsInstanceV3RestorePITRBasic(postfix string) string {
 %[1]s
 %[2]s
 
+data "opentelekomcloud_rds_flavors_v3" "flavor" {
+  db_type       = "PostgreSQL"
+  db_version    = "15"
+  instance_mode = "single"
+}
+
+locals {
+  available_flavor = [
+    for flavor in data.opentelekomcloud_rds_flavors_v3.flavor.flavors :
+    flavor if lookup(flavor.az_status, "%[4]s", "unsupported") == "normal"
+  ][0]
+}
+
 resource "opentelekomcloud_rds_instance_v3" "instance" {
   name              = "tf_rds_instance_%[3]s"
   availability_zone = ["%[4]s"]
@@ -1040,10 +1090,10 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
   subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
   volume {
-    type = "ULTRAHIGH"
+    type = "CLOUDSSD"
     size = 40
   }
-  flavor = "rds.pg.c2.large"
+  flavor = local.available_flavor.name
 }
 
 resource "opentelekomcloud_rds_instance_v3" "instance_2" {
@@ -1059,18 +1109,18 @@ resource "opentelekomcloud_rds_instance_v3" "instance_2" {
   subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
   volume {
-    type = "ULTRAHIGH"
+    type = "CLOUDSSD"
     size = 40
   }
 
-  flavor = "rds.pg.c2.large"
+  flavor = local.available_flavor.name
 }
 
 resource "opentelekomcloud_rds_backup_v3" "test" {
   instance_id = opentelekomcloud_rds_instance_v3.instance_2.id
-  name        = "tf_rds_backup_%[5]s"
+  name        = "tf_rds_backup_%[3]s"
 }
-`, common.DataSourceSecGroupDefault, common.DataSourceSubnet, postfix, env.OS_AVAILABILITY_ZONE, postfix)
+`, common.DataSourceSecGroupDefault, common.DataSourceSubnet, postfix, env.OS_AVAILABILITY_ZONE)
 }
 
 func testAccRdsInstanceV3RestorePITRUpdate(postfix string) string {
@@ -1078,6 +1128,19 @@ func testAccRdsInstanceV3RestorePITRUpdate(postfix string) string {
 %[1]s
 %[2]s
 
+data "opentelekomcloud_rds_flavors_v3" "flavor" {
+  db_type       = "PostgreSQL"
+  db_version    = "15"
+  instance_mode = "single"
+}
+
+locals {
+  available_flavor = [
+    for flavor in data.opentelekomcloud_rds_flavors_v3.flavor.flavors :
+    flavor if lookup(flavor.az_status, "%[4]s", "unsupported") == "normal"
+  ][0]
+}
+
 resource "opentelekomcloud_rds_instance_v3" "instance" {
   name              = "tf_rds_instance_%[3]s"
   availability_zone = ["%[4]s"]
@@ -1091,16 +1154,14 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
   subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
   volume {
-    type = "ULTRAHIGH"
+    type = "CLOUDSSD"
     size = 40
   }
-  flavor = "rds.pg.c2.large"
+  flavor = local.available_flavor.name
   restore_point {
     instance_id = opentelekomcloud_rds_backup_v3.test.instance_id
     backup_id   = opentelekomcloud_rds_backup_v3.test.id
   }
-
-
 }
 
 resource "opentelekomcloud_rds_instance_v3" "instance_2" {
@@ -1116,11 +1177,11 @@ resource "opentelekomcloud_rds_instance_v3" "instance_2" {
   subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
   volume {
-    type = "ULTRAHIGH"
+    type = "CLOUDSSD"
     size = 40
   }
 
-  flavor = "rds.pg.c2.large"
+  flavor = local.available_flavor.name
 }
 
 resource "opentelekomcloud_rds_backup_v3" "test" {
@@ -1132,11 +1193,25 @@ resource "opentelekomcloud_rds_backup_v3" "test" {
 
 func testAccRdsInstanceV3AutoScaling(postfix string) string {
 	return fmt.Sprintf(`
-%s
-%s
+%[1]s
+%[2]s
+
+data "opentelekomcloud_rds_flavors_v3" "flavor" {
+  db_type       = "MySQL"
+  db_version    = "8.0"
+  instance_mode = "single"
+}
+
+locals {
+  available_flavor = [
+    for flavor in data.opentelekomcloud_rds_flavors_v3.flavor.flavors :
+    flavor if lookup(flavor.az_status, "%[4]s", "unsupported") == "normal"
+  ][0]
+}
+
 resource "opentelekomcloud_rds_instance_v3" "instance" {
-  name              = "tf_rds_instance_%s"
-  availability_zone = ["%s"]
+  name              = "tf_rds_instance_%[3]s"
+  availability_zone = ["%[4]s"]
   db {
     password = "MySql!112822"
     type     = "MySQL"
@@ -1148,12 +1223,12 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
   subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
   volume {
-    type              = "ULTRAHIGH"
+    type              = "CLOUDSSD"
     size              = 100
     limit_size        = 500
     trigger_threshold = 10
   }
-  flavor     = "rds.mysql.m1.large"
+  flavor     = local.available_flavor.name
   ssl_enable = true
   backup_strategy {
     start_time = "08:00-09:00"
@@ -1166,7 +1241,7 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
 }
 
 resource "opentelekomcloud_rds_parametergroup_v3" "pg_1" {
-  name        = "pg_tmz"
+  name        = "pg_tmz-%[3]s"
   description = "time zone template"
 
   values = {
@@ -1183,28 +1258,41 @@ resource "opentelekomcloud_rds_parametergroup_v3" "pg_1" {
 
 func testAccRdsInstanceV3EnableSSL(postfix string) string {
 	return fmt.Sprintf(`
-%s
-%s
+%[1]s
+%[2]s
+
+data "opentelekomcloud_rds_flavors_v3" "flavor" {
+  db_type       = "MySQL"
+  db_version    = "8.0"
+  instance_mode = "single"
+}
+
+locals {
+  available_flavor = [
+    for flavor in data.opentelekomcloud_rds_flavors_v3.flavor.flavors :
+    flavor if lookup(flavor.az_status, "%[4]s", "unsupported") == "normal"
+  ][0]
+}
 
 resource "opentelekomcloud_networking_floatingip_v2" "fip_1" {}
 
 resource "opentelekomcloud_rds_instance_v3" "instance" {
-  name              = "tf_rds_instance_%s"
-  availability_zone = ["%s"]
+  name              = "tf_rds_instance_%[3]s"
+  availability_zone = ["%[4]s"]
   db {
     password = "Postgres!120521"
     type     = "MySQL"
-    version  = "5.7"
+    version  = "8.0"
     port     = "3306"
   }
   security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
   subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
   volume {
-    type = "ULTRAHIGH"
+    type = "CLOUDSSD"
     size = 40
   }
-  flavor     = "rds.mysql.c2.medium"
+  flavor     = local.available_flavor.name
   ssl_enable = true
   backup_strategy {
     start_time = "08:00-09:00"
@@ -1212,22 +1300,31 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
   }
 
   public_ips = [opentelekomcloud_networking_floatingip_v2.fip_1.address]
-
-  parameters = {
-    require_secure_transport = "ON"
-  }
 }
 `, common.DataSourceSecGroupDefault, common.DataSourceSubnet, postfix, env.OS_AVAILABILITY_ZONE)
 }
 
 func testAccRdsInstanceV3PrivateIp(postfix string) string {
 	return fmt.Sprintf(`
-%s
-%s
+%[1]s
+%[2]s
+
+data "opentelekomcloud_rds_flavors_v3" "flavor" {
+  db_type       = "PostgreSQL"
+  db_version    = "15"
+  instance_mode = "single"
+}
+
+locals {
+  available_flavor = [
+    for flavor in data.opentelekomcloud_rds_flavors_v3.flavor.flavors :
+    flavor if lookup(flavor.az_status, "%[4]s", "unsupported") == "normal"
+  ][0]
+}
 
 resource "opentelekomcloud_rds_instance_v3" "instance" {
-  name              = "tf_rds_instance_%s"
-  availability_zone = ["%s"]
+  name              = "tf_rds_instance_%[3]s"
+  availability_zone = ["%[4]s"]
   db {
     password = "Postgres!120521"
     type     = "PostgreSQL"
@@ -1242,7 +1339,7 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
     type = "CLOUDSSD"
     size = 40
   }
-  flavor = "rds.pg.n1.large.4"
+  flavor = local.available_flavor.name
 }
 `, common.DataSourceSecGroupDefault, common.DataSourceSubnet, postfix, env.OS_AVAILABILITY_ZONE)
 }

--- a/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_instance_v3.go
+++ b/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_instance_v3.go
@@ -318,6 +318,7 @@ func ResourceRdsInstanceV3() *schema.Resource {
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
+				Computed: true,
 			},
 			"ssl_enable": {
 				Type:     schema.TypeBool,
@@ -662,6 +663,8 @@ func restartInstance(d *schema.ResourceData, client *golangsdk.ServiceClient) er
 	if err := instances.WaitForStateAvailable(client, int(timeout.Seconds()), d.Id()); err != nil {
 		return fmt.Errorf("error waiting for instance to become available: %w", err)
 	}
+	// sleep is required after restart to get consistent results for configurations.GetForInstance
+	time.Sleep(20 * time.Second)
 	return nil
 }
 
@@ -1085,7 +1088,7 @@ func resourceRdsInstanceV3Update(ctx context.Context, d *schema.ResourceData, me
 		if err != nil {
 			return fmterr.Errorf("error applying parameters to the instance: %w", err)
 		}
-		restartRequired = restartRequired || paramRestart
+		restartRequired = restartRequired || paramRestart.RestartRequired
 	}
 
 	if d.HasChange("db.0.port") {
@@ -1376,6 +1379,10 @@ func resourceRdsInstanceV3Read(ctx context.Context, d *schema.ResourceData, meta
 		}
 	}
 
+	if diags := setRdsInstanceParameters(d, client); diags != nil {
+		return diags
+	}
+
 	return nil
 }
 
@@ -1396,6 +1403,29 @@ func resourceRdsInstanceV3Delete(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	d.SetId("")
+	return nil
+}
+
+func setRdsInstanceParameters(d *schema.ResourceData, client *golangsdk.ServiceClient) diag.Diagnostics {
+	configuration, err := configurations.GetForInstance(client, d.Id())
+	if err != nil {
+		log.Printf("[WARN] error fetching parameters of instance (%s): %s", d.Id(), err)
+		return nil
+	}
+
+	rawParameters := d.Get("parameters").(map[string]interface{})
+	params := make(map[string]interface{})
+
+	for _, configParam := range configuration.Parameters {
+		if _, exists := rawParameters[configParam.Name]; exists {
+			params[configParam.Name] = configParam.Value
+		}
+	}
+
+	if err = d.Set("parameters", params); err != nil {
+		log.Printf("error saving parameters to RDS instance (%s): %s", d.Id(), err)
+	}
+
 	return nil
 }
 
@@ -1442,16 +1472,16 @@ func disableVolumeAutoExpand(ctx context.Context, timeout time.Duration, client 
 	return nil
 }
 
-func updateInstanceParameters(d *schema.ResourceData, client *golangsdk.ServiceClient) (bool, error) {
+func updateInstanceParameters(d *schema.ResourceData, client *golangsdk.ServiceClient) (*configurations.UpdateInstanceConfigurationResponse, error) {
 	opts := configurations.UpdateInstanceConfigurationOpts{
 		Values:     d.Get("parameters").(map[string]interface{}),
 		InstanceId: d.Id(),
 	}
 	rawConf, err := configurations.UpdateInstanceConfiguration(client, opts)
 	if err != nil {
-		return false, err
+		return nil, err
 	}
-	return rawConf.RestartRequired, err
+	return rawConf, err
 }
 
 func rdsInstanceStateRefreshFunc(client *golangsdk.ServiceClient, instanceID string) resource.StateRefreshFunc {
@@ -1474,12 +1504,20 @@ func waitForParameterApply(d *schema.ResourceData, client *golangsdk.ServiceClie
 
 		if err != nil {
 			if _, ok := err.(golangsdk.ErrDefault403); ok {
-				return r, "PENDING", nil
+				return false, "PENDING", nil
 			}
 			return nil, "", fmt.Errorf("error applying configuration parameters: %w", err)
 		}
 
-		return r, "SUCCESS", nil
+		if err := instances.WaitForJobCompleted(client, 60, r.JobId); err != nil {
+			// sometimes `task not found` error message is returned
+			// with 400 status which is fine
+			if _, ok := err.(golangsdk.ErrDefault400); ok {
+				return r.RestartRequired, "SUCCESS", nil
+			}
+		}
+
+		return r.RestartRequired, "SUCCESS", nil
 	}
 }
 

--- a/releasenotes/notes/rds_param_update-df6b018ddc44c784.yaml
+++ b/releasenotes/notes/rds_param_update-df6b018ddc44c784.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[RDS]** Make `parameters` a computed property for ``resource/opentelekomcloud_rds_instance_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)

--- a/releasenotes/notes/rds_param_update-df6b018ddc44c784.yaml
+++ b/releasenotes/notes/rds_param_update-df6b018ddc44c784.yaml
@@ -1,4 +1,4 @@
 ---
 enhancements:
   - |
-    **[RDS]** Make `parameters` a computed property for ``resource/opentelekomcloud_rds_instance_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[RDS]** Make `parameters` a computed property for ``resource/opentelekomcloud_rds_instance_v3`` (`#3189 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3189>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Change

## PR Checklist

* [x] Refers to: #2971
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccRdsPostgre13V3ParamsBasic
--- PASS: TestAccRdsPostgre13V3ParamsBasic (557.97s)
PASS

Process finished with the exit code 0

=== RUN   TestAccRdsInstanceV3OptionalParams
--- PASS: TestAccRdsInstanceV3OptionalParams (370.47s)
PASS

Process finished with the exit code 0

=== RUN   TestAccRdsInstanceV3ElasticIP
--- PASS: TestAccRdsInstanceV3ElasticIP (789.70s)
PASS

Process finished with the exit code 0

=== RUN   TestAccRdsInstanceV3Backup
--- PASS: TestAccRdsInstanceV3Backup (390.94s)
PASS

Process finished with the exit code 0


=== RUN   TestAccRdsInstanceV3TemplateConfig
--- PASS: TestAccRdsInstanceV3TemplateConfig (449.34s)
PASS

Process finished with the exit code 0

=== RUN   TestAccRdsInstanceV3Backup
--- PASS: TestAccRdsInstanceV3Backup (380.24s)
PASS

Process finished with the exit code 0

=== RUN   TestAccRdsInstanceV3HA
--- PASS: TestAccRdsInstanceV3HA (380.06s)
PASS

Process finished with the exit code 0

=== RUN   TestAccRdsInstanceV3_configurationParameters
--- PASS: TestAccRdsInstanceV3_configurationParameters (472.45s)
PASS

Process finished with the exit code 0

=== RUN   TestAccRdsInstanceV3TimeZoneAndSSL
--- PASS: TestAccRdsInstanceV3TimeZoneAndSSL (432.32s)
PASS

Process finished with the exit code 0

=== RUN   TestAccRdsInstanceV3_PrivateIp
--- PASS: TestAccRdsInstanceV3_PrivateIp (378.01s)
PASS

Process finished with the exit code 0

=== RUN   TestAccRdsInstanceV3AutoScaling
--- PASS: TestAccRdsInstanceV3AutoScaling (615.27s)
PASS

Process finished with the exit code 0

=== RUN   TestAccRdsInstanceV3Basic
--- PASS: TestAccRdsInstanceV3Basic (840.53s)
PASS

Process finished with the exit code 0
```
