### PR TITLE
[Feat] CCE/Utils: Add array filter to parse any type

### DIFF
--- a/docs/resources/cce_node_pool_config_v3.md
+++ b/docs/resources/cce_node_pool_config_v3.md
@@ -62,6 +62,9 @@ The `packages` block supports:
 
 -> **Note:** Supported values for package names and their corresponding configurable items can be found at this page in [CCE user guide](https://docs.otc.t-systems.com/cloud-container-engine/umn/node_pools/managing_node_pools/modifying_node_pool_configurations.html#containerd-available-only-for-containerd-node-pools)
 
+-> **Note:** For `registry-mirrors` parameter, use the semicolon separated string in `value`, for example, `"example.com=https://my-mirror.example.com;"` or `"example.com=https://my-mirror.example.com;old-mirror.com=https://new-mirror.com;"`. Semicolon `;` is necessary to distinguish the array from strings. The `https` is required for new value after `=` and the trailing `/` must be avoided.
+
+
 ## Attributes Reference
 
 All above argument parameters can be exported as attribute parameters along with attribute reference.

--- a/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_node_pool_config_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_node_pool_config_v3_test.go
@@ -42,6 +42,13 @@ resource "opentelekomcloud_cce_node_pool_config_v3" "node_pool_config" {
   name        = "configuration"
 
   packages {
+    name = "containerd"
+    configurations {
+      name  = "registry-mirrors"
+      value = "example.com=https://my-mirror.example.com;"
+    }
+  }
+  packages {
     name = "kubelet"
     configurations {
       name  = "system-reserved-mem"

--- a/opentelekomcloud/common/utils.go
+++ b/opentelekomcloud/common/utils.go
@@ -692,6 +692,17 @@ func ParseAnyType(s string) interface{} {
 	if f, err := strconv.ParseFloat(s, 64); err == nil {
 		return f
 	}
+	if strings.Contains(s, ";") {
+		parts := strings.Split(s, ";")
+		result := make([]interface{}, 0, len(parts))
+		for _, p := range parts {
+			p = strings.TrimSpace(p)
+			if p != "" { // skip empty strings from trailing/double semicolons
+				result = append(result, p)
+			}
+		}
+		return result
+	}
 	return s
 }
 

--- a/releasenotes/notes/cce-update-cce-nodepool-config-v3-48bd9f66eeafd993.yaml
+++ b/releasenotes/notes/cce-update-cce-nodepool-config-v3-48bd9f66eeafd993.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[CCE]** Allow string array as `value` in `configurations` parameter for ``resource/opentelekomcloud_cce_node_pool_config_v3`` (`#3299 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3299>`_)


### PR DESCRIPTION
## Summary of the Pull Request

Allow string array as `value` in `configurations` parameter for resource `opentelekomcloud_cce_node_pool_config_v3`.
ParseAnyType can now filter string arrays using `;` as identifier.

## PR Checklist

* [x] Refers to: #3294 
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccCCENodePoolConfigV3_basic
=== PAUSE TestAccCCENodePoolConfigV3_basic
=== CONT  TestAccCCENodePoolConfigV3_basic
--- PASS: TestAccCCENodePoolConfigV3_basic (28.65s)
PASS
```
