### PR TITLE
[IAM] Fix perpetual diff on identity_mapping_v3 rules

### DIFF
--- a/opentelekomcloud/services/iam/resource_opentelekomcloud_identity_mapping_v3.go
+++ b/opentelekomcloud/services/iam/resource_opentelekomcloud_identity_mapping_v3.go
@@ -99,7 +99,11 @@ func resourceIdentityMappingV3Read(_ context.Context, d *schema.ResourceData, me
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	if err := d.Set("rules", string(rules)); err != nil {
+	normalizedRules, err := common.NormalizeJsonString(string(rules))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("rules", normalizedRules); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/releasenotes/notes/identity_mapping_perpetual_diff-76f0536268413acf.yaml
+++ b/releasenotes/notes/identity_mapping_perpetual_diff-76f0536268413acf.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  |
+  **[IAM]** Fix perpetual diff on ``resource/opentelekomcloud_identity_mapping_v3`` rules attribute (`#3264 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/3264>`_)


### PR DESCRIPTION
## Summary of the Pull Request

Normalize the JSON returned by the API in the Read function using
`NormalizeJsonString`, matching the `StateFunc` normalization. This
prevents a key-ordering diff on every plan.

## PR Checklist

* [x] Refers to: #3264
* [x] Tests added/passed.
* [ ] Documentation updated. (N/A — no doc changes needed)
* [ ] Schema updated. (N/A — no schema changes)
* [x] Release notes added.

## Acceptance Steps Performed

Waiting for Zuul CI to run `TestAccIdentityV3MappingBasic`.