### PR TITLE
[Feat.] 'force_detach' for `opentelekomcloud_compute_volume_attach_v2`

### DIFF
--- a/docs/resources/compute_volume_attach_v2.md
+++ b/docs/resources/compute_volume_attach_v2.md
@@ -61,6 +61,16 @@ output "volume devices" {
 }
 ```
 
+### Example with force_detach flag
+
+```hcl
+resource "opentelekomcloud_compute_volume_attach_v2" "va_force" {
+  instance_id  = opentelekomcloud_compute_instance_v2.instance_1.id
+  volume_id    = opentelekomcloud_blockstorage_volume_v2.volume_1.id
+  force_detach = true
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -76,6 +86,10 @@ The following arguments are supported:
   the same device the hypervisor chose. If this happens, Terraform will wish
   to update the device upon subsequent applying which will cause the volume
   to be detached and reattached indefinitely. Please use with caution.
+
+* `force_detach` - (Optional) Indicates whether to force detach the disk when deleting the attachment resource.
+  If set to `true`, the provider will call the force detach API, ensuring the disk is detached even
+  if the normal detach operation fails. Defaults to `false`.
 
 ## Attributes Reference
 

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20251105103257-1a85427567b1
+	github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20251110145723-c2baf4c77321
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.43.0
 	golang.org/x/sync v0.17.0

--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20251105103257-1a85427567b1 h1:FLSj9RmUj9FAgzat0zIGsG8NvGFrgsM4hCJ4yT2upao=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20251105103257-1a85427567b1/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20251110145723-c2baf4c77321 h1:oIHm/AHWOckHeq4WG4VNbzgb80KWELRefp1N7X+ZCbE=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20251110145723-c2baf4c77321/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_volume_attach_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_volume_attach_v2_test.go
@@ -321,8 +321,9 @@ resource "opentelekomcloud_compute_volume_attach_v2" "va_2" {
 }
 
 resource "opentelekomcloud_compute_volume_attach_v2" "va_3" {
-  instance_id = opentelekomcloud_ecs_instance_v1.ecs.id
-  volume_id   = opentelekomcloud_evs_volume_v3.volume_3.id
-  device      = "/dev/vdd"
+  instance_id  = opentelekomcloud_ecs_instance_v1.ecs.id
+  volume_id    = opentelekomcloud_evs_volume_v3.volume_3.id
+  device       = "/dev/vdd"
+  force_detach = true
 }
 `, common.DataSourceImage, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE)

--- a/opentelekomcloud/services/ecs/common.go
+++ b/opentelekomcloud/services/ecs/common.go
@@ -5,5 +5,6 @@ const (
 	errCreateV2Client = "error creating OpenTelekomCloud ComputeV2 client: %w"
 
 	keyClientV2  = "ecs-v2-client"
+	keyClientV1  = "ecs-v1-client"
 	microversion = "2.55"
 )

--- a/opentelekomcloud/services/ecs/resource_opentelekomcloud_compute_volume_attach_v2.go
+++ b/opentelekomcloud/services/ecs/resource_opentelekomcloud_compute_volume_attach_v2.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/compute/v2/extensions/volumeattach"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/ecs/v1/disk"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -58,6 +59,13 @@ func ResourceComputeVolumeAttachV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 				Optional: true,
+			},
+
+			"force_detach": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+				Default:  false,
 			},
 		},
 	}
@@ -165,10 +173,17 @@ func resourceComputeVolumeAttachV2Delete(ctx context.Context, d *schema.Resource
 		return diag.FromErr(err)
 	}
 
+	var refresh resource.StateRefreshFunc
+	if v, ok := d.GetOk("force_detach"); ok && v.(bool) {
+		refresh = resourceVolumeAttachV2ForceDetachFunc(instanceId, attachmentId, d, meta)
+	} else {
+		refresh = resourceComputeVolumeAttachV2DetachFunc(client, instanceId, attachmentId)
+	}
+
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{""},
 		Target:     []string{"DETACHED"},
-		Refresh:    resourceComputeVolumeAttachV2DetachFunc(client, instanceId, attachmentId),
+		Refresh:    refresh,
 		Timeout:    d.Timeout(schema.TimeoutDelete),
 		Delay:      15 * time.Second,
 		MinTimeout: 15 * time.Second,
@@ -211,6 +226,42 @@ func resourceComputeVolumeAttachV2DetachFunc(
 		}
 
 		err = volumeattach.Delete(computeClient, instanceId, attachmentId).ExtractErr()
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				return va, "DETACHED", nil
+			}
+
+			if _, ok := err.(golangsdk.ErrDefault400); ok {
+				return nil, "", nil
+			}
+
+			return nil, "", err
+		}
+
+		log.Printf("[DEBUG] OpenTelekomCloud Volume Attachment (%s) is still active.", attachmentId)
+		return nil, "", nil
+	}
+}
+
+func resourceVolumeAttachV2ForceDetachFunc(instanceId, attachmentId string, d *schema.ResourceData, meta interface{}) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		log.Printf("[DEBUG] Attempting to detach OpenTelekomCloud volume %s from instance %s",
+			attachmentId, instanceId)
+		config := meta.(*cfg.Config)
+		client, err := config.ComputeV1Client(config.GetRegion(d))
+		if err != nil {
+			return fmterr.Errorf(errCreateClient, err), "", nil
+		}
+
+		va, err := volumeattach.Get(client, instanceId, attachmentId).Extract()
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				return va, "DETACHED", nil
+			}
+			return va, "", err
+		}
+
+		_, err = disk.Detach(client, instanceId, attachmentId, 1)
 		if err != nil {
 			if _, ok := err.(golangsdk.ErrDefault404); ok {
 				return va, "DETACHED", nil

--- a/opentelekomcloud/services/ecs/resource_opentelekomcloud_compute_volume_attach_v2.go
+++ b/opentelekomcloud/services/ecs/resource_opentelekomcloud_compute_volume_attach_v2.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/compute/v2/extensions/volumeattach"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/ecs/v1/cloudservers"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/ecs/v1/disk"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -167,30 +168,40 @@ func resourceComputeVolumeAttachV2Delete(ctx context.Context, d *schema.Resource
 	if err != nil {
 		return fmterr.Errorf(errCreateV2Client, err)
 	}
+	clientV1, err := common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
+		return config.ComputeV1Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreateClient, err)
+	}
 
 	instanceId, attachmentId, err := ParseComputeVolumeAttachmentId(d.Id())
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	var refresh resource.StateRefreshFunc
 	if v, ok := d.GetOk("force_detach"); ok && v.(bool) {
-		refresh = resourceVolumeAttachV2ForceDetachFunc(instanceId, attachmentId, d, meta)
+		dt, err := disk.Detach(clientV1, instanceId, attachmentId, 1)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		timeout := int(d.Timeout(schema.TimeoutDelete) / time.Second)
+		if err := cloudservers.WaitForJobSuccess(clientV1, timeout, dt.JobID); err != nil {
+			return fmterr.Errorf("error detaching OpenTelekomCloud volume: %s", err)
+		}
 	} else {
-		refresh = resourceComputeVolumeAttachV2DetachFunc(client, instanceId, attachmentId)
-	}
+		stateConf := &resource.StateChangeConf{
+			Pending:    []string{""},
+			Target:     []string{"DETACHED"},
+			Refresh:    resourceComputeVolumeAttachV2DetachFunc(client, instanceId, attachmentId),
+			Timeout:    d.Timeout(schema.TimeoutDelete),
+			Delay:      15 * time.Second,
+			MinTimeout: 15 * time.Second,
+		}
 
-	stateConf := &resource.StateChangeConf{
-		Pending:    []string{""},
-		Target:     []string{"DETACHED"},
-		Refresh:    refresh,
-		Timeout:    d.Timeout(schema.TimeoutDelete),
-		Delay:      15 * time.Second,
-		MinTimeout: 15 * time.Second,
-	}
-
-	if _, err = stateConf.WaitForStateContext(ctx); err != nil {
-		return fmterr.Errorf("error detaching OpenTelekomCloud volume: %s", err)
+		if _, err = stateConf.WaitForStateContext(ctx); err != nil {
+			return fmterr.Errorf("error detaching OpenTelekomCloud volume: %s", err)
+		}
 	}
 
 	return nil
@@ -226,42 +237,6 @@ func resourceComputeVolumeAttachV2DetachFunc(
 		}
 
 		err = volumeattach.Delete(computeClient, instanceId, attachmentId).ExtractErr()
-		if err != nil {
-			if _, ok := err.(golangsdk.ErrDefault404); ok {
-				return va, "DETACHED", nil
-			}
-
-			if _, ok := err.(golangsdk.ErrDefault400); ok {
-				return nil, "", nil
-			}
-
-			return nil, "", err
-		}
-
-		log.Printf("[DEBUG] OpenTelekomCloud Volume Attachment (%s) is still active.", attachmentId)
-		return nil, "", nil
-	}
-}
-
-func resourceVolumeAttachV2ForceDetachFunc(instanceId, attachmentId string, d *schema.ResourceData, meta interface{}) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		log.Printf("[DEBUG] Attempting to detach OpenTelekomCloud volume %s from instance %s",
-			attachmentId, instanceId)
-		config := meta.(*cfg.Config)
-		client, err := config.ComputeV1Client(config.GetRegion(d))
-		if err != nil {
-			return fmterr.Errorf(errCreateClient, err), "", nil
-		}
-
-		va, err := volumeattach.Get(client, instanceId, attachmentId).Extract()
-		if err != nil {
-			if _, ok := err.(golangsdk.ErrDefault404); ok {
-				return va, "DETACHED", nil
-			}
-			return va, "", err
-		}
-
-		_, err = disk.Detach(client, instanceId, attachmentId, 1)
 		if err != nil {
 			if _, ok := err.(golangsdk.ErrDefault404); ok {
 				return va, "DETACHED", nil

--- a/releasenotes/notes/ecs-volume-attach-detach-f4c5692d1a2ea99a.yaml
+++ b/releasenotes/notes/ecs-volume-attach-detach-f4c5692d1a2ea99a.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[ECS]** Add `force_detach` in ``resource/opentelekomcloud_compute_volume_attach_v2`` (`#3203 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3203>`_)


### PR DESCRIPTION
## Summary of the Pull Request
New bool attribute `force_detach`

## PR Checklist

* [x] Refers to: #3134
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccComputeV2VolumeAttach_MultipleDevices
=== PAUSE TestAccComputeV2VolumeAttach_MultipleDevices
=== CONT  TestAccComputeV2VolumeAttach_MultipleDevices
--- PASS: TestAccComputeV2VolumeAttach_MultipleDevices (187.21s)
PASS

Process finished with the exit code 0
```
