### PR TITLE
[Doc.] SFS: Document IP-based access rules and add validation

### DIFF
--- a/docs/resources/sfs_share_access_rules_v2.md
+++ b/docs/resources/sfs_share_access_rules_v2.md
@@ -16,6 +16,8 @@ Provides a possibility to manage access rules of Scalable File System resource.
 
 ## Example Usage
 
+### VPC-based Access
+
 ```hcl
 variable "share_name" {}
 
@@ -55,6 +57,33 @@ resource "opentelekomcloud_sfs_share_access_rules_v2" "sfs_rules" {
 }
 ```
 
+### IP-based Access within VPC
+
+To grant access to specific IP addresses or CIDR ranges within a VPC, use the extended format for `access_to`:
+
+```hcl
+resource "opentelekomcloud_vpc_v1" "vpc_1" {
+  name = "sfs_share_vpc"
+  cidr = "192.168.0.0/16"
+}
+
+resource "opentelekomcloud_sfs_file_system_v2" "sfs_1" {
+  name        = "sfs-with-ip-access"
+  size        = 50
+  share_proto = "NFS"
+}
+
+resource "opentelekomcloud_sfs_share_access_rules_v2" "sfs_rules" {
+  share_id = opentelekomcloud_sfs_file_system_v2.sfs_1.id
+
+  access_rule {
+    access_to    = "${opentelekomcloud_vpc_v1.vpc_1.id}#192.168.1.0/24#100#all_squash,root_squash"
+    access_type  = "cert"
+    access_level = "rw"
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -68,10 +97,17 @@ The `access_rule` block supports:
 * `access_level` - (Required) The access level of the shared file system. Possible values are `ro` (read-only)
   and `rw` (read-write). The default value is `rw` (read/write).
 
-* `access_type` - (Optional) The type of the share access rule. The value `cert` indicates
-  that the certificate is used to access the storage.
+* `access_type` - (Optional) The type of the share access rule. Valid values are:
+  * `cert` - (Default) VPC-based access using VPC ID and optionally IP address.
+  * `user` - Username-based access using Access Key (AK).
 
-* `access_to` - (Required) The access that the back end grants or denies.
+* `access_to` - (Required) The value that defines the access. The format depends on `access_type`:
+  * When `access_type` is `cert`:
+    * VPC ID only: `<vpc_id>` - grants access to the entire VPC.
+    * VPC ID with IP address: `<vpc_id>#<ip_address>/<mask>#<priority>#<user_permission>` - grants access to specific IP addresses within the VPC.
+      * `priority`: An integer from 0 to 100. A smaller value indicates a higher priority. In case of the same VPC ID, only the rule with the highest priority is delivered.
+      * `user_permission`: Possible values are `all_squash`, `root_squash`, `no_all_squash`, `no_root_squash`.
+  * When `access_type` is `user`: Specify the user's Access Key (AK).
 
 ## Attributes Reference
 

--- a/opentelekomcloud/acceptance/sfs/resource_opentelekomcloud_sfs_share_access_rules_v2_test.go
+++ b/opentelekomcloud/acceptance/sfs/resource_opentelekomcloud_sfs_share_access_rules_v2_test.go
@@ -37,6 +37,26 @@ func TestAccSFSShareAccessRulesV2_basic(t *testing.T) {
 	})
 }
 
+func TestAccSFSShareAccessRulesV2_ipBased(t *testing.T) {
+	resourceName := "opentelekomcloud_sfs_share_access_rules_v2.sfs_rules"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckSFSShareAccessRulesV2Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSFSShareAccessRulesV2IpBased,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "access_rule.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "access_rule.0.access_type", "cert"),
+					resource.TestCheckResourceAttr(resourceName, "access_rule.0.access_level", "rw"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckSFSShareAccessRulesV2Destroy(s *terraform.State) error {
 	config := common.TestAccProvider.Meta().(*cfg.Config)
 	client, err := config.SfsV2Client(env.OS_REGION_NAME)
@@ -116,6 +136,30 @@ resource "opentelekomcloud_sfs_share_access_rules_v2" "sfs_rules" {
 
   access_rule {
     access_to    = opentelekomcloud_vpc_v1.vpc_1.id
+    access_type  = "cert"
+    access_level = "rw"
+  }
+}
+`
+
+const testAccSFSShareAccessRulesV2IpBased = `
+resource "opentelekomcloud_vpc_v1" "vpc_1" {
+  name = "sfs_share_vpc_ip"
+  cidr = "192.168.0.0/16"
+}
+
+resource "opentelekomcloud_sfs_file_system_v2" "sfs_1" {
+  share_proto       = "NFS"
+  size              = 1
+  name              = "sfs-test-ip"
+  availability_zone = "eu-de-01"
+}
+
+resource "opentelekomcloud_sfs_share_access_rules_v2" "sfs_rules" {
+  share_id = opentelekomcloud_sfs_file_system_v2.sfs_1.id
+
+  access_rule {
+    access_to    = "${opentelekomcloud_vpc_v1.vpc_1.id}#192.168.1.0/24#100#all_squash,root_squash"
     access_type  = "cert"
     access_level = "rw"
   }

--- a/opentelekomcloud/services/sfs/resource_opentelekomcloud_sfs_share_access_rules_v2.go
+++ b/opentelekomcloud/services/sfs/resource_opentelekomcloud_sfs_share_access_rules_v2.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/sfs/v2/shares"
 
@@ -43,6 +44,9 @@ func ResourceSFSShareAccessRulesV2() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 							Default:  "cert",
+							ValidateFunc: validation.StringInSlice([]string{
+								"cert", "user",
+							}, false),
 						},
 						"access_to": {
 							Type:     schema.TypeString,

--- a/releasenotes/notes/sfs-access-rules-validation-9717b08b482459c6.yaml
+++ b/releasenotes/notes/sfs-access-rules-validation-9717b08b482459c6.yaml
@@ -1,0 +1,5 @@
+---
+other:
+  - |
+    **[SFS]** Added ``access_type`` validation and IP-based access documentation
+    for ``opentelekomcloud_sfs_share_access_rules_v2`` resource (`#3263 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3263>`_)


### PR DESCRIPTION
## Summary of the Pull Request
  - Documented supported `access_type` values (`cert`, `user`) and their usage
  - Added example for IP-based access format (`VPC_ID#IP/MASK#PRIORITY#USER_PERMISSION`)
  - Added `access_type` validation to prevent invalid values
  - Added acceptance test for IP-based access rules

## PR Checklist

* [x] Refers to: #3256
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccSFSShareAccessRulesV2_ipBased
--- PASS: TestAccSFSShareAccessRulesV2_ipBased (75.65s)
PASS

Process finished with the exit code 0

=== RUN   TestAccSFSShareAccessRulesV2_basic
--- PASS: TestAccSFSShareAccessRulesV2_basic (124.85s)
PASS

Process finished with the exit code 0

```
