### PR TITLE
[Doc.] IAM: clarify `Security Administrator` role requirement

### DIFF
--- a/docs/data-sources/identity_group_v3.md
+++ b/docs/data-sources/identity_group_v3.md
@@ -13,7 +13,8 @@ Up-to-date reference of API arguments for IAM group you can get at
 # opentelekomcloud_identity_group_v3
 Use this data source to get the ID of an OpenTelekomCloud group.
 
--> **Note:** This usually requires admin privileges.
+-> **Note:** You _must_ have `Security Administrator` privileges in your OpenTelekomCloud
+cloud to use this data source. Please refer to [User Management Model](https://docs.otc.t-systems.com/en-us/usermanual/iam/iam_01_0034.html).
 
 ## Example Usage
 

--- a/docs/resources/identity_acl_v3.md
+++ b/docs/resources/identity_acl_v3.md
@@ -16,7 +16,8 @@ Up-to-date reference of API arguments for IAM agency you can get at
 Manages an ACL resource within OpenTelekomCloud IAM service. The ACL allows user access only from specified IP address
 ranges and CIDR blocks. The ACL takes effect for IAM users under the Domain account rather than the account itself.
 
--> **NOTE:** You *must* have admin privileges to use this resource.
+-> **NOTE:** You _must_ have `Security Administrator` privileges in your OpenTelekomCloud
+cloud to use this resource. Please refer to [User Management Model](https://docs.otc.t-systems.com/en-us/usermanual/iam/iam_01_0034.html).
 
 ## Example Usage
 

--- a/docs/resources/identity_agency_v3.md
+++ b/docs/resources/identity_agency_v3.md
@@ -14,6 +14,9 @@ Up-to-date reference of API arguments for IAM agency you can get at
 
 Manages an agency resource within OpenTelekomcloud.
 
+-> **Note:** You _must_ have `Security Administrator` privileges in your OpenTelekomCloud
+cloud to use this resource. Please refer to [User Management Model](https://docs.otc.t-systems.com/en-us/usermanual/iam/iam_01_0034.html).
+
 ## Example Usage
 
 ```hcl

--- a/docs/resources/identity_credential_v3.md
+++ b/docs/resources/identity_credential_v3.md
@@ -14,6 +14,9 @@ Up-to-date reference of API arguments for IAM credential you can get at
 
 Manages permanent access key for an OpenTelekomCloud user.
 
+-> **Note:** You _must_ have `Security Administrator` privileges in your OpenTelekomCloud
+cloud to use this resource for managing other users' credentials. Please refer to [User Management Model](https://docs.otc.t-systems.com/en-us/usermanual/iam/iam_01_0034.html).
+
 ## Example Usage
 
 ### Create AK/SK for yourself

--- a/docs/resources/identity_group_membership_v3.md
+++ b/docs/resources/identity_group_membership_v3.md
@@ -14,7 +14,8 @@ Up-to-date reference of API arguments for IAM group membership you can get at
 
 Manages a Group Membership resource within OpenTelekomCloud IAM service.
 
--> **Note:** You _must_ have admin privileges in your OpenTelekomCloud cloud to use this resource.
+-> **Note:** You _must_ have `Security Administrator` privileges in your OpenTelekomCloud
+cloud to use this resource. Please refer to [User Management Model](https://docs.otc.t-systems.com/en-us/usermanual/iam/iam_01_0034.html).
 
 ## Example Usage
 

--- a/docs/resources/identity_group_v3.md
+++ b/docs/resources/identity_group_v3.md
@@ -14,7 +14,8 @@ Up-to-date reference of API arguments for IAM group you can get at
 
 Manages a User Group resource within OpenTelekomCloud IAM service.
 
--> **Note:** You _must_ have admin privileges in your OpenTelekomCloud cloud to use this resource.
+-> **Note:** You _must_ have `Security Administrator` privileges in your OpenTelekomCloud
+cloud to use this resource. Please refer to [User Management Model](https://docs.otc.t-systems.com/en-us/usermanual/iam/iam_01_0034.html).
 
 ## Example Usage
 

--- a/docs/resources/identity_login_policy_v3.md
+++ b/docs/resources/identity_login_policy_v3.md
@@ -15,7 +15,7 @@ Up-to-date reference of API arguments for IAM provider you can get at
 Manages the account login authentication policy within OpenTelekomCloud.
 
 `Please use it with care!`
--> You _must_ have security admin privileges in your OpenTelekomCloud
+-> You _must_ have `Security Administrator` privileges in your OpenTelekomCloud
 cloud to use this resource. Please refer to [User Management Model](https://docs.otc.t-systems.com/en-us/usermanual/iam/iam_01_0034.html).
 
   During action `terraform destroy` it sets values the same as defaults for this resource.

--- a/docs/resources/identity_mapping_v3.md
+++ b/docs/resources/identity_mapping_v3.md
@@ -12,7 +12,7 @@ Up-to-date reference of API arguments for IAM mapping you can get at
 
 # opentelekomcloud_identity_mapping_v3
 
--> You _must_ have security admin privileges in your OpenTelekomCloud
+-> You _must_ have `Security Administrator` privileges in your OpenTelekomCloud
 cloud to use this resource. Please refer to [User Management Model](https://docs.otc.t-systems.com/en-us/usermanual/iam/iam_01_0034.html).
 
 

--- a/docs/resources/identity_password_policy_v3.md
+++ b/docs/resources/identity_password_policy_v3.md
@@ -15,7 +15,7 @@ Up-to-date reference of API arguments for IAM provider you can get at
 Manages the IAM account password policy within OpenTelekomCloud.
 
 `Please use it with care!`
--> You _must_ have security admin privileges in your OpenTelekomCloud
+-> You _must_ have `Security Administrator` privileges in your OpenTelekomCloud
 cloud to use this resource. Please refer to [User Management Model](https://docs.otc.t-systems.com/en-us/usermanual/iam/iam_01_0034.html).
 
   During action `terraform destroy` it sets values the same as defaults for this resource.

--- a/docs/resources/identity_project_v3.md
+++ b/docs/resources/identity_project_v3.md
@@ -15,7 +15,7 @@ Up-to-date reference of API arguments for IAM project you can get at
 Manages a Project resource within OpenTelekomCloud Identity And Access
 Management service.
 
--> **Note:** You _must_ have security admin privileges in your OpenTelekomCloud
+-> **Note:** You _must_ have `Security Administrator` privileges in your OpenTelekomCloud
 cloud to use this resource. Please refer to [User Management Model](https://docs.otc.t-systems.com/en-us/usermanual/iam/iam_01_0034.html).
 
 ## Example Usage

--- a/docs/resources/identity_protection_policy_v3.md
+++ b/docs/resources/identity_protection_policy_v3.md
@@ -15,7 +15,7 @@ Up-to-date reference of API arguments for IAM provider you can get at
 Manages the IAM operation protection policy within OpenTelekomCloud.
 
 `Please use it with care!`
--> You _must_ have security admin privileges in your OpenTelekomCloud
+-> You _must_ have `Security Administrator` privileges in your OpenTelekomCloud
 cloud to use this resource. Please refer to [User Management Model](https://docs.otc.t-systems.com/en-us/usermanual/iam/iam_01_0034.html).
 
   During action `terraform destroy` it sets values the same as defaults for this resource.

--- a/docs/resources/identity_protocol_v3.md
+++ b/docs/resources/identity_protocol_v3.md
@@ -14,7 +14,7 @@ Up-to-date reference of API arguments for IAM protocol you can get at
 
 Manages identity protocol resource providing binding between identity provider and identity mappings.
 
--> You _must_ have security admin privileges in your OpenTelekomCloud cloud to use this resource. Please refer
+-> You _must_ have `Security Administrator` privileges in your OpenTelekomCloud cloud to use this resource. Please refer
 to [User Management Model](https://docs.otc.t-systems.com/en-us/usermanual/iam/iam_01_0034.html).
 
 ## Example Usage

--- a/docs/resources/identity_provider.md
+++ b/docs/resources/identity_provider.md
@@ -12,7 +12,7 @@ Up-to-date reference of API arguments for IAM provider you can get at
 
 # opentelekomcloud_identity_provider
 
--> You _must_ have security admin privileges in your OpenTelekomCloud
+-> You _must_ have `Security Administrator` privileges in your OpenTelekomCloud
 cloud to use this resource. Please refer to [User Management Model](https://docs.otc.t-systems.com/en-us/usermanual/iam/iam_01_0034.html).
 
 

--- a/docs/resources/identity_provider_v3.md
+++ b/docs/resources/identity_provider_v3.md
@@ -12,7 +12,7 @@ Up-to-date reference of API arguments for IAM provider you can get at
 
 # opentelekomcloud_identity_provider_v3
 
--> You _must_ have security admin privileges in your OpenTelekomCloud
+-> You _must_ have `Security Administrator` privileges in your OpenTelekomCloud
 cloud to use this resource. Please refer to [User Management Model](https://docs.otc.t-systems.com/en-us/usermanual/iam/iam_01_0034.html).
 
 

--- a/docs/resources/identity_role_assignment_v3.md
+++ b/docs/resources/identity_role_assignment_v3.md
@@ -14,7 +14,8 @@ Up-to-date reference of API arguments for IAM role assignment you can get at
 
 Manages a V3 Role assignment within group on OpenTelekomCloud IAM Service.
 
--> **Note:** You _must_ have admin privileges in your OpenTelekomCloud cloud to use this resource.
+-> **Note:** You _must_ have `Security Administrator` privileges in your OpenTelekomCloud
+cloud to use this resource. Please refer to [User Management Model](https://docs.otc.t-systems.com/en-us/usermanual/iam/iam_01_0034.html).
 
 ## Example Usage
 

--- a/docs/resources/identity_role_v3.md
+++ b/docs/resources/identity_role_v3.md
@@ -14,6 +14,9 @@ Up-to-date reference of API arguments for IAM role you can get at
 
 Custom role management
 
+-> **Note:** You _must_ have `Security Administrator` privileges in your OpenTelekomCloud
+cloud to use this resource. Please refer to [User Management Model](https://docs.otc.t-systems.com/en-us/usermanual/iam/iam_01_0034.html).
+
 ## Example Usage
 
 ```hcl

--- a/docs/resources/identity_user_group_membership_v3.md
+++ b/docs/resources/identity_user_group_membership_v3.md
@@ -14,7 +14,8 @@ Up-to-date reference of API arguments for IAM user group membership you can get 
 
 Manages a User Group Membership resource within OpenTelekomCloud IAM service.
 
--> **Note:** You _must_ have admin privileges in your OpenTelekomCloud cloud to use this resource.
+-> **Note:** You _must_ have `Security Administrator` privileges in your OpenTelekomCloud
+cloud to use this resource. Please refer to [User Management Model](https://docs.otc.t-systems.com/en-us/usermanual/iam/iam_01_0034.html).
 
 ## Example Usage
 

--- a/docs/resources/identity_user_v3.md
+++ b/docs/resources/identity_user_v3.md
@@ -14,8 +14,8 @@ Up-to-date reference of API arguments for IAM user you can get at
 
 Manages a User resource within OpenTelekomCloud IAM service.
 
--> You need to have admin privileges in your OpenTelekomCloud cloud to use
-this resource.
+-> You _must_ have `Security Administrator` privileges in your OpenTelekomCloud
+cloud to use this resource. Please refer to [User Management Model](https://docs.otc.t-systems.com/en-us/usermanual/iam/iam_01_0034.html).
 
 ## Example Usage
 

--- a/releasenotes/notes/iam-docs-security-administrator-e7a1ae31920aae22.yaml
+++ b/releasenotes/notes/iam-docs-security-administrator-e7a1ae31920aae22.yaml
@@ -1,0 +1,4 @@
+---
+other:
+  - |
+    **[IAM]** Clarify ``Security Administrator`` role requirement in IAM resources documentation (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)

--- a/releasenotes/notes/iam-docs-security-administrator-e7a1ae31920aae22.yaml
+++ b/releasenotes/notes/iam-docs-security-administrator-e7a1ae31920aae22.yaml
@@ -1,4 +1,4 @@
 ---
 other:
   - |
-    **[IAM]** Clarify ``Security Administrator`` role requirement in IAM resources documentation (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[IAM]** Clarify ``Security Administrator`` role requirement in IAM resources documentation (`#3284 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3284>`_)


### PR DESCRIPTION
## Summary of the Pull Request
  - Clarify that IAM resources require `Security Administrator` role
  - Add missing permission notes to `identity_role_v3`, `identity_agency_v3`, `identity_credential_v3`
  - Unify permission note format across all IAM resource and data source docs

## PR Checklist

* [x] Refers to: #3281
* [ ] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.
* [x] Release notes added.
