### PR TITLE
[Feat] VPC: Add `vpc_peering_connections_v2` data source

### DIFF
--- a/docs/data-sources/vpc_peering_connections_v2.md
+++ b/docs/data-sources/vpc_peering_connections_v2.md
@@ -1,0 +1,59 @@
+---
+subcategory: "Virtual Private Cloud (VPC)"
+layout: "opentelekomcloud"
+page_title: "OpenTelekomCloud: opentelekomcloud_vpc_peering_connections_v2"
+sidebar_current: "docs-opentelekomcloud-datasource-vpc-peering-connections-v2"
+description: |-
+  List VPC peering connections from OpenTelekomCloud
+---
+
+Up-to-date reference of API arguments for VPC peering connections you can get at
+[documentation portal](https://docs.otc.t-systems.com/virtual-private-cloud/api-ref/apis/vpc_peering_connection/querying_vpc_peering_connections.html#vpc-peering-0001)
+
+# opentelekomcloud_vpc_peering_connections_v2
+
+Use this data source to list VPC peering connections matching the specified criteria.
+
+## Example Usage
+
+```hcl
+data "opentelekomcloud_vpc_peering_connections_v2" "peerings" {
+  vpc_id = opentelekomcloud_vpc_v1.vpc.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Optional) The name of the VPC peering connection to filter by.
+
+* `status` - (Optional) The status of the VPC peering connection to filter by.
+
+* `vpc_id` - (Optional) The ID of the requester VPC to filter by.
+
+* `peer_vpc_id` - (Optional) The ID of the accepter/peer VPC to filter by.
+
+* `peer_tenant_id` - (Optional) The tenant ID of the accepter/peer VPC to filter by.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `region` - The region of the VPC peering connections.
+
+* `peering_connections` - A list of VPC peering connections. Each element contains the following attributes:
+
+  * `id` - The ID of the VPC peering connection.
+
+  * `name` - The name of the VPC peering connection.
+
+  * `description` - The description of the VPC peering connection.
+
+  * `status` - The status of the VPC peering connection.
+
+  * `vpc_id` - The ID of the requester VPC.
+
+  * `peer_vpc_id` - The ID of the accepter/peer VPC.
+
+  * `peer_tenant_id` - The tenant ID of the accepter/peer VPC.

--- a/opentelekomcloud/acceptance/vpc/data_source_opentelekomcloud_vpc_peering_connections_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/data_source_opentelekomcloud_vpc_peering_connections_v2_test.go
@@ -1,0 +1,117 @@
+package acceptance
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
+)
+
+const (
+	dataSourceVpcPeeringsName         = "data.opentelekomcloud_vpc_peering_connections_v2.by_vpc_id"
+	dataSourceVpcPeeringsNameByName   = "data.opentelekomcloud_vpc_peering_connections_v2.by_name"
+	dataSourceVpcPeeringsNameByStatus = "data.opentelekomcloud_vpc_peering_connections_v2.by_status"
+	dataSourceVpcPeeringsNameEmpty    = "data.opentelekomcloud_vpc_peering_connections_v2.empty"
+)
+
+func TestAccVpcPeeringConnectionsV2DataSource_basic(t *testing.T) {
+	t.Parallel()
+	qts := quotas.MultipleQuotas{
+		{Q: quotas.Router, Count: 3},
+	}
+	quotas.BookMany(t, qts)
+
+	dcByVpcId := common.InitDataSourceCheck(dataSourceVpcPeeringsName)
+	dcByName := common.InitDataSourceCheck(dataSourceVpcPeeringsNameByName)
+	dcByStatus := common.InitDataSourceCheck(dataSourceVpcPeeringsNameByStatus)
+	dcEmpty := common.InitDataSourceCheck(dataSourceVpcPeeringsNameEmpty)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceVpcPeeringConnectionsV2Config,
+				Check: resource.ComposeTestCheckFunc(
+					dcByVpcId.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceVpcPeeringsName, "peering_connections.#", "2"),
+
+					dcByName.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceVpcPeeringsNameByName, "peering_connections.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceVpcPeeringsNameByName, "peering_connections.0.name", "opentelekomcloud_peerings_ds_1"),
+
+					dcByStatus.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceVpcPeeringsNameByStatus, "peering_connections.0.status"),
+
+					dcEmpty.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceVpcPeeringsNameEmpty, "peering_connections.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceVpcPeeringConnectionsV2Config = `
+resource "opentelekomcloud_vpc_v1" "vpc_1" {
+  name = "vpc_test_ds_peerings_1"
+  cidr = "192.168.0.0/16"
+}
+
+resource "opentelekomcloud_vpc_v1" "vpc_2" {
+  name = "vpc_test_ds_peerings_2"
+  cidr = "192.168.0.0/16"
+}
+
+resource "opentelekomcloud_vpc_v1" "vpc_3" {
+  name = "vpc_test_ds_peerings_3"
+  cidr = "192.168.0.0/16"
+}
+
+resource "opentelekomcloud_vpc_peering_connection_v2" "peering_1" {
+  name        = "opentelekomcloud_peerings_ds_1"
+  description = "test peering 1"
+  vpc_id      = opentelekomcloud_vpc_v1.vpc_1.id
+  peer_vpc_id = opentelekomcloud_vpc_v1.vpc_2.id
+}
+
+resource "opentelekomcloud_vpc_peering_connection_v2" "peering_2" {
+  name        = "opentelekomcloud_peerings_ds_2"
+  description = "test peering 2"
+  vpc_id      = opentelekomcloud_vpc_v1.vpc_1.id
+  peer_vpc_id = opentelekomcloud_vpc_v1.vpc_3.id
+}
+
+data "opentelekomcloud_vpc_peering_connections_v2" "by_vpc_id" {
+  vpc_id = opentelekomcloud_vpc_v1.vpc_1.id
+
+  depends_on = [
+    opentelekomcloud_vpc_peering_connection_v2.peering_1,
+    opentelekomcloud_vpc_peering_connection_v2.peering_2,
+  ]
+}
+
+data "opentelekomcloud_vpc_peering_connections_v2" "by_name" {
+  name = opentelekomcloud_vpc_peering_connection_v2.peering_1.name
+}
+
+data "opentelekomcloud_vpc_peering_connections_v2" "by_status" {
+  vpc_id = opentelekomcloud_vpc_v1.vpc_1.id
+  status = "ACTIVE"
+
+  depends_on = [
+    opentelekomcloud_vpc_peering_connection_v2.peering_1,
+    opentelekomcloud_vpc_peering_connection_v2.peering_2,
+  ]
+}
+
+data "opentelekomcloud_vpc_peering_connections_v2" "empty" {
+  vpc_id      = opentelekomcloud_vpc_v1.vpc_1.id
+  peer_vpc_id = opentelekomcloud_vpc_v1.vpc_1.id
+
+  depends_on = [
+    opentelekomcloud_vpc_peering_connection_v2.peering_1,
+    opentelekomcloud_vpc_peering_connection_v2.peering_2,
+  ]
+}
+`

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -432,6 +432,7 @@ func Provider() *schema.Provider {
 			"opentelekomcloud_vbs_backup_v2":                      vbs.DataSourceVBSBackupV2(),
 			"opentelekomcloud_vbs_backup_policy_v2":               vbs.DataSourceVBSBackupPolicyV2(),
 			"opentelekomcloud_vpc_peering_connection_v2":          vpc.DataSourceVpcPeeringConnectionV2(),
+			"opentelekomcloud_vpc_peering_connections_v2":         vpc.DataSourceVpcPeeringConnectionsV2(),
 			"opentelekomcloud_vpc_route_v2":                       vpc.DataSourceVPCRouteV2(),
 			"opentelekomcloud_vpc_route_ids_v2":                   vpc.DataSourceVPCRouteIdsV2(),
 			"opentelekomcloud_vpc_route_table_v1":                 vpc.DataSourceVPCRouteTableV1(),

--- a/opentelekomcloud/services/vpc/data_source_opentelekomcloud_vpc_peering_connections_v2.go
+++ b/opentelekomcloud/services/vpc/data_source_opentelekomcloud_vpc_peering_connections_v2.go
@@ -1,0 +1,139 @@
+package vpc
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/peerings"
+
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
+)
+
+func DataSourceVpcPeeringConnectionsV2() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceVpcPeeringConnectionsV2Read,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: common.ValidateName,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"peer_vpc_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"peer_tenant_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"peering_connections": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"vpc_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"peer_vpc_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"peer_tenant_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceVpcPeeringConnectionsV2Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := config.NetworkingV2Client(config.GetRegion(d))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	listOpts := peerings.ListOpts{
+		Name:       d.Get("name").(string),
+		Status:     d.Get("status").(string),
+		VpcId:      d.Get("vpc_id").(string),
+		Peer_VpcId: d.Get("peer_vpc_id").(string),
+		TenantId:   d.Get("peer_tenant_id").(string),
+	}
+
+	peeringList, err := peerings.List(client, listOpts)
+	if err != nil {
+		return fmterr.Errorf("unable to retrieve VPC peering connections: %s", err)
+	}
+
+	uID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", config.GetRegion(d)),
+		d.Set("peering_connections", flattenPeeringConnections(peeringList)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenPeeringConnections(peeringList []peerings.Peering) []interface{} {
+	if peeringList == nil {
+		return nil
+	}
+
+	result := make([]interface{}, len(peeringList))
+	for i, p := range peeringList {
+		result[i] = map[string]interface{}{
+			"id":             p.ID,
+			"name":           p.Name,
+			"description":    p.Description,
+			"status":         p.Status,
+			"vpc_id":         p.RequestVpcInfo.VpcId,
+			"peer_vpc_id":    p.AcceptVpcInfo.VpcId,
+			"peer_tenant_id": p.AcceptVpcInfo.TenantId,
+		}
+	}
+	return result
+}

--- a/releasenotes/notes/vpc-peering-connections-datasource-9cdb71cd00f47f71.yaml
+++ b/releasenotes/notes/vpc-peering-connections-datasource-9cdb71cd00f47f71.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    **[VPC]** Add new data source ``opentelekomcloud_vpc_peering_connections_v2`` (`#XXXX <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/XXXX>`_).

--- a/releasenotes/notes/vpc-peering-connections-datasource-9cdb71cd00f47f71.yaml
+++ b/releasenotes/notes/vpc-peering-connections-datasource-9cdb71cd00f47f71.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   - |
-    **[VPC]** Add new data source ``opentelekomcloud_vpc_peering_connections_v2`` (`#XXXX <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/XXXX>`_).
+    **[VPC]** Add new data source ``opentelekomcloud_vpc_peering_connections_v2`` (`#3287 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3287>`_).


### PR DESCRIPTION
## Summary of the Pull Request

Add new data source `opentelekomcloud_vpc_peering_connections_v2` that returns a list of VPC peering connections matching the specified filters. Unlike the singular `opentelekomcloud_vpc_peering_connection_v2`, this returns all matches (including an empty list) instead of erroring on multiple results.

## PR Checklist

* [ ] Refers to: #xxx
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccVpcPeeringConnectionsV2DataSource_basic
=== PAUSE TestAccVpcPeeringConnectionsV2DataSource_basic
=== CONT  TestAccVpcPeeringConnectionsV2DataSource_basic
--- PASS: TestAccVpcPeeringConnectionsV2DataSource_basic (86.76s)
PASS
ok  	github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/vpc	89.703s
```
