### PR TITLE
[Fix.] FW: fix ``opentelekomcloud_fw_policy_v2`` name update

### DIFF
--- a/opentelekomcloud/acceptance/fw/resource_opentelekomcloud_fw_policy_v2_test.go
+++ b/opentelekomcloud/acceptance/fw/resource_opentelekomcloud_fw_policy_v2_test.go
@@ -66,6 +66,30 @@ func TestAccFWPolicyV2_deleteRules(t *testing.T) {
 	})
 }
 
+func TestAccFWPolicyV2_rename(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckFWPolicyV2Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFWPolicyV2_rename_1,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFWPolicyV2Exists(
+						"opentelekomcloud_fw_policy_v2.policy_1", "my-policy", "", 2),
+				),
+			},
+			{
+				Config: testAccFWPolicyV2_rename_2,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFWPolicyV2Exists(
+						"opentelekomcloud_fw_policy_v2.policy_1", "my-policy-123", "", 2),
+				),
+			},
+		},
+	})
+}
+
 func TestAccFWPolicyV2_timeout(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -213,6 +237,46 @@ resource "opentelekomcloud_fw_policy_v2" "policy_1" {
 resource "opentelekomcloud_fw_rule_v2" "udp_deny" {
   protocol = "udp"
   action   = "deny"
+}
+`
+
+const testAccFWPolicyV2_rename_1 = `
+resource "opentelekomcloud_fw_rule_v2" "rule_1" {
+  protocol = "tcp"
+  action   = "allow"
+}
+
+resource "opentelekomcloud_fw_rule_v2" "rule_2" {
+  protocol = "udp"
+  action   = "deny"
+}
+
+resource "opentelekomcloud_fw_policy_v2" "policy_1" {
+  name = "my-policy"
+  rules = [
+    opentelekomcloud_fw_rule_v2.rule_1.id,
+    opentelekomcloud_fw_rule_v2.rule_2.id,
+  ]
+}
+`
+
+const testAccFWPolicyV2_rename_2 = `
+resource "opentelekomcloud_fw_rule_v2" "rule_1" {
+  protocol = "tcp"
+  action   = "allow"
+}
+
+resource "opentelekomcloud_fw_rule_v2" "rule_2" {
+  protocol = "udp"
+  action   = "deny"
+}
+
+resource "opentelekomcloud_fw_policy_v2" "policy_1" {
+  name = "my-policy-123"
+  rules = [
+    opentelekomcloud_fw_rule_v2.rule_1.id,
+    opentelekomcloud_fw_rule_v2.rule_2.id,
+  ]
 }
 `
 

--- a/opentelekomcloud/services/fw/resource_opentelekomcloud_fw_policy_v2.go
+++ b/opentelekomcloud/services/fw/resource_opentelekomcloud_fw_policy_v2.go
@@ -174,18 +174,16 @@ func resourceFWPolicyV2Update(ctx context.Context, d *schema.ResourceData, meta 
 		opts.Description = d.Get("description").(string)
 	}
 
-	if d.HasChange("rules") {
-		v := d.Get("rules").([]interface{})
+	v := d.Get("rules").([]interface{})
 
-		log.Printf("[DEBUG] Rules found : %#v", v)
-		log.Printf("[DEBUG] Rules count : %d", len(v))
+	log.Printf("[DEBUG] Rules found : %#v", v)
+	log.Printf("[DEBUG] Rules count : %d", len(v))
 
-		rules := make([]string, len(v))
-		for i, v := range v {
-			rules[i] = v.(string)
-		}
-		opts.Rules = rules
+	rules := make([]string, len(v))
+	for i, v := range v {
+		rules[i] = v.(string)
 	}
+	opts.Rules = rules
 
 	log.Printf("[DEBUG] Updating firewall policy with id %s: %#v", d.Id(), opts)
 

--- a/releasenotes/notes/fix-fw-policy-update-9a6ff7aaef847134.yaml
+++ b/releasenotes/notes/fix-fw-policy-update-9a6ff7aaef847134.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    **[FW]** Fix ``resource/opentelekomcloud_fw_policy_v2`` update failing with ``'firewall_rules' (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/>`_)
+    **[FW]** Fix ``resource/opentelekomcloud_fw_policy_v2`` update failing with ``'firewall_rules' (`#3277 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/3277>`_)

--- a/releasenotes/notes/fix-fw-policy-update-9a6ff7aaef847134.yaml
+++ b/releasenotes/notes/fix-fw-policy-update-9a6ff7aaef847134.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[FW]** Fix ``resource/opentelekomcloud_fw_policy_v2`` update failing with ``'firewall_rules' (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/>`_)

--- a/releasenotes/notes/fix-fw-policy-update-9a6ff7aaef847134.yaml
+++ b/releasenotes/notes/fix-fw-policy-update-9a6ff7aaef847134.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    **[FW]** Fix ``resource/opentelekomcloud_fw_policy_v2`` update failing with ``'firewall_rules' (`#3277 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/3277>`_)
+    **[FW]** Fix ``resource/opentelekomcloud_fw_policy_v2`` update failing with `firewall_rules` (`#3277 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/3277>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Fix ``resource/opentelekomcloud_fw_policy_v2`` update failing with ``'firewall_rules' attribute isn't allowed 'null'`` when only name or description is changed.

## PR Checklist

* [x] Refers to: #3269
* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccFWPolicyV2_rename
--- PASS: TestAccFWPolicyV2_rename (42.98s)
PASS

Process finished with the exit code 0

=== RUN   TestAccFWPolicyV2_basic
--- PASS: TestAccFWPolicyV2_basic (23.99s)
PASS

Process finished with the exit code 0

=== RUN   TestAccFWPolicyV2_deleteRules
--- PASS: TestAccFWPolicyV2_deleteRules (25.53s)
PASS

Process finished with the exit code 0

=== RUN   TestAccFWPolicyV2_addRules
--- PASS: TestAccFWPolicyV2_addRules (25.49s)
PASS

Process finished with the exit code 0

=== RUN   TestAccFWPolicyV2_removeSingleRule
--- PASS: TestAccFWPolicyV2_removeSingleRule (43.17s)
PASS

Process finished with the exit code 0

=== RUN   TestAccFWPolicyV2_timeout
--- PASS: TestAccFWPolicyV2_timeout (24.31s)
PASS

Process finished with the exit code 0

```
