### PR TITLE
[Feat] VPC: add vpc_tenant_id attribute (#3323)

### DIFF
--- a/docs/data-sources/vpc_peering_connections_v2.md
+++ b/docs/data-sources/vpc_peering_connections_v2.md
@@ -54,6 +54,8 @@ In addition to all arguments above, the following attributes are exported:
 
   * `vpc_id` - The ID of the requester VPC.
 
+  * `vpc_tenant_id` - The project ID the requester VPC belongs to.
+
   * `peer_vpc_id` - The ID of the accepter/peer VPC.
 
-  * `peer_tenant_id` - The tenant ID of the accepter/peer VPC.
+  * `peer_tenant_id` - The project ID the accepter VPC belongs to.

--- a/docs/data-sources/vpc_peering_v2.md
+++ b/docs/data-sources/vpc_peering_v2.md
@@ -7,7 +7,7 @@ description: |-
   Get details about a specific VPC peering connection from OpenTelekomCloud
 ---
 
-Up-to-date reference of API arguments for VPC EIP you can get at
+Up-to-date reference of API arguments for VPC Peering Connections you can get at
 [documentation portal](https://docs.otc.t-systems.com/virtual-private-cloud/api-ref/apis/vpc_peering_connection/querying_vpc_peering_connections.html#vpc-peering-0001)
 
 # opentelekomcloud_vpc_peering_connection_v2
@@ -55,3 +55,5 @@ The given filters must match exactly one VPC peering connection whose data will 
 In addition to all arguments above, the following attributes are exported:
 
 * `description` - The description of the VPC peering connection.
+
+* `vpc_tenant_id` - The project ID the requester VPC belongs to.

--- a/opentelekomcloud/services/vpc/data_source_opentelekomcloud_vpc_peering_connection_v2.go
+++ b/opentelekomcloud/services/vpc/data_source_opentelekomcloud_vpc_peering_connection_v2.go
@@ -46,6 +46,10 @@ func DataSourceVpcPeeringConnectionV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"vpc_tenant_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"peer_vpc_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -99,6 +103,7 @@ func dataSourceVpcPeeringConnectionV2Read(_ context.Context, d *schema.ResourceD
 		d.Set("description", Peering.Description),
 		d.Set("status", Peering.Status),
 		d.Set("vpc_id", Peering.RequestVpcInfo.VpcId),
+		d.Set("vpc_tenant_id", Peering.RequestVpcInfo.TenantId),
 		d.Set("peer_vpc_id", Peering.AcceptVpcInfo.VpcId),
 		d.Set("peer_tenant_id", Peering.AcceptVpcInfo.TenantId),
 		d.Set("region", config.GetRegion(d)),

--- a/opentelekomcloud/services/vpc/data_source_opentelekomcloud_vpc_peering_connections_v2.go
+++ b/opentelekomcloud/services/vpc/data_source_opentelekomcloud_vpc_peering_connections_v2.go
@@ -69,6 +69,10 @@ func DataSourceVpcPeeringConnectionsV2() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"vpc_tenant_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"peer_vpc_id": {
 							Type:     schema.TypeString,
 							Computed: true,
@@ -131,6 +135,7 @@ func flattenPeeringConnections(peeringList []peerings.Peering) []interface{} {
 			"description":    p.Description,
 			"status":         p.Status,
 			"vpc_id":         p.RequestVpcInfo.VpcId,
+			"vpc_tenant_id":  p.RequestVpcInfo.TenantId,
 			"peer_vpc_id":    p.AcceptVpcInfo.VpcId,
 			"peer_tenant_id": p.AcceptVpcInfo.TenantId,
 		}

--- a/releasenotes/notes/vpc-peering-connection-attributes-7215b1b9d89a59ec.yaml
+++ b/releasenotes/notes/vpc-peering-connection-attributes-7215b1b9d89a59ec.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    **[VPC]** Data Source: ``opentelekomcloud_vpc_peering_connection_v2`` - export vpc_tenant_id attribute
+  - |
+    **[VPC]** Data Source: ``opentelekomcloud_vpc_peering_connections_v2`` - export connections vpc_tenant_id attribute


### PR DESCRIPTION
## Summary of the Pull Request

Add vpc_tenant_id attribute to `opentelekomcloud_vpc_peering_connection_v2` and `opentelekomcloud_vpc_peering_connections_v2` datasources.


## PR Checklist

* [x] Refers to: #3323 
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
TF_ACC=1 go test -v -timeout=30m ./opentelekomcloud/acceptance/vpc/data_source_opentelekomcloud_vpc_peering_connection* 

=== RUN   TestAccVpcPeeringConnectionV2DataSource_basic
=== PAUSE TestAccVpcPeeringConnectionV2DataSource_basic
=== RUN   TestAccVpcPeeringConnectionsV2DataSource_basic
=== PAUSE TestAccVpcPeeringConnectionsV2DataSource_basic
=== CONT  TestAccVpcPeeringConnectionV2DataSource_basic
=== CONT  TestAccVpcPeeringConnectionsV2DataSource_basic
--- PASS: TestAccVpcPeeringConnectionsV2DataSource_basic (107.75s)
--- PASS: TestAccVpcPeeringConnectionV2DataSource_basic (108.42s)
PASS
ok      command-line-arguments  111.482s

Process finished with exit code 0
```
