### PR TITLE
[Feat] VPC: Add route table route and subnet associate resources

### DIFF
--- a/docs/resources/vpc_route_table_route_v1.md
+++ b/docs/resources/vpc_route_table_route_v1.md
@@ -1,0 +1,134 @@
+---
+subcategory: "Virtual Private Cloud (VPC)"
+layout: "opentelekomcloud"
+page_title: "OpenTelekomCloud: opentelekomcloud_vpc_route_table_route_v1"
+sidebar_current: "docs-opentelekomcloud-resource-vpc-route-table-route-v1"
+description: |-
+  Manages a VPC Route Table Route resource within OpenTelekomCloud.
+---
+
+Up-to-date reference of API arguments for VPC route table you can get at
+[documentation portal](https://docs.otc.t-systems.com/virtual-private-cloud/api-ref/apis/route_table/index.html)
+
+# opentelekomcloud_vpc_route_table_route_v1
+
+Manages an individual route within a VPC route table. This resource allows managing
+routes independently of the route table lifecycle, including adding routes to the
+default route table.
+
+## Example Usage
+
+### Route on Default Route Table
+
+```hcl
+resource "opentelekomcloud_vpc_v1" "vpc_1" {
+  name = "vpc-1"
+  cidr = "192.168.0.0/16"
+}
+
+resource "opentelekomcloud_vpc_v1" "vpc_2" {
+  name = "vpc-2"
+  cidr = "172.16.0.0/16"
+}
+
+resource "opentelekomcloud_vpc_peering_connection_v2" "peering" {
+  name        = "my_peering"
+  vpc_id      = opentelekomcloud_vpc_v1.vpc_1.id
+  peer_vpc_id = opentelekomcloud_vpc_v1.vpc_2.id
+}
+
+resource "opentelekomcloud_vpc_route_table_route_v1" "route" {
+  vpc_id      = opentelekomcloud_vpc_v1.vpc_1.id
+  destination = "172.16.0.0/16"
+  type        = "peering"
+  nexthop     = opentelekomcloud_vpc_peering_connection_v2.peering.id
+  description = "peering route"
+}
+```
+
+### Route on Custom Route Table
+
+```hcl
+resource "opentelekomcloud_vpc_v1" "vpc_1" {
+  name = "vpc-1"
+  cidr = "192.168.0.0/16"
+}
+
+resource "opentelekomcloud_vpc_v1" "vpc_2" {
+  name = "vpc-2"
+  cidr = "172.16.0.0/16"
+}
+
+resource "opentelekomcloud_vpc_peering_connection_v2" "peering" {
+  name        = "my_peering"
+  vpc_id      = opentelekomcloud_vpc_v1.vpc_1.id
+  peer_vpc_id = opentelekomcloud_vpc_v1.vpc_2.id
+}
+
+resource "opentelekomcloud_vpc_route_table_v1" "table" {
+  name   = "my_table"
+  vpc_id = opentelekomcloud_vpc_v1.vpc_1.id
+}
+
+resource "opentelekomcloud_vpc_route_table_route_v1" "route" {
+  vpc_id         = opentelekomcloud_vpc_v1.vpc_1.id
+  route_table_id = opentelekomcloud_vpc_route_table_v1.table.id
+  destination    = "172.16.0.0/16"
+  type           = "peering"
+  nexthop        = opentelekomcloud_vpc_peering_connection_v2.peering.id
+  description    = "peering route on custom table"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the route.
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `vpc_id` - (Required, String, ForceNew) Specifies the VPC ID that the route table belongs to.
+  Changing this creates a new resource.
+
+* `destination` - (Required, String, ForceNew) Specifies the destination address in the CIDR notation format,
+  for example, 192.168.200.0/24. The destination of each route must be unique and cannot overlap
+  with any subnet in the VPC. Changing this creates a new resource.
+
+* `type` - (Required, String) Specifies the route type. Currently, the value can be:
+  **ecs**, **eni**, **vip**, **nat**, **peering**, **vpn**, **dc**, **egw**, **er**, **subeni** and **local**
+
+* `nexthop` - (Required, String) Specifies the next hop.
+  + If the route type is **ecs**, the value is an ECS instance ID in the VPC.
+  + If the route type is **eni**, the value is the extension NIC of an ECS in the VPC.
+  + If the route type is **vip**, the value is a virtual IP address.
+  + If the route type is **nat**, the value is a NAT gateway ID.
+  + If the route type is **peering**, the value is a VPC peering connection ID.
+  + If the route type is **vpn**, the value is a VPN gateway ID.
+  + If the route type is **dc**, the value is a Direct Connect gateway ID.
+  + If the route type is **egw**, the value is a VPC endpoint ID.
+  + If the route type is **er**, the value is the ID of an enterprise router.
+  + If the route type is **subeni**, the value is the ID of a supplementary network interface.
+
+* `description` - (Optional, String) Specifies the supplementary information about the route.
+  The value is a string of no more than 255 characters and cannot contain angle brackets (< or >).
+
+* `route_table_id` - (Optional, String, ForceNew) Specifies the route table ID. If omitted, the
+  default route table of the VPC will be used. Changing this creates a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in format `{route_table_id}/{destination}`.
+* `route_table_name` - The name of the route table.
+
+## Import
+
+Routes can be imported using the route table ID and destination, separated by a slash, e.g.
+
+-> **NOTE:** The import ID contains the route table UUID followed by a `/` and the CIDR destination
+(which itself contains a `/`), e.g. `<route_table_id>/<cidr_destination>`.
+
+```
+$ terraform import opentelekomcloud_vpc_route_table_route_v1.route 14c6491a-f90a-41aa-a206-f58bbacdb47d/172.16.0.0/16
+```

--- a/docs/resources/vpc_route_table_subnet_associate_v1.md
+++ b/docs/resources/vpc_route_table_subnet_associate_v1.md
@@ -1,0 +1,82 @@
+---
+subcategory: "Virtual Private Cloud (VPC)"
+layout: "opentelekomcloud"
+page_title: "OpenTelekomCloud: opentelekomcloud_vpc_route_table_subnet_associate_v1"
+sidebar_current: "docs-opentelekomcloud-resource-vpc-route-table-subnet-associate-v1"
+description: |-
+  Manages a VPC Route Table Subnet Association resource within OpenTelekomCloud.
+---
+
+Up-to-date reference of API arguments for VPC route table you can get at
+[documentation portal](https://docs.otc.t-systems.com/virtual-private-cloud/api-ref/apis/route_table/index.html)
+
+# opentelekomcloud_vpc_route_table_subnet_associate_v1
+
+Manages the association between a subnet and a VPC route table.
+
+A subnet is always associated with exactly one route table. Associating a subnet with a
+new route table automatically moves it from the previous one. Destroying this resource
+disassociates the subnet, which returns it to the VPC's default route table.
+
+~> **NOTE:** When using this resource, the `opentelekomcloud_vpc_route_table_v1` resource must include
+`lifecycle { ignore_changes = [subnets] }` to avoid conflicts. Both resources manage subnet associations
+on the same route table, and without `ignore_changes`, Terraform will detect a perpetual diff on the
+route table's `subnets` attribute.
+
+## Example Usage
+
+```hcl
+resource "opentelekomcloud_vpc_v1" "vpc" {
+  name = "my-vpc"
+  cidr = "192.168.0.0/16"
+}
+
+resource "opentelekomcloud_vpc_subnet_v1" "subnet" {
+  name       = "my-subnet"
+  cidr       = "192.168.0.0/24"
+  gateway_ip = "192.168.0.1"
+  vpc_id     = opentelekomcloud_vpc_v1.vpc.id
+}
+
+resource "opentelekomcloud_vpc_route_table_v1" "table" {
+  name   = "my-table"
+  vpc_id = opentelekomcloud_vpc_v1.vpc.id
+
+  lifecycle {
+    ignore_changes = [subnets]
+  }
+}
+
+resource "opentelekomcloud_vpc_route_table_subnet_associate_v1" "assoc" {
+  route_table_id = opentelekomcloud_vpc_route_table_v1.table.id
+  subnet_id      = opentelekomcloud_vpc_subnet_v1.subnet.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the association.
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `route_table_id` - (Required, String, ForceNew) Specifies the route table ID to associate the
+  subnet with. Changing this creates a new resource.
+
+* `subnet_id` - (Required, String, ForceNew) Specifies the subnet ID to associate with the route
+  table. Changing this creates a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in format `{route_table_id}/{subnet_id}`.
+* `vpc_id` - The VPC ID that the route table belongs to.
+
+## Import
+
+Route table subnet associations can be imported using the route table ID and subnet ID, separated by a slash, e.g.
+
+```
+$ terraform import opentelekomcloud_vpc_route_table_subnet_associate_v1.assoc 14c6491a-f90a-41aa-a206-f58bbacdb47d/a1b2c3d4-e5f6-7890-abcd-ef1234567890
+```

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_vpc_route_table_route_v1_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_vpc_route_table_route_v1_test.go
@@ -2,6 +2,7 @@ package acceptance
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -71,6 +72,24 @@ func TestAccVpcRouteTableRouteV1_withRouteTable(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateIdFunc: testAccVpcRouteTableRouteImportStateID(resourceVPCRouteTableRouteName),
+			},
+		},
+	})
+}
+
+func TestAccVpcRouteTableRouteV1_duplicateDestination(t *testing.T) {
+	name := tools.RandomString("rtbr-", 5)
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckRouteTableRouteV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVpcRouteTableRoute_basic(name),
+			},
+			{
+				Config:      testAccVpcRouteTableRoute_duplicate(name),
+				ExpectError: regexp.MustCompile(`route with destination .+ already exists in route table .+`),
 			},
 		},
 	})
@@ -184,4 +203,26 @@ resource "opentelekomcloud_vpc_route_table_route_v1" "route" {
   description    = "peering route on custom table"
 }
 `, testAccVpcRouteTableRoute_network(name), name)
+}
+
+func testAccVpcRouteTableRoute_duplicate(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "opentelekomcloud_vpc_route_table_route_v1" "route" {
+  vpc_id      = opentelekomcloud_vpc_v1.vpc_1.id
+  destination = "172.16.0.0/16"
+  type        = "peering"
+  nexthop     = opentelekomcloud_vpc_peering_connection_v2.peering.id
+  description = "peering route"
+}
+
+resource "opentelekomcloud_vpc_route_table_route_v1" "route_dup" {
+  vpc_id      = opentelekomcloud_vpc_v1.vpc_1.id
+  destination = "172.16.0.0/16"
+  type        = "peering"
+  nexthop     = opentelekomcloud_vpc_peering_connection_v2.peering.id
+  description = "duplicate route"
+}
+`, testAccVpcRouteTableRoute_network(name))
 }

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_vpc_route_table_route_v1_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_vpc_route_table_route_v1_test.go
@@ -1,0 +1,187 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v1/routetables"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+)
+
+const resourceVPCRouteTableRouteName = "opentelekomcloud_vpc_route_table_route_v1.route"
+
+func TestAccVpcRouteTableRouteV1_basic(t *testing.T) {
+	name := tools.RandomString("rtbr-", 5)
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckRouteTableRouteV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVpcRouteTableRoute_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceVPCRouteTableRouteName, "destination", "172.16.0.0/16"),
+					resource.TestCheckResourceAttr(resourceVPCRouteTableRouteName, "type", "peering"),
+					resource.TestCheckResourceAttr(resourceVPCRouteTableRouteName, "description", "peering route"),
+					resource.TestCheckResourceAttrSet(resourceVPCRouteTableRouteName, "route_table_id"),
+					resource.TestCheckResourceAttrSet(resourceVPCRouteTableRouteName, "route_table_name"),
+				),
+			},
+			{
+				Config: testAccVpcRouteTableRoute_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceVPCRouteTableRouteName, "destination", "172.16.0.0/16"),
+					resource.TestCheckResourceAttr(resourceVPCRouteTableRouteName, "type", "peering"),
+					resource.TestCheckResourceAttr(resourceVPCRouteTableRouteName, "description", "peering route updated"),
+				),
+			},
+			{
+				ResourceName:      resourceVPCRouteTableRouteName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccVpcRouteTableRouteImportStateID(resourceVPCRouteTableRouteName),
+			},
+		},
+	})
+}
+
+func TestAccVpcRouteTableRouteV1_withRouteTable(t *testing.T) {
+	name := tools.RandomString("rtbr-", 5)
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckRouteTableRouteV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVpcRouteTableRoute_withRouteTable(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceVPCRouteTableRouteName, "destination", "172.16.0.0/16"),
+					resource.TestCheckResourceAttr(resourceVPCRouteTableRouteName, "type", "peering"),
+					resource.TestCheckResourceAttrSet(resourceVPCRouteTableRouteName, "route_table_id"),
+					resource.TestCheckResourceAttrSet(resourceVPCRouteTableRouteName, "route_table_name"),
+				),
+			},
+			{
+				ResourceName:      resourceVPCRouteTableRouteName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccVpcRouteTableRouteImportStateID(resourceVPCRouteTableRouteName),
+			},
+		},
+	})
+}
+
+func testAccCheckRouteTableRouteV1Destroy(s *terraform.State) error {
+	config := common.TestAccProvider.Meta().(*cfg.Config)
+	client, err := config.NetworkingV1Client(env.OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("error creating OpenTelekomCloud NetworkingV1 client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "opentelekomcloud_vpc_route_table_route_v1" {
+			continue
+		}
+
+		rtID := rs.Primary.Attributes["route_table_id"]
+		destination := rs.Primary.Attributes["destination"]
+
+		routeTable, err := routetables.Get(client, rtID)
+		if err != nil {
+			continue
+		}
+
+		for _, route := range routeTable.Routes {
+			if route.DestinationCIDR == destination {
+				return fmt.Errorf("route %s still exists in route table %s", destination, rtID)
+			}
+		}
+	}
+
+	return nil
+}
+
+func testAccVpcRouteTableRouteImportStateID(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", name)
+		}
+		rtID := rs.Primary.Attributes["route_table_id"]
+		destination := rs.Primary.Attributes["destination"]
+		return rtID + "/" + destination, nil
+	}
+}
+
+func testAccVpcRouteTableRoute_network(name string) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_vpc_v1" "vpc_1" {
+  name = "%[1]s-1"
+  cidr = "192.168.0.0/16"
+}
+
+resource "opentelekomcloud_vpc_v1" "vpc_2" {
+  name = "%[1]s-2"
+  cidr = "172.16.0.0/16"
+}
+
+resource "opentelekomcloud_vpc_peering_connection_v2" "peering" {
+  name        = "%[1]s"
+  vpc_id      = opentelekomcloud_vpc_v1.vpc_1.id
+  peer_vpc_id = opentelekomcloud_vpc_v1.vpc_2.id
+}
+`, name)
+}
+
+func testAccVpcRouteTableRoute_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "opentelekomcloud_vpc_route_table_route_v1" "route" {
+  vpc_id      = opentelekomcloud_vpc_v1.vpc_1.id
+  destination = "172.16.0.0/16"
+  type        = "peering"
+  nexthop     = opentelekomcloud_vpc_peering_connection_v2.peering.id
+  description = "peering route"
+}
+`, testAccVpcRouteTableRoute_network(name))
+}
+
+func testAccVpcRouteTableRoute_update(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "opentelekomcloud_vpc_route_table_route_v1" "route" {
+  vpc_id      = opentelekomcloud_vpc_v1.vpc_1.id
+  destination = "172.16.0.0/16"
+  type        = "peering"
+  nexthop     = opentelekomcloud_vpc_peering_connection_v2.peering.id
+  description = "peering route updated"
+}
+`, testAccVpcRouteTableRoute_network(name))
+}
+
+func testAccVpcRouteTableRoute_withRouteTable(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "opentelekomcloud_vpc_route_table_v1" "table" {
+  name   = "%[2]s"
+  vpc_id = opentelekomcloud_vpc_v1.vpc_1.id
+}
+
+resource "opentelekomcloud_vpc_route_table_route_v1" "route" {
+  vpc_id         = opentelekomcloud_vpc_v1.vpc_1.id
+  route_table_id = opentelekomcloud_vpc_route_table_v1.table.id
+  destination    = "172.16.0.0/16"
+  type           = "peering"
+  nexthop        = opentelekomcloud_vpc_peering_connection_v2.peering.id
+  description    = "peering route on custom table"
+}
+`, testAccVpcRouteTableRoute_network(name), name)
+}

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_vpc_route_table_subnet_associate_v1_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_vpc_route_table_subnet_associate_v1_test.go
@@ -1,0 +1,113 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v1/routetables"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+)
+
+const resourceVPCRouteTableSubnetAssociateName = "opentelekomcloud_vpc_route_table_subnet_associate_v1.assoc"
+
+func TestAccVpcRouteTableSubnetAssociateV1_basic(t *testing.T) {
+	name := tools.RandomString("rtba-", 5)
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckRouteTableSubnetAssociateV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVpcRouteTableSubnetAssociate_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceVPCRouteTableSubnetAssociateName, "route_table_id"),
+					resource.TestCheckResourceAttrSet(resourceVPCRouteTableSubnetAssociateName, "subnet_id"),
+					resource.TestCheckResourceAttrSet(resourceVPCRouteTableSubnetAssociateName, "vpc_id"),
+				),
+			},
+			{
+				ResourceName:      resourceVPCRouteTableSubnetAssociateName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccVpcRouteTableSubnetAssociateImportStateID(resourceVPCRouteTableSubnetAssociateName),
+			},
+		},
+	})
+}
+
+func testAccCheckRouteTableSubnetAssociateV1Destroy(s *terraform.State) error {
+	config := common.TestAccProvider.Meta().(*cfg.Config)
+	client, err := config.NetworkingV1Client(env.OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("error creating OpenTelekomCloud NetworkingV1 client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "opentelekomcloud_vpc_route_table_subnet_associate_v1" {
+			continue
+		}
+
+		rtID := rs.Primary.Attributes["route_table_id"]
+		subnetID := rs.Primary.Attributes["subnet_id"]
+
+		routeTable, err := routetables.Get(client, rtID)
+		if err != nil {
+			continue
+		}
+
+		for _, subnet := range routeTable.Subnets {
+			if subnet.ID == subnetID {
+				return fmt.Errorf("subnet %s still associated with route table %s", subnetID, rtID)
+			}
+		}
+	}
+
+	return nil
+}
+
+func testAccVpcRouteTableSubnetAssociateImportStateID(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", name)
+		}
+		rtID := rs.Primary.Attributes["route_table_id"]
+		subnetID := rs.Primary.Attributes["subnet_id"]
+		return rtID + "/" + subnetID, nil
+	}
+}
+
+func testAccVpcRouteTableSubnetAssociate_basic(name string) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_vpc_v1" "vpc" {
+  name = "%[1]s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "opentelekomcloud_vpc_subnet_v1" "subnet" {
+  name       = "%[1]s"
+  cidr       = "192.168.0.0/24"
+  gateway_ip = "192.168.0.1"
+  vpc_id     = opentelekomcloud_vpc_v1.vpc.id
+}
+
+resource "opentelekomcloud_vpc_route_table_v1" "table" {
+  name   = "%[1]s"
+  vpc_id = opentelekomcloud_vpc_v1.vpc.id
+
+  lifecycle {
+    ignore_changes = [subnets]
+  }
+}
+
+resource "opentelekomcloud_vpc_route_table_subnet_associate_v1" "assoc" {
+  route_table_id = opentelekomcloud_vpc_route_table_v1.table.id
+  subnet_id      = opentelekomcloud_vpc_subnet_v1.subnet.id
+}
+`, name)
+}

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -709,6 +709,7 @@ func Provider() *schema.Provider {
 			"opentelekomcloud_vpc_peering_connection_accepter_v2":        vpc.ResourceVpcPeeringConnectionAccepterV2(),
 			"opentelekomcloud_vpc_route_table_v1":                        vpc.ResourceVPCRouteTableV1(),
 			"opentelekomcloud_vpc_route_table_route_v1":                  vpc.ResourceVPCRouteTableRouteV1(),
+			"opentelekomcloud_vpc_route_table_subnet_associate_v1":       vpc.ResourceVPCRouteTableSubnetAssociateV1(),
 			"opentelekomcloud_vpcep_approval_v1":                         vpcep.ResourceVPCEPApprovalV1(),
 			"opentelekomcloud_vpcep_endpoint_v1":                         vpcep.ResourceVPCEPEndpointV1(),
 			"opentelekomcloud_vpcep_service_v1":                          vpcep.ResourceVPCEPServiceV1(),

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -708,6 +708,7 @@ func Provider() *schema.Provider {
 			"opentelekomcloud_vpc_peering_connection_v2":                 vpc.ResourceVpcPeeringConnectionV2(),
 			"opentelekomcloud_vpc_peering_connection_accepter_v2":        vpc.ResourceVpcPeeringConnectionAccepterV2(),
 			"opentelekomcloud_vpc_route_table_v1":                        vpc.ResourceVPCRouteTableV1(),
+			"opentelekomcloud_vpc_route_table_route_v1":                  vpc.ResourceVPCRouteTableRouteV1(),
 			"opentelekomcloud_vpcep_approval_v1":                         vpcep.ResourceVPCEPApprovalV1(),
 			"opentelekomcloud_vpcep_endpoint_v1":                         vpcep.ResourceVPCEPEndpointV1(),
 			"opentelekomcloud_vpcep_service_v1":                          vpcep.ResourceVPCEPServiceV1(),

--- a/opentelekomcloud/services/vpc/resource_opentelekomcloud_vpc_route_table_route_v1.go
+++ b/opentelekomcloud/services/vpc/resource_opentelekomcloud_vpc_route_table_route_v1.go
@@ -111,6 +111,9 @@ func resourceVpcRouteTableRouteCreate(ctx context.Context, d *schema.ResourceDat
 
 	log.Printf("[DEBUG] OpenTelekomCloud VPC route table route create: rtb=%s, %#v", routeTableID, updateOpts)
 	if err := routetables.Update(client, routeTableID, updateOpts); err != nil {
+		if strings.Contains(err.Error(), "VPC.2812") {
+			return diag.Errorf("route with destination %s already exists in route table %s — use `terraform import` to manage it", destination, routeTableID)
+		}
 		return diag.Errorf("error creating OpenTelekomCloud VPC route table route: %s", err)
 	}
 

--- a/opentelekomcloud/services/vpc/resource_opentelekomcloud_vpc_route_table_route_v1.go
+++ b/opentelekomcloud/services/vpc/resource_opentelekomcloud_vpc_route_table_route_v1.go
@@ -1,0 +1,286 @@
+package vpc
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v1/routetables"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
+)
+
+// ResourceVPCRouteTableRouteV1 manages individual routes within a VPC route table.
+func ResourceVPCRouteTableRouteV1() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceVpcRouteTableRouteCreate,
+		ReadContext:   resourceVpcRouteTableRouteRead,
+		UpdateContext: resourceVpcRouteTableRouteUpdate,
+		DeleteContext: resourceVpcRouteTableRouteDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceVpcRouteTableRouteImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"destination": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: common.ValidateCIDR,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"ecs", "eni", "vip", "nat", "peering", "vpn",
+					"dc", "egw", "er", "subeni", "local",
+				}, false),
+			},
+			"nexthop": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"route_table_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"route_table_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceVpcRouteTableRouteCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
+		return config.NetworkingV1Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV1Client, err)
+	}
+
+	routeTableID := d.Get("route_table_id").(string)
+	if routeTableID == "" {
+		rtb, err := getDefaultRouteTable(client, d.Get("vpc_id").(string))
+		if err != nil {
+			return diag.Errorf("error retrieving default route table for VPC %s: %s", d.Get("vpc_id").(string), err)
+		}
+		routeTableID = rtb.ID
+	}
+
+	destination := d.Get("destination").(string)
+	desc := d.Get("description").(string)
+	routeOpts := routetables.RouteOpts{
+		Destination: destination,
+		Type:        d.Get("type").(string),
+		NextHop:     d.Get("nexthop").(string),
+		Description: &desc,
+	}
+
+	updateOpts := routetables.UpdateOpts{
+		Routes: map[string][]routetables.RouteOpts{
+			"add": {routeOpts},
+		},
+	}
+
+	log.Printf("[DEBUG] OpenTelekomCloud VPC route table route create: rtb=%s, %#v", routeTableID, updateOpts)
+	if err := routetables.Update(client, routeTableID, updateOpts); err != nil {
+		return diag.Errorf("error creating OpenTelekomCloud VPC route table route: %s", err)
+	}
+
+	d.SetId(routeTableID + "/" + destination)
+
+	clientCtx := common.CtxWithClient(ctx, client, keyClientV1)
+	return resourceVpcRouteTableRouteRead(clientCtx, d, meta)
+}
+
+func resourceVpcRouteTableRouteRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
+		return config.NetworkingV1Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV1Client, err)
+	}
+
+	routeTableID, destination, err := parseRouteTableRouteID(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	routeTable, err := routetables.Get(client, routeTableID)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "OpenTelekomCloud VPC route table route")
+	}
+
+	route := findRouteByDestination(routeTable.Routes, destination)
+	if route == nil {
+		log.Printf("[WARN] OpenTelekomCloud VPC route %s not found in route table %s, removing from state", destination, routeTableID)
+		d.SetId("")
+		return nil
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", config.GetRegion(d)),
+		d.Set("vpc_id", routeTable.VpcID),
+		d.Set("route_table_id", routeTableID),
+		d.Set("route_table_name", routeTable.Name),
+		d.Set("destination", route.DestinationCIDR),
+		d.Set("type", route.Type),
+		d.Set("nexthop", route.NextHop),
+		d.Set("description", route.Description),
+	)
+
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error saving OpenTelekomCloud VPC route table route: %s", err)
+	}
+
+	return nil
+}
+
+func resourceVpcRouteTableRouteUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
+		return config.NetworkingV1Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV1Client, err)
+	}
+
+	routeTableID, destination, err := parseRouteTableRouteID(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	desc := d.Get("description").(string)
+	routeOpts := routetables.RouteOpts{
+		Destination: destination,
+		Type:        d.Get("type").(string),
+		NextHop:     d.Get("nexthop").(string),
+		Description: &desc,
+	}
+
+	updateOpts := routetables.UpdateOpts{
+		Routes: map[string][]routetables.RouteOpts{
+			"mod": {routeOpts},
+		},
+	}
+
+	log.Printf("[DEBUG] OpenTelekomCloud VPC route table route update: rtb=%s, %#v", routeTableID, updateOpts)
+	if err := routetables.Update(client, routeTableID, updateOpts); err != nil {
+		return diag.Errorf("error updating OpenTelekomCloud VPC route table route: %s", err)
+	}
+
+	clientCtx := common.CtxWithClient(ctx, client, keyClientV1)
+	return resourceVpcRouteTableRouteRead(clientCtx, d, meta)
+}
+
+func resourceVpcRouteTableRouteDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
+		return config.NetworkingV1Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV1Client, err)
+	}
+
+	routeTableID, destination, err := parseRouteTableRouteID(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	routeOpts := routetables.RouteOpts{
+		Destination: destination,
+		Type:        d.Get("type").(string),
+		NextHop:     d.Get("nexthop").(string),
+	}
+
+	updateOpts := routetables.UpdateOpts{
+		Routes: map[string][]routetables.RouteOpts{
+			"del": {routeOpts},
+		},
+	}
+
+	log.Printf("[DEBUG] OpenTelekomCloud VPC route table route delete: rtb=%s, %#v", routeTableID, updateOpts)
+	if err := routetables.Update(client, routeTableID, updateOpts); err != nil {
+		if _, ok := err.(golangsdk.ErrDefault404); ok {
+			log.Printf("[WARN] Route table %s already deleted, removing route from state", routeTableID)
+			return nil
+		}
+		return diag.Errorf("error deleting OpenTelekomCloud VPC route table route: %s", err)
+	}
+
+	return nil
+}
+
+func resourceVpcRouteTableRouteImport(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.SplitN(d.Id(), "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format for import ID, want <route_table_id>/<destination>, got: %s", d.Id())
+	}
+
+	d.SetId(parts[0] + "/" + parts[1])
+	if err := d.Set("route_table_id", parts[0]); err != nil {
+		return nil, err
+	}
+
+	return []*schema.ResourceData{d}, nil
+}
+
+func getDefaultRouteTable(client *golangsdk.ServiceClient, vpcID string) (*routetables.RouteTable, error) {
+	rts, err := routetables.List(client, routetables.ListOpts{VpcID: vpcID})
+	if err != nil {
+		return nil, fmt.Errorf("error listing route tables for VPC %s: %w", vpcID, err)
+	}
+
+	for _, rt := range rts {
+		if rt.Default {
+			return &rt, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no default route table found for VPC %s", vpcID)
+}
+
+func parseRouteTableRouteID(id string) (string, string, error) {
+	parts := strings.SplitN(id, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("invalid route table route ID format: %s", id)
+	}
+	return parts[0], parts[1], nil
+}
+
+func findRouteByDestination(routes []routetables.Route, destination string) *routetables.Route {
+	for _, r := range routes {
+		if r.DestinationCIDR == destination {
+			return &r
+		}
+	}
+	return nil
+}

--- a/opentelekomcloud/services/vpc/resource_opentelekomcloud_vpc_route_table_subnet_associate_v1.go
+++ b/opentelekomcloud/services/vpc/resource_opentelekomcloud_vpc_route_table_subnet_associate_v1.go
@@ -1,0 +1,190 @@
+package vpc
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v1/routetables"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
+)
+
+// ResourceVPCRouteTableSubnetAssociateV1 manages the association between a subnet and a route table.
+func ResourceVPCRouteTableSubnetAssociateV1() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceVpcRouteTableSubnetAssociateCreate,
+		ReadContext:   resourceVpcRouteTableSubnetAssociateRead,
+		DeleteContext: resourceVpcRouteTableSubnetAssociateDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceVpcRouteTableSubnetAssociateImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"route_table_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"subnet_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceVpcRouteTableSubnetAssociateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
+		return config.NetworkingV1Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV1Client, err)
+	}
+
+	rtID := d.Get("route_table_id").(string)
+	subnetID := d.Get("subnet_id").(string)
+
+	actionOpts := routetables.ActionOpts{
+		Subnets: routetables.ActionSubnetsOpts{
+			Associate: []string{subnetID},
+		},
+	}
+
+	log.Printf("[DEBUG] OpenTelekomCloud VPC route table subnet associate: rtb=%s subnet=%s", rtID, subnetID)
+	_, err = routetables.Action(client, rtID, actionOpts)
+	if err != nil {
+		return diag.Errorf("error associating subnet %s with route table %s: %s", subnetID, rtID, err)
+	}
+
+	d.SetId(rtID + "/" + subnetID)
+
+	clientCtx := common.CtxWithClient(ctx, client, keyClientV1)
+	return resourceVpcRouteTableSubnetAssociateRead(clientCtx, d, meta)
+}
+
+func resourceVpcRouteTableSubnetAssociateRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
+		return config.NetworkingV1Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV1Client, err)
+	}
+
+	rtID, subnetID, err := parseRouteTableSubnetAssociateID(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	routeTable, err := routetables.Get(client, rtID)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "OpenTelekomCloud VPC route table subnet association")
+	}
+
+	if !subnetInRouteTable(routeTable.Subnets, subnetID) {
+		log.Printf("[WARN] Subnet %s not found in route table %s, removing association from state", subnetID, rtID)
+		d.SetId("")
+		return nil
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", config.GetRegion(d)),
+		d.Set("route_table_id", rtID),
+		d.Set("subnet_id", subnetID),
+		d.Set("vpc_id", routeTable.VpcID),
+	)
+
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error saving OpenTelekomCloud VPC route table subnet association: %s", err)
+	}
+
+	return nil
+}
+
+func resourceVpcRouteTableSubnetAssociateDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
+		return config.NetworkingV1Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV1Client, err)
+	}
+
+	rtID, subnetID, err := parseRouteTableSubnetAssociateID(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	actionOpts := routetables.ActionOpts{
+		Subnets: routetables.ActionSubnetsOpts{
+			Disassociate: []string{subnetID},
+		},
+	}
+
+	log.Printf("[DEBUG] OpenTelekomCloud VPC route table subnet disassociate: rtb=%s subnet=%s", rtID, subnetID)
+	_, err = routetables.Action(client, rtID, actionOpts)
+	if err != nil {
+		if _, ok := err.(golangsdk.ErrDefault404); ok {
+			log.Printf("[WARN] Route table %s already deleted, removing association from state", rtID)
+			return nil
+		}
+		return diag.Errorf("error disassociating subnet %s from route table %s: %s", subnetID, rtID, err)
+	}
+
+	return nil
+}
+
+func resourceVpcRouteTableSubnetAssociateImport(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.SplitN(d.Id(), "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format for import ID, want <route_table_id>/<subnet_id>, got: %s", d.Id())
+	}
+
+	d.SetId(parts[0] + "/" + parts[1])
+
+	mErr := multierror.Append(nil,
+		d.Set("route_table_id", parts[0]),
+		d.Set("subnet_id", parts[1]),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return nil, err
+	}
+
+	return []*schema.ResourceData{d}, nil
+}
+
+func parseRouteTableSubnetAssociateID(id string) (string, string, error) {
+	parts := strings.SplitN(id, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("invalid route table subnet association ID format: %s", id)
+	}
+	return parts[0], parts[1], nil
+}
+
+func subnetInRouteTable(subnets []routetables.Subnet, subnetID string) bool {
+	for _, s := range subnets {
+		if s.ID == subnetID {
+			return true
+		}
+	}
+	return false
+}

--- a/opentelekomcloud/services/vpc/resource_opentelekomcloud_vpc_route_table_v1.go
+++ b/opentelekomcloud/services/vpc/resource_opentelekomcloud_vpc_route_table_v1.go
@@ -294,7 +294,10 @@ func resourceVpcRouteTableDelete(ctx context.Context, d *schema.ResourceData, me
 		subnets := common.ExpandToStringSlice(v.(*schema.Set).List())
 		err = disassociateRouteTableSubnets(client, d.Id(), subnets)
 		if err != nil {
-			return diag.Errorf("error disassociating subnets with OpenTelekomCloud VPC route table %s: %s", d.Id(), err)
+			if _, ok := err.(golangsdk.ErrDefault400); !ok {
+				return diag.Errorf("error disassociating subnets with OpenTelekomCloud VPC route table %s: %s", d.Id(), err)
+			}
+			log.Printf("[WARN] Error disassociating subnets from route table %s (may already be disassociated): %s", d.Id(), err)
 		}
 	}
 

--- a/releasenotes/notes/vpc-route-table-route-and-subnet-associate-e8d70587b05dabc1.yaml
+++ b/releasenotes/notes/vpc-route-table-route-and-subnet-associate-e8d70587b05dabc1.yaml
@@ -1,0 +1,12 @@
+---
+features:
+  - |
+    **New Resource:** ``opentelekomcloud_vpc_route_table_route_v1``
+    (`#3312 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3312>`_)
+  - |
+    **New Resource:** ``opentelekomcloud_vpc_route_table_subnet_associate_v1``
+    (`#3312 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3312>`_)
+fixes:
+  - |
+    **[VPC]** Handle already-disassociated subnets in ``opentelekomcloud_vpc_route_table_v1`` delete
+    (`#3312 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3312>`_)


### PR DESCRIPTION
## Summary of the Pull Request

Add two new resources for managing VPC route table configurations independently of the route table lifecycle:

* `opentelekomcloud_vpc_route_table_route_v1`: manages individual routes within default or custom route tables, supporting all OTC route types and in-place updates
* `opentelekomcloud_vpc_route_table_subnet_associate_v1`: manages the association between a subnet and a custom route table

Also includes:

* Friendly error message when creating a route with a destination that already exists
  (API error `VPC.2812`), guiding users to `terraform import`
* Fix for 400 error in `opentelekomcloud_vpc_route_table_v1` Delete when subnets
  are already disassociated, which occurs when subnet associations are managed by the
  new `_subnet_associate_v1` resource

## PR Checklist

* [x] Refers to: #3310, #3311
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```bash
=== RUN   TestAccVpcRouteTableRouteV1_basic
--- PASS: TestAccVpcRouteTableRouteV1_basic
=== RUN   TestAccVpcRouteTableRouteV1_withRouteTable
--- PASS: TestAccVpcRouteTableRouteV1_withRouteTable
=== RUN   TestAccVpcRouteTableSubnetAssociateV1_basic
--- PASS: TestAccVpcRouteTableSubnetAssociateV1_basic
=== RUN   TestAccVpcRouteTableRouteV1_duplicateDestination
--- PASS: TestAccVpcRouteTableRouteV1_duplicateDestination
PASS
```

Closes #3310 
Closes #3311 