### PR TITLE
[Feat.] CES: alarm rules data source

### DIFF
--- a/docs/data-sources/ces_alarm_rules_v2.md
+++ b/docs/data-sources/ces_alarm_rules_v2.md
@@ -1,0 +1,142 @@
+---
+subcategory: "Cloud Eye (CES)"
+layout: "opentelekomcloud"
+page_title: "OpenTelekomCloud: opentelekomcloud_ces_alarm_rules_v2"
+sidebar_current: "docs-opentelekomcloud-datasource-ces-alarm-rules-v2"
+description: |-
+  Use this data source to get the list of CES alarm rules within OpenTelekomCloud.
+---
+
+Up-to-date reference of API arguments for CES alarm rules you can get at
+[documentation portal](https://docs.otc.t-systems.com/cloud-eye/api-ref/api_v2/alarm_rules/index.html)
+
+# opentelekomcloud_ces_alarm_rules_v2
+
+Use this data source to get the list of CES alarm rules within OpenTelekomCloud.
+
+## Example Usage
+
+```hcl
+data "opentelekomcloud_ces_alarm_rules_v2" "all" {}
+```
+
+### Filter by alarm rule name
+
+```hcl
+data "opentelekomcloud_ces_alarm_rules_v2" "by_name" {
+  name = "my-alarm-rule"
+}
+```
+
+### Filter by namespace
+
+```hcl
+data "opentelekomcloud_ces_alarm_rules_v2" "by_namespace" {
+  namespace = "SYS.ECS"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `alarm_id` - (Optional, String) Specifies the alarm rule ID.
+
+* `name` - (Optional, String) Specifies the name of an alarm rule.
+
+* `namespace` - (Optional, String) Specifies the namespace of a service.
+
+* `resource_id` - (Optional, String) Specifies the alarm resource ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `alarms` - The alarm rule list.
+
+  The [alarms](#alarms_struct) structure is documented below.
+
+<a name="alarms_struct"></a>
+The `alarms` block supports:
+
+* `alarm_id` - The alarm rule ID.
+
+* `name` - The alarm rule name.
+
+* `description` - The alarm rule description.
+
+* `namespace` - The namespace of a service.
+
+* `type` - The alarm rule type.
+
+* `alarm_enabled` - Whether the alarm rule is enabled.
+
+* `notification_enabled` - Whether the action to be triggered by an alarm is enabled.
+
+* `notification_begin_time` - The time when the alarm notification was enabled.
+
+* `notification_end_time` - The time when the alarm notification was disabled.
+
+* `enterprise_project_id` - The enterprise project ID.
+
+* `alarm_template_id` - The ID of an alarm template associated with an alarm rule.
+
+* `policies` - The alarm policy list.
+
+  The [policies](#alarms_policies_struct) structure is documented below.
+
+* `resources` - The resource list.
+
+  The [resources](#alarms_resources_struct) structure is documented below.
+
+* `alarm_actions` - The action triggered by an alarm.
+
+  The [alarm_actions](#notification_struct) structure is documented below.
+
+* `ok_actions` - The action triggered after an alarm is cleared.
+
+  The [ok_actions](#notification_struct) structure is documented below.
+
+<a name="alarms_policies_struct"></a>
+The `policies` block supports:
+
+* `metric_name` - The metric name of a resource.
+
+* `period` - The monitoring period of a metric.
+
+* `filter` - The data rollup method.
+
+* `comparison_operator` - The comparison condition of alarm thresholds.
+
+* `value` - The alarm threshold.
+
+* `unit` - The metric unit.
+
+* `count` - The number of consecutive times that the alarm triggering conditions are met.
+
+* `suppress_duration` - The interval for triggering an alarm if the alarm persists.
+
+* `level` - The alarm severity.
+
+<a name="alarms_resources_struct"></a>
+The `resources` block supports:
+
+* `dimensions` - The dimension information.
+
+  The [dimensions](#resources_dimensions_struct) structure is documented below.
+
+<a name="resources_dimensions_struct"></a>
+The `dimensions` block supports:
+
+* `name` - The name of the metric dimension.
+
+* `value` - The value of the metric dimension.
+
+<a name="notification_struct"></a>
+The `alarm_actions` or `ok_actions` blocks support:
+
+* `type` - The type of action triggered by an alarm.
+
+* `notification_list` - The list of objects to be notified if the alarm status changes.

--- a/opentelekomcloud/acceptance/ces/data_source_opentelekomcloud_ces_alarm_rules_v2_test.go
+++ b/opentelekomcloud/acceptance/ces/data_source_opentelekomcloud_ces_alarm_rules_v2_test.go
@@ -1,0 +1,127 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+)
+
+func TestAccDataSourceCesAlarmRulesV2_basic(t *testing.T) {
+	var (
+		dataSource = "data.opentelekomcloud_ces_alarm_rules_v2.test"
+		dc         = common.InitDataSourceCheck(dataSource)
+		name       = fmt.Sprintf("ces-rule-%s", acctest.RandString(5))
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceCesAlarmRulesV2Basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "alarms.0.alarm_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "alarms.0.name"),
+					resource.TestCheckResourceAttrSet(dataSource, "alarms.0.namespace"),
+					resource.TestCheckResourceAttrSet(dataSource, "alarms.0.type"),
+					resource.TestCheckResourceAttrSet(dataSource, "alarms.0.policies.0.metric_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "alarms.0.policies.0.period"),
+					resource.TestCheckResourceAttrSet(dataSource, "alarms.0.policies.0.filter"),
+					resource.TestCheckResourceAttrSet(dataSource, "alarms.0.policies.0.comparison_operator"),
+					resource.TestCheckResourceAttrSet(dataSource, "alarms.0.policies.0.count"),
+
+					resource.TestCheckOutput("is_default_filter_useful", "true"),
+					resource.TestCheckOutput("is_filter_by_id_useful", "true"),
+					resource.TestCheckOutput("is_filter_by_name_useful", "true"),
+					resource.TestCheckOutput("is_filter_by_namespace_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceCesAlarmRulesV2Basic(name string) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_ces_alarm_rule_v2" "test" {
+  name      = "%[1]s"
+  namespace = "SYS.ECS"
+  type      = "EVENT.SYS"
+
+  resources {
+    dimensions {
+      name  = "resource_id"
+      value = "all_instance"
+    }
+  }
+
+  policies {
+    metric_name         = "stopServer"
+    period              = 0
+    filter              = "average"
+    comparison_operator = ">="
+    value               = 1
+    unit                = "count"
+    count               = 1
+    suppress_duration   = 0
+    level               = 2
+  }
+
+  notification_enabled = false
+  alarm_enabled        = true
+}
+
+locals {
+  id        = opentelekomcloud_ces_alarm_rule_v2.test.alarm_id
+  name      = opentelekomcloud_ces_alarm_rule_v2.test.name
+  namespace = opentelekomcloud_ces_alarm_rule_v2.test.namespace
+}
+
+data "opentelekomcloud_ces_alarm_rules_v2" "test" {
+  depends_on = [opentelekomcloud_ces_alarm_rule_v2.test]
+}
+
+output "is_default_filter_useful" {
+  value = length(data.opentelekomcloud_ces_alarm_rules_v2.test.alarms) > 0
+}
+
+data "opentelekomcloud_ces_alarm_rules_v2" "filter_by_id" {
+  alarm_id = local.id
+
+  depends_on = [opentelekomcloud_ces_alarm_rule_v2.test]
+}
+
+output "is_filter_by_id_useful" {
+  value = length(data.opentelekomcloud_ces_alarm_rules_v2.filter_by_id.alarms) > 0 && alltrue(
+    [for alarm in data.opentelekomcloud_ces_alarm_rules_v2.filter_by_id.alarms[*] : alarm.alarm_id == local.id]
+  )
+}
+
+data "opentelekomcloud_ces_alarm_rules_v2" "filter_by_name" {
+  name = local.name
+
+  depends_on = [opentelekomcloud_ces_alarm_rule_v2.test]
+}
+
+output "is_filter_by_name_useful" {
+  value = length(data.opentelekomcloud_ces_alarm_rules_v2.filter_by_name.alarms) > 0 && alltrue(
+    [for alarm in data.opentelekomcloud_ces_alarm_rules_v2.filter_by_name.alarms[*] : alarm.name == local.name]
+  )
+}
+
+data "opentelekomcloud_ces_alarm_rules_v2" "filter_by_namespace" {
+  namespace = local.namespace
+
+  depends_on = [opentelekomcloud_ces_alarm_rule_v2.test]
+}
+
+output "is_filter_by_namespace_useful" {
+  value = length(data.opentelekomcloud_ces_alarm_rules_v2.filter_by_namespace.alarms) > 0 && alltrue(
+    [for alarm in data.opentelekomcloud_ces_alarm_rules_v2.filter_by_namespace.alarms[*] : alarm.namespace == local.namespace]
+  )
+}
+`, name)
+}

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -286,6 +286,7 @@ func Provider() *schema.Provider {
 			"opentelekomcloud_cce_addon_templates_v3":             cce.DataSourceCceAddonTemplatesV3(),
 			"opentelekomcloud_cce_node_ids_v3":                    cce.DataSourceCceNodeIdsV3(),
 			"opentelekomcloud_cce_node_v3":                        cce.DataSourceCceNodesV3(),
+			"opentelekomcloud_ces_alarm_rules_v2":                 ces.DataSourceCesAlarmRulesV2(),
 			"opentelekomcloud_ces_event_details_v1":               ces.DataSourceCesEventDetailsV1(),
 			"opentelekomcloud_ces_events_v1":                      ces.DataSourceCesEventsV1(),
 			"opentelekomcloud_ces_metrics_v1":                     ces.DataSourceCesMetricsV1(),

--- a/opentelekomcloud/services/ces/data_source_opentelekomcloud_ces_alarm_rules_v2.go
+++ b/opentelekomcloud/services/ces/data_source_opentelekomcloud_ces_alarm_rules_v2.go
@@ -1,0 +1,269 @@
+package ces
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/ces/v2/alarms"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/ces/v2/policies"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/ces/v2/resources"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/helper/hashcode"
+)
+
+func DataSourceCesAlarmRulesV2() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceCesAlarmRulesV2Read,
+
+		Schema: map[string]*schema.Schema{
+			"alarm_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"namespace": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"resource_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"alarms": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"alarm_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"namespace": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"alarm_enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"notification_enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"notification_begin_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"notification_end_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"enterprise_project_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"alarm_template_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"policies": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"metric_name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"period": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"filter": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"comparison_operator": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"value": {
+										Type:     schema.TypeFloat,
+										Computed: true,
+									},
+									"unit": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"count": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"suppress_duration": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"level": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"resources": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"dimensions": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"name": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"value": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"alarm_actions": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"notification_list": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+						},
+						"ok_actions": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"notification_list": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceCesAlarmRulesV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, cesClientV2, func() (*golangsdk.ServiceClient, error) {
+		return config.CesV2Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationClientV2, err)
+	}
+
+	listOpts := alarms.ListOpts{
+		AlarmId:    d.Get("alarm_id").(string),
+		Name:       d.Get("name").(string),
+		Namespace:  d.Get("namespace").(string),
+		ResourceId: d.Get("resource_id").(string),
+	}
+
+	listResp, err := alarms.List(client, listOpts)
+	if err != nil {
+		return fmterr.Errorf("error listing CES alarm rules v2: %w", err)
+	}
+
+	ids := make([]string, 0, len(listResp.Alarms))
+	alarmsList := make([]map[string]interface{}, 0, len(listResp.Alarms))
+
+	for _, alarm := range listResp.Alarms {
+		ids = append(ids, alarm.AlarmId)
+
+		policiesResp, err := policies.List(client, alarm.AlarmId, policies.ListOpts{})
+		if err != nil {
+			log.Printf("[WARN] Error retrieving policies for alarm %s: %s", alarm.AlarmId, err)
+			continue
+		}
+
+		resourcesResp, err := resources.List(client, alarm.AlarmId, resources.ListOpts{})
+		if err != nil {
+			log.Printf("[WARN] Error retrieving resources for alarm %s: %s", alarm.AlarmId, err)
+			continue
+		}
+
+		alarmMap := map[string]interface{}{
+			"alarm_id":                alarm.AlarmId,
+			"name":                    alarm.Name,
+			"description":             alarm.Description,
+			"namespace":               alarm.Namespace,
+			"type":                    alarm.Type,
+			"alarm_enabled":           alarm.Enabled,
+			"notification_enabled":    alarm.NotificationEnabled,
+			"notification_begin_time": alarm.NotificationBeginTime,
+			"notification_end_time":   alarm.NotificationEndTime,
+			"enterprise_project_id":   alarm.EnterpriseProjectId,
+			"alarm_template_id":       alarm.AlarmTemplateId,
+			"policies":                flattenPoliciesV2(policiesResp.Policies),
+			"resources":               flattenResourcesV2(resourcesResp.Resources),
+			"alarm_actions":           flattenNotifications(alarm.AlarmNotifications),
+			"ok_actions":              flattenNotifications(alarm.OkNotifications),
+		}
+		alarmsList = append(alarmsList, alarmMap)
+	}
+
+	d.SetId(hashcode.Strings(ids))
+
+	mErr := multierror.Append(nil,
+		d.Set("alarms", alarmsList),
+	)
+
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}

--- a/releasenotes/notes/ces-ds-alarm-rules-v2-f35d3c3f86fddae7.yaml
+++ b/releasenotes/notes/ces-ds-alarm-rules-v2-f35d3c3f86fddae7.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    **[CES]** Add new data source ``opentelekomcloud_ces_alarm_rules_v2`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)

--- a/releasenotes/notes/ces-ds-alarm-rules-v2-f35d3c3f86fddae7.yaml
+++ b/releasenotes/notes/ces-ds-alarm-rules-v2-f35d3c3f86fddae7.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   - |
-    **[CES]** Add new data source ``opentelekomcloud_ces_alarm_rules_v2`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[CES]** Add new data source ``opentelekomcloud_ces_alarm_rules_v2`` (`#3280 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3280>`_)


### PR DESCRIPTION
## Summary of the Pull Request
New data source ``opentelekomcloud_ces_alarm_rules_v2``

## PR Checklist

* [x] Refers to: #3231
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccDataSourceCesAlarmRulesV2_basic
=== PAUSE TestAccDataSourceCesAlarmRulesV2_basic
=== CONT  TestAccDataSourceCesAlarmRulesV2_basic
--- PASS: TestAccDataSourceCesAlarmRulesV2_basic (28.51s)
PASS

Process finished with the exit code 0
```
