### PR TITLE
[Feat.] Zone lookup by id in `data-source/opentelekomcloud_dns_zone_v2`

### DIFF
--- a/docs/data-sources/dns_zone_v2.md
+++ b/docs/data-sources/dns_zone_v2.md
@@ -25,6 +25,9 @@ data "opentelekomcloud_dns_zone_v2" "zone_1" {
 
 ## Argument Reference
 
+* `id` - (Optional) The ID of the zone. If specified, the zone is retrieved
+  directly by ID and other lookup arguments are ignored.
+
 * `zone_type` - (Optional) The type of the zone: `private` or `public`.
   This argument is **required** to match `private` zones.
 
@@ -45,6 +48,8 @@ data "opentelekomcloud_dns_zone_v2" "zone_1" {
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the zone.
 
 * `masters` - An array of master DNS servers.
 

--- a/opentelekomcloud/acceptance/dns/data_source_opentelekomcloud_dns_zone_v2_test.go
+++ b/opentelekomcloud/acceptance/dns/data_source_opentelekomcloud_dns_zone_v2_test.go
@@ -8,9 +8,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
 )
 
 const dataZoneName = "data.opentelekomcloud_dns_zone_v2.z1"
+const dataPrivateZoneName = "data.opentelekomcloud_dns_zone_v2.private"
 
 func TestAccOpenStackDNSZoneV2DataSource_basic(t *testing.T) {
 	zone := randomZoneName()
@@ -66,6 +68,36 @@ func TestAccOpenStackDNSZoneV2DataSource_byTag(t *testing.T) {
 	})
 }
 
+func TestAccOpenStackDNSZoneV2DataSource_byID(t *testing.T) {
+	zone := randomZoneName()
+	randZoneTag := fmt.Sprintf("value-%s", acctest.RandString(5))
+	dc := common.InitDataSourceCheck(dataZoneName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheckRequiredEnvVars(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      dc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOpenStackDNSZoneV2DataSourceZone(zone, randZoneTag),
+			},
+			{
+				Config: testAccOpenStackDNSZoneV2DataSourceByID(zone, randZoneTag),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					testAccCheckDNSZoneV2DataSourceID(dataZoneName),
+					resource.TestCheckResourceAttrPair(
+						dataZoneName, "id",
+						"opentelekomcloud_dns_zone_v2.zone_1", "id",
+					),
+					resource.TestCheckResourceAttr(dataZoneName, "name", zone),
+					resource.TestCheckResourceAttr(dataZoneName, "zone_type", "public"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccOpenStackDNSZoneV2DataSource_private(t *testing.T) {
 	zone1 := randomZoneName()
 	dc := common.InitDataSourceCheck(dataZoneName)
@@ -82,6 +114,31 @@ func TestAccOpenStackDNSZoneV2DataSource_private(t *testing.T) {
 				Config: testAccOpenStackDNSZoneV2DataSourcePrivate(zone1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDNSZoneV2DataSourceID(dataZoneName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccOpenStackDNSZoneV2DataSource_privateByTag(t *testing.T) {
+	zone1 := "otc.dev.local."
+	dc := common.InitDataSourceCheck(dataPrivateZoneName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheckRequiredEnvVars(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      dc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOpenStackDNSZoneV2DataSourcePrivateZone(zone1),
+			},
+			{
+				Config: testAccOpenStackDNSZoneV2DataSourcePrivateByTag(zone1),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					testAccCheckDNSZoneV2DataSourceID(dataPrivateZoneName),
+					resource.TestCheckResourceAttr(dataPrivateZoneName, "name", zone1),
+					resource.TestCheckResourceAttr(dataPrivateZoneName, "zone_type", "private"),
 				),
 			},
 		},
@@ -162,6 +219,16 @@ data "opentelekomcloud_dns_zone_v2" "z1" {
 `, base, zoneTagValue)
 }
 
+func testAccOpenStackDNSZoneV2DataSourceByID(zoneName, zoneTagValue string) string {
+	base := testAccOpenStackDNSZoneV2DataSourceZone(zoneName, zoneTagValue)
+	return fmt.Sprintf(`
+%s
+data "opentelekomcloud_dns_zone_v2" "z1" {
+  id = opentelekomcloud_dns_zone_v2.zone_1.id
+}
+`, base)
+}
+
 func testAccOpenStackDNSZoneV2DataSourcePrivate(zoneName string) string {
 	base := testAccDNSV2ZonePrivate(zoneName)
 	return fmt.Sprintf(`
@@ -169,6 +236,43 @@ func testAccOpenStackDNSZoneV2DataSourcePrivate(zoneName string) string {
 
 data "opentelekomcloud_dns_zone_v2" "z1" {
   name      = "%s"
+  zone_type = "private"
+}
+`, base, zoneName)
+}
+
+func testAccOpenStackDNSZoneV2DataSourcePrivateZone(zoneName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "opentelekomcloud_dns_zone_v2" "zone_1" {
+  name        = "%s"
+  email       = "email1@example.com"
+  description = "a private zone"
+  ttl         = 3000
+  type        = "private"
+
+  router {
+    router_id     = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+    router_region = "%s"
+  }
+
+  tags = {
+    Name = "%s"
+  }
+}
+`, common.DataSourceSubnet, zoneName, env.OS_REGION_NAME, zoneName)
+}
+
+func testAccOpenStackDNSZoneV2DataSourcePrivateByTag(zoneName string) string {
+	base := testAccOpenStackDNSZoneV2DataSourcePrivateZone(zoneName)
+	return fmt.Sprintf(`
+%s
+
+data "opentelekomcloud_dns_zone_v2" "private" {
+  tags = {
+    Name = "%s"
+  }
   zone_type = "private"
 }
 `, base, zoneName)

--- a/opentelekomcloud/services/dns/data_source_opentelekomcloud_dns_zone_v2.go
+++ b/opentelekomcloud/services/dns/data_source_opentelekomcloud_dns_zone_v2.go
@@ -19,6 +19,11 @@ func DataSourceDNSZoneV2() *schema.Resource {
 		ReadContext: dataSourceDNSZoneV2Read,
 
 		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"name": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -91,6 +96,25 @@ func dataSourceDNSZoneV2Read(_ context.Context, d *schema.ResourceData, meta int
 		return fmterr.Errorf(errCreationClient, err)
 	}
 
+	if v, ok := d.GetOk("id"); ok {
+		zoneID := v.(string)
+
+		zone, err := zones.Get(client, zoneID).Extract()
+		if err != nil {
+			if config.GetRegion(d) == "eu-nl" {
+				replaceNlEndpoint(client)
+				zone, err = zones.Get(client, zoneID).Extract()
+				if err != nil {
+					return fmterr.Errorf("unable to retrieve zone %s: %w", zoneID, err)
+				}
+			} else {
+				return fmterr.Errorf("unable to retrieve zone %s: %w", zoneID, err)
+			}
+		}
+
+		return setDNSZoneV2DataSourceAttributes(d, zone)
+	}
+
 	listOpts := zones.ListOpts{}
 
 	if v, ok := d.GetOk("name"); ok {
@@ -152,10 +176,15 @@ func dataSourceDNSZoneV2Read(_ context.Context, d *schema.ResourceData, meta int
 
 	zone := allZones[0]
 
+	return setDNSZoneV2DataSourceAttributes(d, &zone)
+}
+
+func setDNSZoneV2DataSourceAttributes(d *schema.ResourceData, zone *zones.Zone) diag.Diagnostics {
 	log.Printf("[DEBUG] Retrieved DNS Zone %s: %+v", zone.ID, zone)
 	d.SetId(zone.ID)
 
 	mErr := multierror.Append(
+		d.Set("id", zone.ID),
 		d.Set("name", zone.Name),
 		d.Set("pool_id", zone.PoolID),
 		d.Set("email", zone.Email),

--- a/releasenotes/notes/ds-dns-zone-by-id-7e32179f43698959.yaml
+++ b/releasenotes/notes/ds-dns-zone-by-id-7e32179f43698959.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[DNS]** Add lookup by `id` in ``data-source/opentelekomcloud_dns_zone_v2`` (`#3348 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3348>`_)


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [x] Refers to: #3347
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccOpenStackDNSZoneV2DataSource_basic
--- PASS: TestAccOpenStackDNSZoneV2DataSource_basic (70.83s)
=== RUN   TestAccOpenStackDNSZoneV2DataSource_byID
--- PASS: TestAccOpenStackDNSZoneV2DataSource_byID (51.42s)
=== RUN   TestAccOpenStackDNSZoneV2DataSource_private
--- PASS: TestAccOpenStackDNSZoneV2DataSource_private (57.01s)
=== RUN   TestAccOpenStackDNSZoneV2DataSource_privateByTag
--- PASS: TestAccOpenStackDNSZoneV2DataSource_privateByTag (58.16s)
PASS

Process finished with exit code 0
```
