### PR TITLE
[Fix] acl drift in `opentelekomcloud_obs_bucket` for cloud only values

### DIFF
--- a/docs/resources/obs_bucket.md
+++ b/docs/resources/obs_bucket.md
@@ -15,6 +15,11 @@ Up-to-date reference of API arguments for OBS bucket you can get at
 Provides an OBS bucket resource within OpenTelekomCloud.
 Now respects HTTP_PROXY, HTTPS_PROXY environment variables.
 
+-> **NOTE:** The `acl` argument manages supported canned ACLs only: `private`, `public-read`,
+`public-read-write`, and `log-delivery-write`. Drift for those canned ACLs is detected on refresh.
+If the bucket is managed with a custom ACL grant set, use [`opentelekomcloud_obs_bucket_acl`](obs_bucket_acl.md)
+instead of the inline `acl` argument.
+
 ## Example Usage
 
 ### Private Bucket with Tags
@@ -400,8 +405,10 @@ The following arguments are supported:
 
 * `parallel_fs` - (Optional) Whether enable a bucket as a parallel file system.
 
-* `acl` - (Optional) Specifies the ACL policy for a bucket. The predefined common policies are as follows:
+* `acl` - (Optional) Specifies the canned ACL policy for a bucket. Supported values are:
   `private`, `public-read`, `public-read-write` and `log-delivery-write`. Defaults to `private`.
+  Drift is detected for these canned ACLs during refresh. For custom ACL grants, use
+  `opentelekomcloud_obs_bucket_acl`.
 
 * `tags` - (Optional) A mapping of tags to assign to the bucket. Each tag is represented by one key-value pair.
 

--- a/opentelekomcloud/acceptance/obs/resource_opentelekomcloud_obs_bucket_test.go
+++ b/opentelekomcloud/acceptance/obs/resource_opentelekomcloud_obs_bucket_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/obs"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
@@ -51,6 +52,39 @@ func TestAccObsBucket_basic(t *testing.T) {
 				Config: testAccObsBucketUpdate(rInt),
 				Check: resource.ComposeTestCheckFunc(testAccCheckObsBucketExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "server_side_encryption.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccObsBucket_aclDrift(t *testing.T) {
+	rInt := acctest.RandInt()
+	rName := "opentelekomcloud_obs_bucket.bucket"
+	bucketName := testAccObsBucketName(rInt)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckObsBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccObsBucketBasic(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketExists(rName),
+					resource.TestCheckResourceAttr(rName, "acl", "private"),
+					testAccCheckObsBucketACL(rName, obs.AclPrivate),
+				),
+			},
+			{
+				PreConfig: func() {
+					testAccSetObsBucketACL(t, bucketName, obs.AclPublicRead)
+				},
+				Config: testAccObsBucketBasic(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketExists(rName),
+					resource.TestCheckResourceAttr(rName, "acl", "private"),
+					testAccCheckObsBucketACL(rName, obs.AclPrivate),
 				),
 			},
 		},
@@ -418,6 +452,123 @@ func testAccCheckObsBucketLogging(name, target, prefix string) resource.TestChec
 
 		return nil
 	}
+}
+
+func testAccCheckObsBucketACL(name string, expected obs.AclType) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("not found: %s", name)
+		}
+
+		config := common.TestAccProvider.Meta().(*cfg.Config)
+		client, err := config.NewObjectStorageClient(env.OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("error creating OpenTelekomCloud OBS client: %s", err)
+		}
+
+		output, err := client.GetBucketAcl(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("error getting acl configuration of OBS bucket: %s", err)
+		}
+
+		actual, ok := flattenTestAccObsBucketACL(output)
+		if !ok {
+			return fmt.Errorf("bucket %s acl does not match a supported canned acl: owner=%q grants=%s",
+				rs.Primary.ID, output.Owner.ID, formatTestAccObsBucketGrants(output.Grants))
+		}
+		if actual != expected {
+			return fmt.Errorf("%s.acl: expected %s, got %s (owner=%q grants=%s)",
+				name, expected, actual, output.Owner.ID, formatTestAccObsBucketGrants(output.Grants))
+		}
+
+		return nil
+	}
+}
+
+func testAccSetObsBucketACL(t *testing.T, bucketName string, acl obs.AclType) {
+	t.Helper()
+
+	config := common.TestAccProvider.Meta().(*cfg.Config)
+	client, err := config.NewObjectStorageClient(env.OS_REGION_NAME)
+	if err != nil {
+		t.Fatalf("error creating OpenTelekomCloud OBS client: %s", err)
+	}
+
+	_, err = client.SetBucketAcl(&obs.SetBucketAclInput{
+		Bucket: bucketName,
+		ACL:    acl,
+	})
+	if err != nil {
+		t.Fatalf("error updating acl of OBS bucket: %s", err)
+	}
+}
+
+func flattenTestAccObsBucketACL(output *obs.GetBucketAclOutput) (obs.AclType, bool) {
+	if output == nil || output.Owner.ID == "" {
+		return "", false
+	}
+
+	ownerID := output.Owner.ID
+	has := func(granteeType obs.GranteeType, granteeID string, granteeURI obs.GroupUriType, permission obs.PermissionType) bool {
+		for _, grant := range output.Grants {
+			actualURI := grant.Grantee.URI
+			if grant.Grantee.Type == obs.GranteeUser {
+				actualURI = ""
+			}
+			if grant.Grantee.Type == granteeType &&
+				grant.Grantee.ID == granteeID &&
+				actualURI == granteeURI &&
+				grant.Permission == permission {
+				return true
+			}
+		}
+		return false
+	}
+
+	switch {
+	case len(output.Grants) == 1 &&
+		has(obs.GranteeUser, ownerID, "", obs.PermissionFullControl):
+		return obs.AclPrivate, true
+	case len(output.Grants) == 2 &&
+		has(obs.GranteeUser, ownerID, "", obs.PermissionFullControl) &&
+		has(obs.GranteeGroup, "", obs.GroupAllUsers, obs.PermissionRead):
+		return obs.AclPublicRead, true
+	case len(output.Grants) == 3 &&
+		has(obs.GranteeUser, ownerID, "", obs.PermissionFullControl) &&
+		has(obs.GranteeGroup, "", obs.GroupAllUsers, obs.PermissionRead) &&
+		has(obs.GranteeGroup, "", obs.GroupAllUsers, obs.PermissionWrite):
+		return obs.AclPublicReadWrite, true
+	case len(output.Grants) == 3 &&
+		has(obs.GranteeUser, ownerID, "", obs.PermissionFullControl) &&
+		has(obs.GranteeGroup, "", obs.GroupLogDelivery, obs.PermissionWrite) &&
+		has(obs.GranteeGroup, "", obs.GroupLogDelivery, obs.PermissionReadAcp):
+		return obs.AclLogDeliveryWrite, true
+	default:
+		return "", false
+	}
+}
+
+func formatTestAccObsBucketGrants(grants []obs.Grant) string {
+	if len(grants) == 0 {
+		return "[]"
+	}
+
+	out := "["
+	for i, grant := range grants {
+		if i > 0 {
+			out += ", "
+		}
+		out += fmt.Sprintf("{type=%q id=%q uri=%q permission=%q delivered=%t}",
+			grant.Grantee.Type,
+			grant.Grantee.ID,
+			grant.Grantee.URI,
+			grant.Permission,
+			grant.Delivered,
+		)
+	}
+	out += "]"
+	return out
 }
 
 // These need a bit of randomness as the name can only be used once globally

--- a/opentelekomcloud/services/obs/resource_opentelekomcloud_obs_bucket.go
+++ b/opentelekomcloud/services/obs/resource_opentelekomcloud_obs_bucket.go
@@ -557,6 +557,10 @@ func resourceObsBucketRead(_ context.Context, d *schema.ResourceData, meta inter
 		return fmterr.Errorf("error setting OBS bucket fields: %s", err)
 	}
 
+	if err := setObsBucketAcl(client, d); err != nil {
+		return diag.FromErr(err)
+	}
+
 	// Read storage class
 	if err := setObsBucketStorageClass(client, d); err != nil {
 		return diag.FromErr(err)
@@ -687,9 +691,110 @@ func resourceObsBucketAclUpdate(client *obs.ObsClient, d *schema.ResourceData) e
 		return GetObsError("error updating acl of OBS bucket", bucket, err)
 	}
 
-	// acl policy can not be retrieved by obsClient.GetBucketAcl method
 	err = d.Set("acl", acl)
 	return err
+}
+
+func setObsBucketAcl(client *obs.ObsClient, d *schema.ResourceData) error {
+	output, err := client.GetBucketAcl(d.Id())
+	if err != nil {
+		return GetObsError("error reading acl of OBS bucket", d.Id(), err)
+	}
+
+	acl, ok := flattenObsBucketCannedACL(output)
+	if !ok {
+		log.Printf("[WARN] OBS bucket %s ACL does not match a supported canned ACL", d.Id())
+		return nil
+	}
+
+	return d.Set("acl", string(acl))
+}
+
+type obsBucketGrantSignature struct {
+	granteeType obs.GranteeType
+	granteeID   string
+	granteeURI  string
+	permission  obs.PermissionType
+	delivered   bool
+}
+
+func flattenObsBucketCannedACL(output *obs.GetBucketAclOutput) (obs.AclType, bool) {
+	if output == nil || output.Owner.ID == "" {
+		return "", false
+	}
+
+	ownerGrant := obsBucketGrantSignature{
+		granteeType: obs.GranteeUser,
+		granteeID:   output.Owner.ID,
+		permission:  obs.PermissionFullControl,
+	}
+	publicReadGrant := obsBucketGrantSignature{
+		granteeType: obs.GranteeGroup,
+		granteeURI:  string(obs.GroupAllUsers),
+		permission:  obs.PermissionRead,
+	}
+	publicWriteGrant := obsBucketGrantSignature{
+		granteeType: obs.GranteeGroup,
+		granteeURI:  string(obs.GroupAllUsers),
+		permission:  obs.PermissionWrite,
+	}
+	logDeliveryWriteGrant := obsBucketGrantSignature{
+		granteeType: obs.GranteeGroup,
+		granteeURI:  string(obs.GroupLogDelivery),
+		permission:  obs.PermissionWrite,
+	}
+	logDeliveryReadACPGrant := obsBucketGrantSignature{
+		granteeType: obs.GranteeGroup,
+		granteeURI:  string(obs.GroupLogDelivery),
+		permission:  obs.PermissionReadAcp,
+	}
+
+	switch {
+	case obsBucketACLMatches(output.Grants, ownerGrant):
+		return obs.AclPrivate, true
+	case obsBucketACLMatches(output.Grants, ownerGrant, publicReadGrant):
+		return obs.AclPublicRead, true
+	case obsBucketACLMatches(output.Grants, ownerGrant, publicReadGrant, publicWriteGrant):
+		return obs.AclPublicReadWrite, true
+	case obsBucketACLMatches(output.Grants, ownerGrant, logDeliveryWriteGrant, logDeliveryReadACPGrant):
+		return obs.AclLogDeliveryWrite, true
+	default:
+		return "", false
+	}
+}
+
+func obsBucketACLMatches(actual []obs.Grant, expected ...obsBucketGrantSignature) bool {
+	if len(actual) != len(expected) {
+		return false
+	}
+
+	actualSet := make(map[obsBucketGrantSignature]struct{}, len(actual))
+	for _, grant := range actual {
+		signature := obsBucketGrantSignature{
+			granteeType: grant.Grantee.Type,
+			granteeID:   grant.Grantee.ID,
+			granteeURI:  normalizeObsBucketGrantURI(grant.Grantee.Type, grant.Grantee.URI),
+			permission:  grant.Permission,
+			delivered:   grant.Delivered,
+		}
+		actualSet[signature] = struct{}{}
+	}
+
+	for _, grant := range expected {
+		if _, ok := actualSet[grant]; !ok {
+			return false
+		}
+	}
+
+	return true
+}
+
+func normalizeObsBucketGrantURI(granteeType obs.GranteeType, granteeURI obs.GroupUriType) string {
+	if granteeType == obs.GranteeUser {
+		return ""
+	}
+
+	return parseGranteeURI(granteeURI)
 }
 
 func resourceObsBucketClassUpdate(client *obs.ObsClient, d *schema.ResourceData) error {

--- a/releasenotes/notes/obs-bucket-acl-drift-0a13b861f19bdada.yaml
+++ b/releasenotes/notes/obs-bucket-acl-drift-0a13b861f19bdada.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[OBS]** Fix `acl` set for ``resource/opentelekomcloud_obs_bucket`` (`#3361 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3361>`_)


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [x] Refers to: #3344
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccObsBucket_notifications
=== PAUSE TestAccObsBucket_notifications
=== CONT  TestAccObsBucket_notifications
--- PASS: TestAccObsBucket_notifications (35.86s)
=== RUN   TestAccObsBucket_pfs
=== PAUSE TestAccObsBucket_pfs
=== CONT  TestAccObsBucket_pfs
--- PASS: TestAccObsBucket_pfs (26.97s)
=== RUN   TestAccObsBucket_WormPolicy
=== PAUSE TestAccObsBucket_WormPolicy
=== CONT  TestAccObsBucket_WormPolicy
--- PASS: TestAccObsBucket_WormPolicy (52.99s)
=== RUN   TestAccObsBucket_UserDomainNames
=== PAUSE TestAccObsBucket_UserDomainNames
=== CONT  TestAccObsBucket_UserDomainNames
--- PASS: TestAccObsBucket_UserDomainNames (50.99s)
=== RUN   TestAccOBSBucket_VersioningObjectLockValidation
=== PAUSE TestAccOBSBucket_VersioningObjectLockValidation
=== CONT  TestAccOBSBucket_VersioningObjectLockValidation
--- PASS: TestAccOBSBucket_VersioningObjectLockValidation (4.49s)
PASS

Process finished with the exit code 0
```
