### PR TITLE
[Feat.] CESv2: alarm rule resource

### DIFF
--- a/docs/resources/ces_alarmrule_v2.md
+++ b/docs/resources/ces_alarmrule_v2.md
@@ -1,0 +1,403 @@
+---
+subcategory: "Cloud Eye (CES)"
+layout: "opentelekomcloud"
+page_title: "OpenTelekomCloud: opentelekomcloud_ces_alarmrule_v2"
+sidebar_current: "docs-opentelekomcloud-resource-ces-alarmrule-v2"
+description: |-
+  Manages a CES Alarm Rule v2 resource within OpenTelekomCloud.
+---
+
+Up-to-date reference of API arguments for CES alarm rule you can get at
+[documentation portal](https://docs.otc.t-systems.com/cloud-eye/api-ref/api_v2/alarm_rules/index.html)
+
+# opentelekomcloud_ces_alarmrule_v2
+
+Manages a CES Alarm Rule v2 resource within OpenTelekomCloud.
+
+~>
+  Alarm rule `namespaces` and `dimensions` are available on our [github link](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/tree/devel/opentelekomcloud/services/ces/interconnected_services.md) or [official documentation](https://docs.otc.t-systems.com/cloud-eye/api-ref/appendix/services_interconnected_with_cloud_eye.html).
+
+## Example Usage
+
+### Basic alarm rule for multiple ECS instances
+
+```hcl
+variable "instance_id_1" {}
+variable "instance_id_2" {}
+variable "topic_urn" {}
+
+resource "opentelekomcloud_ces_alarmrule_v2" "test" {
+  name                 = "alarm-rule-test"
+  namespace            = "SYS.ECS"
+  type                 = "MULTI_INSTANCE"
+  notification_enabled = true
+  alarm_enabled        = true
+
+  resources {
+    dimensions {
+      name  = "instance_id"
+      value = var.instance_id_1
+    }
+  }
+
+  resources {
+    dimensions {
+      name  = "instance_id"
+      value = var.instance_id_2
+    }
+  }
+
+  policies {
+    metric_name         = "network_outgoing_bytes_rate_inband"
+    period              = 1200
+    filter              = "average"
+    comparison_operator = ">"
+    value               = 6.5
+    unit                = "B/s"
+    count               = 1
+    suppress_duration   = 300
+    level               = 4
+  }
+
+  policies {
+    metric_name         = "network_outgoing_bytes_rate_inband"
+    period              = 3600
+    filter              = "average"
+    comparison_operator = ">="
+    value               = 20
+    unit                = "B/s"
+    count               = 1
+    suppress_duration   = 300
+    level               = 4
+  }
+
+  alarm_actions {
+    type              = "notification"
+    notification_list = [var.topic_urn]
+  }
+}
+```
+
+### Alarm rule for all instances
+
+```hcl
+variable "topic_urn" {}
+
+resource "opentelekomcloud_ces_alarmrule_v2" "test" {
+  name                 = "alarm-rule-all-instance"
+  namespace            = "AGT.ECS"
+  type                 = "ALL_INSTANCE"
+  notification_enabled = true
+  alarm_enabled        = true
+
+  resources {
+    dimensions {
+      name = "instance_id"
+    }
+
+    dimensions {
+      name = "mount_point"
+    }
+  }
+
+  policies {
+    metric_name         = "disk_usedPercent"
+    period              = 1
+    filter              = "average"
+    comparison_operator = ">"
+    value               = 80
+    count               = 1
+    suppress_duration   = 0
+    level               = 2
+  }
+
+  alarm_actions {
+    type              = "notification"
+    notification_list = [var.topic_urn]
+  }
+}
+```
+
+### Alarm rule for system event monitoring
+
+```hcl
+resource "opentelekomcloud_ces_alarmrule_v2" "test" {
+  name                 = "alarm-rule-sys-event"
+  namespace            = "SYS.ECS"
+  type                 = "EVENT.SYS"
+  notification_enabled = false
+  alarm_enabled        = true
+
+  resources {
+    dimensions {
+      name  = "resource_id"
+      value = "all_instance"
+    }
+  }
+
+  policies {
+    metric_name         = "stopServer"
+    period              = 0
+    filter              = "average"
+    comparison_operator = ">="
+    value               = 1
+    unit                = "count"
+    count               = 1
+    suppress_duration   = 0
+    level               = 2
+  }
+}
+```
+
+### Alarm rule for system event monitoring with notification
+
+```hcl
+variable "topic_urn" {}
+
+resource "opentelekomcloud_ces_alarmrule_v2" "test" {
+  name                 = "alarm-rule-sys-event"
+  namespace            = "SYS.ECS"
+  type                 = "EVENT.SYS"
+  notification_enabled = true
+  alarm_enabled        = true
+
+  resources {
+    dimensions {
+      name  = "resource_id"
+      value = "all_instance"
+    }
+  }
+
+  policies {
+    metric_name         = "stopServer"
+    period              = 0
+    filter              = "average"
+    comparison_operator = ">="
+    value               = 1
+    unit                = "count"
+    count               = 1
+    suppress_duration   = 0
+    level               = 2
+  }
+
+  alarm_actions {
+    type              = "notification"
+    notification_list = [var.topic_urn]
+  }
+}
+```
+
+### Alarm rule with OK actions
+
+```hcl
+variable "instance_id" {}
+variable "topic_urn" {}
+
+resource "opentelekomcloud_ces_alarmrule_v2" "test" {
+  name                 = "alarm-rule-with-ok-actions"
+  namespace            = "SYS.ECS"
+  type                 = "MULTI_INSTANCE"
+  notification_enabled = true
+  alarm_enabled        = true
+
+  resources {
+    dimensions {
+      name  = "instance_id"
+      value = var.instance_id
+    }
+  }
+
+  policies {
+    metric_name         = "network_outgoing_bytes_rate_inband"
+    period              = 300
+    filter              = "average"
+    comparison_operator = ">"
+    value               = 6.5
+    unit                = "B/s"
+    count               = 1
+    level               = 2
+  }
+
+  alarm_actions {
+    type              = "notification"
+    notification_list = [var.topic_urn]
+  }
+
+  ok_actions {
+    type              = "notification"
+    notification_list = [var.topic_urn]
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required, String, ForceNew) Specifies the name of an alarm rule. The value can be a string of `1` to `128`
+  characters that can consist of letters, digits, underscores (_), and hyphens (-).
+  Changing this creates a new resource.
+
+* `namespace` - (Required, String, ForceNew) Specifies the namespace in `service.item` format. `service` and `item`
+  each must be a string that starts with a letter and contains only letters, digits, and underscores (_).
+  Changing this creates a new resource.
+  For details, see [Services Interconnected with Cloud Eye](https://docs.otc.t-systems.com/cloud-eye/api-ref/appendix/services_interconnected_with_cloud_eye.html).
+
+* `policies` - (Required, Set) Specifies the alarm policies. The [policies](#policies_struct) structure is
+  documented below.
+
+* `description` - (Optional, String, ForceNew) The value can be a string of `0` to `256` characters.
+  Changing this creates a new resource.
+
+* `type` - (Optional, String, ForceNew) Specifies the alarm type. The value can be:
+  + **EVENT.SYS**: The alarm rule is created for system events.
+  + **EVENT.CUSTOM**: The alarm rule is created for custom events.
+  + **MULTI_INSTANCE**: The alarm rule is created for multiple instances.
+  + **ALL_INSTANCE**: The alarm rule is created for all instances.
+
+  Defaults to **MULTI_INSTANCE**. Changing this creates a new resource.
+
+* `resources` - (Optional, Set) Specifies the list of resources to monitor.
+  The [resources](#resources_struct) structure is documented below.
+
+* `resource_group_id` - (Optional, String, ForceNew) Specifies the resource group ID.
+  Changing this creates a new resource.
+
+* `alarm_template_id` - (Optional, String, ForceNew) Specifies the ID of the alarm template.
+  Changing this creates a new resource.
+
+* `alarm_actions` - (Optional, List, ForceNew) Specifies the action triggered by an alarm.
+  The [alarm_actions](#actions_struct) structure is documented below.
+  Changing this creates a new resource.
+
+* `ok_actions` - (Optional, List, ForceNew) Specifies the action triggered by the clearing of an alarm.
+  The [ok_actions](#actions_struct) structure is documented below.
+  Changing this creates a new resource.
+
+* `notification_enabled` - (Optional, Bool, ForceNew) Specifies whether to enable the action to be triggered by an alarm.
+  The default value is `false`. Changing this creates a new resource.
+
+* `alarm_enabled` - (Optional, Bool) Specifies whether to enable the alarm rule.
+  The default value is `true`.
+
+* `notification_begin_time` - (Optional, String, ForceNew) Specifies the alarm notification start time,
+  for example: **05:30**. Changing this creates a new resource.
+
+* `notification_end_time` - (Optional, String, ForceNew) Specifies the alarm notification stop time,
+  for example: **22:10**. Changing this creates a new resource.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID of the alarm rule.
+  Changing this creates a new resource.
+
+-> **Note** If `notification_enabled` is set to `true`, either `alarm_actions` or `ok_actions` cannot be empty.
+If `alarm_actions` and `ok_actions` coexist, their corresponding `notification_list` must be of the same value.
+
+<a name="policies_struct"></a>
+The `policies` block supports:
+
+* `metric_name` - (Required, String) Specifies the metric name. The value can be a string of `1` to `64` characters
+  that must start with a letter and contain only letters, digits, and underscores (_).
+  For details, see [Services Interconnected with Cloud Eye](https://docs.otc.t-systems.com/cloud-eye/api-ref/appendix/services_interconnected_with_cloud_eye.html).
+
+* `period` - (Required, Int) Specifies the alarm checking period in seconds. The value can be `0`, `1`, `300`,
+  `1200`, `3600`, `14400`, and `86400`.
+
+  -> If `period` is set to `1`, the raw metric data is used to determine whether to generate an alarm.
+  When the value of `type` is **EVENT.SYS** or **EVENT.CUSTOM**, `period` can be set to `0`.
+
+* `filter` - (Required, String) Specifies the data rollup method. The value can be `max`, `min`, `average`,
+  `sum`, and `variance`.
+
+* `comparison_operator` - (Required, String) Specifies the comparison condition of alarm thresholds.
+  The value can be `>`, `=`, `<`, `>=`, `<=`, or `!=`.
+
+* `value` - (Optional, Float) Specifies the alarm threshold. The value ranges from `0` to
+  `Number.MAX_VALUE` (1.7976931348623157e+108).
+
+* `count` - (Required, Int) Specifies the number of consecutive occurrence times.
+  The value ranges from `1` to `5`.
+
+* `unit` - (Optional, String) Specifies the data unit. The value can be a string of `0` to `32` characters.
+
+* `suppress_duration` - (Optional, Int) Specifies the interval for triggering an alarm if the alarm persists.
+  Possible values are as follows:
+  + **0**: Cloud Eye triggers the alarm only once.
+  + **300**: Cloud Eye triggers the alarm every 5 minutes.
+  + **600**: Cloud Eye triggers the alarm every 10 minutes.
+  + **900**: Cloud Eye triggers the alarm every 15 minutes.
+  + **1800**: Cloud Eye triggers the alarm every 30 minutes.
+  + **3600**: Cloud Eye triggers the alarm every hour.
+  + **10800**: Cloud Eye triggers the alarm every 3 hours.
+  + **21600**: Cloud Eye triggers the alarm every 6 hours.
+  + **43200**: Cloud Eye triggers the alarm every 12 hours.
+  + **86400**: Cloud Eye triggers the alarm every day.
+
+  The default value is `0`.
+
+* `level` - (Optional, Int) Specifies the alarm severity. The value can be `1`, `2`, `3`, or `4`, which indicates
+  *critical*, *major*, *minor*, and *informational*, respectively.
+  The default value is `2`.
+
+<a name="resources_struct"></a>
+The `resources` block supports:
+
+* `dimensions` - (Required, List) Specifies the list of metric dimensions.
+  The [dimensions](#dimensions_struct) structure is documented below.
+
+<a name="dimensions_struct"></a>
+The `dimensions` block supports:
+
+* `name` - (Required, String) Specifies the dimension name. The value can be a string of `1` to `32` characters
+  that must start with a letter and contain only letters, digits, underscores (_), and hyphens (-).
+
+* `value` - (Optional, String) Specifies the dimension value. The value can be a string of `1` to `64` characters
+  that must start with a letter or a number and contain only letters, digits, underscores (_), and hyphens (-).
+  For **ALL_INSTANCE** type alarms, this field can be left empty.
+
+<a name="actions_struct"></a>
+The `alarm_actions` block supports:
+
+* `type` - (Required, String) Specifies the type of action triggered by an alarm. The value can be:
+  + **notification**: indicates that a notification will be sent to the user.
+  + **autoscaling**: indicates that a scaling action will be triggered.
+
+* `notification_list` - (Required, List) Specifies the list of objects to be notified if the alarm status changes.
+  The maximum length is `5`. If `type` is set to **notification**, the value of `notification_list` cannot be empty.
+  If `type` is set to **autoscaling**, the value of `notification_list` must be `[]` and the value of `namespace`
+  must be **SYS.AS**.
+
+  -> To enable the autoscaling alarm rules take effect, you must bind scaling policies.
+
+The `ok_actions` block supports:
+
+* `type` - (Required, String) Specifies the type of action triggered by the clearing of an alarm.
+  The value can be:
+  + **notification**: indicates that a notification will be sent to the user.
+  + **autoscaling**: indicates that a scaling action will be triggered.
+
+* `notification_list` - (Required, List) Specifies the list of objects to be notified if the alarm status changes.
+  The maximum length is `5`.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.
+
+* `alarm_id` - The alarm rule ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `update` - Default is 10 minutes.
+* `delete` - Default is 5 minutes.
+
+## Import
+
+CES alarm rules v2 can be imported using the `id`, e.g.
+
+```bash
+$ terraform import opentelekomcloud_ces_alarmrule_v2.alarm_rule al1619578509719Ga0X1RGWv
+```

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20260112114808-d96673e357fc
+	github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20260119085658-5c3e7aa2cc3c
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.45.0
 	golang.org/x/sync v0.18.0

--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20260112114808-d96673e357fc h1:IS842Al1AnVojNsEtLcidbUE+vYNmA2DZFkmUHIohfA=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20260112114808-d96673e357fc/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20260119085658-5c3e7aa2cc3c h1:FbAN2bAj18oD31ObxmEwgVePOd8N2hEKrOrqj3xeXGM=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20260119085658-5c3e7aa2cc3c/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/opentelekomcloud/acceptance/ces/resource_opentelekomcloud_ces_alarmrule_v2_test.go
+++ b/opentelekomcloud/acceptance/ces/resource_opentelekomcloud_ces_alarmrule_v2_test.go
@@ -1,0 +1,1011 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/ces/v2/alarms"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
+	ecs "github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/ecs"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+)
+
+const resourceAlarmRuleV2Name = "opentelekomcloud_ces_alarmrule_v2.alarmrule_1"
+
+func getAlarmRuleV2Func(conf *cfg.Config, state *terraform.ResourceState) (interface{}, error) {
+	c, err := conf.CesV2Client(env.OS_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating OpenTelekomCloud CES v2 client: %s", err)
+	}
+	listResp, err := alarms.List(c, alarms.ListOpts{
+		AlarmId: state.Primary.ID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if listResp == nil || len(listResp.Alarms) == 0 {
+		return nil, golangsdk.ErrDefault404{}
+	}
+	return listResp.Alarms[0], nil
+}
+
+func TestCESAlarmRuleV2_basic(t *testing.T) {
+	var (
+		ar    alarms.Alarm
+		rName = resourceAlarmRuleV2Name
+	)
+
+	rc := common.InitResourceCheck(
+		rName,
+		&ar,
+		getAlarmRuleV2Func,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+			qts := ecs.QuotasForFlavor(env.OsFlavorID)
+			qts = append(qts,
+				&quotas.ExpectedQuota{Q: quotas.Server, Count: 1},
+				&quotas.ExpectedQuota{Q: quotas.Volume, Count: 1},
+				&quotas.ExpectedQuota{Q: quotas.VolumeSize, Count: 4},
+			)
+			quotas.BookMany(t, qts)
+		},
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testCESAlarmRuleV2Basic,
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", "alarm_rule_v2_1"),
+					resource.TestCheckResourceAttr(rName, "namespace", "SYS.ECS"),
+					resource.TestCheckResourceAttr(rName, "type", "MULTI_INSTANCE"),
+					resource.TestCheckResourceAttr(rName, "alarm_enabled", "true"),
+					resource.TestCheckResourceAttr(rName, "notification_enabled", "false"),
+				),
+			},
+			{
+				Config: testCESAlarmRuleV2Update,
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", "alarm_rule_v2_1"),
+					resource.TestCheckResourceAttr(rName, "alarm_enabled", "false"),
+				),
+			},
+			{
+				ResourceName:      resourceAlarmRuleV2Name,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestCESAlarmRuleV2_withNotification(t *testing.T) {
+	var (
+		ar    alarms.Alarm
+		rName = resourceAlarmRuleV2Name
+	)
+
+	rc := common.InitResourceCheck(
+		rName,
+		&ar,
+		getAlarmRuleV2Func,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+			qts := ecs.QuotasForFlavor(env.OsFlavorID)
+			qts = append(qts,
+				&quotas.ExpectedQuota{Q: quotas.Server, Count: 1},
+				&quotas.ExpectedQuota{Q: quotas.Volume, Count: 1},
+				&quotas.ExpectedQuota{Q: quotas.VolumeSize, Count: 4},
+			)
+			quotas.BookMany(t, qts)
+		},
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testCESAlarmRuleV2WithNotification,
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", "alarm_rule_v2_1"),
+					resource.TestCheckResourceAttr(rName, "notification_enabled", "true"),
+					resource.TestCheckResourceAttr(rName, "alarm_actions.#", "1"),
+					resource.TestCheckResourceAttr(rName, "alarm_actions.0.type", "notification"),
+				),
+			},
+		},
+	})
+}
+
+var testCESAlarmRuleV2Basic = fmt.Sprintf(`
+%s
+
+resource "opentelekomcloud_compute_instance_v2" "vm_1" {
+  name        = "instance_1"
+  image_name  = "Standard_Debian_11_latest"
+  flavor_name = "s3.large.2"
+
+  network {
+    uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  }
+}
+
+resource "opentelekomcloud_ces_alarmrule_v2" "alarmrule_1" {
+  name      = "alarm_rule_v2_1"
+  namespace = "SYS.ECS"
+  type      = "MULTI_INSTANCE"
+
+  policies {
+    metric_name         = "network_outgoing_bytes_rate_inband"
+    period              = 300
+    filter              = "average"
+    comparison_operator = ">"
+    value               = 6
+    unit                = "B/s"
+    count               = 1
+    level               = 2
+  }
+
+  resources {
+    dimensions {
+      name  = "instance_id"
+      value = opentelekomcloud_compute_instance_v2.vm_1.id
+    }
+  }
+
+  notification_enabled = false
+  alarm_enabled        = true
+}
+`, common.DataSourceSubnet)
+
+var testCESAlarmRuleV2Update = fmt.Sprintf(`
+%s
+
+resource "opentelekomcloud_compute_instance_v2" "vm_1" {
+  name        = "instance_1"
+  image_name  = "Standard_Debian_11_latest"
+  flavor_name = "s3.large.2"
+
+  network {
+    uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  }
+}
+
+resource "opentelekomcloud_ces_alarmrule_v2" "alarmrule_1" {
+  name      = "alarm_rule_v2_1"
+  namespace = "SYS.ECS"
+  type      = "MULTI_INSTANCE"
+
+  policies {
+    metric_name         = "network_outgoing_bytes_rate_inband"
+    period              = 300
+    filter              = "average"
+    comparison_operator = ">"
+    value               = 10
+    unit                = "B/s"
+    count               = 1
+    level               = 2
+  }
+
+  resources {
+    dimensions {
+      name  = "instance_id"
+      value = opentelekomcloud_compute_instance_v2.vm_1.id
+    }
+  }
+
+  notification_enabled = false
+  alarm_enabled        = false
+}
+`, common.DataSourceSubnet)
+
+var testCESAlarmRuleV2WithNotification = fmt.Sprintf(`
+%s
+
+resource "opentelekomcloud_compute_instance_v2" "vm_1" {
+  name        = "instance_1"
+  image_name  = "Standard_Debian_11_latest"
+  flavor_name = "s3.large.2"
+
+  network {
+    uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  }
+}
+
+resource "opentelekomcloud_smn_topic_v2" "topic_1" {
+  name         = "topic_1"
+  display_name = "The display name of topic_1"
+}
+
+resource "opentelekomcloud_ces_alarmrule_v2" "alarmrule_1" {
+  name      = "alarm_rule_v2_1"
+  namespace = "SYS.ECS"
+  type      = "MULTI_INSTANCE"
+
+  policies {
+    metric_name         = "network_outgoing_bytes_rate_inband"
+    period              = 300
+    filter              = "average"
+    comparison_operator = ">"
+    value               = 6
+    unit                = "B/s"
+    count               = 1
+    level               = 2
+  }
+
+  resources {
+    dimensions {
+      name  = "instance_id"
+      value = opentelekomcloud_compute_instance_v2.vm_1.id
+    }
+  }
+
+  notification_enabled = true
+  alarm_enabled        = true
+
+  alarm_actions {
+    type = "notification"
+    notification_list = [
+      opentelekomcloud_smn_topic_v2.topic_1.topic_urn
+    ]
+  }
+}
+`, common.DataSourceSubnet)
+
+func TestCESAlarmRuleV2_multiplePolicies(t *testing.T) {
+	var (
+		ar    alarms.Alarm
+		rName = "opentelekomcloud_ces_alarmrule_v2.test"
+		name  = fmt.Sprintf("ces-rule-%s", acctest.RandString(5))
+	)
+
+	rc := common.InitResourceCheck(
+		rName,
+		&ar,
+		getAlarmRuleV2Func,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+			qts := ecs.QuotasForFlavor(env.OsFlavorID)
+			qts = append(qts,
+				&quotas.ExpectedQuota{Q: quotas.Server, Count: 1},
+				&quotas.ExpectedQuota{Q: quotas.Volume, Count: 1},
+				&quotas.ExpectedQuota{Q: quotas.VolumeSize, Count: 4},
+			)
+			quotas.BookMany(t, qts)
+		},
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testCESAlarmRuleV2MultiplePolicies(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "namespace", "SYS.ECS"),
+					resource.TestCheckResourceAttr(rName, "type", "MULTI_INSTANCE"),
+					resource.TestCheckResourceAttr(rName, "alarm_enabled", "true"),
+					resource.TestCheckResourceAttr(rName, "notification_enabled", "true"),
+					resource.TestCheckResourceAttr(rName, "policies.#", "2"),
+				),
+			},
+			{
+				Config: testCESAlarmRuleV2MultiplePoliciesUpdate(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "alarm_enabled", "false"),
+					resource.TestCheckResourceAttr(rName, "policies.#", "2"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testCESAlarmRuleV2MultiplePolicies(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "opentelekomcloud_compute_instance_v2" "test" {
+  name        = "ecs-%[2]s"
+  image_name  = "Standard_Debian_11_latest"
+  flavor_name = "s3.large.2"
+
+  network {
+    uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  }
+}
+
+resource "opentelekomcloud_smn_topic_v2" "test" {
+  name         = "smn-%[2]s"
+  display_name = "The display name of smn topic"
+}
+
+resource "opentelekomcloud_ces_alarmrule_v2" "test" {
+  name      = "%[2]s"
+  namespace = "SYS.ECS"
+  type      = "MULTI_INSTANCE"
+
+  resources {
+    dimensions {
+      name  = "instance_id"
+      value = opentelekomcloud_compute_instance_v2.test.id
+    }
+  }
+
+  policies {
+    metric_name         = "network_incoming_bytes_rate_inband"
+    period              = 300
+    filter              = "average"
+    comparison_operator = ">"
+    value               = 6.5
+    unit                = "B/s"
+    count               = 1
+    suppress_duration   = 300
+    level               = 3
+  }
+
+  policies {
+    metric_name         = "network_outgoing_bytes_rate_inband"
+    period              = 300
+    filter              = "average"
+    comparison_operator = ">"
+    value               = 6.5
+    unit                = "B/s"
+    count               = 1
+    suppress_duration   = 300
+    level               = 3
+  }
+
+  notification_enabled = true
+  alarm_enabled        = true
+
+  alarm_actions {
+    type = "notification"
+    notification_list = [
+      opentelekomcloud_smn_topic_v2.test.topic_urn
+    ]
+  }
+}
+`, common.DataSourceSubnet, name)
+}
+
+func testCESAlarmRuleV2MultiplePoliciesUpdate(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "opentelekomcloud_compute_instance_v2" "test" {
+  name        = "ecs-%[2]s"
+  image_name  = "Standard_Debian_11_latest"
+  flavor_name = "s3.large.2"
+
+  network {
+    uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  }
+}
+
+resource "opentelekomcloud_smn_topic_v2" "test" {
+  name         = "smn-%[2]s"
+  display_name = "The display name of smn topic"
+}
+
+resource "opentelekomcloud_ces_alarmrule_v2" "test" {
+  name      = "%[2]s"
+  namespace = "SYS.ECS"
+  type      = "MULTI_INSTANCE"
+
+  resources {
+    dimensions {
+      name  = "instance_id"
+      value = opentelekomcloud_compute_instance_v2.test.id
+    }
+  }
+
+  policies {
+    metric_name         = "network_outgoing_bytes_rate_inband"
+    period              = 1200
+    filter              = "average"
+    comparison_operator = ">"
+    value               = 6.5
+    unit                = "B/s"
+    count               = 1
+    suppress_duration   = 300
+    level               = 4
+  }
+
+  policies {
+    metric_name         = "network_outgoing_bytes_rate_inband"
+    period              = 3600
+    filter              = "average"
+    comparison_operator = ">="
+    value               = 20
+    unit                = "B/s"
+    count               = 1
+    suppress_duration   = 300
+    level               = 4
+  }
+
+  notification_enabled = true
+  alarm_enabled        = false
+
+  alarm_actions {
+    type = "notification"
+    notification_list = [
+      opentelekomcloud_smn_topic_v2.test.topic_urn
+    ]
+  }
+}
+`, common.DataSourceSubnet, name)
+}
+
+func TestCESAlarmRuleV2_multipleResources(t *testing.T) {
+	var (
+		ar    alarms.Alarm
+		rName = "opentelekomcloud_ces_alarmrule_v2.test"
+		name  = fmt.Sprintf("ces-rule-%s", acctest.RandString(5))
+	)
+
+	rc := common.InitResourceCheck(
+		rName,
+		&ar,
+		getAlarmRuleV2Func,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+			qts := ecs.QuotasForFlavor(env.OsFlavorID)
+			qts = append(qts,
+				&quotas.ExpectedQuota{Q: quotas.Server, Count: 2},
+				&quotas.ExpectedQuota{Q: quotas.Volume, Count: 2},
+				&quotas.ExpectedQuota{Q: quotas.VolumeSize, Count: 8},
+			)
+			quotas.BookMany(t, qts)
+		},
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testCESAlarmRuleV2MultipleResources(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "resources.#", "1"),
+				),
+			},
+			{
+				Config: testCESAlarmRuleV2MultipleResourcesUpdate(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "resources.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testCESAlarmRuleV2MultipleResources(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "opentelekomcloud_compute_instance_v2" "test" {
+  count       = 2
+  name        = "ecs-%[2]s-${count.index}"
+  image_name  = "Standard_Debian_11_latest"
+  flavor_name = "s3.large.2"
+
+  network {
+    uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  }
+}
+
+resource "opentelekomcloud_smn_topic_v2" "test" {
+  name         = "smn-%[2]s"
+  display_name = "The display name of smn topic"
+}
+
+resource "opentelekomcloud_ces_alarmrule_v2" "test" {
+  name      = "%[2]s"
+  namespace = "SYS.ECS"
+  type      = "MULTI_INSTANCE"
+
+  resources {
+    dimensions {
+      name  = "instance_id"
+      value = opentelekomcloud_compute_instance_v2.test[0].id
+    }
+  }
+
+  policies {
+    metric_name         = "network_outgoing_bytes_rate_inband"
+    period              = 300
+    filter              = "average"
+    comparison_operator = ">"
+    value               = 6.5
+    unit                = "B/s"
+    count               = 1
+    level               = 2
+  }
+
+  notification_enabled = true
+  alarm_enabled        = true
+
+  alarm_actions {
+    type = "notification"
+    notification_list = [
+      opentelekomcloud_smn_topic_v2.test.topic_urn
+    ]
+  }
+}
+`, common.DataSourceSubnet, name)
+}
+
+func testCESAlarmRuleV2MultipleResourcesUpdate(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "opentelekomcloud_compute_instance_v2" "test" {
+  count       = 2
+  name        = "ecs-%[2]s-${count.index}"
+  image_name  = "Standard_Debian_11_latest"
+  flavor_name = "s3.large.2"
+
+  network {
+    uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  }
+}
+
+resource "opentelekomcloud_smn_topic_v2" "test" {
+  name         = "smn-%[2]s"
+  display_name = "The display name of smn topic"
+}
+
+resource "opentelekomcloud_ces_alarmrule_v2" "test" {
+  name      = "%[2]s"
+  namespace = "SYS.ECS"
+  type      = "MULTI_INSTANCE"
+
+  resources {
+    dimensions {
+      name  = "instance_id"
+      value = opentelekomcloud_compute_instance_v2.test[0].id
+    }
+  }
+
+  resources {
+    dimensions {
+      name  = "instance_id"
+      value = opentelekomcloud_compute_instance_v2.test[1].id
+    }
+  }
+
+  policies {
+    metric_name         = "network_outgoing_bytes_rate_inband"
+    period              = 300
+    filter              = "average"
+    comparison_operator = ">"
+    value               = 6.5
+    unit                = "B/s"
+    count               = 1
+    level               = 2
+  }
+
+  notification_enabled = true
+  alarm_enabled        = true
+
+  alarm_actions {
+    type = "notification"
+    notification_list = [
+      opentelekomcloud_smn_topic_v2.test.topic_urn
+    ]
+  }
+}
+`, common.DataSourceSubnet, name)
+}
+
+func TestCESAlarmRuleV2_sysEvent(t *testing.T) {
+	var (
+		ar    alarms.Alarm
+		rName = "opentelekomcloud_ces_alarmrule_v2.test"
+		name  = fmt.Sprintf("ces-rule-%s", acctest.RandString(5))
+	)
+
+	rc := common.InitResourceCheck(
+		rName,
+		&ar,
+		getAlarmRuleV2Func,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testCESAlarmRuleV2SysEvent(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "namespace", "SYS.ECS"),
+					resource.TestCheckResourceAttr(rName, "type", "EVENT.SYS"),
+					resource.TestCheckResourceAttr(rName, "alarm_enabled", "true"),
+					resource.TestCheckResourceAttr(rName, "notification_enabled", "false"),
+				),
+			},
+			{
+				Config: testCESAlarmRuleV2SysEventUpdate(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "alarm_enabled", "false"),
+					resource.TestCheckResourceAttr(rName, "policies.#", "1"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testCESAlarmRuleV2SysEvent(name string) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_ces_alarmrule_v2" "test" {
+  name      = "%[1]s"
+  namespace = "SYS.ECS"
+  type      = "EVENT.SYS"
+
+  resources {
+    dimensions {
+      name  = "resource_id"
+      value = "all_instance"
+    }
+  }
+
+  policies {
+    metric_name         = "stopServer"
+    period              = 0
+    filter              = "average"
+    comparison_operator = ">="
+    value               = 1
+    unit                = "count"
+    count               = 1
+    suppress_duration   = 0
+    level               = 2
+  }
+
+  notification_enabled = false
+  alarm_enabled        = true
+}
+`, name)
+}
+
+func testCESAlarmRuleV2SysEventUpdate(name string) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_ces_alarmrule_v2" "test" {
+  name      = "%[1]s"
+  namespace = "SYS.ECS"
+  type      = "EVENT.SYS"
+
+  resources {
+    dimensions {
+      name  = "resource_id"
+      value = "all_instance"
+    }
+  }
+
+  policies {
+    metric_name         = "stopServer"
+    period              = 0
+    filter              = "average"
+    comparison_operator = ">="
+    value               = 2
+    unit                = "count"
+    count               = 2
+    suppress_duration   = 300
+    level               = 3
+  }
+
+  notification_enabled = false
+  alarm_enabled        = false
+}
+`, name)
+}
+
+func TestCESAlarmRuleV2_sysEventWithNotification(t *testing.T) {
+	var (
+		ar    alarms.Alarm
+		rName = "opentelekomcloud_ces_alarmrule_v2.test"
+		name  = fmt.Sprintf("ces-rule-%s", acctest.RandString(5))
+	)
+
+	rc := common.InitResourceCheck(
+		rName,
+		&ar,
+		getAlarmRuleV2Func,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testCESAlarmRuleV2SysEventWithNotification(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "namespace", "SYS.ECS"),
+					resource.TestCheckResourceAttr(rName, "type", "EVENT.SYS"),
+					resource.TestCheckResourceAttr(rName, "alarm_enabled", "true"),
+					resource.TestCheckResourceAttr(rName, "notification_enabled", "true"),
+					resource.TestCheckResourceAttr(rName, "alarm_actions.#", "1"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testCESAlarmRuleV2SysEventWithNotification(name string) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_smn_topic_v2" "test" {
+  name         = "smn-%[1]s"
+  display_name = "The display name of smn topic"
+}
+
+resource "opentelekomcloud_ces_alarmrule_v2" "test" {
+  name      = "%[1]s"
+  namespace = "SYS.ECS"
+  type      = "EVENT.SYS"
+
+  resources {
+    dimensions {
+      name  = "resource_id"
+      value = "all_instance"
+    }
+  }
+
+  policies {
+    metric_name         = "stopServer"
+    period              = 0
+    filter              = "average"
+    comparison_operator = ">="
+    value               = 1
+    unit                = "count"
+    count               = 1
+    suppress_duration   = 0
+    level               = 2
+  }
+
+  notification_enabled = true
+  alarm_enabled        = true
+
+  alarm_actions {
+    type = "notification"
+    notification_list = [
+      opentelekomcloud_smn_topic_v2.test.topic_urn
+    ]
+  }
+}
+`, name)
+}
+
+func TestCESAlarmRuleV2_allInstance(t *testing.T) {
+	var (
+		ar    alarms.Alarm
+		rName = "opentelekomcloud_ces_alarmrule_v2.test"
+		name  = fmt.Sprintf("ces-rule-%s", acctest.RandString(5))
+	)
+
+	rc := common.InitResourceCheck(
+		rName,
+		&ar,
+		getAlarmRuleV2Func,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testCESAlarmRuleV2AllInstance(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "type", "ALL_INSTANCE"),
+					resource.TestCheckResourceAttr(rName, "alarm_enabled", "true"),
+					resource.TestCheckResourceAttr(rName, "notification_enabled", "true"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testCESAlarmRuleV2AllInstance(name string) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_smn_topic_v2" "test" {
+  name         = "smn-%[1]s"
+  display_name = "The display name of smn topic"
+}
+
+resource "opentelekomcloud_ces_alarmrule_v2" "test" {
+  name      = "%[1]s"
+  namespace = "AGT.ECS"
+  type      = "ALL_INSTANCE"
+
+  resources {
+    dimensions {
+      name = "instance_id"
+    }
+
+    dimensions {
+      name = "mount_point"
+    }
+  }
+
+  policies {
+    metric_name         = "disk_usedPercent"
+    period              = 1
+    filter              = "average"
+    comparison_operator = ">"
+    value               = 80
+    count               = 1
+    suppress_duration   = 0
+    level               = 2
+  }
+
+  notification_enabled = true
+  alarm_enabled        = true
+
+  alarm_actions {
+    type = "notification"
+    notification_list = [
+      opentelekomcloud_smn_topic_v2.test.topic_urn
+    ]
+  }
+}
+`, name)
+}
+
+func TestCESAlarmRuleV2_withOkActions(t *testing.T) {
+	var (
+		ar    alarms.Alarm
+		rName = "opentelekomcloud_ces_alarmrule_v2.test"
+		name  = fmt.Sprintf("ces-rule-%s", acctest.RandString(5))
+	)
+
+	rc := common.InitResourceCheck(
+		rName,
+		&ar,
+		getAlarmRuleV2Func,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+			qts := ecs.QuotasForFlavor(env.OsFlavorID)
+			qts = append(qts,
+				&quotas.ExpectedQuota{Q: quotas.Server, Count: 1},
+				&quotas.ExpectedQuota{Q: quotas.Volume, Count: 1},
+				&quotas.ExpectedQuota{Q: quotas.VolumeSize, Count: 4},
+			)
+			quotas.BookMany(t, qts)
+		},
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testCESAlarmRuleV2WithOkActions(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "notification_enabled", "true"),
+					resource.TestCheckResourceAttr(rName, "alarm_actions.#", "1"),
+					resource.TestCheckResourceAttr(rName, "alarm_actions.0.type", "notification"),
+					resource.TestCheckResourceAttr(rName, "ok_actions.#", "1"),
+					resource.TestCheckResourceAttr(rName, "ok_actions.0.type", "notification"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testCESAlarmRuleV2WithOkActions(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "opentelekomcloud_compute_instance_v2" "test" {
+  name        = "ecs-%[2]s"
+  image_name  = "Standard_Debian_11_latest"
+  flavor_name = "s3.large.2"
+
+  network {
+    uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  }
+}
+
+resource "opentelekomcloud_smn_topic_v2" "test" {
+  name         = "smn-%[2]s"
+  display_name = "The display name of smn topic"
+}
+
+resource "opentelekomcloud_ces_alarmrule_v2" "test" {
+  name      = "%[2]s"
+  namespace = "SYS.ECS"
+  type      = "MULTI_INSTANCE"
+
+  resources {
+    dimensions {
+      name  = "instance_id"
+      value = opentelekomcloud_compute_instance_v2.test.id
+    }
+  }
+
+  policies {
+    metric_name         = "network_outgoing_bytes_rate_inband"
+    period              = 300
+    filter              = "average"
+    comparison_operator = ">"
+    value               = 6.5
+    unit                = "B/s"
+    count               = 1
+    level               = 2
+  }
+
+  notification_enabled = true
+  alarm_enabled        = true
+
+  alarm_actions {
+    type = "notification"
+    notification_list = [
+      opentelekomcloud_smn_topic_v2.test.topic_urn
+    ]
+  }
+
+  ok_actions {
+    type = "notification"
+    notification_list = [
+      opentelekomcloud_smn_topic_v2.test.topic_urn
+    ]
+  }
+}
+`, common.DataSourceSubnet, name)
+}

--- a/opentelekomcloud/common/cfg/config.go
+++ b/opentelekomcloud/common/cfg/config.go
@@ -852,6 +852,13 @@ func (c *Config) CesV1Client(region string) (*golangsdk.ServiceClient, error) {
 	})
 }
 
+func (c *Config) CesV2Client(region string) (*golangsdk.ServiceClient, error) {
+	return openstack.NewCESV2(c.HwClient, golangsdk.EndpointOpts{
+		Region:       region,
+		Availability: c.getEndpointType(),
+	})
+}
+
 func (c *Config) getEndpointType() golangsdk.Availability {
 	if c.EndpointType == "internal" || c.EndpointType == "internalURL" {
 		return golangsdk.AvailabilityInternal

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -483,6 +483,7 @@ func Provider() *schema.Provider {
 			"opentelekomcloud_cce_node_pool_v3":                          cce.ResourceCCENodePoolV3(),
 			"opentelekomcloud_cci_namespace_v2":                          cci.ResourceCCINamespaceV2(),
 			"opentelekomcloud_ces_alarmrule":                             ces.ResourceAlarmRule(),
+			"opentelekomcloud_ces_alarmrule_v2":                          ces.ResourceAlarmRuleV2(),
 			"opentelekomcloud_ces_event_report_v1":                       ces.ResourceCesEventReportV1(),
 			"opentelekomcloud_ces_metric_data_v1":                        ces.ResourceCesMetricDataV1(),
 			"opentelekomcloud_cfw_acl_rule_v1":                           cfw.ResourceCfwAclRuleV1(),

--- a/opentelekomcloud/services/ces/common.go
+++ b/opentelekomcloud/services/ces/common.go
@@ -3,8 +3,10 @@ package ces
 import "github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
 
 const (
-	errCreationClient = "error creating CESv1 client: %w"
-	cesClientV1       = "ces-v1-client"
+	errCreationClient   = "error creating CESv1 client: %w"
+	errCreationClientV2 = "error creating CESv2 client: %w"
+	cesClientV1         = "ces-v1-client"
+	cesClientV2         = "ces-v2-client"
 )
 
 func InterfaceToInt64(i interface{}) int64 {

--- a/opentelekomcloud/services/ces/resource_opentelekomcloud_ces_alarmrule_v2.go
+++ b/opentelekomcloud/services/ces/resource_opentelekomcloud_ces_alarmrule_v2.go
@@ -1,0 +1,694 @@
+package ces
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log"
+	"regexp"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/ces/v2/alarms"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/ces/v2/policies"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/ces/v2/resources"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/helper/hashcode"
+)
+
+func ResourceAlarmRuleV2() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAlarmRuleV2Create,
+		ReadContext:   resourceAlarmRuleV2Read,
+		UpdateContext: resourceAlarmRuleV2Update,
+		DeleteContext: resourceAlarmRuleV2Delete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(1, 128),
+					validation.StringMatch(
+						regexp.MustCompile(`^[\w-]+$`),
+						"Only letters, digits, underscores (_), and hyphens (-) are allowed.",
+					),
+				),
+			},
+			"description": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(0, 256),
+			},
+			"namespace": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"resource_group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"alarm_template_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"policies": {
+				Type:     schema.TypeSet,
+				Required: true,
+				Set:      resourcePolicyHash,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"metric_name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"period": {
+							Type:     schema.TypeInt,
+							Required: true,
+							ValidateFunc: validation.IntInSlice([]int{
+								0, 1, 300, 1200, 3600, 14400, 86400,
+							}),
+						},
+						"filter": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"max", "min", "average", "sum", "variance",
+							}, false),
+						},
+						"comparison_operator": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								">", "=", "<", ">=", "<=", "!=",
+							}, false),
+						},
+						"value": {
+							Type:     schema.TypeFloat,
+							Optional: true,
+						},
+						"unit": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringLenBetween(0, 32),
+						},
+						"count": {
+							Type:         schema.TypeInt,
+							Required:     true,
+							ValidateFunc: validation.IntBetween(1, 5),
+						},
+						"suppress_duration": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							ValidateFunc: validation.IntInSlice([]int{
+								0, 300, 600, 900, 1800, 3600, 10800, 21600, 43200, 86400,
+							}),
+						},
+						"level": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      2,
+							ValidateFunc: validation.IntBetween(1, 4),
+						},
+					},
+				},
+			},
+			"resources": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"dimensions": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"value": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "MULTI_INSTANCE",
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"ALL_INSTANCE", "MULTI_INSTANCE", "RESOURCE_GROUP", "EVENT.SYS", "EVENT.CUSTOM",
+				}, false),
+			},
+			"alarm_actions": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				MaxItems: 5,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"notification", "autoscaling",
+							}, false),
+						},
+						"notification_list": {
+							Type:     schema.TypeList,
+							Required: true,
+							MaxItems: 5,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+			"ok_actions": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				MaxItems: 5,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"notification", "autoscaling",
+							}, false),
+						},
+						"notification_list": {
+							Type:     schema.TypeList,
+							Required: true,
+							MaxItems: 5,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+			"notification_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+				Default:  false,
+			},
+			"alarm_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"notification_begin_time": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"notification_end_time": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"alarm_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourcePolicyHash(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+
+	if m["metric_name"] != nil {
+		buf.WriteString(fmt.Sprintf("%s-", m["metric_name"].(string)))
+	}
+	if m["period"] != nil {
+		buf.WriteString(fmt.Sprintf("%d-", m["period"].(int)))
+	}
+	if m["filter"] != nil {
+		buf.WriteString(fmt.Sprintf("%s-", m["filter"].(string)))
+	}
+	if m["comparison_operator"] != nil {
+		buf.WriteString(fmt.Sprintf("%s-", m["comparison_operator"].(string)))
+	}
+	if m["value"] != nil {
+		buf.WriteString(fmt.Sprintf("%f-", m["value"].(float64)))
+	}
+	if m["count"] != nil {
+		buf.WriteString(fmt.Sprintf("%d-", m["count"].(int)))
+	}
+	if m["unit"] != nil {
+		buf.WriteString(fmt.Sprintf("%s-", m["unit"].(string)))
+	}
+	if m["suppress_duration"] != nil {
+		buf.WriteString(fmt.Sprintf("%d-", m["suppress_duration"].(int)))
+	}
+	if m["level"] != nil {
+		buf.WriteString(fmt.Sprintf("%d-", m["level"].(int)))
+	}
+
+	return hashcode.String(buf.String())
+}
+
+func buildPoliciesOptsV2(d *schema.ResourceData) []alarms.Policy {
+	rawPolicies := d.Get("policies").(*schema.Set).List()
+	if len(rawPolicies) == 0 {
+		return nil
+	}
+
+	policiesOpts := make([]alarms.Policy, len(rawPolicies))
+	for i, v := range rawPolicies {
+		policy := v.(map[string]interface{})
+		policiesOpts[i] = alarms.Policy{
+			MetricName:         policy["metric_name"].(string),
+			Period:             policy["period"].(int),
+			Filter:             policy["filter"].(string),
+			ComparisonOperator: policy["comparison_operator"].(string),
+			Value:              policy["value"].(float64),
+			Unit:               policy["unit"].(string),
+			Count:              policy["count"].(int),
+			SuppressDuration:   policy["suppress_duration"].(int),
+			Level:              policy["level"].(int),
+		}
+	}
+	return policiesOpts
+}
+
+func buildResourcesOptsV2(d *schema.ResourceData) [][]alarms.Dimension {
+	rawResources := d.Get("resources").(*schema.Set).List()
+	if len(rawResources) == 0 {
+		return nil
+	}
+
+	resourcesOpts := make([][]alarms.Dimension, len(rawResources))
+	for i, v := range rawResources {
+		resource := v.(map[string]interface{})
+		dimensionsRaw := resource["dimensions"].([]interface{})
+		dimensions := make([]alarms.Dimension, len(dimensionsRaw))
+		for j, dim := range dimensionsRaw {
+			dimension := dim.(map[string]interface{})
+			dimensions[j] = alarms.Dimension{
+				Name:  dimension["name"].(string),
+				Value: dimension["value"].(string),
+			}
+		}
+		resourcesOpts[i] = dimensions
+	}
+	return resourcesOpts
+}
+
+func buildNotificationsOpts(d *schema.ResourceData, key string) []alarms.Notification {
+	rawNotifications := d.Get(key).([]interface{})
+	if len(rawNotifications) == 0 {
+		return nil
+	}
+
+	notifications := make([]alarms.Notification, len(rawNotifications))
+	for i, v := range rawNotifications {
+		notification := v.(map[string]interface{})
+		notifyListRaw := notification["notification_list"].([]interface{})
+		notifyList := make([]string, len(notifyListRaw))
+		for j, n := range notifyListRaw {
+			notifyList[j] = n.(string)
+		}
+		notifications[i] = alarms.Notification{
+			Type:             notification["type"].(string),
+			NotificationList: notifyList,
+		}
+	}
+	return notifications
+}
+
+func resourceAlarmRuleV2Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, cesClientV2, func() (*golangsdk.ServiceClient, error) {
+		return config.CesV2Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationClientV2, err)
+	}
+
+	alarmEnabled := d.Get("alarm_enabled").(bool)
+	notificationEnabled := d.Get("notification_enabled").(bool)
+
+	createOpts := alarms.CreateOpts{
+		Name:                  d.Get("name").(string),
+		Description:           d.Get("description").(string),
+		Namespace:             d.Get("namespace").(string),
+		ResourceGroupId:       d.Get("resource_group_id").(string),
+		AlarmTemplateId:       d.Get("alarm_template_id").(string),
+		Policies:              buildPoliciesOptsV2(d),
+		Resources:             buildResourcesOptsV2(d),
+		Type:                  d.Get("type").(string),
+		NotificationEnabled:   &notificationEnabled,
+		Enabled:               &alarmEnabled,
+		NotificationBeginTime: d.Get("notification_begin_time").(string),
+		NotificationEndTime:   d.Get("notification_end_time").(string),
+		EnterpriseProjectId:   d.Get("enterprise_project_id").(string),
+	}
+
+	if notificationEnabled {
+		createOpts.AlarmNotifications = buildNotificationsOpts(d, "alarm_actions")
+		createOpts.OkNotifications = buildNotificationsOpts(d, "ok_actions")
+	}
+
+	log.Printf("[DEBUG] CES Alarm Rule V2 Create Options: %#v", createOpts)
+
+	alarmId, err := alarms.Create(client, createOpts)
+	if err != nil {
+		return fmterr.Errorf("error creating CES Alarm Rule V2: %w", err)
+	}
+
+	log.Printf("[DEBUG] CES Alarm Rule V2 created with ID: %s", alarmId)
+	d.SetId(alarmId)
+
+	clientCtx := common.CtxWithClient(ctx, client, cesClientV2)
+	return resourceAlarmRuleV2Read(clientCtx, d, meta)
+}
+
+func resourceAlarmRuleV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, cesClientV2, func() (*golangsdk.ServiceClient, error) {
+		return config.CesV2Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationClientV2, err)
+	}
+
+	listOpts := alarms.ListOpts{
+		AlarmId: d.Id(),
+	}
+	listResp, err := alarms.List(client, listOpts)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "CES Alarm Rule V2")
+	}
+
+	if listResp == nil || len(listResp.Alarms) == 0 {
+		log.Printf("[WARN] CES Alarm Rule V2 (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	alarm := listResp.Alarms[0]
+
+	// Get policies
+	policiesResp, err := policies.List(client, d.Id(), policies.ListOpts{})
+	if err != nil {
+		return fmterr.Errorf("error retrieving CES Alarm Rule V2 policies: %w", err)
+	}
+
+	// Get resources
+	resourcesResp, err := resources.List(client, d.Id(), resources.ListOpts{})
+	if err != nil {
+		return fmterr.Errorf("error retrieving CES Alarm Rule V2 resources: %w", err)
+	}
+
+	// Extract resource_group_id from the first resource if available
+	var resourceGroupId string
+	if len(alarm.Resources) > 0 {
+		resourceGroupId = alarm.Resources[0].ResourceGroupId
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("name", alarm.Name),
+		d.Set("description", alarm.Description),
+		d.Set("namespace", alarm.Namespace),
+		d.Set("resource_group_id", resourceGroupId),
+		d.Set("type", alarm.Type),
+		d.Set("alarm_enabled", alarm.Enabled),
+		d.Set("notification_enabled", alarm.NotificationEnabled),
+		d.Set("notification_begin_time", alarm.NotificationBeginTime),
+		d.Set("notification_end_time", alarm.NotificationEndTime),
+		d.Set("alarm_id", alarm.AlarmId),
+		d.Set("alarm_template_id", alarm.AlarmTemplateId),
+		d.Set("enterprise_project_id", alarm.EnterpriseProjectId),
+		d.Set("policies", flattenPoliciesV2(policiesResp.Policies)),
+		d.Set("resources", flattenResourcesV2(resourcesResp.Resources)),
+		d.Set("alarm_actions", flattenNotifications(alarm.AlarmNotifications)),
+		d.Set("ok_actions", flattenNotifications(alarm.OkNotifications)),
+	)
+
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func flattenPoliciesV2(policiesResp []policies.PolicyResp) []map[string]interface{} {
+	if len(policiesResp) == 0 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, len(policiesResp))
+	for i, policy := range policiesResp {
+		result[i] = map[string]interface{}{
+			"metric_name":         policy.MetricName,
+			"period":              policy.Period,
+			"filter":              policy.Filter,
+			"comparison_operator": policy.ComparisonOperator,
+			"value":               policy.Value,
+			"unit":                policy.Unit,
+			"count":               policy.Count,
+			"suppress_duration":   policy.SuppressDuration,
+			"level":               policy.Level,
+		}
+	}
+	return result
+}
+
+func flattenResourcesV2(resourcesResp [][]resources.Dimension) []map[string]interface{} {
+	if len(resourcesResp) == 0 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, len(resourcesResp))
+	for i, dims := range resourcesResp {
+		dimensions := make([]map[string]interface{}, len(dims))
+		for j, dim := range dims {
+			dimensions[j] = map[string]interface{}{
+				"name":  dim.Name,
+				"value": dim.Value,
+			}
+		}
+		result[i] = map[string]interface{}{
+			"dimensions": dimensions,
+		}
+	}
+	return result
+}
+
+func flattenNotifications(notifications []alarms.Notification) []map[string]interface{} {
+	if len(notifications) == 0 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, len(notifications))
+	for i, notification := range notifications {
+		notifyList := make([]string, len(notification.NotificationList))
+		copy(notifyList, notification.NotificationList)
+		result[i] = map[string]interface{}{
+			"type":              notification.Type,
+			"notification_list": notifyList,
+		}
+	}
+	return result
+}
+
+func resourceAlarmRuleV2Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, cesClientV2, func() (*golangsdk.ServiceClient, error) {
+		return config.CesV2Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationClientV2, err)
+	}
+
+	alarmId := d.Id()
+
+	// Update policies if changed
+	if d.HasChange("policies") {
+		updatePolicies := buildUpdatePoliciesOpts(d)
+		_, err := policies.Update(client, alarmId, policies.UpdateOpts{
+			Policies: updatePolicies,
+		})
+		if err != nil {
+			return fmterr.Errorf("error updating CES Alarm Rule V2 policies: %w", err)
+		}
+	}
+
+	// Update resources if changed
+	if d.HasChange("resources") {
+		oldRaw, newRaw := d.GetChange("resources")
+		oldResources := oldRaw.(*schema.Set).List()
+		newResources := newRaw.(*schema.Set).List()
+
+		// Delete old resources
+		if len(oldResources) > 0 {
+			deleteOpts := buildResourcesDimensionDelete(oldResources)
+			if len(deleteOpts) > 0 {
+				err := resources.Delete(client, alarmId, resources.DeleteOpts{
+					Resources: deleteOpts,
+				})
+				if err != nil {
+					return fmterr.Errorf("error deleting old resources from CES Alarm Rule V2: %w", err)
+				}
+			}
+		}
+
+		// Add new resources
+		if len(newResources) > 0 {
+			addOpts := buildResourcesDimensionAdd(newResources)
+			if len(addOpts) > 0 {
+				err := resources.Add(client, alarmId, resources.AddOpts{
+					Resources: addOpts,
+				})
+				if err != nil {
+					return fmterr.Errorf("error adding new resources to CES Alarm Rule V2: %w", err)
+				}
+			}
+		}
+	}
+
+	// Update alarm enabled state if changed
+	if d.HasChange("alarm_enabled") {
+		enabled := d.Get("alarm_enabled").(bool)
+		_, err := alarms.Action(client, alarms.ActionOpts{
+			AlarmIds:     []string{alarmId},
+			AlarmEnabled: enabled,
+		})
+		if err != nil {
+			return fmterr.Errorf("error updating CES Alarm Rule V2 enabled state: %w", err)
+		}
+	}
+
+	clientCtx := common.CtxWithClient(ctx, client, cesClientV2)
+	return resourceAlarmRuleV2Read(clientCtx, d, meta)
+}
+
+func buildUpdatePoliciesOpts(d *schema.ResourceData) []policies.Policy {
+	rawPolicies := d.Get("policies").(*schema.Set).List()
+	if len(rawPolicies) == 0 {
+		return nil
+	}
+
+	policyOpts := make([]policies.Policy, len(rawPolicies))
+	for i, v := range rawPolicies {
+		policy := v.(map[string]interface{})
+		policyOpts[i] = policies.Policy{
+			MetricName:         policy["metric_name"].(string),
+			Period:             policy["period"].(int),
+			Filter:             policy["filter"].(string),
+			ComparisonOperator: policy["comparison_operator"].(string),
+			Value:              policy["value"].(float64),
+			Unit:               policy["unit"].(string),
+			Count:              policy["count"].(int),
+			SuppressDuration:   policy["suppress_duration"].(int),
+			Level:              policy["level"].(int),
+		}
+	}
+	return policyOpts
+}
+
+func buildResourcesDimensionDelete(resourcesList []interface{}) [][]resources.Dimension {
+	if len(resourcesList) == 0 {
+		return nil
+	}
+
+	result := make([][]resources.Dimension, len(resourcesList))
+	for i, v := range resourcesList {
+		resource := v.(map[string]interface{})
+		dimensionsRaw := resource["dimensions"].([]interface{})
+		dimensions := make([]resources.Dimension, len(dimensionsRaw))
+		for j, dim := range dimensionsRaw {
+			dimension := dim.(map[string]interface{})
+			dimensions[j] = resources.Dimension{
+				Name:  dimension["name"].(string),
+				Value: dimension["value"].(string),
+			}
+		}
+		result[i] = dimensions
+	}
+	return result
+}
+
+func buildResourcesDimensionAdd(resourcesList []interface{}) [][]resources.Dimension {
+	if len(resourcesList) == 0 {
+		return nil
+	}
+
+	result := make([][]resources.Dimension, len(resourcesList))
+	for i, v := range resourcesList {
+		resource := v.(map[string]interface{})
+		dimensionsRaw := resource["dimensions"].([]interface{})
+		dimensions := make([]resources.Dimension, len(dimensionsRaw))
+		for j, dim := range dimensionsRaw {
+			dimension := dim.(map[string]interface{})
+			dimensions[j] = resources.Dimension{
+				Name:  dimension["name"].(string),
+				Value: dimension["value"].(string),
+			}
+		}
+		result[i] = dimensions
+	}
+	return result
+}
+
+func resourceAlarmRuleV2Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, cesClientV2, func() (*golangsdk.ServiceClient, error) {
+		return config.CesV2Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationClientV2, err)
+	}
+
+	alarmId := d.Id()
+	log.Printf("[DEBUG] Deleting CES Alarm Rule V2: %s", alarmId)
+
+	_, err = alarms.Delete(client, alarms.DeleteOpts{
+		AlarmIds: []string{alarmId},
+	})
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error deleting CES Alarm Rule V2")
+	}
+
+	return nil
+}

--- a/releasenotes/notes/ces_v2_alarmrule-cfcacad82b62d57d.yaml
+++ b/releasenotes/notes/ces_v2_alarmrule-cfcacad82b62d57d.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   - |
-    **[CES]** New resource ``resource/opentelekomcloud_ces_alarmrule_v2`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[CES]** New resource ``resource/opentelekomcloud_ces_alarmrule_v2`` (`#3242 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3242>`_)

--- a/releasenotes/notes/ces_v2_alarmrule-cfcacad82b62d57d.yaml
+++ b/releasenotes/notes/ces_v2_alarmrule-cfcacad82b62d57d.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    **[CES]** New resource ``resource/opentelekomcloud_ces_alarmrule_v2`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)


### PR DESCRIPTION
## Summary of the Pull Request
New resource `opentelekomcloud_ces_alarmrule_v2`.

## PR Checklist

* [x] Refers to: #3231
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestCESAlarmRuleV2_basic
=== PAUSE TestCESAlarmRuleV2_basic
=== CONT  TestCESAlarmRuleV2_basic
--- PASS: TestCESAlarmRuleV2_basic (127.01s)
=== RUN   TestCESAlarmRuleV2_withNotification
=== PAUSE TestCESAlarmRuleV2_withNotification
=== CONT  TestCESAlarmRuleV2_withNotification
--- PASS: TestCESAlarmRuleV2_withNotification (89.62s)
=== RUN   TestCESAlarmRuleV2_multiplePolicies
=== PAUSE TestCESAlarmRuleV2_multiplePolicies
=== CONT  TestCESAlarmRuleV2_multiplePolicies
--- PASS: TestCESAlarmRuleV2_multiplePolicies (128.02s)
=== RUN   TestCESAlarmRuleV2_multipleResources
=== PAUSE TestCESAlarmRuleV2_multipleResources
=== CONT  TestCESAlarmRuleV2_multipleResources
--- PASS: TestCESAlarmRuleV2_multipleResources (120.35s)
=== RUN   TestCESAlarmRuleV2_sysEvent
=== PAUSE TestCESAlarmRuleV2_sysEvent
=== CONT  TestCESAlarmRuleV2_sysEvent
--- PASS: TestCESAlarmRuleV2_sysEvent (51.29s)
=== RUN   TestCESAlarmRuleV2_sysEventWithNotification
=== PAUSE TestCESAlarmRuleV2_sysEventWithNotification
=== CONT  TestCESAlarmRuleV2_sysEventWithNotification
--- PASS: TestCESAlarmRuleV2_sysEventWithNotification (36.30s)
=== RUN   TestCESAlarmRuleV2_allInstance
=== PAUSE TestCESAlarmRuleV2_allInstance
=== CONT  TestCESAlarmRuleV2_allInstance
--- PASS: TestCESAlarmRuleV2_allInstance (35.97s)
=== RUN   TestCESAlarmRuleV2_withOkActions
=== PAUSE TestCESAlarmRuleV2_withOkActions
=== CONT  TestCESAlarmRuleV2_withOkActions
--- PASS: TestCESAlarmRuleV2_withOkActions (95.75s)
PASS

Process finished with the exit code 0
```
