### PR TITLE
[Feat] CCE: Changes to pre or postinstall in nodepool forces new when desired

### DIFF
--- a/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_pool_v3.go
+++ b/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_pool_v3.go
@@ -50,6 +50,7 @@ func ResourceCCENodePoolV3() *schema.Resource {
 			common.ValidateVolumeType("root_volume.*.volumetype"),
 			common.ValidateVolumeType("data_volumes.*.volumetype"),
 			common.ValidateSubnet("subnet_id"),
+			recreateOnInstallDiff,
 		),
 
 		Schema: map[string]*schema.Schema{
@@ -245,6 +246,11 @@ func ResourceCCENodePoolV3() *schema.Resource {
 				Computed:  true,
 				StateFunc: common.GetHashOrEmpty,
 			},
+			"recreate_on_install": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 			"max_pods": {
 				Type:     schema.TypeInt,
 				Optional: true,
@@ -304,6 +310,20 @@ func ResourceCCENodePoolV3() *schema.Resource {
 			},
 		},
 	}
+}
+
+func recreateOnInstallDiff(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
+	if !d.Get("recreate_on_install").(bool) {
+		return nil
+	}
+	for _, field := range []string{"preinstall", "postinstall"} {
+		if d.HasChange(field) {
+			if err := d.ForceNew(field); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 func resourceCCENodePoolUserTags(d *schema.ResourceData) []tags.ResourceTag {


### PR DESCRIPTION
## Summary of the Pull Request

Add new parameter `recreate_on_install` to force recreation of resources whenever `postinstall` or `preinstall` is changed.

## PR Checklist

* [ ] Refers to: #3292 
* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (101.71s)
=== RUN   TestAccSomethingV0_timeout
--- PASS: TestAccSomethingV0_timeout (128.67s)
PASS

Process finished with exit code 0
```
