### PR TITLE
[Feat] AS: Add argument enable to as_group_v1

### DIFF
--- a/docs/resources/as_group_v1.md
+++ b/docs/resources/as_group_v1.md
@@ -133,6 +133,9 @@ The following arguments are supported:
 * `cool_down_time` - (Optional) The cooling duration (in seconds). The value ranges
   from 0 to 86400, and is 900 by default.
 
+* `enable` - (Optional) It specifies whether to enable or disable the AS group. Supported values: `true`, `false`.
+  Default value: `true`.
+
 * `lb_listener_id` **DEPRECATED** - (Optional) The Classic LB listener IDs. The system
   supports up to six Classic LB listeners, the IDs of which are separated using a comma (,).
   This parameter is alternative to `lbaas_listeners`.

--- a/opentelekomcloud/acceptance/as/resource_opentelekomcloud_as_group_v1_test.go
+++ b/opentelekomcloud/acceptance/as/resource_opentelekomcloud_as_group_v1_test.go
@@ -2,6 +2,7 @@ package acceptance
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -15,6 +16,9 @@ import (
 )
 
 func TestAccASV1Group_basic(t *testing.T) {
+	if os.Getenv("RUN_AS_TESTS") == "" {
+		t.Skip("RUN_AS_TESTS not set, skipping OpenTelekomCloud Autoscaling group test.")
+	}
 	supportedRegions := []string{"eu-de", "eu-nl", "eu-ch2"}
 	var asGroup groups.Group
 	resourceName := "opentelekomcloud_as_group_v1.as_group"

--- a/opentelekomcloud/services/as/resource_opentelekomcloud_as_group_v1.go
+++ b/opentelekomcloud/services/as/resource_opentelekomcloud_as_group_v1.go
@@ -187,6 +187,11 @@ func ResourceASGroup() *schema.Resource {
 				}, true),
 				Description: "Whether to delete instances when they are removed from the AS group.",
 			},
+			"enable": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
 			"instances": {
 				Type:        schema.TypeList,
 				Computed:    true,
@@ -336,6 +341,30 @@ func refreshInstancesLifeStates(client *golangsdk.ServiceClient, groupID string,
 	}
 }
 
+func enableGroup(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient, asGroupID string, initNum int) error {
+	enableResult := groups.Enable(client, asGroupID)
+	if enableResult != nil {
+		return fmt.Errorf("error enabling ASGroup %q: %s", asGroupID, enableResult)
+	}
+	log.Printf("[DEBUG] Enable ASGroup %q success!", asGroupID)
+	// check all instances are inService
+	if initNum > 0 {
+		stateConf := &resource.StateChangeConf{
+			Pending: []string{"PENDING"},
+			Target:  []string{"INSERVICE"}, // if there is no lifecycle status, meaning no instances in asg
+			Refresh: refreshInstancesLifeStates(client, asGroupID, initNum, true),
+			Timeout: d.Timeout(schema.TimeoutCreate),
+			Delay:   10 * time.Second,
+		}
+
+		_, err := stateConf.WaitForStateContext(ctx)
+		if err != nil {
+			return fmt.Errorf("error waiting for instances in the ASGroup %q to become inservice: %s", asGroupID, err)
+		}
+	}
+	return nil
+}
+
 func resourceASGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
 	client, err := common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
@@ -398,24 +427,16 @@ func resourceASGroupCreate(ctx context.Context, d *schema.ResourceData, meta int
 	time.Sleep(5 * time.Second)
 
 	// enable AutoScaling Group
-	enableResult := groups.Enable(client, asGroupID)
-	if enableResult != nil {
-		return fmterr.Errorf("error enabling ASGroup %q: %s", asGroupID, enableResult)
-	}
-	log.Printf("[DEBUG] Enable ASGroup %q success!", asGroupID)
-	// check all instances are inService
-	if initNum > 0 {
-		stateConf := &resource.StateChangeConf{
-			Pending: []string{"PENDING"},
-			Target:  []string{"INSERVICE"}, // if there is no lifecycle status, meaning no instances in asg
-			Refresh: refreshInstancesLifeStates(client, asGroupID, initNum, true),
-			Timeout: d.Timeout(schema.TimeoutCreate),
-			Delay:   10 * time.Second,
-		}
-
-		_, err := stateConf.WaitForStateContext(ctx)
+	enable := d.Get("enable").(bool)
+	if enable {
+		err = enableGroup(ctx, d, client, asGroupID, initNum)
 		if err != nil {
-			return fmterr.Errorf("error waiting for instances in the ASGroup %q to become inservice: %s", asGroupID, err)
+			return fmterr.Errorf("error enabling ASGroup %q: %s", asGroupID, err)
+		}
+	} else {
+		err = groups.Disable(client, asGroupID)
+		if err != nil {
+			return fmterr.Errorf("error disabling ASGroup %q: %s", asGroupID, err)
 		}
 	}
 
@@ -543,11 +564,20 @@ func resourceASGroupUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	isDeletePublicIp := d.Get("delete_publicip").(bool)
 
 	asgLBaaSListeners := getAllLBaaSListeners(d)
+	minNum := d.Get("min_instance_number").(int)
+	desireNum := d.Get("desire_instance_number").(int)
+	var initNum int
+	if desireNum > 0 {
+		initNum = desireNum
+	} else {
+		initNum = minNum
+	}
+
 	updateOpts := groups.UpdateOpts{
 		Name:                      d.Get("scaling_group_name").(string),
 		ConfigurationID:           d.Get("scaling_configuration_id").(string),
-		DesireInstanceNumber:      d.Get("desire_instance_number").(int),
-		MinInstanceNumber:         d.Get("min_instance_number").(int),
+		DesireInstanceNumber:      desireNum,
+		MinInstanceNumber:         minNum,
 		MaxInstanceNumber:         d.Get("max_instance_number").(int),
 		CoolDownTime:              d.Get("cool_down_time").(int),
 		LBListenerID:              d.Get("lb_listener_id").(string),
@@ -565,6 +595,22 @@ func resourceASGroupUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	asGroupID, err := groups.Update(client, d.Id(), updateOpts)
 	if err != nil {
 		return fmterr.Errorf("error updating ASGroup %q: %s", asGroupID, err)
+	}
+
+	if d.HasChange("enable") {
+		// enable AutoScaling Group
+		enable := d.Get("enable").(bool)
+		if enable {
+			err = enableGroup(ctx, d, client, asGroupID, initNum)
+			if err != nil {
+				return fmterr.Errorf("error enabling ASGroup %q: %s", asGroupID, err)
+			}
+		} else {
+			err = groups.Disable(client, asGroupID)
+			if err != nil {
+				return fmterr.Errorf("error disabling ASGroup %q: %s", asGroupID, err)
+			}
+		}
 	}
 
 	// update tags

--- a/releasenotes/notes/as-add-enbale-to-group-v1-3164c72e22492dcd.yaml
+++ b/releasenotes/notes/as-add-enbale-to-group-v1-3164c72e22492dcd.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    **[AS]** Add argument `enable` in ``resource/opentelekomcloud_as_group_v1`` (`#3215 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3215>`_)


### PR DESCRIPTION
## Summary of the Pull Request

 Add argument `enable` to resource opentelekomcloud_as_group_v1

## PR Checklist

* [x] Refers to: #3213 
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccASV1Group_basic
=== PAUSE TestAccASV1Group_basic
=== CONT  TestAccASV1Group_basic
    common.go:156: Service: asv1, Region eu-de
--- PASS: TestAccASV1Group_basic (3060.52s)
PASS
```
