### PR TITLE
[Fix] AS: Fix validation check in as_group_v1

### DIFF
--- a/opentelekomcloud/services/as/resource_opentelekomcloud_as_group_v1.go
+++ b/opentelekomcloud/services/as/resource_opentelekomcloud_as_group_v1.go
@@ -167,7 +167,7 @@ func ResourceASGroup() *schema.Resource {
 				Optional: true,
 				Default:  "OLD_CONFIG_OLD_INSTANCE",
 				ValidateFunc: validation.StringInSlice([]string{
-					"OLD_CONFIG_OLD_INSTANCE ", "OLD_CONFIG_NEW_INSTANCE", "OLD_INSTANCE", "NEW_INSTANCE",
+					"OLD_CONFIG_OLD_INSTANCE", "OLD_CONFIG_NEW_INSTANCE", "OLD_INSTANCE", "NEW_INSTANCE",
 				}, true),
 			},
 			"notifications": {

--- a/releasenotes/notes/as-fix-resource-group-v1-63a140de895935b0.yaml
+++ b/releasenotes/notes/as-fix-resource-group-v1-63a140de895935b0.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[AS]** Fix validation check for `instance_terminate_policy` in ``resource/opentelekomcloud_as_group_v1`` (`#3214 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3214>`_)


### PR DESCRIPTION
## Summary of the Pull Request

Fix validation check for argument `instance_terminate_policy` in resource `opentelekomcloud_as_group_v1`

## PR Checklist

* [x] Refers to: #3212 
* [x] Tests added/passed.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccASV1Group_basic
=== PAUSE TestAccASV1Group_basic
=== CONT  TestAccASV1Group_basic
    common.go:156: Service: asv1, Region eu-de
--- PASS: TestAccASV1Group_basic (584.88s)
PASS
```
