### PR TITLE
[Fix] VPC: secgroup_rule_v3 drift on out-of-band deletion

### DIFF
--- a/opentelekomcloud/services/vpc/resource_opentelekomcloud_vpc_secgroup_rule_v3.go
+++ b/opentelekomcloud/services/vpc/resource_opentelekomcloud_vpc_secgroup_rule_v3.go
@@ -151,7 +151,7 @@ func resourceVpcSecGroupRuleV3Read(ctx context.Context, d *schema.ResourceData, 
 
 	securityGroupRule, err := rules.Get(client, d.Id())
 	if err != nil {
-		return fmterr.Errorf("error fetching security group rule `%s`: %w", d.Id(), err)
+		return common.CheckDeletedDiag(d, err, "error fetching OpenTelekomCloud VPC Security Group Rule V3")
 	}
 
 	mErr := multierror.Append(

--- a/releasenotes/notes/fix-vpc-secgroup-rule-v3-drift-2ccefcb9832fa3fc.yaml
+++ b/releasenotes/notes/fix-vpc-secgroup-rule-v3-drift-2ccefcb9832fa3fc.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[VPC]** Fix ``opentelekomcloud_vpc_secgroup_rule_v3`` so a rule deleted or replaced out-of-band (e.g. edited via the OTC portal) no longer causes ``terraform plan`` to error. The resource is now marked for re-creation on the next plan. (`#3343 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3343>`_)


### PR DESCRIPTION
## Summary of the Pull Request

`opentelekomcloud_vpc_secgroup_rule_v3` Read() now routes SDK errors through `common.CheckDeletedDiag` so a 404 on the stored rule ID clears state and the planner schedules re-creation — matching the behaviour of the v2 sibling.

The VPC v3 security-group-rule API has no Update endpoint (confirmed in the [API reference](https://docs.otc.t-systems.com/virtual-private-cloud/api-ref/api_v3/security_group_rule/index.html) and the SDK no `Update.go` under `openstack/vpc/v3/security/rules/`). The OTC portal's "edit" action therefore delete-and-recreates the rule with a new UUID, and the stored ID 404s on the next `plan`. Before this patch, Read bubbled the 404 up as a hard error, leaving users unable to recover without manual `terraform state rm`.

## PR Checklist

* [x] Refers to: #3342 
* [x] Tests added/passed.
* [ ] Documentation updated. _(n/a — behavioural fix, no schema/docs change)_
* [ ] Schema updated. _(n/a)_
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccVpcSecGroupRuleV3_basic
--- PASS: TestAccVpcSecGroupRuleV3_basic (68.28s)
PASS
```

Closes #3342 