### PR TITLE
[Feat.] ECS: implement `security_options` for `opentelekomcloud_ecs_instance_v1`

### DIFF
--- a/docs/resources/ecs_instance_v1.md
+++ b/docs/resources/ecs_instance_v1.md
@@ -299,6 +299,11 @@ The following arguments are supported:
 
 * `auto_recovery` - (Optional, Boolean) Whether configure automatic recovery of an instance.
 
+* `tpm_enabled` - (Optional, Boolean) Specifies whether to enable vTPM on the ECS. Defaults to `false`.
+  Currently, only `Pi5e` instance types support TPM.
+
+  ~> **NOTE:** Changing this parameter will cause the server to be automatically stopped, updated, and started again.
+
 * `delete_disks_on_termination` - (Optional, Boolean) Delete the data disks upon termination of the instance.
   Defaults to false. Changing this creates a new server.
 

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20260306091324-4b56abaecb20
+	github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20260317095946-062973d490fd
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.45.0
 	golang.org/x/sync v0.18.0

--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20260306091324-4b56abaecb20 h1:+dYAog1K4fm1WVyJ4FcgfrvRKCzd8VLZOXalrsU3e6g=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20260306091324-4b56abaecb20/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20260317095946-062973d490fd h1:txohhyLhho4bpcV8Sbyl6NX6ZLWYk7lVjVl2/H2e1/I=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20260317095946-062973d490fd/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_ecs_instance_v1_test.go
+++ b/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_ecs_instance_v1_test.go
@@ -393,6 +393,81 @@ func testAccCheckEcsV1InstanceDestroy(s *terraform.State) error {
 	return nil
 }
 
+func TestAccEcsV1InstanceTpmEnabled(t *testing.T) {
+	var instance cloudservers.CloudServer
+
+	const tpmFlavor = "pi5e.2xlarge.4"
+	qts := serverQuotas(10+4, tpmFlavor)
+	t.Parallel()
+	quotas.BookMany(t, qts)
+
+	rc := common.InitResourceCheck(
+		resourceInstanceV1Name,
+		&instance,
+		getEcsInstanceFunc,
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckEcsV1InstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEcsV1InstanceTpmEnabled(true),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceInstanceV1Name, "tpm_enabled", "true"),
+				),
+			},
+			{
+				Config: testAccEcsV1InstanceTpmEnabled(false),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceInstanceV1Name, "tpm_enabled", "false"),
+					testAccCheckEcsV1InstanceIsActive(&instance),
+				),
+			},
+			{
+				Config: testAccEcsV1InstanceTpmEnabled(true),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceInstanceV1Name, "tpm_enabled", "true"),
+					testAccCheckEcsV1InstanceIsActive(&instance),
+				),
+			},
+			{
+				ResourceName:      resourceInstanceV1Name,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"password",
+					"delete_disks_on_termination",
+				},
+			},
+		},
+	})
+}
+
+func testAccCheckEcsV1InstanceIsActive(instance *cloudservers.CloudServer) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		config := common.TestAccProvider.Meta().(*cfg.Config)
+		client, err := config.ComputeV1Client(env.OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("error creating ComputeV1 client: %w", err)
+		}
+
+		server, err := cloudservers.Get(client, instance.ID).Extract()
+		if err != nil {
+			return fmt.Errorf("error getting CloudServer: %w", err)
+		}
+
+		if server.Status != "ACTIVE" {
+			return fmt.Errorf("CloudServer %s is in status %s, expected ACTIVE (server should be restarted after tpm_enabled update)", instance.ID, server.Status)
+		}
+		return nil
+	}
+}
+
 var testAccEcsV1InstanceBasic = fmt.Sprintf(`
 %s
 
@@ -897,3 +972,30 @@ resource "opentelekomcloud_ecs_instance_v1" "instance_1" {
   }
 }
 `, common.DataSourceImage, common.DataSourceSubnet, env.OS_TENANT_NAME, env.OS_AVAILABILITY_ZONE)
+
+func testAccEcsV1InstanceTpmEnabled(tpmEnabled bool) string {
+	return fmt.Sprintf(`
+%s
+
+data "opentelekomcloud_images_image_v2" "tpm_image" {
+  name        = "Enterprise_Windows-Server_2022_STD_amd64_uefi_latest"
+  most_recent = true
+}
+
+resource "opentelekomcloud_ecs_instance_v1" "instance_1" {
+  name     = "server_tpm"
+  image_id = data.opentelekomcloud_images_image_v2.tpm_image.id
+  flavor   = "pi5e.2xlarge.4"
+  vpc_id   = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+
+  nics {
+    network_id = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  }
+
+  password                    = "Password@123"
+  availability_zone           = "%s"
+  delete_disks_on_termination = true
+  tpm_enabled                 = %t
+}
+`, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, tpmEnabled)
+}

--- a/opentelekomcloud/services/ecs/resource_opentelekomcloud_ecs_instance_v1.go
+++ b/opentelekomcloud/services/ecs/resource_opentelekomcloud_ecs_instance_v1.go
@@ -14,6 +14,7 @@ import (
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/pointerto"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/tags"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/compute/v2/extensions/secgroups"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/compute/v2/extensions/startstop"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/compute/v2/servers"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/ecs/v1/cloudservers"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/evs/v3/volumes"
@@ -282,6 +283,11 @@ func ResourceEcsInstanceV1() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"tpm_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
 			"delete_disks_on_termination": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -312,6 +318,12 @@ func resourceEcsInstanceV1Create(ctx context.Context, d *schema.ResourceData, me
 		UserData:         []byte(d.Get("user_data").(string)),
 		MetaData:         resourceInstanceMetadataV1(d),
 		SchedulerHints:   resourceInstanceOsSchedulerHints(d),
+	}
+
+	if v, ok := d.GetOk("tpm_enabled"); ok {
+		createOpts.SecurityOptions = &cloudservers.SecurityOptions{
+			TpmEnabled: pointerto.Bool(v.(bool)),
+		}
 	}
 
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)
@@ -370,6 +382,11 @@ func resourceEcsInstanceV1Read(ctx context.Context, d *schema.ResourceData, meta
 		return nil
 	}
 
+	var tpmEnabled bool
+	if server.SecurityOptions != nil && server.SecurityOptions.TpmEnabled != nil {
+		tpmEnabled = *server.SecurityOptions.TpmEnabled
+	}
+
 	mErr := multierror.Append(
 		d.Set("name", server.Name),
 		d.Set("image_id", server.Image.ID),
@@ -378,6 +395,7 @@ func resourceEcsInstanceV1Read(ctx context.Context, d *schema.ResourceData, meta
 		d.Set("key_name", server.KeyName),
 		d.Set("vpc_id", server.Metadata.VpcID),
 		d.Set("availability_zone", server.AvailabilityZone),
+		d.Set("tpm_enabled", tpmEnabled),
 	)
 	var secGrpIDs []string
 	for _, sg := range server.SecurityGroups {
@@ -635,7 +653,63 @@ func resourceEcsInstanceV1Update(ctx context.Context, d *schema.ResourceData, me
 		}
 	}
 
-	return resourceEcsInstanceV1Read(ctx, d, meta)
+	if d.HasChange("tpm_enabled") {
+		computeV1Client, err := config.ComputeV1Client(config.GetRegion(d))
+		if err != nil {
+			return fmterr.Errorf(errCreateClient, err)
+		}
+
+		log.Printf("[WARN] Updating tpm_enabled requires the CloudServer (%s) to be stopped and restarted", d.Id())
+
+		// Server must be stopped to update security_options
+		if err := startstop.Stop(client, d.Id()).ExtractErr(); err != nil {
+			return fmterr.Errorf("error stopping CloudServer: %w", err)
+		}
+		stopStateConf := &resource.StateChangeConf{
+			Target:     []string{"SHUTOFF"},
+			Refresh:    ServerV2StateRefreshFunc(client, d.Id()),
+			Timeout:    d.Timeout(schema.TimeoutUpdate),
+			Delay:      10 * time.Second,
+			MinTimeout: 3 * time.Second,
+		}
+		if _, err := stopStateConf.WaitForStateContext(ctx); err != nil {
+			return fmterr.Errorf("error waiting for CloudServer (%s) to stop: %w", d.Id(), err)
+		}
+
+		tpmEnabled := d.Get("tpm_enabled").(bool)
+		updateOpts := cloudservers.UpdateOpts{
+			SecurityOptions: &cloudservers.SecurityOptions{
+				TpmEnabled: pointerto.Bool(tpmEnabled),
+			},
+		}
+		if _, err := cloudservers.Update(computeV1Client, d.Id(), updateOpts); err != nil {
+			return fmterr.Errorf("error updating tpm_enabled of CloudServer: %w", err)
+		}
+
+		// Start the server back
+		if err := startstop.Start(client, d.Id()).ExtractErr(); err != nil {
+			return fmterr.Errorf("error starting CloudServer: %w", err)
+		}
+		startStateConf := &resource.StateChangeConf{
+			Target:     []string{"ACTIVE"},
+			Refresh:    ServerV2StateRefreshFunc(client, d.Id()),
+			Timeout:    d.Timeout(schema.TimeoutUpdate),
+			Delay:      10 * time.Second,
+			MinTimeout: 3 * time.Second,
+		}
+		if _, err := startStateConf.WaitForStateContext(ctx); err != nil {
+			return fmterr.Errorf("error waiting for CloudServer (%s) to start: %w", d.Id(), err)
+		}
+	}
+
+	readDiags := resourceEcsInstanceV1Read(ctx, d, meta)
+	if d.HasChange("tpm_enabled") {
+		readDiags = append(readDiags, diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  "CloudServer was stopped and restarted to update tpm_enabled",
+		})
+	}
+	return readDiags
 }
 
 func resourceEcsInstanceV1Delete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/releasenotes/notes/ecs-instance-tpm-enabled-a061ab7506e7496e.yaml
+++ b/releasenotes/notes/ecs-instance-tpm-enabled-a061ab7506e7496e.yaml
@@ -1,4 +1,4 @@
 ---
 enhancements:
   - |
-    **[ECS]** Added ``tpm_enabled`` argument to ``resource/opentelekomcloud_ecs_instance_v1`` to support vTPM for ``Pi5e`` instance types (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[ECS]** Added ``tpm_enabled`` argument to ``resource/opentelekomcloud_ecs_instance_v1`` to support vTPM for ``Pi5e`` instance types (`#3304 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3304>`_)

--- a/releasenotes/notes/ecs-instance-tpm-enabled-a061ab7506e7496e.yaml
+++ b/releasenotes/notes/ecs-instance-tpm-enabled-a061ab7506e7496e.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[ECS]** Added ``tpm_enabled`` argument to ``resource/opentelekomcloud_ecs_instance_v1`` to support vTPM for ``Pi5e`` instance types (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Add `tpm_enabled` optional parameter to opentelekomcloud_ecs_instance_v1 resource to support vTPM (virtual Trusted Platform Module) for Pi5e instance types

## PR Checklist

* [x] Refers to: #3286
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccEcsV1InstanceBasic
=== PAUSE TestAccEcsV1InstanceBasic
=== CONT  TestAccEcsV1InstanceBasic
--- PASS: TestAccEcsV1InstanceBasic (163.01s)
PASS

Process finished with the exit code 0

=== RUN   TestAccEcsV1InstanceIp
=== PAUSE TestAccEcsV1InstanceIp
=== CONT  TestAccEcsV1InstanceIp
--- PASS: TestAccEcsV1InstanceIp (124.23s)
PASS

Process finished with the exit code 0

=== RUN   TestAccEcsV1InstanceDeleted
=== PAUSE TestAccEcsV1InstanceDeleted
=== CONT  TestAccEcsV1InstanceDeleted
--- PASS: TestAccEcsV1InstanceDeleted (225.48s)
PASS

Process finished with the exit code 0

=== RUN   TestAccEcsV1InstanceDiskTypeValidation
=== PAUSE TestAccEcsV1InstanceDiskTypeValidation
=== CONT  TestAccEcsV1InstanceDiskTypeValidation
--- PASS: TestAccEcsV1InstanceDiskTypeValidation (14.32s)
PASS

Process finished with the exit code 0

=== RUN   TestAccEcsV1InstanceTpmEnabled
=== PAUSE TestAccEcsV1InstanceTpmEnabled
=== CONT  TestAccEcsV1InstanceTpmEnabled
--- PASS: TestAccEcsV1InstanceTpmEnabled (333.46s)
PASS

Process finished with the exit code 0
```
