### PR TITLE
[Feat] VPC: Add `description` to vpc_peering_connection_v2

### DIFF
--- a/docs/data-sources/vpc_peering_v2.md
+++ b/docs/data-sources/vpc_peering_v2.md
@@ -52,4 +52,6 @@ The given filters must match exactly one VPC peering connection whose data will 
 
 ## Attributes Reference
 
-All of the argument attributes are exported as result attributes.
+In addition to all arguments above, the following attributes are exported:
+
+* `description` - The description of the VPC peering connection.

--- a/docs/resources/vpc_peering_connection_v2.md
+++ b/docs/resources/vpc_peering_connection_v2.md
@@ -30,17 +30,19 @@ resource "opentelekomcloud_vpc_peering_connection_v2" "peering" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the VPC peering connection. The value can contain 1 to 64 characters.
+* `name` - (Required, String) Specifies the name of the VPC peering connection. The value can contain 1 to 64 characters.
 
-* `vpc_id` - (Required) Specifies the ID of a VPC involved in a VPC peering connection. Changing this creates a new VPC peering connection.
+* `description` - (Optional, String) Specifies the description of the VPC peering connection.
 
-* `peer_vpc_id` - (Required) Specifies the VPC ID of the accepter tenant. Changing this creates a new VPC peering connection.
+* `vpc_id` - (Required, String, ForceNew) Specifies the ID of a VPC involved in a VPC peering connection. Changing this creates a new VPC peering connection.
 
-* `peer_tenant_id` - (Optional) Specified the Tenant Id of the accepter tenant. Changing this creates a new VPC peering connection.
+* `peer_vpc_id` - (Required, String, ForceNew) Specifies the VPC ID of the accepter tenant. Changing this creates a new VPC peering connection.
+
+* `peer_tenant_id` - (Optional, String, ForceNew) Specified the Tenant Id of the accepter tenant. Changing this creates a new VPC peering connection.
 
 ## Attributes Reference
 
-All the argument attributes are also exported as result attributes:
+In addition to all arguments above, the following attributes are exported:
 
 * `id` - The VPC peering connection ID.
 

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20260217175632-5801f378524e
+	github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20260225121447-d7ae3ce649b4
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.45.0
 	golang.org/x/sync v0.18.0

--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20260217175632-5801f378524e h1:8HYlKnV39awReMPa2+EXXObYIJC0yJmF2tHylnYe8m8=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20260217175632-5801f378524e/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20260225121447-d7ae3ce649b4 h1:VEOKBvnPVQtSddyLGooXqS3OIl2+kybCB2CCX1YgNEQ=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20260225121447-d7ae3ce649b4/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/opentelekomcloud/acceptance/vpc/data_source_opentelekomcloud_vpc_peering_connection_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/data_source_opentelekomcloud_vpc_peering_connection_v2_test.go
@@ -33,6 +33,7 @@ func TestAccVpcPeeringConnectionV2DataSource_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVpcPeeringConnectionV2DataSourceID(dataSourceVpcPeeringNameID),
 					resource.TestCheckResourceAttr(dataSourceVpcPeeringNameID, "name", "opentelekomcloud_peering_ds"),
+					resource.TestCheckResourceAttr(dataSourceVpcPeeringNameID, "description", "test peering"),
 					resource.TestCheckResourceAttr(dataSourceVpcPeeringNameID, "status", "ACTIVE"),
 					testAccCheckVpcPeeringConnectionV2DataSourceID(dataSourceVpcPeeringNameVpcID),
 					resource.TestCheckResourceAttr(dataSourceVpcPeeringNameVpcID, "name", "opentelekomcloud_peering_ds"),
@@ -82,6 +83,7 @@ resource "opentelekomcloud_vpc_v1" "vpc_3" {
 
 resource "opentelekomcloud_vpc_peering_connection_v2" "peering_1" {
   name        = "opentelekomcloud_peering_ds"
+  description = "test peering"
   vpc_id      = opentelekomcloud_vpc_v1.vpc_1.id
   peer_vpc_id = opentelekomcloud_vpc_v1.vpc_2.id
 }

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_vpc_peering_connection_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_vpc_peering_connection_v2_test.go
@@ -31,6 +31,7 @@ func TestAccVpcPeeringConnectionV2_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckOTCVpcPeeringConnectionV2Exists(resourceVPCPeeringName, &peering),
 					resource.TestCheckResourceAttr(resourceVPCPeeringName, "name", "opentelekomcloud_peering"),
+					resource.TestCheckResourceAttr(resourceVPCPeeringName, "description", "test vpc peering"),
 					resource.TestCheckResourceAttr(resourceVPCPeeringName, "status", "ACTIVE"),
 				),
 			},
@@ -38,6 +39,7 @@ func TestAccVpcPeeringConnectionV2_basic(t *testing.T) {
 				Config: testAccVpcPeeringConnectionV2Update,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceVPCPeeringName, "name", "opentelekomcloud_peering_1"),
+					resource.TestCheckResourceAttr(resourceVPCPeeringName, "description", "test vpc peering update"),
 				),
 			},
 		},
@@ -151,23 +153,7 @@ resource "opentelekomcloud_vpc_v1" "vpc_2" {
 
 resource "opentelekomcloud_vpc_peering_connection_v2" "peering_1" {
   name        = "opentelekomcloud_peering"
-  vpc_id      = opentelekomcloud_vpc_v1.vpc_1.id
-  peer_vpc_id = opentelekomcloud_vpc_v1.vpc_2.id
-}
-`
-const testAccVpcPeeringConnectionV2Import = `
-resource "opentelekomcloud_vpc_v1" "vpc_1" {
-  name = "vpc_test_p_imp"
-  cidr = "192.168.0.0/16"
-}
-
-resource "opentelekomcloud_vpc_v1" "vpc_2" {
-  name = "vpc_test_p_imp1"
-  cidr = "192.168.0.0/16"
-}
-
-resource "opentelekomcloud_vpc_peering_connection_v2" "peering_1" {
-  name        = "opentelekomcloud_peering_imp"
+  description = "test vpc peering"
   vpc_id      = opentelekomcloud_vpc_v1.vpc_1.id
   peer_vpc_id = opentelekomcloud_vpc_v1.vpc_2.id
 }
@@ -185,10 +171,30 @@ resource "opentelekomcloud_vpc_v1" "vpc_2" {
 
 resource "opentelekomcloud_vpc_peering_connection_v2" "peering_1" {
   name        = "opentelekomcloud_peering_1"
+  description = "test vpc peering update"
   vpc_id      = opentelekomcloud_vpc_v1.vpc_1.id
   peer_vpc_id = opentelekomcloud_vpc_v1.vpc_2.id
 }
 `
+
+const testAccVpcPeeringConnectionV2Import = `
+resource "opentelekomcloud_vpc_v1" "vpc_1" {
+  name = "vpc_test_p_imp"
+  cidr = "192.168.0.0/16"
+}
+
+resource "opentelekomcloud_vpc_v1" "vpc_2" {
+  name = "vpc_test_p_imp1"
+  cidr = "192.168.0.0/16"
+}
+
+resource "opentelekomcloud_vpc_peering_connection_v2" "peering_1" {
+  name        = "opentelekomcloud_peering_imp"
+  vpc_id      = opentelekomcloud_vpc_v1.vpc_1.id
+  peer_vpc_id = opentelekomcloud_vpc_v1.vpc_2.id
+}
+`
+
 const testAccVpcPeeringConnectionV2Timeout = `
 resource "opentelekomcloud_vpc_v1" "vpc_1" {
   name = "vpc_test_p_t"

--- a/opentelekomcloud/services/vpc/data_source_opentelekomcloud_vpc_peering_connection_v2.go
+++ b/opentelekomcloud/services/vpc/data_source_opentelekomcloud_vpc_peering_connection_v2.go
@@ -34,6 +34,10 @@ func DataSourceVpcPeeringConnectionV2() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: common.ValidateName,
 			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"status": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -92,6 +96,7 @@ func dataSourceVpcPeeringConnectionV2Read(_ context.Context, d *schema.ResourceD
 
 	mErr := multierror.Append(
 		d.Set("name", Peering.Name),
+		d.Set("description", Peering.Description),
 		d.Set("status", Peering.Status),
 		d.Set("vpc_id", Peering.RequestVpcInfo.VpcId),
 		d.Set("peer_vpc_id", Peering.AcceptVpcInfo.VpcId),

--- a/opentelekomcloud/services/vpc/resource_opentelekomcloud_vpc_peering_connection_v2.go
+++ b/opentelekomcloud/services/vpc/resource_opentelekomcloud_vpc_peering_connection_v2.go
@@ -45,6 +45,10 @@ func ResourceVpcPeeringConnectionV2() *schema.Resource {
 				Required:     true,
 				ValidateFunc: common.ValidateName,
 			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"status": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -89,6 +93,7 @@ func resourceVPCPeeringV2Create(ctx context.Context, d *schema.ResourceData, met
 
 	createOpts := peerings.CreateOpts{
 		Name:           d.Get("name").(string),
+		Description:    d.Get("description").(string),
 		RequestVpcInfo: requestvpcinfo,
 		AcceptVpcInfo:  acceptvpcinfo,
 	}
@@ -139,6 +144,7 @@ func resourceVPCPeeringV2Read(ctx context.Context, d *schema.ResourceData, meta 
 
 	mErr := multierror.Append(
 		d.Set("name", n.Name),
+		d.Set("description", n.Description),
 		d.Set("status", n.Status),
 		d.Set("vpc_id", n.RequestVpcInfo.VpcId),
 		d.Set("peer_vpc_id", n.AcceptVpcInfo.VpcId),
@@ -162,7 +168,8 @@ func resourceVPCPeeringV2Update(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	updateOpts := peerings.UpdateOpts{
-		Name: d.Get("name").(string),
+		Name:        d.Get("name").(string),
+		Description: d.Get("description").(string),
 	}
 
 	_, err = peerings.Update(client, d.Id(), updateOpts).Extract()

--- a/releasenotes/notes/vpc-add-description-peering-v2-00feee76a5d229b4.yaml
+++ b/releasenotes/notes/vpc-add-description-peering-v2-00feee76a5d229b4.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    **[VPC]** Add argument `description` to resource ``opentelekomcloud_vpc_peering_connection_v2`` (`#3283 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3283>`_).
+  - |
+    **[VPC]** Add attribute `description` to data source ``opentelekomcloud_vpc_peering_connection_v2`` (`#3283 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3283>`_).


### PR DESCRIPTION
## Summary of the Pull Request

Add `description` to resource `opentelekomcloud_vpc_peering_connection_v2` and data source `opentelekomcloud_vpc_peering_connection_v2`

## PR Checklist

* [x] Refers to: #3276 
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccVpcPeeringConnectionV2_basic
=== PAUSE TestAccVpcPeeringConnectionV2_basic
=== CONT  TestAccVpcPeeringConnectionV2_basic
--- PASS: TestAccVpcPeeringConnectionV2_basic (87.25s)
PASS
=== RUN   TestAccVpcPeeringConnectionV2_import
=== PAUSE TestAccVpcPeeringConnectionV2_import
=== CONT  TestAccVpcPeeringConnectionV2_import
--- PASS: TestAccVpcPeeringConnectionV2_import (66.24s)
PASS
=== RUN   TestAccVpcPeeringConnectionV2DataSource_basic
=== PAUSE TestAccVpcPeeringConnectionV2DataSource_basic
=== CONT  TestAccVpcPeeringConnectionV2DataSource_basic
--- PASS: TestAccVpcPeeringConnectionV2DataSource_basic (58.52s)
PASS
```
