### PR TITLE
[Fix] CESv2: `alarm_policy_id` parameter fix

### DIFF
--- a/docs/resources/ces_alarm_rule_v2.md
+++ b/docs/resources/ces_alarm_rule_v2.md
@@ -230,6 +230,40 @@ resource "opentelekomcloud_ces_alarm_rule_v2" "test" {
 }
 ```
 
+### Alarm rule using alarm template
+
+```hcl
+variable "instance_id" {}
+variable "topic_urn" {}
+variable "alarm_template_id" {}
+
+resource "opentelekomcloud_ces_alarm_rule_v2" "test" {
+  name                 = "alarm-rule-with-template"
+  namespace            = "SYS.ECS"
+  type                 = "MULTI_INSTANCE"
+  alarm_template_id    = var.alarm_template_id
+  notification_enabled = true
+  alarm_enabled        = true
+
+  resources {
+    dimensions {
+      name  = "instance_id"
+      value = var.instance_id
+    }
+  }
+
+  alarm_actions {
+    type              = "notification"
+    notification_list = [var.topic_urn]
+  }
+
+  ok_actions {
+    type              = "notification"
+    notification_list = [var.topic_urn]
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -243,8 +277,9 @@ The following arguments are supported:
   Changing this creates a new resource.
   For details, see [Services Interconnected with Cloud Eye](https://docs.otc.t-systems.com/cloud-eye/api-ref/appendix/services_interconnected_with_cloud_eye.html).
 
-* `policies` - (Required, Set) Specifies the alarm policies. The [policies](#policies_struct) structure is
-  documented below.
+* `policies` - (Optional, Set) Specifies the alarm policies. The [policies](#policies_struct) structure is
+  documented below. Exactly one of `policies` or `alarm_template_id` must be specified.
+  When using `alarm_template_id`, the policies are inherited from the template and cannot be modified directly.
 
 * `description` - (Optional, String, ForceNew) The value can be a string of `0` to `256` characters.
   Changing this creates a new resource.
@@ -264,6 +299,8 @@ The following arguments are supported:
   Changing this creates a new resource.
 
 * `alarm_template_id` - (Optional, String, ForceNew) Specifies the ID of the alarm template.
+  When using an alarm template, the policies are inherited from the template.
+  Exactly one of `alarm_template_id` or `policies` must be specified.
   Changing this creates a new resource.
 
 * `alarm_actions` - (Optional, List, ForceNew) Specifies the action triggered by an alarm.

--- a/opentelekomcloud/acceptance/ces/resource_opentelekomcloud_ces_alarm_rule_v2_test.go
+++ b/opentelekomcloud/acceptance/ces/resource_opentelekomcloud_ces_alarm_rule_v2_test.go
@@ -1009,3 +1009,217 @@ resource "opentelekomcloud_ces_alarm_rule_v2" "test" {
 }
 `, common.DataSourceSubnet, name)
 }
+
+func TestCESAlarmRuleV2_withAlarmTemplate(t *testing.T) {
+	var (
+		ar    alarms.Alarm
+		rName = "opentelekomcloud_ces_alarm_rule_v2.test"
+		name  = fmt.Sprintf("ces-rule-%s", acctest.RandString(5))
+	)
+
+	rc := common.InitResourceCheck(
+		rName,
+		&ar,
+		getAlarmRuleV2Func,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+			qts := ecs.QuotasForFlavor(env.OsFlavorID)
+			qts = append(qts,
+				&quotas.ExpectedQuota{Q: quotas.Server, Count: 2},
+				&quotas.ExpectedQuota{Q: quotas.Volume, Count: 2},
+				&quotas.ExpectedQuota{Q: quotas.VolumeSize, Count: 8},
+			)
+			quotas.BookMany(t, qts)
+		},
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testCESAlarmRuleV2WithAlarmTemplate(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "namespace", "SYS.ECS"),
+					resource.TestCheckResourceAttr(rName, "type", "MULTI_INSTANCE"),
+					resource.TestCheckResourceAttr(rName, "alarm_enabled", "true"),
+					resource.TestCheckResourceAttr(rName, "notification_enabled", "true"),
+					resource.TestCheckResourceAttrPair(rName, "alarm_template_id",
+						"opentelekomcloud_ces_alarm_template_v2.test", "id"),
+					resource.TestCheckResourceAttr(rName, "policies.#", "1"),
+				),
+			},
+			{
+				Config: testCESAlarmRuleV2WithAlarmTemplateUpdate(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "alarm_enabled", "false"),
+					resource.TestCheckResourceAttrPair(rName, "alarm_template_id",
+						"opentelekomcloud_ces_alarm_template_v2.test", "id"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testCESAlarmRuleV2WithAlarmTemplate(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "opentelekomcloud_compute_instance_v2" "test" {
+  count       = 2
+  name        = "ecs-%[2]s-${count.index}"
+  image_name  = "Standard_Debian_11_latest"
+  flavor_name = "s3.large.2"
+
+  network {
+    uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  }
+}
+
+resource "opentelekomcloud_smn_topic_v2" "test" {
+  name         = "smn-%[2]s"
+  display_name = "The display name of smn topic"
+}
+
+resource "opentelekomcloud_ces_alarm_template_v2" "test" {
+  name        = "template-%[2]s"
+  description = "Test alarm template for alarm rule"
+
+  policies {
+    namespace           = "SYS.ECS"
+    dimension_name      = "instance_id"
+    metric_name         = "cpu_util"
+    period              = 300
+    filter              = "average"
+    comparison_operator = ">"
+    value               = 80
+    unit                = "%%%%"
+    count               = 3
+    alarm_level         = 2
+    suppress_duration   = 300
+  }
+
+  depends_on = [
+    opentelekomcloud_compute_instance_v2.test,
+    opentelekomcloud_smn_topic_v2.test
+  ]
+}
+
+resource "opentelekomcloud_ces_alarm_rule_v2" "test" {
+  name              = "%[2]s"
+  namespace         = "SYS.ECS"
+  type              = "MULTI_INSTANCE"
+  alarm_template_id = opentelekomcloud_ces_alarm_template_v2.test.id
+
+  resources {
+    dimensions {
+      name  = "instance_id"
+      value = opentelekomcloud_compute_instance_v2.test[0].id
+    }
+  }
+
+  notification_enabled = true
+  alarm_enabled        = true
+
+  alarm_actions {
+    type = "notification"
+    notification_list = [
+      opentelekomcloud_smn_topic_v2.test.topic_urn
+    ]
+  }
+
+  ok_actions {
+    type = "notification"
+    notification_list = [
+      opentelekomcloud_smn_topic_v2.test.topic_urn
+    ]
+  }
+}
+`, common.DataSourceSubnet, name)
+}
+
+func testCESAlarmRuleV2WithAlarmTemplateUpdate(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "opentelekomcloud_compute_instance_v2" "test" {
+  count       = 2
+  name        = "ecs-%[2]s-${count.index}"
+  image_name  = "Standard_Debian_11_latest"
+  flavor_name = "s3.large.2"
+
+  network {
+    uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  }
+}
+
+resource "opentelekomcloud_smn_topic_v2" "test" {
+  name         = "smn-%[2]s"
+  display_name = "The display name of smn topic"
+}
+
+resource "opentelekomcloud_ces_alarm_template_v2" "test" {
+  name        = "template-%[2]s"
+  description = "Test alarm template for alarm rule"
+
+  policies {
+    namespace           = "SYS.ECS"
+    dimension_name      = "instance_id"
+    metric_name         = "cpu_util"
+    period              = 300
+    filter              = "average"
+    comparison_operator = ">"
+    value               = 80
+    unit                = "%%%%"
+    count               = 3
+    alarm_level         = 2
+    suppress_duration   = 300
+  }
+
+  depends_on = [
+    opentelekomcloud_compute_instance_v2.test,
+    opentelekomcloud_smn_topic_v2.test
+  ]
+}
+
+resource "opentelekomcloud_ces_alarm_rule_v2" "test" {
+  name              = "%[2]s"
+  namespace         = "SYS.ECS"
+  type              = "MULTI_INSTANCE"
+  alarm_template_id = opentelekomcloud_ces_alarm_template_v2.test.id
+
+  resources {
+    dimensions {
+      name  = "instance_id"
+      value = opentelekomcloud_compute_instance_v2.test[1].id
+    }
+  }
+
+  notification_enabled = true
+  alarm_enabled        = false
+
+  alarm_actions {
+    type = "notification"
+    notification_list = [
+      opentelekomcloud_smn_topic_v2.test.topic_urn
+    ]
+  }
+
+  ok_actions {
+    type = "notification"
+    notification_list = [
+      opentelekomcloud_smn_topic_v2.test.topic_urn
+    ]
+  }
+}
+`, common.DataSourceSubnet, name)
+}

--- a/opentelekomcloud/services/ces/resource_opentelekomcloud_ces_alarm_rule_v2.go
+++ b/opentelekomcloud/services/ces/resource_opentelekomcloud_ces_alarm_rule_v2.go
@@ -69,14 +69,17 @@ func ResourceAlarmRuleV2() *schema.Resource {
 				ForceNew: true,
 			},
 			"alarm_template_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ExactlyOneOf: []string{"alarm_template_id", "policies"},
 			},
 			"policies": {
-				Type:     schema.TypeSet,
-				Required: true,
-				Set:      resourcePolicyHash,
+				Type:         schema.TypeSet,
+				Optional:     true,
+				Computed:     true,
+				Set:          resourcePolicyHash,
+				ExactlyOneOf: []string{"alarm_template_id", "policies"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"metric_name": {
@@ -543,8 +546,9 @@ func resourceAlarmRuleV2Update(ctx context.Context, d *schema.ResourceData, meta
 
 	alarmId := d.Id()
 
-	// Update policies if changed
-	if d.HasChange("policies") {
+	// Update policies if changed (only when not using alarm_template_id)
+	// Template-associated alarm's policies cannot be modified via API
+	if d.HasChange("policies") && d.Get("alarm_template_id").(string) == "" {
 		updatePolicies := buildUpdatePoliciesOpts(d)
 		_, err := policies.Update(client, alarmId, policies.UpdateOpts{
 			Policies: updatePolicies,

--- a/releasenotes/notes/ces_alarm_rule_v2_fix-4839032c942f4450.yaml
+++ b/releasenotes/notes/ces_alarm_rule_v2_fix-4839032c942f4450.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[CES]** Fix `alarm_template_id` and `policies` parameters set/update for ``resource/opentelekomcloud_ces_alarm_rule_v2`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)

--- a/releasenotes/notes/ces_alarm_rule_v2_fix-4839032c942f4450.yaml
+++ b/releasenotes/notes/ces_alarm_rule_v2_fix-4839032c942f4450.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    **[CES]** Fix `alarm_template_id` and `policies` parameters set/update for ``resource/opentelekomcloud_ces_alarm_rule_v2`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[CES]** Fix `alarm_template_id` and `policies` parameters set/update for ``resource/opentelekomcloud_ces_alarm_rule_v2`` (`#3248 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3248>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Fix schema for `alarm_policy_id` and `policies`.

## PR Checklist

* [x] Refers to: #3246
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestCESAlarmRuleV2_basic
=== PAUSE TestCESAlarmRuleV2_basic
=== CONT  TestCESAlarmRuleV2_basic
--- PASS: TestCESAlarmRuleV2_basic (119.41s)
=== RUN   TestCESAlarmRuleV2_withNotification
=== PAUSE TestCESAlarmRuleV2_withNotification
=== CONT  TestCESAlarmRuleV2_withNotification
--- PASS: TestCESAlarmRuleV2_withNotification (97.62s)
=== RUN   TestCESAlarmRuleV2_multiplePolicies
=== PAUSE TestCESAlarmRuleV2_multiplePolicies
=== CONT  TestCESAlarmRuleV2_multiplePolicies
--- PASS: TestCESAlarmRuleV2_multiplePolicies (118.33s)
=== RUN   TestCESAlarmRuleV2_multipleResources
=== PAUSE TestCESAlarmRuleV2_multipleResources
=== CONT  TestCESAlarmRuleV2_multipleResources
--- PASS: TestCESAlarmRuleV2_multipleResources (112.27s)
=== RUN   TestCESAlarmRuleV2_sysEvent
=== PAUSE TestCESAlarmRuleV2_sysEvent
=== CONT  TestCESAlarmRuleV2_sysEvent
--- PASS: TestCESAlarmRuleV2_sysEvent (53.11s)
=== RUN   TestCESAlarmRuleV2_sysEventWithNotification
=== PAUSE TestCESAlarmRuleV2_sysEventWithNotification
=== CONT  TestCESAlarmRuleV2_sysEventWithNotification
--- PASS: TestCESAlarmRuleV2_sysEventWithNotification (37.47s)
=== RUN   TestCESAlarmRuleV2_allInstance
=== PAUSE TestCESAlarmRuleV2_allInstance
=== CONT  TestCESAlarmRuleV2_allInstance
--- PASS: TestCESAlarmRuleV2_allInstance (37.84s)
=== RUN   TestCESAlarmRuleV2_withOkActions
=== PAUSE TestCESAlarmRuleV2_withOkActions
=== CONT  TestCESAlarmRuleV2_withOkActions
--- PASS: TestCESAlarmRuleV2_withOkActions (88.95s)
=== RUN   TestCESAlarmRuleV2_withAlarmTemplate
=== PAUSE TestCESAlarmRuleV2_withAlarmTemplate
=== CONT  TestCESAlarmRuleV2_withAlarmTemplate
--- PASS: TestCESAlarmRuleV2_withAlarmTemplate (122.83s)
PASS

Process finished with the exit code 0

=== RUN   TestAccCESAlarmTemplateV2_basic
=== PAUSE TestAccCESAlarmTemplateV2_basic
=== CONT  TestAccCESAlarmTemplateV2_basic
--- PASS: TestAccCESAlarmTemplateV2_basic (47.94s)
=== RUN   TestAccCESAlarmTemplateV2_event
=== PAUSE TestAccCESAlarmTemplateV2_event
=== CONT  TestAccCESAlarmTemplateV2_event
--- PASS: TestAccCESAlarmTemplateV2_event (48.74s)
=== RUN   TestAccCESAlarmTemplateV2_multiplePolicies
=== PAUSE TestAccCESAlarmTemplateV2_multiplePolicies
=== CONT  TestAccCESAlarmTemplateV2_multiplePolicies
--- PASS: TestAccCESAlarmTemplateV2_multiplePolicies (48.22s)
PASS

Process finished with the exit code 0
```
