### PR TITLE
[Feat.] Support Bandwidth Associate Ecs Ipv6 Ports 'opentelekomcloud_vpc_bandwidth_associate_v2'

### DIFF
--- a/docs/resources/vpc_bandwidth_associate_v2.md
+++ b/docs/resources/vpc_bandwidth_associate_v2.md
@@ -13,6 +13,7 @@ Up-to-date reference of API arguments for VPC bandwidth association you can get 
 # opentelekomcloud_vpc_bandwidth_associate_v2
 
 Provides a resource to associate floating IP with a shared bandwidth within Open Telekom Cloud.
+The resource can also associate an ECS NIC `port_id` when it represents the IPv6 public path.
 
 ## Example Usage
 
@@ -34,13 +35,27 @@ resource "opentelekomcloud_vpc_bandwidth_associate_v2" "associate" {
 }
 ```
 
+For an IPv6 ECS NIC port:
+
+```hcl
+resource "opentelekomcloud_vpc_bandwidth_associate_v2" "associate" {
+  bandwidth = opentelekomcloud_vpc_bandwidth_v2.band20m.id
+  floating_ips = [
+    opentelekomcloud_ecs_instance_v1.instance_1.nics[0].port_id,
+  ]
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
 
 * `bandwidth` - (Required) Specifies ID of the bandwidth to be assigned.
 
-* `floating_ips` - (Required) Specifies IDs of floating IPs to be added to the bandwidth.
+* `floating_ips` - (Required) Specifies IDs to be added to the bandwidth.
+  The values can be floating IP IDs or ECS NIC `port_id` values.
+  When a value is a `port_id`, the provider verifies that the port exists and
+  sends the association as a dual-stack public IP path.
 
 ->
 After an EIP is removed from a shared bandwidth, a dedicated bandwidth will be allocated to the EIP, and you will be

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20260329203346-ce1539b84cdc
+	github.com/opentelekomcloud/gophertelekomcloud v0.9.7-0.20260427110910-b87174af457e
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.46.0
 	golang.org/x/sync v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -167,8 +167,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20260329203346-ce1539b84cdc h1:OincfCr3lFfSJBKei3GSjYudcPFKfY40p7WWrMsyZyw=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.6-0.20260329203346-ce1539b84cdc/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.7-0.20260427110910-b87174af457e h1:VyY7qOS0Lto/plvgwBdJr4cVTPIOjjwHbMEmLmGI1wc=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.7-0.20260427110910-b87174af457e/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_port_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_port_v2_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/portsecurity"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/networks"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/ports"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/subnets"
@@ -16,11 +15,6 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 )
-
-type testPortWithExtensions struct {
-	ports.Port
-	portsecurity.PortSecurityExt
-}
 
 const resourceNwPortName = "opentelekomcloud_networking_port_v2.port_1"
 
@@ -130,7 +124,7 @@ func TestAccNetworkingV2Port_allowedAddressPairs(t *testing.T) {
 }
 
 func TestAccNetworkingV2Port_portSecurity_enabled(t *testing.T) {
-	var port testPortWithExtensions
+	var port ports.Port
 	resourceName := "opentelekomcloud_networking_port_v2.port_1"
 	t.Parallel()
 	qts := subnetQuotas()
@@ -162,7 +156,7 @@ func TestAccNetworkingV2Port_portSecurity_enabled(t *testing.T) {
 }
 
 func TestAccNetworkingV2Port_extendedDhcpOpts(t *testing.T) {
-	var port testPortWithExtensions
+	var port ports.Port
 	resourceName := "opentelekomcloud_networking_port_v2.port_1"
 	t.Parallel()
 	qts := subnetQuotas()
@@ -196,7 +190,7 @@ func TestAccNetworkingV2Port_extendedDhcpOpts(t *testing.T) {
 }
 
 func TestAccNetworkingV2Port_noPortSecurityNoSecurityGroups(t *testing.T) {
-	var port testPortWithExtensions
+	var port ports.Port
 	resourceName := "opentelekomcloud_networking_port_v2.port_1"
 	t.Parallel()
 	qts := subnetQuotas()
@@ -298,7 +292,7 @@ func testAccCheckNetworkingV2PortExists(n string, port *ports.Port) resource.Tes
 	}
 }
 
-func testAccCheckNetworkingV2PortWithExtensionsExists(n string, port *testPortWithExtensions) resource.TestCheckFunc {
+func testAccCheckNetworkingV2PortWithExtensionsExists(n string, port *ports.Port) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -315,7 +309,7 @@ func testAccCheckNetworkingV2PortWithExtensionsExists(n string, port *testPortWi
 			return fmt.Errorf("error creating OpenTelekomCloud NetworkingV2 client: %s", err)
 		}
 
-		var found testPortWithExtensions
+		var found ports.Port
 		err = ports.Get(client, rs.Primary.ID).ExtractInto(&found)
 		if err != nil {
 			return err
@@ -341,7 +335,7 @@ func testAccCheckNetworkingV2PortCountFixedIPs(port *ports.Port, expected int) r
 	}
 }
 
-func testAccCheckNetworkingV2PortPortSecurity(port *testPortWithExtensions, expected bool) resource.TestCheckFunc {
+func testAccCheckNetworkingV2PortPortSecurity(port *ports.Port, expected bool) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if port.PortSecurityEnabled != expected {
 			return fmt.Errorf("port has wrong port_security_enabled. Expected %t, got %t", expected, port.PortSecurityEnabled)

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_vpc_bandwidth_associate_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_vpc_bandwidth_associate_v2_test.go
@@ -1,12 +1,15 @@
 package acceptance
 
 import (
+	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/bandwidths"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
 )
 
 const resourceBandwidthAssociateName = "opentelekomcloud_vpc_bandwidth_associate_v2.associate"
@@ -97,6 +100,42 @@ func TestBandwidthAssociateV2_import(t *testing.T) {
 	})
 }
 
+func TestBandwidthAssociateV2_EcsIpv6PortID(t *testing.T) {
+	networkID := os.Getenv("OS_IPV6_ENABLED_NETWORK_ID")
+	if networkID == "" {
+		t.Skip("TestBandwidthAssociateV2_EcsIpv6PortID requires OS_IPV6_ENABLED_NETWORK_ID to continue.")
+	}
+
+	var b bandwidths.Bandwidth
+
+	t.Parallel()
+	qts := quotas.MultipleQuotas{
+		{Q: quotas.SharedBandwidth, Count: 1},
+		{Q: quotas.FloatingIP, Count: 1},
+		{Q: quotas.Server, Count: 1},
+	}
+	quotas.BookMany(t, qts)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheckRequiredEnvVars(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testCheckBandwidthV2Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testBandwidthAssociateV2EcsIpv6PortID(networkID),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckBandwidthExists(resourceBandwidthAssociateName, &b),
+					resource.TestCheckResourceAttrSet("opentelekomcloud_ecs_instance_v1.instance_1", "nics.0.port_id"),
+					resource.TestCheckResourceAttrPair(
+						"opentelekomcloud_vpc_eip_v1.eip", "publicip.0.port_id",
+						"opentelekomcloud_ecs_instance_v1.instance_1", "nics.0.port_id",
+					),
+				),
+			},
+		},
+	})
+}
+
 const testBandwidthAssociateV2Basic = `
 resource "opentelekomcloud_networking_floatingip_v2" "ip" {}
 
@@ -147,3 +186,59 @@ resource "opentelekomcloud_vpc_bandwidth_associate_v2" "associate" {
   floating_ips = [opentelekomcloud_vpc_eip_v1.eip.id]
 }
 `
+
+func testBandwidthAssociateV2EcsIpv6PortID(networkID string) string {
+	return fmt.Sprintf(`
+%s
+
+data "opentelekomcloud_vpc_subnet_v1" "ipv6_subnet" {
+  name = "%s"
+}
+
+resource "opentelekomcloud_ecs_instance_v1" "instance_1" {
+  name     = "ecs-ipv6-bandwidth-associate"
+  image_id = data.opentelekomcloud_images_image_v2.latest_image.id
+  flavor   = "s3.xlarge.4"
+  vpc_id   = data.opentelekomcloud_vpc_subnet_v1.ipv6_subnet.vpc_id
+
+  nics {
+    network_id  = data.opentelekomcloud_vpc_subnet_v1.ipv6_subnet.network_id
+    ipv6_enable = true
+  }
+
+  data_disks {
+    size = 10
+    type = "SSD"
+  }
+
+  password                    = "Password@123"
+  availability_zone           = "%s"
+  delete_disks_on_termination = true
+}
+
+resource "opentelekomcloud_vpc_eip_v1" "eip" {
+  publicip {
+    type    = "5_bgp"
+    port_id = opentelekomcloud_ecs_instance_v1.instance_1.nics.0.port_id
+  }
+
+  bandwidth {
+    name       = "tmp-band"
+    share_type = "PER"
+    size       = 10
+  }
+}
+
+resource "opentelekomcloud_vpc_bandwidth_v2" "band_test" {
+  name = "shared-test-associate-ipv6-port"
+  size = 20
+}
+
+resource "opentelekomcloud_vpc_bandwidth_associate_v2" "associate" {
+  depends_on = [opentelekomcloud_vpc_eip_v1.eip]
+
+  bandwidth      = opentelekomcloud_vpc_bandwidth_v2.band_test.id
+  floating_ips   = [opentelekomcloud_ecs_instance_v1.instance_1.nics.0.port_id]
+}
+`, common.DataSourceImage, networkID, env.OS_AVAILABILITY_ZONE)
+}

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_vpc_bandwidth_associate_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_vpc_bandwidth_associate_v2_test.go
@@ -237,8 +237,8 @@ resource "opentelekomcloud_vpc_bandwidth_v2" "band_test" {
 resource "opentelekomcloud_vpc_bandwidth_associate_v2" "associate" {
   depends_on = [opentelekomcloud_vpc_eip_v1.eip]
 
-  bandwidth      = opentelekomcloud_vpc_bandwidth_v2.band_test.id
-  floating_ips   = [opentelekomcloud_ecs_instance_v1.instance_1.nics.0.port_id]
+  bandwidth    = opentelekomcloud_vpc_bandwidth_v2.band_test.id
+  floating_ips = [opentelekomcloud_ecs_instance_v1.instance_1.nics.0.port_id]
 }
 `, common.DataSourceImage, networkID, env.OS_AVAILABILITY_ZONE)
 }

--- a/opentelekomcloud/services/vpc/resource_opentelekomcloud_networking_port_v2.go
+++ b/opentelekomcloud/services/vpc/resource_opentelekomcloud_networking_port_v2.go
@@ -263,8 +263,7 @@ func resourceNetworkingPortV2Read(ctx context.Context, d *schema.ResourceData, m
 		return fmterr.Errorf(errCreationV2Client, err)
 	}
 
-	var port portWithPortSecurityExtensions
-	err = ports.Get(client, d.Id()).ExtractInto(&port)
+	port, err := ports.Get(client, d.Id()).Extract()
 	if err != nil {
 		return common.CheckDeletedDiag(d, err, "port")
 	}
@@ -284,12 +283,12 @@ func resourceNetworkingPortV2Read(ctx context.Context, d *schema.ResourceData, m
 		d.Set("device_id", port.DeviceID),
 		d.Set("port_security_enabled", port.PortSecurityEnabled),
 		d.Set("region", config.GetRegion(d)),
-		d.Set("extra_dhcp_option", flattenNetworkingPortDHCPOptsV2(port.ExtraDHCPOptsExt)),
+		d.Set("extra_dhcp_option", flattenNetworkingPortDHCPOptsV2(port.ExtraDhcpOpts)),
 	)
 
 	// Create a slice of all returned Fixed IPs.
 	// This will be in the order returned by the API,
-	// which is usually alpha-numeric.
+	// which is usually alphanumeric.
 	var ips []string
 	for _, ipObject := range port.FixedIPs {
 		ips = append(ips, ipObject.IPAddress)
@@ -465,7 +464,7 @@ func ResourcePortSecurityGroupsV2(d *schema.ResourceData) []string {
 	return groups
 }
 
-func resourcePortFixedIpsV2(d *schema.ResourceData) interface{} {
+func resourcePortFixedIpsV2(d *schema.ResourceData) []ports.IP {
 	rawIP := d.Get("fixed_ip").([]interface{})
 
 	if len(rawIP) == 0 {
@@ -557,12 +556,6 @@ func waitForNetworkPortDelete(client *golangsdk.ServiceClient, portID string) re
 	}
 }
 
-type portWithPortSecurityExtensions struct {
-	ports.Port
-	portsecurity.PortSecurityExt
-	extradhcpopts.ExtraDHCPOptsExt
-}
-
 func expandNetworkingPortDHCPOptsV2Create(dhcpOpts *schema.Set) []extradhcpopts.CreateExtraDHCPOpt {
 	var extraDHCPOpts []extradhcpopts.CreateExtraDHCPOpt
 
@@ -582,10 +575,10 @@ func expandNetworkingPortDHCPOptsV2Create(dhcpOpts *schema.Set) []extradhcpopts.
 	return extraDHCPOpts
 }
 
-func flattenNetworkingPortDHCPOptsV2(dhcpOpts extradhcpopts.ExtraDHCPOptsExt) []map[string]interface{} {
-	dhcpOptsSet := make([]map[string]interface{}, len(dhcpOpts.ExtraDHCPOpts))
+func flattenNetworkingPortDHCPOptsV2(dhcpOpts []ports.ExtraDhcpOpt) []map[string]interface{} {
+	dhcpOptsSet := make([]map[string]interface{}, len(dhcpOpts))
 
-	for i, dhcpOpt := range dhcpOpts.ExtraDHCPOpts {
+	for i, dhcpOpt := range dhcpOpts {
 		dhcpOptsSet[i] = map[string]interface{}{
 			"name":  dhcpOpt.OptName,
 			"value": dhcpOpt.OptValue,

--- a/opentelekomcloud/services/vpc/resource_opentelekomcloud_vpc_bandwidth_associate_v2.go
+++ b/opentelekomcloud/services/vpc/resource_opentelekomcloud_vpc_bandwidth_associate_v2.go
@@ -157,15 +157,10 @@ func addIPsToBandwidth(client *golangsdk.ServiceClient, d *schema.ResourceData, 
 	}
 
 	for _, id := range failedIDs {
-		_, err := ports.Get(client, id).Extract()
+		err := insertPortToBandwidth(client, d.Id(), id)
 		if err != nil {
 			continue
 		}
-
-		ipOpts = append(ipOpts, bandwidths.PublicIpInfoInsertOpts{
-			PublicIpID:   id,
-			PublicIpType: dualStackPublicIPType,
-		})
 	}
 
 	if len(ipOpts) == 0 {
@@ -197,15 +192,9 @@ func removeIPsFromBandwidth(client *golangsdk.ServiceClient, d *schema.ResourceD
 	}
 
 	for _, id := range failedIDs {
-		_, err := ports.Get(client, id).Extract()
-		if err != nil {
+		if err := removePortFromBandwidth(client, d.Id(), id, d.Get("backup_charge_mode").(string), d.Get("backup_size").(int)); err != nil {
 			continue
 		}
-
-		ipInfo = append(ipInfo, bandwidths.PublicIpInfoRemove{
-			PublicIpID:   id,
-			PublicIpType: dualStackPublicIPType,
-		})
 	}
 
 	if len(ipInfo) == 0 {
@@ -221,6 +210,60 @@ func removeIPsFromBandwidth(client *golangsdk.ServiceClient, d *schema.ResourceD
 	if err := bandwidths.Remove(client, d.Id(), opts).ExtractErr(); err != nil {
 		return fmt.Errorf("error removing IPs from the bandwidth: %w", err)
 	}
+	return nil
+}
+
+func insertPortToBandwidth(client *golangsdk.ServiceClient, bwID, portID string) error {
+	associatedPort, err := ports.Get(client, portID).Extract()
+	if err != nil {
+		return fmt.Errorf("error fetching port %s: %w", portID, err)
+	}
+	if associatedPort.Ipv6BandwidthId != "" {
+		if associatedPort.Ipv6BandwidthId == bwID {
+			return nil
+		}
+
+		if err := removePortFromBandwidth(client, associatedPort.Ipv6BandwidthId, portID, "bandwidth", 1); err != nil {
+			return err
+		}
+	}
+
+	insertOpts := bandwidths.InsertOpts{
+		PublicIpInfo: []bandwidths.PublicIpInfoInsertOpts{
+			{
+				PublicIpID:   portID,
+				PublicIpType: dualStackPublicIPType,
+			},
+		},
+	}
+
+	if _, err := bandwidths.Insert(client, bwID, insertOpts).Extract(); err != nil {
+		return fmt.Errorf("error inserting %s into bandwidth %s: %w", portID, bwID, err)
+	}
+
+	return nil
+}
+
+func removePortFromBandwidth(client *golangsdk.ServiceClient, bwID, portID, chargeMode string, size int) error {
+	if _, err := ports.Get(client, portID).Extract(); err != nil {
+		return fmt.Errorf("error fetching port %s: %w", portID, err)
+	}
+
+	removeOpts := bandwidths.RemoveOpts{
+		ChargeMode: chargeMode,
+		Size:       size,
+		PublicIpInfo: []bandwidths.PublicIpInfoRemove{
+			{
+				PublicIpID:   portID,
+				PublicIpType: dualStackPublicIPType,
+			},
+		},
+	}
+
+	if err := bandwidths.Remove(client, bwID, removeOpts).ExtractErr(); err != nil {
+		return fmt.Errorf("error removing %s from bandwidth %s: %w", portID, bwID, err)
+	}
+
 	return nil
 }
 

--- a/opentelekomcloud/services/vpc/resource_opentelekomcloud_vpc_bandwidth_associate_v2.go
+++ b/opentelekomcloud/services/vpc/resource_opentelekomcloud_vpc_bandwidth_associate_v2.go
@@ -10,10 +10,13 @@ import (
 	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/bandwidths"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/layer3/floatingips"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/ports"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
 )
+
+const dualStackPublicIPType = "5_dualStack"
 
 func ResourceBandwidthAssociateV2() *schema.Resource {
 	return &schema.Resource{
@@ -138,20 +141,37 @@ func resourceBandwidthAssociateV2Delete(ctx context.Context, d *schema.ResourceD
 }
 
 func addIPsToBandwidth(client *golangsdk.ServiceClient, d *schema.ResourceData, ips *schema.Set) error {
-	ips, err := filterExistingFloatingIPs(client, ips)
+	fips, failedIDs, err := filterExistingFloatingIPs(client, ips)
 	if err != nil {
 		return err
 	}
-	if ips.Len() == 0 {
+	if fips.Len() == 0 && len(failedIDs) == 0 {
 		return nil
 	}
 
-	ipOpts := make([]bandwidths.PublicIpInfoInsertOpts, ips.Len())
-	for i, ip := range ips.List() {
-		ipOpts[i] = bandwidths.PublicIpInfoInsertOpts{
+	ipOpts := make([]bandwidths.PublicIpInfoInsertOpts, 0, fips.Len()+len(failedIDs))
+	for _, ip := range fips.List() {
+		ipOpts = append(ipOpts, bandwidths.PublicIpInfoInsertOpts{
 			PublicIpID: ip.(string),
-		}
+		})
 	}
+
+	for _, id := range failedIDs {
+		_, err := ports.Get(client, id).Extract()
+		if err != nil {
+			continue
+		}
+
+		ipOpts = append(ipOpts, bandwidths.PublicIpInfoInsertOpts{
+			PublicIpID:   id,
+			PublicIpType: dualStackPublicIPType,
+		})
+	}
+
+	if len(ipOpts) == 0 {
+		return nil
+	}
+
 	opts := bandwidths.InsertOpts{PublicIpInfo: ipOpts}
 
 	if _, err := bandwidths.Insert(client, d.Id(), opts).Extract(); err != nil {
@@ -161,19 +181,35 @@ func addIPsToBandwidth(client *golangsdk.ServiceClient, d *schema.ResourceData, 
 }
 
 func removeIPsFromBandwidth(client *golangsdk.ServiceClient, d *schema.ResourceData, ips *schema.Set) error {
-	ips, err := filterExistingFloatingIPs(client, ips)
+	fips, failedIDs, err := filterExistingFloatingIPs(client, ips)
 	if err != nil {
 		return err
 	}
-	if ips.Len() == 0 {
+	if fips.Len() == 0 && len(failedIDs) == 0 {
 		return nil
 	}
 
-	ipInfo := make([]bandwidths.PublicIpInfoID, ips.Len())
-	for i, ip := range ips.List() {
-		ipInfo[i] = bandwidths.PublicIpInfoID{
+	ipInfo := make([]bandwidths.PublicIpInfoRemove, 0, fips.Len()+len(failedIDs))
+	for _, ip := range fips.List() {
+		ipInfo = append(ipInfo, bandwidths.PublicIpInfoRemove{
 			PublicIpID: ip.(string),
+		})
+	}
+
+	for _, id := range failedIDs {
+		_, err := ports.Get(client, id).Extract()
+		if err != nil {
+			continue
 		}
+
+		ipInfo = append(ipInfo, bandwidths.PublicIpInfoRemove{
+			PublicIpID:   id,
+			PublicIpType: dualStackPublicIPType,
+		})
+	}
+
+	if len(ipInfo) == 0 {
+		return nil
 	}
 
 	opts := bandwidths.RemoveOpts{
@@ -188,23 +224,35 @@ func removeIPsFromBandwidth(client *golangsdk.ServiceClient, d *schema.ResourceD
 	return nil
 }
 
-// filterExistingFloatingIPs returns only existing IPs from given slice
-func filterExistingFloatingIPs(clientV2 *golangsdk.ServiceClient, ipIDs *schema.Set) (*schema.Set, error) {
+// filterExistingFloatingIPs returns existing floating IP IDs and unresolved IDs from the given set.
+func filterExistingFloatingIPs(clientV2 *golangsdk.ServiceClient, ipIDs *schema.Set) (*schema.Set, []string, error) {
 	filtered := schema.NewSet(schema.HashString, []interface{}{})
+	unresolved := make(map[string]struct{}, ipIDs.Len())
+
+	for _, raw := range ipIDs.List() {
+		unresolved[raw.(string)] = struct{}{}
+	}
 
 	// check IPs in v2:
 	pages, err := floatingips.List(clientV2, floatingips.ListOpts{}).AllPages()
 	if err != nil {
-		return nil, fmt.Errorf("error listing floating IPs: %w", err)
+		return nil, nil, fmt.Errorf("error listing floating IPs: %w", err)
 	}
 	fips, err := floatingips.ExtractFloatingIPs(pages)
 	if err != nil {
-		return nil, fmt.Errorf("error extracting floating IPs: %w", err)
+		return nil, nil, fmt.Errorf("error extracting floating IPs: %w", err)
 	}
 	for _, ip := range fips {
 		if id := ip.ID; ipIDs.Contains(id) {
 			filtered.Add(id)
+			delete(unresolved, id)
 		}
 	}
-	return filtered, nil
+
+	failedIDs := make([]string, 0, len(unresolved))
+	for id := range unresolved {
+		failedIDs = append(failedIDs, id)
+	}
+
+	return filtered, failedIDs, nil
 }

--- a/releasenotes/notes/bw-associate-ipv6-fcab1d42fda4335a.yaml
+++ b/releasenotes/notes/bw-associate-ipv6-fcab1d42fda4335a.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    **[VPC]** added association ipv6 support through ECS port id in ``opentelekomcloud_vpc_bandwidth_associate_v2`` (`#3349 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3349>`_)
+other:
+  - |
+    **[VPC]** small refactoring in ``opentelekomcloud_networking_port_v2`` (`#3349 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3349>`_)


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [ ] Refers to: #xxx
* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestBandwidthAssociateV2_basic
=== PAUSE TestBandwidthAssociateV2_basic
=== CONT  TestBandwidthAssociateV2_basic
--- PASS: TestBandwidthAssociateV2_basic (71.75s)
=== RUN   TestBandwidthAssociateV2_EIPv1
=== PAUSE TestBandwidthAssociateV2_EIPv1
=== CONT  TestBandwidthAssociateV2_EIPv1
--- PASS: TestBandwidthAssociateV2_EIPv1 (116.83s)
=== RUN   TestBandwidthAssociateV2_import
=== PAUSE TestBandwidthAssociateV2_import
=== CONT  TestBandwidthAssociateV2_import
--- PASS: TestBandwidthAssociateV2_import (46.62s)
=== RUN   TestBandwidthAssociateV2_EcsIpv6PortID
=== PAUSE TestBandwidthAssociateV2_EcsIpv6PortID
=== CONT  TestBandwidthAssociateV2_EcsIpv6PortID
--- PASS: TestBandwidthAssociateV2_EcsIpv6PortID (195.19s)
PASS

Process finished with the exit code 0
```
