### PR TITLE
[Fix.] CCE: component_configurations JSON string value handling

### DIFF
--- a/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_cluster_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_cluster_v3_test.go
@@ -394,6 +394,41 @@ func TestAccCCEClusterV3_cillium(t *testing.T) {
 	})
 }
 
+// TestAccCCEClusterV3_componentConfigJSONString tests that JSON-like string values
+// in component_configurations are sent as strings, not parsed as JSON objects.
+// This is a regression test for https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/3254
+func TestAccCCEClusterV3_componentConfigJSONString(t *testing.T) {
+	var cluster clusters.Clusters
+	rc := common.InitResourceCheck(
+		resourceClusterName,
+		&cluster,
+		getCceClusterResourceFunc,
+	)
+	clusterName := randClusterName()
+	t.Parallel()
+
+	quotas.BookOne(t, quotas.CCEClusterQuota)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCCEClusterV3ComponentConfigJSONString(clusterName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceClusterName, "name", clusterName),
+					resource.TestCheckResourceAttr(resourceClusterName, "status", "Available"),
+					resource.TestCheckResourceAttr(resourceClusterName, "component_configurations.0.name", "kube-apiserver"),
+					resource.TestCheckResourceAttr(resourceClusterName, "component_configurations.0.configurations.0.name", "oidc-required-claim"),
+					resource.TestCheckResourceAttr(resourceClusterName, "component_configurations.0.configurations.0.value", `{ "aud" : "oidc-test" }`),
+				),
+			},
+		},
+	})
+}
+
 func testAccCCEClusterV3Basic(clusterName string) string {
 	return fmt.Sprintf(`
 %s
@@ -792,6 +827,33 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
     configurations {
       name  = "support-overload"
       value = "true" # will be sent as boolean true
+    }
+  }
+}
+`, common.DataSourceSubnet, clusterName)
+}
+
+func testAccCCEClusterV3ComponentConfigJSONString(clusterName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
+  name                    = "%s"
+  cluster_type            = "VirtualMachine"
+  flavor_id               = "cce.s1.small"
+  vpc_id                  = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  subnet_id               = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  container_network_type  = "eni"
+  kubernetes_svc_ip_range = "10.247.0.0/16"
+  ignore_addons           = true
+  eni_subnet_id           = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.subnet_id
+  eni_subnet_cidr         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.cidr
+
+  component_configurations {
+    name = "kube-apiserver"
+    configurations {
+      name  = "oidc-required-claim"
+      value = "{ \"aud\" : \"oidc-test\" }"
     }
   }
 }

--- a/opentelekomcloud/common/utils.go
+++ b/opentelekomcloud/common/utils.go
@@ -675,7 +675,7 @@ func TryMapValueAnalysis(v interface{}) map[string]interface{} {
 	return result
 }
 
-// ParseAnyType tries to coerce a string to bool/number/JSON; falls back to the original string.
+// ParseAnyType tries to coerce a string to bool/number; falls back to the original string.
 func ParseAnyType(s string) interface{} {
 	ls := strings.ToLower(strings.TrimSpace(s))
 	if ls == "true" {
@@ -691,11 +691,6 @@ func ParseAnyType(s string) interface{} {
 	// Try float
 	if f, err := strconv.ParseFloat(s, 64); err == nil {
 		return f
-	}
-	// Try JSON object/array/string literal
-	var v interface{}
-	if err := json.Unmarshal([]byte(s), &v); err == nil {
-		return v
 	}
 	return s
 }

--- a/releasenotes/notes/cce-component-config-json-string-fix-e645ba725d2d228e.yaml
+++ b/releasenotes/notes/cce-component-config-json-string-fix-e645ba725d2d228e.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    **[CCE]** Fixed ``component_configurations`` in ``opentelekomcloud_cce_cluster_v3`` sending
+    JSON string values as objects instead of strings
+    (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)

--- a/releasenotes/notes/cce-component-config-json-string-fix-e645ba725d2d228e.yaml
+++ b/releasenotes/notes/cce-component-config-json-string-fix-e645ba725d2d228e.yaml
@@ -3,4 +3,4 @@ fixes:
   - |
     **[CCE]** Fixed ``component_configurations`` in ``opentelekomcloud_cce_cluster_v3`` sending
     JSON string values as objects instead of strings
-    (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    (`#3260 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3260>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Fix component_configurations in opentelekomcloud_cce_cluster_v3 incorrectly parsing JSON string values as objects instead of sending them as strings

## PR Checklist

* [x] Refers to: #3254
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccCCEClusterV3_componentConfigJSONString
=== PAUSE TestAccCCEClusterV3_componentConfigJSONString
=== CONT  TestAccCCEClusterV3_componentConfigJSONString
--- PASS: TestAccCCEClusterV3_componentConfigJSONString (455.79s)
PASS

Process finished with the exit code 0
```
