### PR TITLE
[Fix] RMS: Fix pagination and filter bugs in rms_policy_states_v1 data source

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20260323130726-5844a1acfb29
+	github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20260326114400-f18a3f4a5030
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.46.0
 	golang.org/x/sync v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -167,8 +167,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20260323130726-5844a1acfb29 h1:xvC7TWnoZM5o3s6NeZkswFwpLPMksGS6XRlmMqdJmHc=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20260323130726-5844a1acfb29/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20260326114400-f18a3f4a5030 h1:EgL/BTE8W86qWHUw6kocYylW1gYbIPLYF+HkZQVLv7I=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20260326114400-f18a3f4a5030/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/opentelekomcloud/acceptance/rms/data_source_opentelekomcloud_rms_policy_states_v1_test.go
+++ b/opentelekomcloud/acceptance/rms/data_source_opentelekomcloud_rms_policy_states_v1_test.go
@@ -3,6 +3,7 @@ package rms
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -30,6 +31,13 @@ func TestAccDataSourceRmsPolicyStates_basic(t *testing.T) {
 		ProviderFactories: common.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
+				Config: testDataSourceDataSourceRmsPolicyStates_base(rName),
+			},
+			{
+				PreConfig: func() {
+					t.Log("Waiting 30s for policy evaluation to complete...")
+					time.Sleep(30 * time.Second)
+				},
 				Config: testDataSourceDataSourceRmsPolicyStates_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					dc1.CheckResourceExists(),
@@ -76,6 +84,10 @@ resource "opentelekomcloud_rms_policy_assignment_v1" "test" {
     listOfAllowedFlavors = "[\"${data.opentelekomcloud_compute_flavor_v2.test.id}\"]"
   }
 }
+
+resource "opentelekomcloud_rms_policy_assignment_evaluate_v1" "test" {
+  policy_assignment_id = opentelekomcloud_rms_policy_assignment_v1.test.id
+}
 `, testAccPolicyAssignment_ecsConfig(name), name, env.OS_REGION_NAME)
 }
 
@@ -83,20 +95,32 @@ func testDataSourceDataSourceRmsPolicyStates_basic(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
-data "opentelekomcloud_rms_policy_states_v1" "basic" {}
+data "opentelekomcloud_rms_policy_states_v1" "basic" {
+  depends_on = [opentelekomcloud_rms_policy_assignment_evaluate_v1.test]
+}
+
+data "opentelekomcloud_rms_policy_states_v1" "filter_by_compliance_state" {
+  compliance_state = "Compliant"
+
+  depends_on = [opentelekomcloud_rms_policy_assignment_evaluate_v1.test]
+}
 
 data "opentelekomcloud_rms_policy_states_v1" "filter_by_resource_name" {
   resource_name = "%[2]s"
 
-  depends_on = [opentelekomcloud_compute_instance_v2.test]
+  depends_on = [opentelekomcloud_rms_policy_assignment_evaluate_v1.test]
 }
 
 data "opentelekomcloud_rms_policy_states_v1" "filter_by_resource_id" {
   resource_id = opentelekomcloud_compute_instance_v2.test.id
+
+  depends_on = [opentelekomcloud_rms_policy_assignment_evaluate_v1.test]
 }
 
 data "opentelekomcloud_rms_policy_states_v1" "filter_by_assignment_id" {
   policy_assignment_id = opentelekomcloud_rms_policy_assignment_v1.test.id
+
+  depends_on = [opentelekomcloud_rms_policy_assignment_evaluate_v1.test]
 }
 
 locals {

--- a/opentelekomcloud/services/rms/data_opentelekomcloud_rms_policy_states_v1.go
+++ b/opentelekomcloud/services/rms/data_opentelekomcloud_rms_policy_states_v1.go
@@ -95,6 +95,7 @@ func DataSourcePolicyStates() *schema.Resource {
 		},
 	}
 }
+
 func dataSourcePolicyStatesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
 	client, err := common.ClientFromCtx(ctx, rmsClientV1, func() (*golangsdk.ServiceClient, error) {
@@ -104,40 +105,44 @@ func dataSourcePolicyStatesRead(ctx context.Context, d *schema.ResourceData, met
 		return fmterr.Errorf(errCreationRMSV1Client, err)
 	}
 
-	var policyStates []compliance.PolicyState
-	if _, ok := d.GetOk("policy_assignment_id"); ok {
-		policyStates, err = compliance.ListAllRuleCompliance(client, compliance.ListAllComplianceOpts{
-			DomainId: GetRmsDomainId(client, config),
-			PolicyId: d.Get("policy_assignment_id").(string),
-		})
+	domainID := GetRmsDomainId(client, config)
+	complianceState := d.Get("compliance_state").(string)
+	resourceName := d.Get("resource_name").(string)
+	resourceID := d.Get("resource_id").(string)
 
-		if err != nil {
-			return diag.FromErr(err)
-		}
+	var policyStates []compliance.PolicyState
+	if v, ok := d.GetOk("policy_assignment_id"); ok {
+		policyStates, err = compliance.ListAllRuleCompliance(client, compliance.ListAllComplianceOpts{
+			DomainId:        domainID,
+			PolicyId:        v.(string),
+			ComplianceState: complianceState,
+			ResourceName:    resourceName,
+			ResourceId:      resourceID,
+		})
 	} else {
 		policyStates, err = compliance.ListAllUserCompliance(client, compliance.ListAllUserComplianceOpts{
-			DomainId: GetRmsDomainId(client, config),
+			DomainId:        domainID,
+			ComplianceState: complianceState,
+			ResourceName:    resourceName,
+			ResourceId:      resourceID,
 		})
-
-		if err != nil {
-			return diag.FromErr(err)
-		}
+	}
+	if err != nil {
+		return diag.FromErr(err)
 	}
 
-	filteredStates := filterPolicyStates(policyStates, d)
-
-	if len(filteredStates) == 0 {
+	if len(policyStates) == 0 {
 		return diag.FromErr(fmt.Errorf("policy states not found"))
 	}
 
-	uuid, err := uuid.GenerateUUID()
+	id, err := uuid.GenerateUUID()
 	if err != nil {
 		return diag.Errorf("unable to generate ID: %s", err)
 	}
-	d.SetId(uuid)
+	d.SetId(id)
 
-	states := make([]map[string]interface{}, len(filteredStates))
-	for i, state := range filteredStates {
+	states := make([]map[string]interface{}, len(policyStates))
+	for i, state := range policyStates {
 		states[i] = map[string]interface{}{
 			"domain_id":              state.DomainID,
 			"region_id":              state.RegionID,
@@ -160,30 +165,4 @@ func dataSourcePolicyStatesRead(ctx context.Context, d *schema.ResourceData, met
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())
-}
-
-func filterPolicyStates(states []compliance.PolicyState, d *schema.ResourceData) []compliance.PolicyState {
-	var filtered []compliance.PolicyState
-
-	for _, state := range states {
-		if v, ok := d.GetOk("compliance_state"); ok && v.(string) != state.ComplianceState {
-			continue
-		}
-
-		if v, ok := d.GetOk("resource_name"); ok && v.(string) != state.ResourceName {
-			continue
-		}
-
-		if v, ok := d.GetOk("resource_id"); ok && v.(string) != state.ResourceID {
-			continue
-		}
-
-		filtered = append(filtered, state)
-	}
-
-	if len(filtered) == 0 {
-		return states
-	}
-
-	return filtered
 }

--- a/releasenotes/notes/rms-policy-states-pagination-fix-f3ff6c496ee5a868.yaml
+++ b/releasenotes/notes/rms-policy-states-pagination-fix-f3ff6c496ee5a868.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    **[RMS]** Fix pagination and filter bugs in ``datasource/opentelekomcloud_rms_policy_states_v1`` where only the first page of results was returned and filtering by ``compliance_state`` could return unfiltered data
+    (`#3315 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3315>`_)


### PR DESCRIPTION
## Summary of the Pull Request

Fix two bugs in `opentelekomcloud_rms_policy_states_v1` that caused incomplete and incorrect results in environments with paginated policy states:

* **Pagination**: Bump `gophertelekomcloud` SDK which fixes marker-based pagination for RMS compliance (`NewPageInfoBase` replaces `NewSinglePageBase` in `ListAllUserCompliance`/ `ListAllRuleCompliance`). The old SDK short-circuited `NewAllPages()` after page 1.
* **Filtering**: Pass `compliance_state`, `resource_name`, and `resource_id` as query parameters to the SDK calls for server-side filtering. Remove `filterPolicyStates()` which returned all unfiltered states when no match was found instead of an empty slice.

Also fixes pre-existing acceptance test issues:

* Add missing `filter_by_compliance_state` data source block in HCL config
* Add `opentelekomcloud_rms_policy_assignment_evaluate_v1` to make the test self-contained
  (no longer depends on pre-existing policy states)
* Split into two test steps with 30s wait for evaluation to complete

## PR Checklist

* [x] Refers to: #3316 
* [x] Tests added/passed.
* [x] Documentation updated. (N/A — no schema or behavior change from user perspective)
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

Prerequisites: RMS Resource Recorder must be enabled on the test account.

```bash
=== RUN   TestAccDataSourceRmsPolicyStates_basic
=== PAUSE TestAccDataSourceRmsPolicyStates_basic
=== CONT  TestAccDataSourceRmsPolicyStates_basic
    data_source_opentelekomcloud_rms_policy_states_v1_test.go:38: Waiting 30s for policy evaluation to complete...
--- PASS: TestAccDataSourceRmsPolicyStates_basic (269.36s)
PASS
```