### PR TITLE
[Feat.] OBS: bucket storage class enable for `eu-ch`

### DIFF
--- a/opentelekomcloud/services/obs/resource_opentelekomcloud_obs_bucket.go
+++ b/opentelekomcloud/services/obs/resource_opentelekomcloud_obs_bucket.go
@@ -410,10 +410,7 @@ func resourceObsBucketCreate(ctx context.Context, d *schema.ResourceData, meta i
 	bucket := d.Get("bucket").(string)
 	acl := d.Get("acl").(string)
 
-	var class string
-	if config.GetRegion(d) != "eu-ch2" {
-		class = d.Get("storage_class").(string)
-	}
+	class := d.Get("storage_class").(string)
 
 	opts := &obs.CreateBucketInput{
 		Bucket:            bucket,
@@ -452,7 +449,7 @@ func resourceObsBucketUpdate(ctx context.Context, d *schema.ResourceData, meta i
 		}
 	}
 
-	if d.HasChange("storage_class") && !d.IsNewResource() && config.GetRegion(d) != "eu-ch2" {
+	if d.HasChange("storage_class") && !d.IsNewResource() {
 		if err := resourceObsBucketClassUpdate(client, d); err != nil {
 			return diag.FromErr(err)
 		}
@@ -561,10 +558,8 @@ func resourceObsBucketRead(_ context.Context, d *schema.ResourceData, meta inter
 	}
 
 	// Read storage class
-	if region != "eu-ch2" {
-		if err := setObsBucketStorageClass(client, d); err != nil {
-			return diag.FromErr(err)
-		}
+	if err := setObsBucketStorageClass(client, d); err != nil {
+		return diag.FromErr(err)
 	}
 
 	// Read the versioning

--- a/releasenotes/notes/obs_eu-ch_storage-44e09ba46a73271b.yaml
+++ b/releasenotes/notes/obs_eu-ch_storage-44e09ba46a73271b.yaml
@@ -1,4 +1,4 @@
 ---
 enhancements:
   - |
-    **[OBS]** Enable storage class for `eu-ch` region for ``resource/opentelekomcloud_obs_bucket`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[OBS]** Enable storage class for `eu-ch` region for ``resource/opentelekomcloud_obs_bucket`` (`#3227 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3227>`_)

--- a/releasenotes/notes/obs_eu-ch_storage-44e09ba46a73271b.yaml
+++ b/releasenotes/notes/obs_eu-ch_storage-44e09ba46a73271b.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[OBS]** Enable storage class for `eu-ch` region for ``resource/opentelekomcloud_obs_bucket`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Enable storage class data for bucket in `eu-ch` region.

## PR Checklist

* [x] Refers to: #3225
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```

=== RUN   TestAccObsBucket_basic
=== PAUSE TestAccObsBucket_basic
=== CONT  TestAccObsBucket_basic
--- PASS: TestAccObsBucket_basic (79.79s)
PASS

Process finished with the exit code 0

=== RUN   TestAccObsBucket_tags
=== PAUSE TestAccObsBucket_tags
=== CONT  TestAccObsBucket_tags
--- PASS: TestAccObsBucket_tags (22.78s)
PASS

Process finished with the exit code 0

=== RUN   TestAccObsBucket_versioning
=== PAUSE TestAccObsBucket_versioning
=== CONT  TestAccObsBucket_versioning
--- PASS: TestAccObsBucket_versioning (42.08s)
PASS

Process finished with the exit code 0

```
