### PR TITLE
[Fix] RDS: Add region check for private domain name in rds_instance_v3

### DIFF
--- a/docs/data-sources/rds_instance_v3.md
+++ b/docs/data-sources/rds_instance_v3.md
@@ -53,9 +53,9 @@ The following attributes are exported:
 
 * `private_ips` - Indicates the private IP address. It is a blank string until an ECS is created.
 
-* `private_domain_name` - Indicates the prefix of the new domain name.
+* `private_domain_name` - Indicates the prefix of the new domain name (not supported in `eu-ch2` region).
 
-* `private_fqdn` - Indicates the fully qualified domain name of an RDS instance.
+* `private_fqdn` - Indicates the fully qualified domain name of an RDS instance (not supported in `eu-ch2` region).
 
 * `public_ips` - Indicates the public IP address.
 

--- a/docs/resources/rds_instance_v3.md
+++ b/docs/resources/rds_instance_v3.md
@@ -351,6 +351,8 @@ For example, the parameter can be UTC+08:00 rather than UTC+08:30.
 
 * `private_domain_name` - (Optional) Specifies the prefix of the new domain name. The value contains `8` to `63` characters. Only uppercase letters, lowercase letters, and digits are allowed.
 
+~> **Warning** The argument `private_domain_name` not supported in `eu-ch2` region.
+
 * `backup_strategy` - (Optional) Specifies the advanced backup policy. Structure is documented below.
 
 * `ha_replication_mode` - (Optional, ForceNew) Specifies the replication mode for the standby DB instance. For MySQL, the value
@@ -465,7 +467,7 @@ The `backup_strategy` block supports:
   format. The current time is in the UTC format. The HH value must
   be 1 greater than the hh value. The values of mm and MM must be
   the same and must be set to any of the following: 00, 15, 30, or
-  45. Example value: 08:15-09:15 23:00-00:00.
+  1.  Example value: 08:15-09:15 23:00-00:00.
 
 * `period` - (Optional) Specifies the backup cycle configuration. Data will be automatically backed up on the selected days every week.
   This parameter is mandatory except that the automated backup policy is disabled.
@@ -517,7 +519,7 @@ In addition to the arguments listed above, the following computed attributes are
 * `private_ips` - Indicates the private IP address list. It is a blank string until an
   ECS is created.
 
-* `private_fqdn` - Indicates the fully qualified domain name of an RDS instance.
+* `private_fqdn` - Indicates the fully qualified domain name of an RDS instance (not supported in `eu-ch2` region).
 
 * `public_ips` - Indicates the public IP address list.
 

--- a/docs/resources/rds_instance_v3.md
+++ b/docs/resources/rds_instance_v3.md
@@ -466,8 +466,8 @@ The `backup_strategy` block supports:
   triggered during the backup time window. It must be a valid value in the &quot;hh:mm-HH:MM&quot;
   format. The current time is in the UTC format. The HH value must
   be 1 greater than the hh value. The values of mm and MM must be
-  the same and must be set to any of the following: 00, 15, 30, or
-  1.  Example value: 08:15-09:15 23:00-00:00.
+  the same and must be set to any of the following: 00, 15, 30, or 45.
+  Example value: 08:15-09:15 23:00-00:00.
 
 * `period` - (Optional) Specifies the backup cycle configuration. Data will be automatically backed up on the selected days every week.
   This parameter is mandatory except that the automated backup policy is disabled.

--- a/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
+++ b/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
@@ -423,6 +423,26 @@ func TestAccRdsInstanceV3_PrivateDNS(t *testing.T) {
 	})
 }
 
+func TestAccRdsInstanceV3_Swiss(t *testing.T) {
+	postfix := acctest.RandString(3)
+	var rdsInstance instances.InstanceResponse
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckRdsInstanceV3Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRdsInstanceV3_Swiss(postfix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRdsInstanceV3Exists(instanceV3ResourceName, &rdsInstance),
+					resource.TestCheckResourceAttr(instanceV3ResourceName, "flavor", "rds.pg.s3.large.2"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckRdsInstanceV3Destroy(s *terraform.State) error {
 	config := common.TestAccProvider.Meta().(*cfg.Config)
 	client, err := config.RdsV3Client(env.OS_REGION_NAME)
@@ -1400,6 +1420,32 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
     size = 40
   }
   flavor = local.available_flavor.name
+}
+`, common.DataSourceSecGroupDefault, common.DataSourceSubnet, postfix, env.OS_AVAILABILITY_ZONE)
+}
+
+func testAccRdsInstanceV3_Swiss(postfix string) string {
+	return fmt.Sprintf(`
+%[1]s
+%[2]s
+
+resource "opentelekomcloud_rds_instance_v3" "instance" {
+  name              = "tf_rds_instance_%[3]s"
+  availability_zone = ["%[4]s"]
+  db {
+    password = "Postgres!120521"
+    type     = "PostgreSQL"
+    version  = "15"
+    port     = "8635"
+  }
+  security_group_id   = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
+  subnet_id           = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  vpc_id              = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  volume {
+    type = "ULTRAHIGH"
+    size = 40
+  }
+  flavor = "rds.pg.s3.large.2"
 }
 `, common.DataSourceSecGroupDefault, common.DataSourceSubnet, postfix, env.OS_AVAILABILITY_ZONE)
 }

--- a/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
+++ b/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
@@ -1438,9 +1438,9 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
     version  = "15"
     port     = "8635"
   }
-  security_group_id   = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
-  subnet_id           = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
-  vpc_id              = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
+  subnet_id         = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
   volume {
     type = "ULTRAHIGH"
     size = 40

--- a/opentelekomcloud/services/rds/data_source_opentelekomcloud_rds_instance_v3.go
+++ b/opentelekomcloud/services/rds/data_source_opentelekomcloud_rds_instance_v3.go
@@ -255,16 +255,18 @@ func dataSourceRdsInstanceV3Read(_ context.Context, d *schema.ResourceData, meta
 		d.Set("public_ips", rdsInstance.PublicIps),
 	)
 
-	domain, err := instances.GetPrivateDomainName(client, d.Id(), instances.GetPrivateDomainNameParams{
-		DnsType: "private",
-	})
-	if err != nil {
-		return diag.FromErr(err)
+	if config.GetRegion(d) != "eu-ch2" {
+		domain, err := instances.GetPrivateDomainName(client, d.Id(), instances.GetPrivateDomainNameParams{
+			DnsType: "private",
+		})
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		mErr = multierror.Append(mErr,
+			d.Set("private_domain_name", strings.Split(domain.DnsName, ".")[0]),
+			d.Set("private_fqdn", domain.DnsName),
+		)
 	}
-	mErr = multierror.Append(mErr,
-		d.Set("private_domain_name", strings.Split(domain.DnsName, ".")[0]),
-		d.Set("private_fqdn", domain.DnsName),
-	)
 	// backup
 	backup := make([]map[string]interface{}, 1)
 	backup[0] = map[string]interface{}{

--- a/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_instance_v3.go
+++ b/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_instance_v3.go
@@ -1370,17 +1370,19 @@ func resourceRdsInstanceV3Read(ctx context.Context, d *schema.ResourceData, meta
 		}
 	}
 
-	domain, err := instances.GetPrivateDomainName(client, d.Id(), instances.GetPrivateDomainNameParams{
-		DnsType: "private",
-	})
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	if err = d.Set("private_domain_name", strings.Split(domain.DnsName, ".")[0]); err != nil {
-		return diag.FromErr(err)
-	}
-	if err = d.Set("private_fqdn", domain.DnsName); err != nil {
-		return diag.FromErr(err)
+	if region != "eu-ch2" {
+		domain, err := instances.GetPrivateDomainName(client, d.Id(), instances.GetPrivateDomainNameParams{
+			DnsType: "private",
+		})
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		if err = d.Set("private_domain_name", strings.Split(domain.DnsName, ".")[0]); err != nil {
+			return diag.FromErr(err)
+		}
+		if err = d.Set("private_fqdn", domain.DnsName); err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	var tagParamName string

--- a/releasenotes/notes/rds-fix-domain-instance-v3-62c856137dde4607.yaml
+++ b/releasenotes/notes/rds-fix-domain-instance-v3-62c856137dde4607.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[RDS]** Add region check for domain name in `resource/opentelekomcloud_rds_instance_v3`` (`#3302 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3302>`_)


### PR DESCRIPTION
## Summary of the Pull Request

Private Domain Name is not supported in swiss cloud.
Add region check for private domain name in opentelekomcloud_rds_instance_v3 resource and data source.

## PR Checklist

* [x] Refers to: #3301 
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccRdsInstanceV3_PrivateDNS
--- PASS: TestAccRdsInstanceV3_PrivateDNS (350.16s)
PASS
=== RUN   TestAccRdsInstanceV3_Swiss
--- PASS: TestAccRdsInstanceV3_Swiss (364.44s)
PASS
```
