### PR TITLE
[Fix.] OBS: fix bucket data source `agency` parameter

### DIFF
--- a/docs/data-sources/obs_bucket.md
+++ b/docs/data-sources/obs_bucket.md
@@ -62,6 +62,8 @@ The `logging` object supports the following:
 
 * `target_prefix` - To specify a key prefix for log objects.
 
+* `agency` - The agency name for logging.
+
 The `website` object supports the following:
 
 * `index_document` - Specifies the default homepage of the static website, only HTML web pages are supported.

--- a/opentelekomcloud/services/obs/data_source_opentelekomcloud_obs_bucket.go
+++ b/opentelekomcloud/services/obs/data_source_opentelekomcloud_obs_bucket.go
@@ -50,6 +50,10 @@ func DataSourceObsBucket() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"agency": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 					},
 				},
 			},

--- a/releasenotes/notes/fix-obs-bucket-datasource-logging-agency-2122fb0c9bcdee3d.yaml
+++ b/releasenotes/notes/fix-obs-bucket-datasource-logging-agency-2122fb0c9bcdee3d.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    **[OBS]** Fix ``data_source/opentelekomcloud_obs_bucket`` failing with missing ``agency`` attribute (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[OBS]** Fix ``data_source/opentelekomcloud_obs_bucket`` failing with missing ``agency`` attribute (`#3279 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3279>`_)

--- a/releasenotes/notes/fix-obs-bucket-datasource-logging-agency-2122fb0c9bcdee3d.yaml
+++ b/releasenotes/notes/fix-obs-bucket-datasource-logging-agency-2122fb0c9bcdee3d.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[OBS]** Fix ``data_source/opentelekomcloud_obs_bucket`` failing with missing ``agency`` attribute (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Fix ``data_source/opentelekomcloud_obs_bucket`` failing with missing ``agency`` attribute in ``logging`` block

## PR Checklist

* [x] Refers to: #3278
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccDataSourceObsBucket_basic
=== PAUSE TestAccDataSourceObsBucket_basic
=== CONT  TestAccDataSourceObsBucket_basic
--- PASS: TestAccDataSourceObsBucket_basic (50.02s)
PASS

Process finished with the exit code 0
```
