### PR TITLE
[Fix.] CCE: initial_node_count fix during update

### DIFF
--- a/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_node_pool_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_node_pool_v3_test.go
@@ -1,9 +1,13 @@
 package acceptance
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 	"testing"
+	"time"
+
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -666,6 +670,223 @@ resource "opentelekomcloud_cce_node_pool_v3" "node_pool" {
   max_pods         = 16
   docker_base_size = 32
 }`, shared.DataSourceCluster, env.OS_KEYPAIR_NAME, env.OS_KMS_ID)
+
+// TestAccCCENodePoolsV3_autoscaling tests that changing k8s_tags preserves
+// initial_node_count when autoscaler has modified the node count.
+// Reference: https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/2249
+func TestAccCCENodePoolsV3_autoscaling(t *testing.T) {
+	var nodePool nodepools.NodePool
+	rc := common.InitResourceCheck(
+		nodePoolResourceName,
+		&nodePool,
+		getNodePoolFunc,
+	)
+	t.Parallel()
+	qts := []*quotas.ExpectedQuota{
+		{Q: quotas.Server, Count: 2},
+		{Q: quotas.Volume, Count: 2},
+		{Q: quotas.VolumeSize, Count: 40 + 100},
+	}
+	qts = append(qts, ecs.QuotasForFlavor("s2.large.2")...)
+	quotas.BookMany(t, qts)
+	shared.BookCluster(t)
+
+	var clusterID, nodePoolID string
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccCCEKeyPairPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCCENodePoolV3AutoscalerBug_basic,
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(nodePoolResourceName, "initial_node_count", "1"),
+					resource.TestCheckResourceAttr(nodePoolResourceName, "scale_enable", "true"),
+					resource.TestCheckResourceAttr(nodePoolResourceName, "k8s_tags.test-tag", "initial-value"),
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources[nodePoolResourceName]
+						if !ok {
+							return fmt.Errorf("resource not found: %s", nodePoolResourceName)
+						}
+						clusterID = rs.Primary.Attributes["cluster_id"]
+						nodePoolID = rs.Primary.ID
+						return nil
+					},
+				),
+			},
+			{
+				PreConfig: func() {
+					simulateAutoscalerScaleUp(t, clusterID, nodePoolID, 2)
+				},
+				Config: testAccCCENodePoolV3AutoscalerBug_updateTags,
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(nodePoolResourceName, "k8s_tags.test-tag", "updated-value"),
+					// After fix: autoscaler value (2) should be preserved, not reset to config value (1)
+					checkNodePoolInitialCount(t, &clusterID, &nodePoolID, 2, "update tags only"),
+				),
+			},
+		},
+	})
+}
+
+func simulateAutoscalerScaleUp(t *testing.T, clusterID, nodePoolID string, targetCount int) {
+	config := common.TestAccProvider.Meta().(*cfg.Config)
+	client, err := config.CceV3Client(env.OS_REGION_NAME)
+	if err != nil {
+		t.Fatalf("error creating CCE client: %s", err)
+	}
+
+	currentPool, err := nodepools.Get(client, clusterID, nodePoolID)
+	if err != nil {
+		t.Fatalf("error getting node pool: %s", err)
+	}
+
+	updateOpts := nodepools.UpdateOpts{
+		Metadata: nodepools.UpdateMetaData{
+			Name: currentPool.Metadata.Name,
+		},
+		Spec: nodepools.UpdateSpec{
+			InitialNodeCount: targetCount,
+			Autoscaling: nodepools.UpdateAutoscalingSpec{
+				Enable:                currentPool.Spec.Autoscaling.Enable,
+				MinNodeCount:          currentPool.Spec.Autoscaling.MinNodeCount,
+				MaxNodeCount:          currentPool.Spec.Autoscaling.MaxNodeCount,
+				ScaleDownCooldownTime: currentPool.Spec.Autoscaling.ScaleDownCooldownTime,
+				Priority:              currentPool.Spec.Autoscaling.Priority,
+			},
+		},
+	}
+	updateOpts.Spec.NodeTemplate = currentPool.Spec.NodeTemplate
+
+	_, err = nodepools.Update(client, clusterID, nodePoolID, updateOpts)
+	if err != nil {
+		t.Fatalf("error simulating autoscaler: %s", err)
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"Synchronizing", "Synchronized"},
+		Target:     []string{""},
+		Refresh:    waitForNodePoolPhase(client, clusterID, nodePoolID),
+		Timeout:    15 * time.Minute,
+		Delay:      15 * time.Second,
+		MinTimeout: 5 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(context.Background())
+	if err != nil {
+		t.Fatalf("error waiting for node pool: %s", err)
+	}
+
+	pool, err := nodepools.Get(client, clusterID, nodePoolID)
+	if err != nil {
+		t.Fatalf("error getting node pool: %s", err)
+	}
+	if pool.Spec.InitialNodeCount != targetCount {
+		t.Fatalf("expected InitialNodeCount=%d, got %d", targetCount, pool.Spec.InitialNodeCount)
+	}
+}
+
+func checkNodePoolInitialCount(t *testing.T, clusterID, nodePoolID *string, expectedCount int, scenario string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		config := common.TestAccProvider.Meta().(*cfg.Config)
+		client, err := config.CceV3Client(env.OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("error creating CCE client: %s", err)
+		}
+
+		pool, err := nodepools.Get(client, *clusterID, *nodePoolID)
+		if err != nil {
+			return fmt.Errorf("error getting node pool: %s", err)
+		}
+
+		t.Logf("[%s] InitialNodeCount after update: %d (expected: %d)",
+			scenario, pool.Spec.InitialNodeCount, expectedCount)
+
+		if pool.Spec.InitialNodeCount != expectedCount {
+			return fmt.Errorf("[%s] InitialNodeCount = %d, expected %d (autoscaler value should be preserved)",
+				scenario, pool.Spec.InitialNodeCount, expectedCount)
+		}
+		return nil
+	}
+}
+
+func waitForNodePoolPhase(client *golangsdk.ServiceClient, clusterID, nodePoolID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		pool, err := nodepools.Get(client, clusterID, nodePoolID)
+		if err != nil {
+			return nil, "", err
+		}
+		return pool, pool.Status.Phase, nil
+	}
+}
+
+var testAccCCENodePoolV3AutoscalerBug_basic = fmt.Sprintf(`
+%s
+
+resource "opentelekomcloud_cce_node_pool_v3" "node_pool" {
+  cluster_id         = data.opentelekomcloud_cce_cluster_v3.cluster.id
+  name               = "autoscaler-bug-test"
+  os                 = "EulerOS 2.9"
+  flavor             = "s2.large.2"
+  initial_node_count = 1
+  availability_zone  = "%s"
+  key_pair           = "%s"
+
+  scale_enable             = true
+  min_node_count           = 1
+  max_node_count           = 10
+  scale_down_cooldown_time = 15
+  priority                 = 1
+
+  root_volume {
+    size       = 40
+    volumetype = "SSD"
+  }
+
+  data_volumes {
+    size       = 100
+    volumetype = "SSD"
+  }
+
+  k8s_tags = {
+    "test-tag" = "initial-value"
+  }
+}`, shared.DataSourceCluster, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME)
+
+var testAccCCENodePoolV3AutoscalerBug_updateTags = fmt.Sprintf(`
+%s
+
+resource "opentelekomcloud_cce_node_pool_v3" "node_pool" {
+  cluster_id         = data.opentelekomcloud_cce_cluster_v3.cluster.id
+  name               = "autoscaler-bug-test"
+  os                 = "EulerOS 2.9"
+  flavor             = "s2.large.2"
+  initial_node_count = 1
+  availability_zone  = "%s"
+  key_pair           = "%s"
+
+  scale_enable             = true
+  min_node_count           = 1
+  max_node_count           = 10
+  scale_down_cooldown_time = 15
+  priority                 = 1
+
+  root_volume {
+    size       = 40
+    volumetype = "SSD"
+  }
+
+  data_volumes {
+    size       = 100
+    volumetype = "SSD"
+  }
+
+  k8s_tags = {
+    "test-tag" = "updated-value"
+  }
+}`, shared.DataSourceCluster, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME)
 
 var testAccCCENodePoolV3SecurityGroupIds = fmt.Sprintf(`
 %s

--- a/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_pool_v3.go
+++ b/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_pool_v3.go
@@ -559,6 +559,14 @@ func resourceCCENodePoolV3Update(ctx context.Context, d *schema.ResourceData, me
 		return fmterr.Errorf(cceClientError, err)
 	}
 
+	clusterID := d.Get("cluster_id").(string)
+
+	// Get current node pool state from API to preserve values not changed by user
+	currentPool, err := nodepools.Get(client, clusterID, d.Id())
+	if err != nil {
+		return fmterr.Errorf("error getting current CCE Node Pool state: %w", err)
+	}
+
 	var base64PreInstall, base64PostInstall string
 	if v, ok := d.GetOk("preinstall"); ok {
 		base64PreInstall = common.InstallScriptEncode(v.(string))
@@ -579,12 +587,20 @@ func resourceCCENodePoolV3Update(ctx context.Context, d *schema.ResourceData, me
 		}
 	}
 
+	// Use current API value for initial_node_count unless explicitly changed by user.
+	// This prevents unwanted scaling when autoscaler has modified the node count.
+	// Reference: https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/2249
+	initialNodeCount := currentPool.Spec.InitialNodeCount
+	if d.HasChange("initial_node_count") {
+		initialNodeCount = d.Get("initial_node_count").(int)
+	}
+
 	updateOpts := nodepools.UpdateOpts{
 		Metadata: nodepools.UpdateMetaData{
 			Name: d.Get("name").(string),
 		},
 		Spec: nodepools.UpdateSpec{
-			InitialNodeCount: d.Get("initial_node_count").(int),
+			InitialNodeCount: initialNodeCount,
 			Autoscaling: nodepools.UpdateAutoscalingSpec{
 				Enable:                d.Get("scale_enable").(bool),
 				MinNodeCount:          d.Get("min_node_count").(int),
@@ -620,7 +636,6 @@ func resourceCCENodePoolV3Update(ctx context.Context, d *schema.ResourceData, me
 		},
 	}
 
-	clusterID := d.Get("cluster_id").(string)
 	_, err = nodepools.Update(client, clusterID, d.Id(), updateOpts)
 	if err != nil {
 		return fmterr.Errorf("error updating Open Telekom Cloud CCE Node Pool: %w", err)

--- a/releasenotes/notes/cce_nodepool_fix-249b7f7e9d996231.yaml
+++ b/releasenotes/notes/cce_nodepool_fix-249b7f7e9d996231.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[CCE]** Fix `initial_node_count` update for ``resource/opentelekomcloud_cce_node_pool_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)

--- a/releasenotes/notes/cce_nodepool_fix-249b7f7e9d996231.yaml
+++ b/releasenotes/notes/cce_nodepool_fix-249b7f7e9d996231.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    **[CCE]** Fix `initial_node_count` update for ``resource/opentelekomcloud_cce_node_pool_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[CCE]** Fix `initial_node_count` update for ``resource/opentelekomcloud_cce_node_pool_v3`` (`#3257 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3257>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Fix `initial_node_count` update for `opentelekomcloud_cce_node_pool_v3`

## PR Checklist

* [x] Refers to: #2249
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccCCENodePoolsV3_basic
=== PAUSE TestAccCCENodePoolsV3_basic
=== CONT  TestAccCCENodePoolsV3_basic
    resource_opentelekomcloud_cce_node_pool_v3_test.go:51: Cluster is required by the test. 1 test(s) are using cluster.
    cluster.go:117: Cluster is released by the test. 1 test(s) are still using cluster.
--- PASS: TestAccCCENodePoolsV3_basic (656.97s)
=== RUN   TestAccCCENodePoolsV3_agency
=== PAUSE TestAccCCENodePoolsV3_agency
=== CONT  TestAccCCENodePoolsV3_agency
    resource_opentelekomcloud_cce_node_pool_v3_test.go:127: Cluster is required by the test. 5 test(s) are using cluster.
    cluster.go:117: Cluster is released by the test. 5 test(s) are still using cluster.
--- PASS: TestAccCCENodePoolsV3_agency (514.97s)
=== RUN   TestAccCCENodePoolsV3_SecurityGroupIds
=== PAUSE TestAccCCENodePoolsV3_SecurityGroupIds
=== CONT  TestAccCCENodePoolsV3_SecurityGroupIds
    resource_opentelekomcloud_cce_node_pool_v3_test.go:164: Cluster is required by the test. 4 test(s) are using cluster.
    cluster.go:117: Cluster is released by the test. 2 test(s) are still using cluster.
--- PASS: TestAccCCENodePoolsV3_SecurityGroupIds (536.79s)
=== RUN   TestAccCCENodePoolsV3_randomAZ
=== PAUSE TestAccCCENodePoolsV3_randomAZ
=== CONT  TestAccCCENodePoolsV3_randomAZ
    resource_opentelekomcloud_cce_node_pool_v3_test.go:208: Cluster is required by the test. 3 test(s) are using cluster.
    cluster.go:117: Cluster is released by the test. 3 test(s) are still using cluster.
--- PASS: TestAccCCENodePoolsV3_randomAZ (523.14s)
=== RUN   TestAccCCENodePoolsV3EncryptedVolume
=== PAUSE TestAccCCENodePoolsV3EncryptedVolume
=== CONT  TestAccCCENodePoolsV3EncryptedVolume
    resource_opentelekomcloud_cce_node_pool_v3_test.go:234: Cluster is required by the test. 6 test(s) are using cluster.
    cluster.go:121: starting creating shared cluster
2026/02/02 14:36:39 [DEBUG] Waiting for state to become: [Available]
...
2026/02/02 14:40:19 [TRACE] Waiting 10s before next try
2026/02/02 14:40:29 [TRACE] Waiting 10s before next try
2026/02/02 14:40:39 [TRACE] Waiting 10s before next try

=== RUN   TestAccCCENodePoolsV3_autoscaling
=== PAUSE TestAccCCENodePoolsV3_autoscaling
=== CONT  TestAccCCENodePoolsV3_autoscaling
    resource_opentelekomcloud_cce_node_pool_v3_test.go:692: Cluster is required by the test. 6 test(s) are using cluster.
    resource_opentelekomcloud_cce_node_pool_v3_test.go:804: [update tags only] InitialNodeCount after update: 2 (expected: 2)
    cluster.go:117: Cluster usage is 0 now, ready to delete the cluster
    cluster.go:80: starting deleting shared cluster
--- PASS: TestAccCCENodePoolsV3_autoscaling (796.11s)
PASS

Process finished with the exit code 0


=== RUN   TestAccCCENodePoolsV3ExtendParams
=== PAUSE TestAccCCENodePoolsV3ExtendParams
=== CONT  TestAccCCENodePoolsV3ExtendParams
    resource_opentelekomcloud_cce_node_pool_v3_test.go:261: Cluster is required by the test. 1 test(s) are using cluster.
    cluster.go:121: starting creating shared cluster
2026/02/02 14:52:18 [DEBUG] Waiting for state to become: [Available]
2026/02/02 14:56:19 [TRACE] Waiting 10s before next try
    cluster.go:117: Cluster usage is 0 now, ready to delete the cluster
    cluster.go:80: starting deleting shared cluster
--- PASS: TestAccCCENodePoolsV3ExtendParams (618.56s)
PASS

Process finished with the exit code 0
```
