### PR TITLE
[Fix.] CES: remove `dimension_name` validatefunc for `ces_alarm_template_v2`

### DIFF
--- a/docs/resources/ces_alarm_template_v2.md
+++ b/docs/resources/ces_alarm_template_v2.md
@@ -181,10 +181,8 @@ The `policies` block supports:
   + **4**: warning.
 
 * `unit` - (Optional, String) Specifies the unit string of the alarm threshold.
-  The unit can contain a maximum of `32` characters.
 
 * `dimension_name` - (Optional, String) Specifies the resource dimension.
-  The name can contain a maximum of `32` characters.
   Leave this parameter blank for an event alarm template.
 
 ## Attribute Reference

--- a/opentelekomcloud/services/ces/resource_opentelekomcloud_ces_alarm_template_v2.go
+++ b/opentelekomcloud/services/ces/resource_opentelekomcloud_ces_alarm_template_v2.go
@@ -115,9 +115,8 @@ func ResourceAlarmTemplateV2() *schema.Resource {
 							Optional: true,
 						},
 						"unit": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ValidateFunc: validation.StringLenBetween(0, 32),
+							Type:     schema.TypeString,
+							Optional: true,
 						},
 						"count": {
 							Type:         schema.TypeInt,

--- a/opentelekomcloud/services/ces/resource_opentelekomcloud_ces_alarm_template_v2.go
+++ b/opentelekomcloud/services/ces/resource_opentelekomcloud_ces_alarm_template_v2.go
@@ -75,9 +75,8 @@ func ResourceAlarmTemplateV2() *schema.Resource {
 							),
 						},
 						"dimension_name": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ValidateFunc: validation.StringLenBetween(0, 32),
+							Type:     schema.TypeString,
+							Optional: true,
 						},
 						"metric_name": {
 							Type:     schema.TypeString,

--- a/releasenotes/notes/ces-alarm-template-dimension-name-validation-fix-a1b2c3d4e5f67890.yaml
+++ b/releasenotes/notes/ces-alarm-template-dimension-name-validation-fix-a1b2c3d4e5f67890.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    **[CES]** Remove ``dimension_name`` length validation for ``resource/opentelekomcloud_ces_alarm_template_v2`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[CES]** Remove ``dimension_name`` and ``unit`` length validation for ``resource/opentelekomcloud_ces_alarm_template_v2`` (`#3272 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3272>`_)

--- a/releasenotes/notes/ces-alarm-template-dimension-name-validation-fix-a1b2c3d4e5f67890.yaml
+++ b/releasenotes/notes/ces-alarm-template-dimension-name-validation-fix-a1b2c3d4e5f67890.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[CES]** Remove ``dimension_name`` length validation for ``resource/opentelekomcloud_ces_alarm_template_v2`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Remove `dimension_name` length validation for `ces_alarm_template_v2`.

## PR Checklist

* [x] Refers to: #3270
* [ ] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

