### PR TITLE
[Doc.] LTS: remove invalid example block

### DIFF
--- a/docs/resources/lts_cce_access_v3.md
+++ b/docs/resources/lts_cce_access_v3.md
@@ -32,13 +32,6 @@ resource "opentelekomcloud_lts_cce_access_v3" "container_stdout" {
     path_type = "container_stdout"
     stdout    = true
 
-    windows_log_info {
-      categories       = ["System", "Application"]
-      event_level      = ["warning", "error"]
-      time_offset_unit = "day"
-      time_offset      = 7
-    }
-
     single_log_format {
       mode = "system"
     }

--- a/releasenotes/notes/lts-cce-access-doc-fix-76b444b01905580e.yaml
+++ b/releasenotes/notes/lts-cce-access-doc-fix-76b444b01905580e.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    **[LTS]** Removed invalid ``windows_log_info`` block from ``resource/opentelekomcloud_lts_cce_access_v3`` documentation example (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[LTS]** Removed invalid ``windows_log_info`` block from ``resource/opentelekomcloud_lts_cce_access_v3`` documentation example (`#3275 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3275>`_)

--- a/releasenotes/notes/lts-cce-access-doc-fix-76b444b01905580e.yaml
+++ b/releasenotes/notes/lts-cce-access-doc-fix-76b444b01905580e.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[LTS]** Removed invalid ``windows_log_info`` block from ``resource/opentelekomcloud_lts_cce_access_v3`` documentation example (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Removed invalid ``windows_log_info`` block from ``resource/opentelekomcloud_lts_cce_access_v3``

## PR Checklist

* [x] Refers to: #2894
* [ ] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.
* [x] Release notes added.
