### PR TITLE
[Feat.] CCI: configmap resource

### DIFF
--- a/docs/resources/cci_configmap_v2.md
+++ b/docs/resources/cci_configmap_v2.md
@@ -1,0 +1,90 @@
+---
+subcategory: "Cloud Container Instance (CCI)"
+layout: "opentelekomcloud"
+page_title: "OpenTelekomCloud: opentelekomcloud_cci_configmap_v2"
+sidebar_current: "docs-opentelekomcloud-resource-cci-configmap-v2"
+description: |-
+  Manages a CCI v2 ConfigMap resource within OpenTelekomCloud.
+---
+
+Up-to-date reference of API arguments for CCI ConfigMap you can get at
+[documentation portal](https://docs.otc.t-systems.com/cloud-container-instance/api-ref/proprietary_apis/index.html)
+
+# opentelekomcloud_cci_configmap_v2
+
+Manages a CCI v2 ConfigMap resource within OpenTelekomCloud.
+
+## Example Usage
+
+### Basic ConfigMap
+
+```hcl
+resource "opentelekomcloud_cci_configmap_v2" "test" {
+  namespace = opentelekomcloud_cci_namespace_v2.test.name
+  name      = "my-configmap"
+
+  data = {
+    "app.properties" = "debug=false\nlog_level=info"
+    "timeout"        = "30s"
+  }
+}
+```
+
+### ConfigMap with a Certificate
+
+```hcl
+resource "opentelekomcloud_cci_configmap_v2" "tls" {
+  namespace = opentelekomcloud_cci_namespace_v2.test.name
+  name      = "my-tls-config"
+
+  data = {
+    "ca.crt" = file("ca.crt")
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `namespace` - (Required, String, ForceNew) Specifies the namespace of the CCI ConfigMap.
+
+* `name` - (Required, String, ForceNew) Specifies the name of the CCI ConfigMap.
+
+* `data` - (Optional, Map) Specifies the configuration data of the CCI ConfigMap.
+  Each value must be a UTF-8 string.
+
+* `binary_data` - (Optional, Map) Specifies the binary data of the CCI ConfigMap.
+  Each value must be a base64-encoded string.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in format `<namespace>/<name>`.
+
+* `region` - The region of the CCI ConfigMap.
+
+* `api_version` - The API version of the CCI ConfigMap.
+
+* `kind` - The kind of the CCI ConfigMap.
+
+* `annotations` - The annotations of the CCI ConfigMap.
+
+* `labels` - The labels of the CCI ConfigMap.
+
+* `creation_timestamp` - The creation timestamp of the CCI ConfigMap.
+
+* `resource_version` - The resource version of the CCI ConfigMap.
+
+* `uid` - The UID of the CCI ConfigMap.
+
+* `immutable` - Whether the CCI ConfigMap is immutable.
+
+## Import
+
+The CCI v2 ConfigMap can be imported using `namespace` and `name`, separated by a slash, e.g.
+
+```bash
+$ terraform import opentelekomcloud_cci_configmap_v2.test <namespace>/<name>
+```

--- a/opentelekomcloud/acceptance/cci/resource_opentelekomcloud_cci_configmap_v2_test.go
+++ b/opentelekomcloud/acceptance/cci/resource_opentelekomcloud_cci_configmap_v2_test.go
@@ -1,0 +1,105 @@
+package cci
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/cci/v2/configmap"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+)
+
+func getV2ConfigMapResourceFunc(conf *cfg.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.CciV2Client(env.OS_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating OpenTelekomCloud CCI v2 client: %s", err)
+	}
+	return configmap.Get(client, state.Primary.Attributes["namespace"], state.Primary.Attributes["name"])
+}
+
+func TestAccV2ConfigMap_basic(t *testing.T) {
+	var cm configmap.ConfigMap
+	rName := fmt.Sprintf("cci-configmap-%s", acctest.RandString(5))
+	nsName := fmt.Sprintf("cci-ns-%s", acctest.RandString(5))
+	resourceName := "opentelekomcloud_cci_configmap_v2.test"
+
+	rc := common.InitResourceCheck(
+		resourceName,
+		&cm,
+		getV2ConfigMapResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+		},
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccV2ConfigMap_basic(nsName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "api_version", "cci/v2"),
+					resource.TestCheckResourceAttr(resourceName, "kind", "ConfigMap"),
+					resource.TestCheckResourceAttrSet(resourceName, "annotations.%"),
+					resource.TestCheckResourceAttrSet(resourceName, "labels.%"),
+					resource.TestCheckResourceAttrSet(resourceName, "creation_timestamp"),
+					resource.TestCheckResourceAttrSet(resourceName, "resource_version"),
+					resource.TestCheckResourceAttrSet(resourceName, "uid"),
+					resource.TestCheckResourceAttrSet(resourceName, "data.%"),
+					resource.TestCheckResourceAttr(resourceName, "data.key1", "value1"),
+				),
+			},
+			{
+				Config: testAccV2ConfigMap_update(nsName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "data.key1", "updated_value1"),
+					resource.TestCheckResourceAttr(resourceName, "data.key2", "value2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccV2ConfigMap_basic(nsName, rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "opentelekomcloud_cci_configmap_v2" "test" {
+  namespace = opentelekomcloud_cci_namespace_v2.test.name
+  name      = "%[2]s"
+
+  data = {
+    "key1" = "value1"
+  }
+}
+`, testAccV2Namespace_basic(nsName), rName)
+}
+
+func testAccV2ConfigMap_update(nsName, rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "opentelekomcloud_cci_configmap_v2" "test" {
+  namespace = opentelekomcloud_cci_namespace_v2.test.name
+  name      = "%[2]s"
+
+  data = {
+    "key1" = "updated_value1"
+    "key2" = "value2"
+  }
+}
+`, testAccV2Namespace_basic(nsName), rName)
+}

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -488,6 +488,7 @@ func Provider() *schema.Provider {
 			"opentelekomcloud_cce_node_v3":                               cce.ResourceCCENodeV3(),
 			"opentelekomcloud_cce_node_pool_v3":                          cce.ResourceCCENodePoolV3(),
 			"opentelekomcloud_cce_node_pool_config_v3":                   cce.ResourceCCENodePoolConfigV3(),
+			"opentelekomcloud_cci_configmap_v2":                          cci.ResourceCCIConfigMapV2(),
 			"opentelekomcloud_cci_namespace_v2":                          cci.ResourceCCINamespaceV2(),
 			"opentelekomcloud_cci_network_v2":                            cci.ResourceCCINetworkV2(),
 			"opentelekomcloud_cci_pod_v2":                                cci.ResourceCCIPodV2(),

--- a/opentelekomcloud/services/cci/resource_opentelekomcloud_cci_configmap_v2.go
+++ b/opentelekomcloud/services/cci/resource_opentelekomcloud_cci_configmap_v2.go
@@ -1,0 +1,226 @@
+package cci
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/cci/v2/configmap"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
+)
+
+func ResourceCCIConfigMapV2() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceCciConfigMapV2Create,
+		ReadContext:   resourceCciConfigMapV2Read,
+		UpdateContext: resourceCciConfigMapV2Update,
+		DeleteContext: resourceCciConfigMapV2Delete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceCciConfigMapV2ImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"namespace": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"data": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"binary_data": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"immutable": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"annotations": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"labels": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"creation_timestamp": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"resource_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"uid": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"api_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"kind": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceCciConfigMapV2Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, cciClientV2, func() (*golangsdk.ServiceClient, error) {
+		return config.CciV2Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationCciClient, err)
+	}
+
+	ns := d.Get("namespace").(string)
+	createOpts := configmap.CreateOpts{
+		Metadata: configmap.ObjectMeta{
+			Name: d.Get("name").(string),
+		},
+		Data:       expandStringMap(d.Get("data")),
+		BinaryData: expandStringMap(d.Get("binary_data")),
+	}
+
+	resp, err := configmap.Create(client, ns, createOpts)
+	if err != nil {
+		return diag.Errorf("error creating CCI v2 ConfigMap: %s", err)
+	}
+
+	respNs := resp.Metadata.Namespace
+	respName := resp.Metadata.Name
+	if respNs == "" || respName == "" {
+		return diag.Errorf("unable to find namespace or CCI v2 ConfigMap name from API response")
+	}
+	d.SetId(respNs + "/" + respName)
+
+	return resourceCciConfigMapV2Read(ctx, d, meta)
+}
+
+func resourceCciConfigMapV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, cciClientV2, func() (*golangsdk.ServiceClient, error) {
+		return config.CciV2Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationCciClient, err)
+	}
+
+	ns := d.Get("namespace").(string)
+	name := d.Get("name").(string)
+
+	resp, err := configmap.Get(client, ns, name)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error querying CCI v2 ConfigMap")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", config.GetRegion(d)),
+		d.Set("namespace", resp.Metadata.Namespace),
+		d.Set("name", resp.Metadata.Name),
+		d.Set("api_version", resp.APIVersion),
+		d.Set("kind", resp.Kind),
+		d.Set("annotations", resp.Metadata.Annotations),
+		d.Set("labels", resp.Metadata.Labels),
+		d.Set("creation_timestamp", resp.Metadata.CreationTimestamp),
+		d.Set("resource_version", resp.Metadata.ResourceVersion),
+		d.Set("uid", resp.Metadata.UID),
+		d.Set("data", resp.Data),
+		d.Set("binary_data", resp.BinaryData),
+		d.Set("immutable", resp.Immutable),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceCciConfigMapV2Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, cciClientV2, func() (*golangsdk.ServiceClient, error) {
+		return config.CciV2Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationCciClient, err)
+	}
+
+	ns := d.Get("namespace").(string)
+	name := d.Get("name").(string)
+
+	updateOpts := configmap.UpdateOpts{
+		Metadata: &configmap.ObjectMeta{
+			Name: name,
+		},
+		Data:       expandStringMap(d.Get("data")),
+		BinaryData: expandStringMap(d.Get("binary_data")),
+	}
+
+	_, err = configmap.Update(client, ns, name, updateOpts)
+	if err != nil {
+		return diag.Errorf("error updating CCI v2 ConfigMap: %s", err)
+	}
+
+	return resourceCciConfigMapV2Read(ctx, d, meta)
+}
+
+func resourceCciConfigMapV2Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, cciClientV2, func() (*golangsdk.ServiceClient, error) {
+		return config.CciV2Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationCciClient, err)
+	}
+
+	ns := d.Get("namespace").(string)
+	name := d.Get("name").(string)
+
+	_, err = configmap.Delete(client, ns, name, configmap.DeleteOpts{})
+	if err != nil {
+		return diag.Errorf("error deleting CCI v2 ConfigMap (%s/%s): %s", ns, name, err)
+	}
+
+	return nil
+}
+
+func resourceCciConfigMapV2ImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<namespace>/<name>', but got '%s'", d.Id())
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("namespace", parts[0]),
+		d.Set("name", parts[1]),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return nil, err
+	}
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/releasenotes/notes/cci_configmap_v2-211f6574d13090f4.yaml
+++ b/releasenotes/notes/cci_configmap_v2-211f6574d13090f4.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   - |
-    **[CCI]** Add new resource ``resource/opentelekomcloud_cci_configmap_v2``  (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_).
+    **[CCI]** Add new resource ``resource/opentelekomcloud_cci_configmap_v2``  (`#3333 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3333>`_).

--- a/releasenotes/notes/cci_configmap_v2-211f6574d13090f4.yaml
+++ b/releasenotes/notes/cci_configmap_v2-211f6574d13090f4.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    **[CCI]** Add new resource ``resource/opentelekomcloud_cci_configmap_v2``  (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_).


### PR DESCRIPTION
## Summary of the Pull Request
New resource `opentelekomcloud_cci_configmap_v2`.

## PR Checklist

* [x] Refers to: #2691
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccV2ConfigMap_basic
=== PAUSE TestAccV2ConfigMap_basic
=== CONT  TestAccV2ConfigMap_basic
--- PASS: TestAccV2ConfigMap_basic (69.88s)
PASS

Process finished with the exit code 0
```
