### PR TITLE
[Feat] IAM: Add IPv6 arguments to identity_acl_v3

### DIFF
--- a/docs/resources/identity_acl_v3.md
+++ b/docs/resources/identity_acl_v3.md
@@ -14,15 +14,45 @@ Up-to-date reference of API arguments for IAM agency you can get at
 # opentelekomcloud_identity_acl_v3
 
 Manages an ACL resource within OpenTelekomCloud IAM service. The ACL allows user access only from specified IP address
-ranges and IPv4 CIDR blocks. The ACL takes effect for IAM users under the Domain account rather than the account itself.
+ranges and CIDR blocks. The ACL takes effect for IAM users under the Domain account rather than the account itself.
 
 -> **NOTE:** You *must* have admin privileges to use this resource.
 
 ## Example Usage
 
+### ACL through console
+
 ```hcl
 resource "opentelekomcloud_identity_acl_v3" "acl" {
   type = "console"
+
+  ip_ranges {
+    range       = "172.16.0.0-172.16.255.255"
+    description = "This is a basic ip range for console access"
+  }
+
+  ip_cidrs {
+    cidr        = "192.168.0.1/32"
+    description = "This is a basic ip address for console access"
+  }
+
+  ipv6_ranges {
+    range       = "0000:0000:0000:0000:0000:0000:0000:0000-FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF"
+    description = "This is a basic ipv6 range for console access"
+  }
+
+  ipv6_cidrs {
+    cidr        = "0000:0000:0000:0000:0000:0000:0000:0000/100"
+    description = "This is a basic ipv6 address for console access"
+  }
+}
+```
+
+### ACL through API
+
+```hcl
+resource "opentelekomcloud_identity_acl_v3" "acl" {
+  type = "api"
 
   ip_cidrs {
     cidr        = "159.138.39.192/32"
@@ -43,26 +73,26 @@ The following arguments are supported:
   Valid values are **console** and **api**. Changing this parameter will create a new ACL.
 
 * `ip_cidrs` - (Optional, List) Specifies the IPv4 CIDR blocks from which console access or api access is allowed.
-  The `ip_cidrs` cannot repeat. The [object](#ip_cidrs_object) structure is documented below.
+  The `ip_cidrs` cannot repeat. The structure is documented below.
+    * `cidr` - (Required, String) Specifies the IPv4 CIDR block, for example, **192.168.0.0/24**.
+    * `description` - (Optional, String) Specifies a description about an IPv4 CIDR block.
 
 * `ip_ranges` - (Optional, List) Specifies the IP address ranges from which console access or api access is allowed.
-  The `ip_ranges` cannot repeat. The [object](#ip_ranges_object) structure is documented below.
+  The `ip_ranges` cannot repeat. The structure is documented below.
+    * `range` - (Required, String) Specifies the Ip address range, for example, **0.0.0.0-255.255.255.0**.
+    * `description` - (Optional, String) Specifies a description about an IP address range.
 
--> **NOTE:** Up to 200 `ip_cidrs` and `ip_ranges` can be created in total for each access method.
+* `ipv6_cidrs` - (Optional, List) Specifies the IPv6 CIDR blocks from which console access or api access is allowed.
+  The `ipv6_cidrs` cannot repeat. The `ipv6_cidrs` can only be used when `type` is `console`. The structure is documented below.
+    * `cidr` - (Required, String) Specifies the IPv6 CIDR block, for example, **0000:0000:0000:0000:0000:0000:0000:0000/100**.
+    * `description` - (Optional, String) Specifies a description about an IPv6 CIDR block.
 
-<a name="ip_cidrs_object"></a>
-The `ip_cidrs` block supports:
+* `ipv6_ranges` - (Optional, List) Specifies the IPv6 address ranges from which console access or api access is allowed.
+  The `ipv6_ranges` cannot repeat. The `ipv6_ranges` can only be used when `type` is `console`. The structure is documented below.
+    * `range` - (Required, String) Specifies the IPv6 address range, for example, **0000:0000:0000:0000:0000:0000:0000:0000-FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF**.
+    * `description` - (Optional, String) Specifies a description about an IPv6 address range.
 
-* `cidr` - (Required, String) Specifies the IPv4 CIDR block, for example, **192.168.0.0/24**.
-
-* `description` - (Optional, String) Specifies a description about an IPv4 CIDR block.
-
-<a name="ip_ranges_object"></a>
-The `ip_ranges` block supports:
-
-* `range` - (Required, String) Specifies the Ip address range, for example, **0.0.0.0-255.255.255.0**.
-
-* `description` - (Optional, String) Specifies a description about an IP address range.
+-> **NOTE:** Up to 200 `ip_cidrs`, `ip_ranges`, `ipv6_cidrs`, and `ipv6_ranges` can be created in total for each access method.
 
 ## Attribute Reference
 

--- a/docs/resources/identity_acl_v3.md
+++ b/docs/resources/identity_acl_v3.md
@@ -72,23 +72,23 @@ The following arguments are supported:
 * `type` - (Required, String, ForceNew) Specifies the ACL is created through the Console or API.
   Valid values are **console** and **api**. Changing this parameter will create a new ACL.
 
-* `ip_cidrs` - (Optional, List) Specifies the IPv4 CIDR blocks from which console access or api access is allowed.
-  The `ip_cidrs` cannot repeat. The structure is documented below.
+* `ip_cidrs` - (Optional, List) Specifies the IPv4 CIDR blocks from which console access or api access is allowed. The `ip_cidrs` cannot repeat. At least one of the two, `ip_cidrs` and `ip_ranges`, must be specified. Both cannot be empty.
+The structure is documented below.
     * `cidr` - (Required, String) Specifies the IPv4 CIDR block, for example, **192.168.0.0/24**.
     * `description` - (Optional, String) Specifies a description about an IPv4 CIDR block.
 
-* `ip_ranges` - (Optional, List) Specifies the IP address ranges from which console access or api access is allowed.
-  The `ip_ranges` cannot repeat. The structure is documented below.
+* `ip_ranges` - (Optional, List) Specifies the IP address ranges from which console access or api access is allowed. The `ip_ranges` cannot repeat. At least one of the two, `ip_cidrs` and `ip_ranges`, must be specified. Both cannot be empty. 
+The structure is documented below.
     * `range` - (Required, String) Specifies the Ip address range, for example, **0.0.0.0-255.255.255.0**.
     * `description` - (Optional, String) Specifies a description about an IP address range.
 
-* `ipv6_cidrs` - (Optional, List) Specifies the IPv6 CIDR blocks from which console access or api access is allowed.
-  The `ipv6_cidrs` cannot repeat. The `ipv6_cidrs` can only be used when `type` is `console`. The structure is documented below.
+* `ipv6_cidrs` - (Optional, List) Specifies the IPv6 CIDR blocks from which console access or api access is allowed. The `ipv6_cidrs` cannot repeat. The `ipv6_cidrs` can only be used when `type` is `console`. At least one of the two, `ipv6_cidrs` and `ipv6_ranges`, must be specified. Both cannot be empty. 
+  The structure is documented below.
     * `cidr` - (Required, String) Specifies the IPv6 CIDR block, for example, **0000:0000:0000:0000:0000:0000:0000:0000/100**.
     * `description` - (Optional, String) Specifies a description about an IPv6 CIDR block.
 
-* `ipv6_ranges` - (Optional, List) Specifies the IPv6 address ranges from which console access or api access is allowed.
-  The `ipv6_ranges` cannot repeat. The `ipv6_ranges` can only be used when `type` is `console`. The structure is documented below.
+* `ipv6_ranges` - (Optional, List) Specifies the IPv6 address ranges from which console access or api access is allowed. The `ipv6_ranges` cannot repeat. The `ipv6_ranges` can only be used when `type` is `console`. At least one of the two, `ipv6_cidrs` and `ipv6_ranges`, must be specified. Both cannot be empty. 
+  The structure is documented below.
     * `range` - (Required, String) Specifies the IPv6 address range, for example, **0000:0000:0000:0000:0000:0000:0000:0000-FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF**.
     * `description` - (Optional, String) Specifies a description about an IPv6 address range.
 

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20260129165239-3e10a8ea8fe8
+	github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20260212155604-4770a60ad843
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.45.0
 	golang.org/x/sync v0.18.0

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20260212155604-4770a60ad843
+	github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20260217175632-5801f378524e
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.45.0
 	golang.org/x/sync v0.18.0

--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20260212155604-4770a60ad843 h1:dvh9cQGOnS5peQlvxn0aO51rjZugWpImJF/INw1P1EY=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20260212155604-4770a60ad843/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20260217175632-5801f378524e h1:8HYlKnV39awReMPa2+EXXObYIJC0yJmF2tHylnYe8m8=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20260217175632-5801f378524e/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20260129165239-3e10a8ea8fe8 h1:tM1w1dGP5TWZFrwG7b30FPahKxDBHBlIbvBq7F9xYg0=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20260129165239-3e10a8ea8fe8/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20260212155604-4770a60ad843 h1:dvh9cQGOnS5peQlvxn0aO51rjZugWpImJF/INw1P1EY=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20260212155604-4770a60ad843/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/opentelekomcloud/acceptance/iam/resource_opentelekomcloud_identity_acl_v3_test.go
+++ b/opentelekomcloud/acceptance/iam/resource_opentelekomcloud_identity_acl_v3_test.go
@@ -61,20 +61,23 @@ func TestAccIdentitACL_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIdentityACL_basic("console"),
+				Config: testAccIdentityACLConsole_basic,
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "type", "console"),
 					resource.TestCheckResourceAttr(resourceName, "ip_ranges.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "ip_cidrs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ipv6_ranges.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ipv6_cidrs.#", "1"),
 				),
 			},
 			{
-				Config: testAccIdentityACL_update("console"),
+				Config: testAccIdentityACLConsole_update,
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "type", "console"),
 					resource.TestCheckResourceAttr(resourceName, "ip_ranges.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "ipv6_ranges.#", "2"),
 				),
 			},
 		},
@@ -99,7 +102,7 @@ func TestAccIdentitACL_apiAccess(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIdentityACL_basic("api"),
+				Config: testAccIdentityACLAPI_basic,
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "type", "api"),
@@ -108,7 +111,7 @@ func TestAccIdentitACL_apiAccess(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccIdentityACL_update("api"),
+				Config: testAccIdentityACLAPI_update,
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "type", "api"),
@@ -119,7 +122,7 @@ func TestAccIdentitACL_apiAccess(t *testing.T) {
 	})
 }
 
-func TestAccACLConsoleIPv6_basic(t *testing.T) {
+func TestAccIdentitACL_CIDR(t *testing.T) {
 	var object acl.ACLPolicy
 	resourceName := "opentelekomcloud_identity_acl_v3.test"
 
@@ -138,59 +141,18 @@ func TestAccACLConsoleIPv6_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIdentityACLIPv6_basic,
+				Config: testAccIdentityACLConsole_CIDR,
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "type", "console"),
-					resource.TestCheckResourceAttr(resourceName, "ipv6_ranges.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "ipv6_cidrs.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ip_cidrs.#", "1"),
 				),
 			},
 		},
 	})
 }
 
-func testAccIdentityACL_basic(aclType string) string {
-	return fmt.Sprintf(`
-resource "opentelekomcloud_identity_acl_v3" "test" {
-  type = "%[1]s"
-
-  ip_ranges {
-    range       = "172.16.0.0-172.16.255.255"
-    description = "This is a basic ip range for %[1]s access"
-  }
-
-  ip_cidrs {
-    cidr        = "192.168.0.1/32"
-    description = "This is a basic ip address for %[1]s access"
-  }
-}
-`, aclType)
-}
-
-func testAccIdentityACL_update(aclType string) string {
-	return fmt.Sprintf(`
-resource "opentelekomcloud_identity_acl_v3" "test" {
-  type = "%[1]s"
-
-  ip_ranges {
-    range       = "172.16.0.0-172.16.255.255"
-    description = "This is a update ip range 1 for %[1]s access"
-  }
-  ip_ranges {
-    range       = "192.168.0.0-192.168.255.255"
-    description = "This is a update ip range 2 for %[1]s access"
-  }
-
-  ip_cidrs {
-    cidr        = "192.168.0.1/32"
-    description = "This is a update ip address for %[1]s access"
-  }
-}
-`, aclType)
-}
-
-var testAccIdentityACLIPv6_basic = `
+var testAccIdentityACLConsole_basic = `
 resource "opentelekomcloud_identity_acl_v3" "test" {
   type = "console"
 
@@ -212,6 +174,89 @@ resource "opentelekomcloud_identity_acl_v3" "test" {
   ipv6_cidrs {
     cidr        = "0000:0000:0000:0000:0000:0000:0000:0000/100"
     description = "This is a basic ipv6 address for console access"
+  }
+}
+`
+
+var testAccIdentityACLConsole_update = `
+resource "opentelekomcloud_identity_acl_v3" "test" {
+  type = "console"
+
+  ip_ranges {
+    range       = "172.16.0.0-172.16.255.255"
+    description = "This is a basic ip range for console access"
+  }
+
+  ip_ranges {
+    range       = "192.168.0.0-192.168.255.255"
+    description = "This is a update ip range 2 for console access"
+  }
+
+  ip_cidrs {
+    cidr        = "192.168.0.1/32"
+    description = "This is a basic ip address for console access"
+  }
+
+  ipv6_ranges {
+    range       = "0000:0000:0000:0000:0000:0000:0000:0000-FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF"
+    description = "This is a basic ipv6 range for console access"
+  }
+
+  ipv6_ranges {
+    range       = "0000:0000:0000:FFFF:0000:0000:0000:FFFF-FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF"
+    description = "This is a basic ipv6 range 2 for console access"
+  }
+
+  ipv6_cidrs {
+    cidr        = "0000:0000:0000:0000:0000:0000:0000:0000/100"
+    description = "This is a basic ipv6 address for console access"
+  }
+}
+`
+
+var testAccIdentityACLAPI_basic = `
+resource "opentelekomcloud_identity_acl_v3" "test" {
+  type = "api"
+
+  ip_ranges {
+    range       = "172.16.0.0-172.16.255.255"
+    description = "This is a basic ip range for api access"
+  }
+
+  ip_cidrs {
+    cidr        = "192.168.0.1/32"
+    description = "This is a basic ip address for api access"
+  }
+}
+`
+
+var testAccIdentityACLAPI_update = `
+resource "opentelekomcloud_identity_acl_v3" "test" {
+  type = "api"
+
+  ip_ranges {
+    range       = "172.16.0.0-172.16.255.255"
+    description = "This is a update ip range 1 for api access"
+  }
+  ip_ranges {
+    range       = "192.168.0.0-192.168.255.255"
+    description = "This is a update ip range 2 for api access"
+  }
+
+  ip_cidrs {
+    cidr        = "192.168.0.1/32"
+    description = "This is a update ip address for api access"
+  }
+}
+`
+
+var testAccIdentityACLConsole_CIDR = `
+resource "opentelekomcloud_identity_acl_v3" "test" {
+  type = "console"
+
+  ip_cidrs {
+    cidr        = "192.168.0.1/32"
+    description = "This is a basic ip address for console access"
   }
 }
 `

--- a/opentelekomcloud/acceptance/iam/resource_opentelekomcloud_identity_acl_v3_test.go
+++ b/opentelekomcloud/acceptance/iam/resource_opentelekomcloud_identity_acl_v3_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func getIdentitACLResourceFunc(c *cfg.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := c.IdentityV30AdminClient()
+	client, err := c.IdentityV30Client()
 	if err != nil {
 		return nil, fmt.Errorf("error creating IAM client: %s", err)
 	}

--- a/opentelekomcloud/acceptance/iam/resource_opentelekomcloud_identity_acl_v3_test.go
+++ b/opentelekomcloud/acceptance/iam/resource_opentelekomcloud_identity_acl_v3_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func getIdentitACLResourceFunc(c *cfg.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := c.IdentityV30Client()
+	client, err := c.IdentityV30AdminClient()
 	if err != nil {
 		return nil, fmt.Errorf("error creating IAM client: %s", err)
 	}
@@ -119,6 +119,37 @@ func TestAccIdentitACL_apiAccess(t *testing.T) {
 	})
 }
 
+func TestAccACLConsoleIPv6_basic(t *testing.T) {
+	var object acl.ACLPolicy
+	resourceName := "opentelekomcloud_identity_acl_v3.test"
+
+	rc := common.InitResourceCheck(
+		resourceName,
+		&object,
+		getIdentitACLResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+			common.TestAccPreCheckAdminOnly(t)
+		},
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIdentityACLIPv6_basic,
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "type", "console"),
+					resource.TestCheckResourceAttr(resourceName, "ipv6_ranges.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ipv6_cidrs.#", "1"),
+				),
+			},
+		},
+	})
+}
+
 func testAccIdentityACL_basic(aclType string) string {
 	return fmt.Sprintf(`
 resource "opentelekomcloud_identity_acl_v3" "test" {
@@ -158,3 +189,29 @@ resource "opentelekomcloud_identity_acl_v3" "test" {
 }
 `, aclType)
 }
+
+var testAccIdentityACLIPv6_basic = `
+resource "opentelekomcloud_identity_acl_v3" "test" {
+  type = "console"
+
+  ip_ranges {
+    range       = "172.16.0.0-172.16.255.255"
+    description = "This is a basic ip range for console access"
+  }
+
+  ip_cidrs {
+    cidr        = "192.168.0.1/32"
+    description = "This is a basic ip address for console access"
+  }
+
+  ipv6_ranges {
+    range       = "0000:0000:0000:0000:0000:0000:0000:0000-FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF"
+    description = "This is a basic ipv6 range for console access"
+  }
+
+  ipv6_cidrs {
+    cidr        = "0000:0000:0000:0000:0000:0000:0000:0000/100"
+    description = "This is a basic ipv6 address for console access"
+  }
+}
+`

--- a/opentelekomcloud/common/cfg/config.go
+++ b/opentelekomcloud/common/cfg/config.go
@@ -785,18 +785,6 @@ func (c *Config) IdentityV30Client() (*golangsdk.ServiceClient, error) {
 	return service, nil
 }
 
-// IdentityV30AdminClient returns a *ServiceClient for making calls to the OpenStack Identity v3 API on a `domain` level with v3.0 IAM endpoint.
-// An error will be returned if authentication or client creation was not possible.
-func (c *Config) IdentityV30AdminClient() (*golangsdk.ServiceClient, error) {
-	client, err := openstack.NewIdentityV3(c.DomainClient, golangsdk.EndpointOpts{})
-	if err != nil {
-		return nil, err
-	}
-
-	client.Endpoint = strings.Replace(client.Endpoint, "v3", "v3.0", 1)
-	return client, err
-}
-
 func (c *Config) RegionIdentityV3Client(region string) (*golangsdk.ServiceClient, error) {
 	return openstack.NewIdentityV3(c.HwClient, golangsdk.EndpointOpts{
 		Region:       region,

--- a/opentelekomcloud/common/cfg/config.go
+++ b/opentelekomcloud/common/cfg/config.go
@@ -785,6 +785,18 @@ func (c *Config) IdentityV30Client() (*golangsdk.ServiceClient, error) {
 	return service, nil
 }
 
+// IdentityV30AdminClient returns a *ServiceClient for making calls to the OpenStack Identity v3 API on a `domain` level with v3.0 IAM endpoint.
+// An error will be returned if authentication or client creation was not possible.
+func (c *Config) IdentityV30AdminClient() (*golangsdk.ServiceClient, error) {
+	client, err := openstack.NewIdentityV3(c.DomainClient, golangsdk.EndpointOpts{})
+	if err != nil {
+		return nil, err
+	}
+
+	client.Endpoint = strings.Replace(client.Endpoint, "v3", "v3.0", 1)
+	return client, err
+}
+
 func (c *Config) RegionIdentityV3Client(region string) (*golangsdk.ServiceClient, error) {
 	return openstack.NewIdentityV3(c.HwClient, golangsdk.EndpointOpts{
 		Region:       region,

--- a/opentelekomcloud/common/validators.go
+++ b/opentelekomcloud/common/validators.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"bytes"
 	"fmt"
 	"net"
 	"net/mail"
@@ -424,6 +425,79 @@ func ValidateIPRange(v interface{}, k string) (ws []string, errors []error) {
 				return
 			}
 		}
+	}
+
+	return
+}
+
+func ValidateIPv6Range(v interface{}, k string) (ws []string, errors []error) {
+	value, ok := v.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("%q must be a string", k))
+		return
+	}
+
+	ipAddresses := strings.Split(value, "-")
+	if len(ipAddresses) != 2 {
+		errors = append(errors, fmt.Errorf(
+			"%q must be a valid IPv6 range like 2001:db8::1-2001:db8::ffff, got %q",
+			k, value))
+		return
+	}
+
+	startStr := strings.TrimSpace(ipAddresses[0])
+	endStr := strings.TrimSpace(ipAddresses[1])
+
+	startIP := net.ParseIP(startStr)
+	endIP := net.ParseIP(endStr)
+
+	if startIP == nil || startIP.To16() == nil || startIP.To4() != nil {
+		errors = append(errors, fmt.Errorf("%q contains invalid IPv6 address %q", k, startStr))
+	}
+
+	if endIP == nil || endIP.To16() == nil || endIP.To4() != nil {
+		errors = append(errors, fmt.Errorf("%q contains invalid IPv6 address %q", k, endStr))
+	}
+
+	if len(errors) > 0 {
+		return
+	}
+
+	startIP = startIP.To16()
+	endIP = endIP.To16()
+
+	// Check equality
+	if startIP.Equal(endIP) {
+		errors = append(errors, fmt.Errorf(
+			"two IPv6 addresses of %q cannot be equal, got %q", k, value))
+		return
+	}
+
+	// Compare lexicographically (byte-wise comparison)
+	if bytes.Compare(startIP, endIP) > 0 {
+		errors = append(errors, fmt.Errorf(
+			"%q starting IPv6 address cannot be greater than ending IPv6 address, got %q",
+			k, value))
+	}
+
+	return
+}
+
+func ValidateIPv6CIDR(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+
+	ip, _, err := net.ParseCIDR(value)
+	if err != nil {
+		errors = append(errors, fmt.Errorf(
+			"%q must contain a valid IPv6 CIDR, got parsing error: %s", k, err))
+		return
+	}
+
+	// Ensure parsed IP is IPv6
+	if ip == nil || ip.To16() == nil || ip.To4() != nil {
+		errors = append(errors, fmt.Errorf(
+			"%q must contain a valid IPv6 CIDR, got %q", k, value))
+		return
 	}
 
 	return

--- a/opentelekomcloud/services/iam/resource_opentelekomcloud_identity_acl_v3.go
+++ b/opentelekomcloud/services/iam/resource_opentelekomcloud_identity_acl_v3.go
@@ -350,7 +350,6 @@ func resourceIdentityACLV3CustomizeDiff(
 	d *schema.ResourceDiff,
 	meta interface{},
 ) error {
-
 	if d.Get("type").(string) != "console" {
 		if d.Get("ipv6_cidrs").(*schema.Set).Len() > 0 {
 			return fmt.Errorf(`ipv6_cidrs can only be specified when type = "console"`)

--- a/opentelekomcloud/services/iam/resource_opentelekomcloud_identity_acl_v3.go
+++ b/opentelekomcloud/services/iam/resource_opentelekomcloud_identity_acl_v3.go
@@ -228,20 +228,20 @@ func resourceIdentityACLV3Delete(_ context.Context, d *schema.ResourceData, meta
 		return diag.Errorf("error creating IAM client: %s", err)
 	}
 
-	netmasksList := make([]acl.AllowAddressNetmasks, 0, 1)
-	netmask := acl.AllowAddressNetmasks{
-		AddressNetmask: "0.0.0.0-255.255.255.255",
+	rangesList := make([]acl.AllowIPRanges, 0, 1)
+	ipRange := acl.AllowIPRanges{
+		IPRange: "0.0.0.0-255.255.255.255",
 	}
-	netmasksList = append(netmasksList, netmask)
+	rangesList = append(rangesList, ipRange)
 
 	deleteOpts := acl.ACLPolicy{
-		AllowAddressNetmasks: netmasksList,
-		DomainId:             d.Id(),
+		AllowIPRanges: rangesList,
+		DomainId:      d.Id(),
 	}
 	if d.Get("type").(string) == "console" {
-		deleteOpts.AllowAddressNetmasksIPv6 = []acl.AllowAddressNetmasks{
+		deleteOpts.AllowIPRangesIPv6 = []acl.AllowIPRanges{
 			{
-				AddressNetmask: "0000:0000:0000:0000:0000:0000:0000:0000-FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF",
+				IPRange: "0000:0000:0000:0000:0000:0000:0000:0000-FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF",
 			},
 		}
 	}

--- a/opentelekomcloud/services/iam/resource_opentelekomcloud_identity_acl_v3.go
+++ b/opentelekomcloud/services/iam/resource_opentelekomcloud_identity_acl_v3.go
@@ -24,6 +24,8 @@ func ResourceIdentityAclV3() *schema.Resource {
 		UpdateContext: resourceIdentityACLV3Update,
 		DeleteContext: resourceIdentityACLV3Delete,
 
+		CustomizeDiff: resourceIdentityACLV3CustomizeDiff,
+
 		Schema: map[string]*schema.Schema{
 			"type": {
 				Type:     schema.TypeString,
@@ -34,10 +36,9 @@ func ResourceIdentityAclV3() *schema.Resource {
 				}, true),
 			},
 			"ip_cidrs": {
-				Type:         schema.TypeSet,
-				Optional:     true,
-				MaxItems:     200,
-				AtLeastOneOf: []string{"ip_ranges"},
+				Type:     schema.TypeSet,
+				Optional: true,
+				MaxItems: 200,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"cidr": {
@@ -72,13 +73,51 @@ func ResourceIdentityAclV3() *schema.Resource {
 				},
 				Set: resourceACLPolicyRangeHash,
 			},
+			"ipv6_cidrs": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				MaxItems: 200,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"cidr": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: common.ValidateIPv6CIDR,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+				Set: resourceACLPolicyCIDRHash,
+			},
+			"ipv6_ranges": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				MaxItems: 200,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"range": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: common.ValidateIPv6Range,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+				Set: resourceACLPolicyRangeHash,
+			},
 		},
 	}
 }
 
 func resourceIdentityACLV3Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	iamClient, err := config.IdentityV30Client()
+	iamClient, err := config.IdentityV30AdminClient()
 	if err != nil {
 		return fmterr.Errorf("error creating client: %s", err)
 	}
@@ -98,7 +137,7 @@ func resourceIdentityACLV3Create(ctx context.Context, d *schema.ResourceData, me
 func resourceIdentityACLV3Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	mErr := &multierror.Error{}
 	config := meta.(*cfg.Config)
-	iamClient, err := config.IdentityV30Client()
+	iamClient, err := config.IdentityV30AdminClient()
 	if err != nil {
 		return diag.Errorf("error creating IAM client: %s", err)
 	}
@@ -140,6 +179,28 @@ func resourceIdentityACLV3Read(_ context.Context, d *schema.ResourceData, meta i
 		}
 		mErr = multierror.Append(mErr, d.Set("ip_ranges", ipRanges))
 	}
+	if len(res.AllowAddressNetmasksIPv6) > 0 {
+		addressNetmasks := make([]map[string]string, 0, len(res.AllowAddressNetmasksIPv6))
+		for _, v := range res.AllowAddressNetmasksIPv6 {
+			addressNetmask := map[string]string{
+				"cidr":        v.AddressNetmask,
+				"description": v.Description,
+			}
+			addressNetmasks = append(addressNetmasks, addressNetmask)
+		}
+		mErr = multierror.Append(mErr, d.Set("ipv6_cidrs", addressNetmasks))
+	}
+	if len(res.AllowIPRangesIPv6) > 0 {
+		ipRanges := make([]map[string]string, 0, len(res.AllowIPRangesIPv6))
+		for _, v := range res.AllowIPRangesIPv6 {
+			ipRange := map[string]string{
+				"range":       v.IPRange,
+				"description": v.Description,
+			}
+			ipRanges = append(ipRanges, ipRange)
+		}
+		mErr = multierror.Append(mErr, d.Set("ipv6_ranges", ipRanges))
+	}
 
 	if err = mErr.ErrorOrNil(); err != nil {
 		return diag.Errorf("error setting identity ACL fields: %s", err)
@@ -149,7 +210,7 @@ func resourceIdentityACLV3Read(_ context.Context, d *schema.ResourceData, meta i
 }
 
 func resourceIdentityACLV3Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	if d.HasChanges("ip_cidrs", "ip_ranges") {
+	if d.HasChanges("ip_cidrs", "ip_ranges", "ipv6_cidrs", "ipv6_ranges") {
 		if err := updateACLPolicy(d, meta); err != nil {
 			return diag.Errorf("error updating identity ACL: %s", err)
 		}
@@ -160,7 +221,7 @@ func resourceIdentityACLV3Update(ctx context.Context, d *schema.ResourceData, me
 
 func resourceIdentityACLV3Delete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	iamClient, err := config.IdentityV30Client()
+	iamClient, err := config.IdentityV30AdminClient()
 	if err != nil {
 		return diag.Errorf("error creating IAM client: %s", err)
 	}
@@ -192,9 +253,16 @@ func resourceIdentityACLV3Delete(_ context.Context, d *schema.ResourceData, meta
 
 func updateACLPolicy(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*cfg.Config)
-	iamClient, err := config.IdentityV30Client()
+	iamClient, err := config.IdentityV30AdminClient()
 	if err != nil {
 		return fmt.Errorf("error creating IAM client: %s", err)
+	}
+
+	t := d.Get("type").(string)
+	if t != "console" {
+		if d.Get("ipv6_cidrs").(*schema.Set).Len() > 0 || d.Get("ipv6_ranges").(*schema.Set).Len() > 0 {
+			return fmt.Errorf(`ipv6_cidrs and ipv6_ranges can only be set when type = "console"`)
+		}
 	}
 
 	updateOpts := acl.ACLPolicy{
@@ -221,6 +289,28 @@ func updateACLPolicy(d *schema.ResourceData, meta interface{}) error {
 			rangeList = append(rangeList, ipRange)
 		}
 		updateOpts.AllowIPRanges = rangeList
+	}
+	if addressNetmasksv6, ok := d.GetOk("ipv6_cidrs"); ok {
+		netmasksList := make([]acl.AllowAddressNetmasks, 0, addressNetmasksv6.(*schema.Set).Len())
+		for _, v := range addressNetmasksv6.(*schema.Set).List() {
+			netmask := acl.AllowAddressNetmasks{
+				AddressNetmask: v.(map[string]interface{})["cidr"].(string),
+				Description:    v.(map[string]interface{})["description"].(string),
+			}
+			netmasksList = append(netmasksList, netmask)
+		}
+		updateOpts.AllowAddressNetmasksIPv6 = netmasksList
+	}
+	if ipRangesv6, ok := d.GetOk("ipv6_ranges"); ok {
+		rangeList := make([]acl.AllowIPRanges, 0, ipRangesv6.(*schema.Set).Len())
+		for _, v := range ipRangesv6.(*schema.Set).List() {
+			ipRange := acl.AllowIPRanges{
+				IPRange:     v.(map[string]interface{})["range"].(string),
+				Description: v.(map[string]interface{})["description"].(string),
+			}
+			rangeList = append(rangeList, ipRange)
+		}
+		updateOpts.AllowIPRangesIPv6 = rangeList
 	}
 
 	switch d.Get("type").(string) {
@@ -253,4 +343,23 @@ func resourceACLPolicyRangeHash(v interface{}) int {
 	}
 
 	return hashcode.String(buf.String())
+}
+
+func resourceIdentityACLV3CustomizeDiff(
+	ctx context.Context,
+	d *schema.ResourceDiff,
+	meta interface{},
+) error {
+
+	if d.Get("type").(string) != "console" {
+		if d.Get("ipv6_cidrs").(*schema.Set).Len() > 0 {
+			return fmt.Errorf(`ipv6_cidrs can only be specified when type = "console"`)
+		}
+
+		if d.Get("ipv6_ranges").(*schema.Set).Len() > 0 {
+			return fmt.Errorf(`ipv6_ranges can only be specified when type = "console"`)
+		}
+	}
+
+	return nil
 }

--- a/opentelekomcloud/services/iam/resource_opentelekomcloud_identity_acl_v3.go
+++ b/opentelekomcloud/services/iam/resource_opentelekomcloud_identity_acl_v3.go
@@ -119,7 +119,7 @@ func ResourceIdentityAclV3() *schema.Resource {
 
 func resourceIdentityACLV3Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	iamClient, err := config.IdentityV30AdminClient()
+	iamClient, err := config.IdentityV30Client()
 	if err != nil {
 		return fmterr.Errorf("error creating client: %s", err)
 	}
@@ -139,7 +139,7 @@ func resourceIdentityACLV3Create(ctx context.Context, d *schema.ResourceData, me
 func resourceIdentityACLV3Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	mErr := &multierror.Error{}
 	config := meta.(*cfg.Config)
-	iamClient, err := config.IdentityV30AdminClient()
+	iamClient, err := config.IdentityV30Client()
 	if err != nil {
 		return diag.Errorf("error creating IAM client: %s", err)
 	}
@@ -223,7 +223,7 @@ func resourceIdentityACLV3Update(ctx context.Context, d *schema.ResourceData, me
 
 func resourceIdentityACLV3Delete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	iamClient, err := config.IdentityV30AdminClient()
+	iamClient, err := config.IdentityV30Client()
 	if err != nil {
 		return diag.Errorf("error creating IAM client: %s", err)
 	}
@@ -262,7 +262,7 @@ func resourceIdentityACLV3Delete(_ context.Context, d *schema.ResourceData, meta
 
 func updateACLPolicy(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*cfg.Config)
-	iamClient, err := config.IdentityV30AdminClient()
+	iamClient, err := config.IdentityV30Client()
 	if err != nil {
 		return fmt.Errorf("error creating IAM client: %s", err)
 	}

--- a/opentelekomcloud/services/iam/resource_opentelekomcloud_identity_acl_v3.go
+++ b/opentelekomcloud/services/iam/resource_opentelekomcloud_identity_acl_v3.go
@@ -36,9 +36,10 @@ func ResourceIdentityAclV3() *schema.Resource {
 				}, true),
 			},
 			"ip_cidrs": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				MaxItems: 200,
+				Type:         schema.TypeSet,
+				Optional:     true,
+				MaxItems:     200,
+				AtLeastOneOf: []string{"ip_ranges"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"cidr": {
@@ -95,6 +96,7 @@ func ResourceIdentityAclV3() *schema.Resource {
 			"ipv6_ranges": {
 				Type:     schema.TypeSet,
 				Optional: true,
+				Computed: true,
 				MaxItems: 200,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -235,6 +237,13 @@ func resourceIdentityACLV3Delete(_ context.Context, d *schema.ResourceData, meta
 	deleteOpts := acl.ACLPolicy{
 		AllowAddressNetmasks: netmasksList,
 		DomainId:             d.Id(),
+	}
+	if d.Get("type").(string) == "console" {
+		deleteOpts.AllowAddressNetmasksIPv6 = []acl.AllowAddressNetmasks{
+			{
+				AddressNetmask: "0000:0000:0000:0000:0000:0000:0000:0000-FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF",
+			},
+		}
 	}
 
 	switch d.Get("type").(string) {

--- a/releasenotes/notes/iam-add-ipv6-acl-v3-2c2cc48277bc2433.yaml
+++ b/releasenotes/notes/iam-add-ipv6-acl-v3-2c2cc48277bc2433.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    **[IAM]** Add arguments ``ipv6_cidrs`` and ``ipv6_ranges`` in ``resource/opentelekomcloud_identity_acl_v3`` (`#3268 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3268>`_)


### PR DESCRIPTION
## Summary of the Pull Request

Add new argument `ipv6_ranges` and `ipv6_cidrs` to `resource opentelekomcloud_identity_acl_v3`

## PR Checklist

* [x] Refers to: #3247
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccIdentitACL_basic
=== PAUSE TestAccIdentitACL_basic
=== CONT  TestAccIdentitACL_basic
--- PASS: TestAccIdentitACL_basic (40.15s)
PASS
=== RUN   TestAccIdentitACL_apiAccess
=== PAUSE TestAccIdentitACL_apiAccess
=== CONT  TestAccIdentitACL_apiAccess
--- PASS: TestAccIdentitACL_apiAccess (62.25s)
PASS
=== RUN   TestAccIdentitACL_CIDR
=== PAUSE TestAccIdentitACL_CIDR
=== CONT  TestAccIdentitACL_CIDR
--- PASS: TestAccIdentitACL_CIDR (26.58s)
PASS
```
