### PR TITLE
[Feat.] CCI: secrets resource

### DIFF
--- a/docs/resources/cci_secret_v2.md
+++ b/docs/resources/cci_secret_v2.md
@@ -1,0 +1,103 @@
+---
+subcategory: "Cloud Container Instance (CCI)"
+layout: "opentelekomcloud"
+page_title: "OpenTelekomCloud: opentelekomcloud_cci_secret_v2"
+sidebar_current: "docs-opentelekomcloud-resource-cci-secret-v2"
+description: |-
+  Manages a CCI v2 Secret resource within OpenTelekomCloud.
+---
+
+Up-to-date reference of API arguments for CCI secret you can get at
+[documentation portal](https://docs.otc.t-systems.com/cloud-container-instance/api-ref/proprietary_apis/index.html)
+
+# opentelekomcloud_cci_secret_v2
+
+Manages a CCI v2 Secret resource within OpenTelekomCloud.
+
+## Example Usage
+
+### Opaque Secret
+
+```hcl
+resource "opentelekomcloud_cci_secret_v2" "opaque" {
+  namespace = opentelekomcloud_cci_namespace_v2.test.name
+  name      = "my-opaque-secret"
+  type      = "Opaque"
+
+  data = {
+    "username" = base64encode("admin")
+    "password" = base64encode("p@ssw0rd")
+  }
+}
+```
+
+### Docker Registry Secret
+
+```hcl
+resource "opentelekomcloud_cci_secret_v2" "registry" {
+  namespace = opentelekomcloud_cci_namespace_v2.test.name
+  name      = "my-registry-secret"
+  type      = "kubernetes.io/dockerconfigjson"
+
+  data = {
+    ".dockerconfigjson" = base64encode(jsonencode({
+      auths = {
+        "swr.eu-de.otc.t-systems.com" = {
+          username = "user"
+          password = "token"
+          auth     = base64encode("user:token")
+        }
+      }
+    }))
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `namespace` - (Required, String, ForceNew) Specifies the namespace of the CCI Secret.
+
+* `name` - (Required, String, ForceNew) Specifies the name of the CCI Secret.
+
+* `string_data` - (Optional, Map) Specifies string data of the CCI Secret.
+  The values will be encoded to base64 by the API before storage.
+
+* `data` - (Optional, Map) Specifies the data of the CCI Secret.
+  The values must be base64-encoded strings.
+
+* `type` - (Optional, String) Specifies the type of the CCI Secret.
+  For example, `Opaque`, `kubernetes.io/dockerconfigjson`, etc.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in format `<namespace>/<name>`.
+
+* `region` - The region of the CCI Secret.
+
+* `api_version` - The API version of the CCI Secret.
+
+* `kind` - The kind of the CCI Secret.
+
+* `annotations` - The annotations of the CCI Secret.
+
+* `labels` - The labels of the CCI Secret.
+
+* `creation_timestamp` - The creation timestamp of the CCI Secret.
+
+* `resource_version` - The resource version of the CCI Secret.
+
+* `uid` - The uid of the CCI Secret.
+
+* `immutable` - Whether the CCI Secret is immutable.
+
+## Import
+
+The CCI v2 Secret can be imported using `namespace` and `name`, separated by a slash, e.g.
+
+```bash
+$ terraform import opentelekomcloud_cci_secret_v2.test <namespace>/<name>
+```

--- a/opentelekomcloud/acceptance/cci/resource_opentelekomcloud_cci_secret_v2_test.go
+++ b/opentelekomcloud/acceptance/cci/resource_opentelekomcloud_cci_secret_v2_test.go
@@ -1,0 +1,183 @@
+package cci
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/cci/v2/secret"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+)
+
+func getV2SecretResourceFunc(conf *cfg.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.CciV2Client(env.OS_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating OpenTelekomCloud CCI v2 client: %s", err)
+	}
+	return secret.Get(client, state.Primary.Attributes["namespace"], state.Primary.Attributes["name"])
+}
+
+func TestAccV2Secret_basic(t *testing.T) {
+	var sec secret.Secret
+	rName := fmt.Sprintf("cci-secret-%s", acctest.RandString(5))
+	nsName := fmt.Sprintf("cci-ns-%s", acctest.RandString(5))
+	resourceName := "opentelekomcloud_cci_secret_v2.test"
+
+	rc := common.InitResourceCheck(
+		resourceName,
+		&sec,
+		getV2SecretResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+		},
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccV2Secret_basic(nsName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "api_version", "cci/v2"),
+					resource.TestCheckResourceAttr(resourceName, "kind", "Secret"),
+					resource.TestCheckResourceAttrSet(resourceName, "annotations.%"),
+					resource.TestCheckResourceAttrSet(resourceName, "labels.%"),
+					resource.TestCheckResourceAttrSet(resourceName, "creation_timestamp"),
+					resource.TestCheckResourceAttrSet(resourceName, "resource_version"),
+					resource.TestCheckResourceAttrSet(resourceName, "uid"),
+					resource.TestCheckResourceAttrSet(resourceName, "data.%"),
+					resource.TestCheckOutput("key1_verify", "true"),
+				),
+			},
+			{
+				Config: testAccV2Secret_update(nsName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckOutput("key1_verify", "true"),
+					resource.TestCheckOutput("key3_verify", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccV2Secret_basic(nsName, rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "opentelekomcloud_cci_secret_v2" "test" {
+  namespace = opentelekomcloud_cci_namespace_v2.test.name
+  name      = "%[2]s"
+  type      = "Opaque"
+
+  data = {
+    "key1" = "dmFsdWUx"
+  }
+}
+
+output "key1_verify" {
+  value = opentelekomcloud_cci_secret_v2.test.data["key1"] == "dmFsdWUx"
+}
+`, testAccV2Namespace_basic(nsName), rName)
+}
+
+func TestAccV2Secret_dockerRegistry(t *testing.T) {
+	var sec secret.Secret
+	rName := fmt.Sprintf("cci-secret-%s", acctest.RandString(5))
+	nsName := fmt.Sprintf("cci-ns-%s", acctest.RandString(5))
+	resourceName := "opentelekomcloud_cci_secret_v2.test"
+
+	rc := common.InitResourceCheck(
+		resourceName,
+		&sec,
+		getV2SecretResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+		},
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccV2Secret_dockerRegistry(nsName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "type", "kubernetes.io/dockerconfigjson"),
+					resource.TestCheckResourceAttrSet(resourceName, "data..dockerconfigjson"),
+					resource.TestCheckResourceAttrSet(resourceName, "creation_timestamp"),
+					resource.TestCheckResourceAttrSet(resourceName, "resource_version"),
+					resource.TestCheckResourceAttrSet(resourceName, "uid"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccV2Secret_dockerRegistry(nsName, rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "opentelekomcloud_cci_secret_v2" "test" {
+  namespace = opentelekomcloud_cci_namespace_v2.test.name
+  name      = "%[2]s"
+  type      = "kubernetes.io/dockerconfigjson"
+
+  data = {
+    ".dockerconfigjson" = base64encode(jsonencode({
+      auths = {
+        "swr.eu-de.otc.t-systems.com" = {
+          username = "testuser"
+          password = "testpassword"
+          auth     = base64encode("testuser:testpassword")
+        }
+      }
+    }))
+  }
+}
+`, testAccV2Namespace_basic(nsName), rName)
+}
+
+func testAccV2Secret_update(nsName, rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "opentelekomcloud_cci_secret_v2" "test" {
+  namespace = opentelekomcloud_cci_namespace_v2.test.name
+  name      = "%[2]s"
+  type      = "Opaque"
+
+  data = {
+    "key1"       = "dXBkYXRlZF92YWx1ZTE="
+    "expired.at" = "MjAyNS0wNC0xNlQwNTo1NzowMVo="
+  }
+}
+
+output "key1_verify" {
+  value = opentelekomcloud_cci_secret_v2.test.data["key1"] == "dXBkYXRlZF92YWx1ZTE="
+}
+
+output "key3_verify" {
+  value = opentelekomcloud_cci_secret_v2.test.data["expired.at"] == "MjAyNS0wNC0xNlQwNTo1NzowMVo="
+}
+`, testAccV2Namespace_basic(nsName), rName)
+}

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -489,6 +489,7 @@ func Provider() *schema.Provider {
 			"opentelekomcloud_cce_node_pool_config_v3":                   cce.ResourceCCENodePoolConfigV3(),
 			"opentelekomcloud_cci_namespace_v2":                          cci.ResourceCCINamespaceV2(),
 			"opentelekomcloud_cci_network_v2":                            cci.ResourceCCINetworkV2(),
+			"opentelekomcloud_cci_secret_v2":                             cci.ResourceCCISecretV2(),
 			"opentelekomcloud_ces_alarmrule":                             ces.ResourceAlarmRule(),
 			"opentelekomcloud_ces_alarm_rule_v2":                         ces.ResourceAlarmRuleV2(),
 			"opentelekomcloud_ces_alarm_template_v2":                     ces.ResourceAlarmTemplateV2(),

--- a/opentelekomcloud/services/cci/resource_opentelekomcloud_cci_secret_v2.go
+++ b/opentelekomcloud/services/cci/resource_opentelekomcloud_cci_secret_v2.go
@@ -1,0 +1,235 @@
+package cci
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/cci/v2/secret"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
+)
+
+func ResourceCCISecretV2() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceCciSecretV2Create,
+		ReadContext:   resourceCciSecretV2Read,
+		UpdateContext: resourceCciSecretV2Update,
+		DeleteContext: resourceCciSecretV2Delete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceCciSecretV2ImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"namespace": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"string_data": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"data": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"annotations": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"labels": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"creation_timestamp": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"resource_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"uid": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"api_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"kind": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"immutable": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceCciSecretV2Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, cciClientV2, func() (*golangsdk.ServiceClient, error) {
+		return config.CciV2Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationCciClient, err)
+	}
+
+	createOpts := secret.CreateOpts{
+		Namespace: d.Get("namespace").(string),
+		Metadata: &secret.ObjectMeta{
+			Name: d.Get("name").(string),
+		},
+		StringData: expandStringMap(d.Get("string_data")),
+		Data:       expandStringMap(d.Get("data")),
+		Type:       d.Get("type").(string),
+	}
+
+	resp, err := secret.Create(client, createOpts)
+	if err != nil {
+		return diag.Errorf("error creating CCI v2 Secret: %s", err)
+	}
+
+	ns := resp.Metadata.Namespace
+	name := resp.Metadata.Name
+	if ns == "" || name == "" {
+		return diag.Errorf("unable to find namespace or CCI v2 Secret name from API response")
+	}
+	d.SetId(ns + "/" + name)
+
+	return resourceCciSecretV2Read(ctx, d, meta)
+}
+
+func resourceCciSecretV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, cciClientV2, func() (*golangsdk.ServiceClient, error) {
+		return config.CciV2Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationCciClient, err)
+	}
+
+	ns := d.Get("namespace").(string)
+	name := d.Get("name").(string)
+
+	resp, err := secret.Get(client, ns, name)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error querying CCI v2 Secret")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", config.GetRegion(d)),
+		d.Set("namespace", resp.Metadata.Namespace),
+		d.Set("name", resp.Metadata.Name),
+		d.Set("api_version", resp.APIVersion),
+		d.Set("kind", resp.Kind),
+		d.Set("annotations", resp.Metadata.Annotations),
+		d.Set("labels", resp.Metadata.Labels),
+		d.Set("creation_timestamp", resp.Metadata.CreationTimestamp),
+		d.Set("resource_version", resp.Metadata.ResourceVersion),
+		d.Set("uid", resp.Metadata.UID),
+		d.Set("data", resp.Data),
+		d.Set("type", resp.Type),
+		d.Set("immutable", resp.Immutable),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceCciSecretV2Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, cciClientV2, func() (*golangsdk.ServiceClient, error) {
+		return config.CciV2Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationCciClient, err)
+	}
+
+	ns := d.Get("namespace").(string)
+	name := d.Get("name").(string)
+
+	updateOpts := secret.UpdateOpts{
+		Metadata: &secret.ObjectMeta{
+			Name: name,
+		},
+		StringData: expandStringMap(d.Get("string_data")),
+		Data:       expandStringMap(d.Get("data")),
+		Type:       d.Get("type").(string),
+	}
+
+	_, err = secret.Update(client, ns, name, updateOpts)
+	if err != nil {
+		return diag.Errorf("error updating CCI v2 Secret: %s", err)
+	}
+
+	return resourceCciSecretV2Read(ctx, d, meta)
+}
+
+func resourceCciSecretV2Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, cciClientV2, func() (*golangsdk.ServiceClient, error) {
+		return config.CciV2Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationCciClient, err)
+	}
+
+	ns := d.Get("namespace").(string)
+	name := d.Get("name").(string)
+
+	_, err = secret.Delete(client, secret.DeleteOpts{
+		Namespace: ns,
+		Name:      name,
+	})
+	if err != nil {
+		return diag.Errorf("error deleting CCI v2 Secret: %s", err)
+	}
+
+	return nil
+}
+
+func resourceCciSecretV2ImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<namespace>/<name>', but got '%s'", d.Id())
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("namespace", parts[0]),
+		d.Set("name", parts[1]),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return nil, err
+	}
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/releasenotes/notes/cci_secret_v2-85df8fda15141d9e.yaml
+++ b/releasenotes/notes/cci_secret_v2-85df8fda15141d9e.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   - |
-    **[CCI]** Add new resource ``resource/opentelekomcloud_cci_secret_v2`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_).
+    **[CCI]** Add new resource ``resource/opentelekomcloud_cci_secret_v2`` (`#3326 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3326>`_).

--- a/releasenotes/notes/cci_secret_v2-85df8fda15141d9e.yaml
+++ b/releasenotes/notes/cci_secret_v2-85df8fda15141d9e.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    **[CCI]** Add new resource ``resource/opentelekomcloud_cci_secret_v2`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_).


### PR DESCRIPTION
## Summary of the Pull Request
Implementation of new resource `opentelekomcloud_cci_secret_v2`.

## PR Checklist

* [x] Refers to: #2691
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccV2Secret_basic
=== PAUSE TestAccV2Secret_basic
=== CONT  TestAccV2Secret_basic
--- PASS: TestAccV2Secret_basic (71.17s)
=== RUN   TestAccV2Secret_dockerRegistry
=== PAUSE TestAccV2Secret_dockerRegistry
=== CONT  TestAccV2Secret_dockerRegistry
--- PASS: TestAccV2Secret_dockerRegistry (52.05s)
PASS

Process finished with the exit code 0

```
