### PR TITLE
[Fix] improvement in update of basic,custom and flavor in opentelekomcloud_cce_addon_v3

### DIFF
--- a/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_addon_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_addon_v3_test.go
@@ -468,20 +468,21 @@ resource "opentelekomcloud_cce_addon_v3" "autoscaler" {
       "tenant_id" : data.opentelekomcloud_identity_project_v3.project.id,
     }
     flavor = <<EOF
-    {
-      "description": "custom resources",
-      "name": "custom-resources",
-      "replicas": 2,
-      "resources": [
-        {
-          "limitsCpu": "8000m",
-          "limitsMem": "4Gi",
-          "name": "autoscaler",
-          "requestsCpu": "4000m",
-          "requestsMem": "2Gi"
-        }
-      ]
-    EOF
+      {
+        "description": "custom resources",
+        "name": "custom-resources",
+        "replicas": 2,
+        "resources": [
+          {
+            "limitsCpu": "8000m",
+            "limitsMem": "4Gi",
+            "name": "autoscaler",
+            "requestsCpu": "4000m",
+            "requestsMem": "2Gi"
+          }
+        ]
+      }
+	EOF
   }
 }
 `, common.DataSourceSubnet, common.DataSourceProject, cName)
@@ -498,7 +499,7 @@ resource opentelekomcloud_cce_cluster_v3 cluster_1 {
   flavor_id               = "cce.s1.medium"
   vpc_id                  = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
   subnet_id               = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
-  cluster_version         = "v1.29"
+  cluster_version         = "v1.30"
   container_network_type  = "overlay_l2"
   kubernetes_svc_ip_range = "10.247.0.0/16"
   no_addons               = true
@@ -506,20 +507,23 @@ resource opentelekomcloud_cce_cluster_v3 cluster_1 {
 
 resource "opentelekomcloud_cce_addon_v3" "coredns" {
   template_name    = "coredns"
-  template_version = "1.29.4"
+  template_version = "1.30.33"
   cluster_id       = opentelekomcloud_cce_cluster_v3.cluster_1.id
 
   values {
     basic = {
       "cluster_ip" : "10.247.3.10",
-      "image_version" : "1.29.4",
+      "image_version" : "1.30.33",
       "swr_addr" : "100.125.7.25:20202",
       "swr_user" : "cce-addons"
     }
-    custom = {
-      "stub_domains" : "{\"test\":[\"10.10.40.10\"], \"test2\":[\"10.10.40.20\"]}"
-      "upstream_nameservers" : "[\"8.8.8.8\",\"8.8.4.4\"]"
-    }
+    custom_json = jsonencode({
+      stub_domains = {
+        test  = ["10.10.40.10"]
+        test2 = ["10.10.40.20"]
+      }
+      upstream_nameservers = ["8.8.8.8", "8.8.4.4"]
+    })
   }
 }
 `, common.DataSourceSubnet, common.DataSourceProject, name)

--- a/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_addon_v3.go
+++ b/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_addon_v3.go
@@ -235,9 +235,26 @@ func resourceCCEAddonV3Update(ctx context.Context, d *schema.ResourceData, meta 
 
 	clusterID := d.Get("cluster_id").(string)
 	addonID := d.Id()
-	basic, custom, flavor, err := buildAddonValues(d)
+
+	addon, err := addons.Get(client, addonID, clusterID)
+	if err != nil {
+		return diag.Errorf("error reading current CCE add-on (%s) before update: %s", addonID, logHttpError(err))
+	}
+
+	desiredBasic, desiredCustom, desiredFlavor, err := buildAddonValues(d)
 	if err != nil {
 		return diag.Errorf("error getting values for CCE add-on: %s", err)
+	}
+
+	updateValues := addon.Spec.Values
+	if addonValuesFieldChanged(d, "basic", "basic_json") {
+		updateValues.Basic = desiredBasic
+	}
+	if addonValuesFieldChanged(d, "custom", "custom_json") {
+		updateValues.Advanced = desiredCustom
+	}
+	if addonValuesFieldChanged(d, "flavor", "flavor_json") {
+		updateValues.Flavor = desiredFlavor
 	}
 
 	updateOpts := addons.UpdateOpts{
@@ -252,11 +269,7 @@ func resourceCCEAddonV3Update(ctx context.Context, d *schema.ResourceData, meta 
 			Version:           d.Get("template_version").(string),
 			ClusterID:         clusterID,
 			AddonTemplateName: d.Get("template_name").(string),
-			Values: addons.Values{
-				Basic:    basic,
-				Advanced: custom,
-				Flavor:   flavor,
-			},
+			Values:            updateValues,
 		},
 	}
 
@@ -279,6 +292,11 @@ func resourceCCEAddonV3Update(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	return resourceCCEAddonV3Read(ctx, d, meta)
+}
+
+func addonValuesFieldChanged(d *schema.ResourceData, plainKey, jsonKey string) bool {
+	return d.HasChange(fmt.Sprintf("values.0.%s", plainKey)) ||
+		d.HasChange(fmt.Sprintf("values.0.%s", jsonKey))
 }
 
 func buildAddonValues(d *schema.ResourceData) (basic, custom, flavor map[string]interface{}, err error) {

--- a/releasenotes/notes/cce-addon-update-fix-babf3edd11ed02f5.yaml
+++ b/releasenotes/notes/cce-addon-update-fix-babf3edd11ed02f5.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[CCE]** Fixed unintentionally resetting other value sections when only one part of values is modified in ``resource/opentelekomcloud_cce_addon_v3`` (`#3303 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3303>`_)


### PR DESCRIPTION
## Summary of the Pull Request
The update logic for values is section-aware and avoids overwriting unchanged parts.

During Update, the provider first reads the current add-on configuration from the API and initializes the update payload with the existing values:

updateValues := addon.Spec.Values

Then it checks whether Terraform detected a change in each section (basic, custom, flavor) using d.HasChange. If a section changed, it replaces only that section with the desired configuration built from the Terraform state.

Unchanged sections are preserved from the current add-on state.

This prevents unintentionally resetting other value sections when only one part of values is modified.

## PR Checklist

* [x] Refers to: #3298, #3228
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccCCEAddonV3Basic
=== PAUSE TestAccCCEAddonV3Basic
=== CONT  TestAccCCEAddonV3Basic
--- PASS: TestAccCCEAddonV3Basic (654.66s)
=== RUN   TestAccCCEAddonV3ForceNewCCE
=== PAUSE TestAccCCEAddonV3ForceNewCCE
=== CONT  TestAccCCEAddonV3ForceNewCCE
--- PASS: TestAccCCEAddonV3ForceNewCCE (1008.83s)
=== RUN   TestAccCCEAddonV3CoreDNS
=== PAUSE TestAccCCEAddonV3CoreDNS
=== CONT  TestAccCCEAddonV3CoreDNS
--- PASS: TestAccCCEAddonV3CoreDNS (614.32s)
=== RUN   TestAccCCEAddonV3Flavor
=== PAUSE TestAccCCEAddonV3Flavor
=== CONT  TestAccCCEAddonV3Flavor
--- PASS: TestAccCCEAddonV3Flavor (622.60s)
=== RUN   TestAccCCEAddonV3JsonEncoded
=== PAUSE TestAccCCEAddonV3JsonEncoded
=== CONT  TestAccCCEAddonV3JsonEncoded
--- PASS: TestAccCCEAddonV3JsonEncoded (686.10s)
PASS

Process finished with the exit code 0
```
