### PR TITLE
Adds ForceNew to preinstall and postinstall fields of resource opentelekomcloud_cce_node_pool_v3

### DIFF
--- a/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_pool_v3.go
+++ b/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_pool_v3.go
@@ -238,12 +238,14 @@ func ResourceCCENodePoolV3() *schema.Resource {
 				Optional:  true,
 				Computed:  true,
 				StateFunc: common.GetHashOrEmpty,
+				ForceNew:  true,
 			},
 			"postinstall": {
 				Type:      schema.TypeString,
 				Optional:  true,
 				Computed:  true,
 				StateFunc: common.GetHashOrEmpty,
+				ForceNew:  true,
 			},
 			"max_pods": {
 				Type:     schema.TypeInt,


### PR DESCRIPTION
## Summary of the Pull Request
Adds ForceNew to "preinstall" and "postinstall" fields of opentelekomcloud_cce_node_pool_v3 schema. As per documentation changes to these fields should force a recreation of the node_pool resource (see https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/cce_node_pool_v3#preinstall-2)

## PR Checklist

* [x] Refers to: #3292
* [ ] Tests added/passed.
* [x] Documentation updated. (Documentation is already reflecting the behavior after the change)
* [x] Schema updated.
* [ ] Release notes added.

# Tests performed
Ran `terraform apply` in our own CCE environment with a custom build of the terraform provider.
Output:
```
   # opentelekomcloud_cce_node_pool_v3.nodes["worker"] must be replaced
 -/+ resource "opentelekomcloud_cce_node_pool_v3" "nodes" {
       ...
       ~ preinstall               = "xxxx" -> "xxxx" # forces replacement
       ..
     }
```

Node pool was rotated as intended with the new preinstall changes applied. Did not test postinstall, but I don't see why that should behave any different.
