### PR TITLE
[Feat.] CCE: allow user_tags update in-place for node pool  

### DIFF
--- a/docs/resources/cce_node_pool_v3.md
+++ b/docs/resources/cce_node_pool_v3.md
@@ -199,7 +199,7 @@ the AZ based on the AZ sequence. For more details see
 
 * `priority` - (Optional, Int) Weight of a node pool. A node pool with a higher weight has a higher priority during scaling.
 
-* `user_tags` - (Optional, Map, ForceNew) Tag of a VM, key/value pair format. Changing this parameter will create a new resource.
+* `user_tags` - (Optional, Map) Tag of a VM, key/value pair format.
 
 * `k8s_tags` - (Optional, Map) Tags of a Kubernetes node, key/value pair format.
 

--- a/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_node_pool_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_node_pool_v3_test.go
@@ -888,6 +888,116 @@ resource "opentelekomcloud_cce_node_pool_v3" "node_pool" {
   }
 }`, shared.DataSourceCluster, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME)
 
+func TestAccCCENodePoolsV3_userTags(t *testing.T) {
+	var nodePool nodepools.NodePool
+	rc := common.InitResourceCheck(
+		nodePoolResourceName,
+		&nodePool,
+		getNodePoolFunc,
+	)
+	t.Parallel()
+	qts := []*quotas.ExpectedQuota{
+		{Q: quotas.Server, Count: 2},
+		{Q: quotas.Volume, Count: 2},
+		{Q: quotas.VolumeSize, Count: 40 + 100},
+	}
+	qts = append(qts, ecs.QuotasForFlavor("s2.large.2")...)
+	quotas.BookMany(t, qts)
+	shared.BookCluster(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccCCEKeyPairPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCCENodePoolV3UserTags_basic,
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(nodePoolResourceName, "name", "opentelekomcloud-cce-node-pool-tags"),
+					resource.TestCheckResourceAttr(nodePoolResourceName, "user_tags.env", "dev"),
+					resource.TestCheckResourceAttr(nodePoolResourceName, "user_tags.owner", "terraform"),
+				),
+			},
+			{
+				Config: testAccCCENodePoolV3UserTags_update,
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(nodePoolResourceName, "user_tags.env", "prod"),
+					resource.TestCheckResourceAttr(nodePoolResourceName, "user_tags.owner", "terraform"),
+					resource.TestCheckResourceAttr(nodePoolResourceName, "user_tags.project", "test"),
+				),
+			},
+			{
+				ResourceName:      nodePoolResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccCCENodePoolV3ImportStateIdFunc(),
+				ImportStateVerifyIgnore: []string{
+					"max_node_count", "min_node_count", "priority",
+					"scale_down_cooldown_time", "initial_node_count",
+					"root_volume", "taints",
+				},
+			},
+		},
+	})
+}
+
+var testAccCCENodePoolV3UserTags_basic = fmt.Sprintf(`
+%s
+
+resource "opentelekomcloud_cce_node_pool_v3" "node_pool" {
+  cluster_id         = data.opentelekomcloud_cce_cluster_v3.cluster.id
+  name               = "opentelekomcloud-cce-node-pool-tags"
+  os                 = "EulerOS 2.9"
+  flavor             = "s2.large.2"
+  initial_node_count = 1
+  availability_zone  = "%s"
+  key_pair           = "%s"
+
+  root_volume {
+    size       = 40
+    volumetype = "SSD"
+  }
+  data_volumes {
+    size       = 100
+    volumetype = "SSD"
+  }
+
+  user_tags = {
+    "env"   = "dev"
+    "owner" = "terraform"
+  }
+}`, shared.DataSourceCluster, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME)
+
+var testAccCCENodePoolV3UserTags_update = fmt.Sprintf(`
+%s
+
+resource "opentelekomcloud_cce_node_pool_v3" "node_pool" {
+  cluster_id         = data.opentelekomcloud_cce_cluster_v3.cluster.id
+  name               = "opentelekomcloud-cce-node-pool-tags"
+  os                 = "EulerOS 2.9"
+  flavor             = "s2.large.2"
+  initial_node_count = 1
+  availability_zone  = "%s"
+  key_pair           = "%s"
+
+  root_volume {
+    size       = 40
+    volumetype = "SSD"
+  }
+  data_volumes {
+    size       = 100
+    volumetype = "SSD"
+  }
+
+  user_tags = {
+    "env"     = "prod"
+    "owner"   = "terraform"
+    "project" = "test"
+  }
+}`, shared.DataSourceCluster, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME)
+
 var testAccCCENodePoolV3SecurityGroupIds = fmt.Sprintf(`
 %s
 

--- a/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_pool_v3.go
+++ b/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_pool_v3.go
@@ -182,7 +182,6 @@ func ResourceCCENodePoolV3() *schema.Resource {
 			"user_tags": {
 				Type:     schema.TypeMap,
 				Optional: true,
-				ForceNew: true,
 			},
 			"taints": {
 				Type:     schema.TypeList,
@@ -528,6 +527,10 @@ func resourceCCENodePoolV3Read(ctx context.Context, d *schema.ResourceData, meta
 	}
 	if err := d.Set("k8s_tags", k8sTags); err != nil {
 		return fmterr.Errorf(setError, "k8s_tags", err)
+	}
+
+	if err := d.Set("user_tags", common.TagsToMap(s.Spec.NodeTemplate.UserTags)); err != nil {
+		return fmterr.Errorf(setError, "user_tags", err)
 	}
 
 	var volumes []interface{}

--- a/releasenotes/notes/cce-node-pool-user-tags-update-a7b3c1d2e4f56789.yaml
+++ b/releasenotes/notes/cce-node-pool-user-tags-update-a7b3c1d2e4f56789.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[CCE]** Allow ``user_tags`` update in-place in ``resource/opentelekomcloud_cce_node_pool_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)

--- a/releasenotes/notes/cce-node-pool-user-tags-update-a7b3c1d2e4f56789.yaml
+++ b/releasenotes/notes/cce-node-pool-user-tags-update-a7b3c1d2e4f56789.yaml
@@ -1,4 +1,4 @@
 ---
 enhancements:
   - |
-    **[CCE]** Allow ``user_tags`` update in-place in ``resource/opentelekomcloud_cce_node_pool_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[CCE]** Allow ``user_tags`` update in-place in ``resource/opentelekomcloud_cce_node_pool_v3`` (`#3267 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3267>`_)


### PR DESCRIPTION
## Summary of the Pull Request
  - Remove `ForceNew` from `user_tags` in `opentelekomcloud_cce_node_pool_v3` to allow in-place update without node pool recreation                                                                                                                                              
  - Add acceptance test for `user_tags` create, update, and import
  - Update documentation

## PR Checklist

* [x] Refers to: #3266
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccCCENodePoolsV3_userTags
=== PAUSE TestAccCCENodePoolsV3_userTags
=== CONT  TestAccCCENodePoolsV3_userTags
    resource_opentelekomcloud_cce_node_pool_v3_test.go:906: Cluster is required by the test. 1 test(s) are using cluster.
    cluster.go:121: starting creating shared cluster
2026/02/16 12:31:35 [DEBUG] Waiting for state to become: [Available]
2026/02/16 12:31:40 [TRACE] Waiting 3s before next try
......
    cluster.go:117: Cluster usage is 0 now, ready to delete the cluster
    cluster.go:80: starting deleting shared cluster
--- PASS: TestAccCCENodePoolsV3_userTags (712.76s)
PASS

Process finished with the exit code 0
```
