### PR TITLE
[Feat.]  support for looking up `opentelekomcloud_identity_project_v3` by project ID

### DIFF
--- a/docs/data-sources/identity_project_v3.md
+++ b/docs/data-sources/identity_project_v3.md
@@ -12,9 +12,19 @@ Up-to-date reference of API arguments for IAM project you can get at
 
 # opentelekomcloud_identity_project_v3
 
-Use this data source to get the ID of an OpenTelekomCloud project.
+Use this data source to get information about an OpenTelekomCloud project by ID or by filter arguments.
 
 ## Example Usage
+
+### Query Project by ID
+
+```hcl
+data "opentelekomcloud_identity_project_v3" "project_1" {
+  id = "<project_id>"
+}
+```
+
+### Query Project by Name
 
 ```hcl
 data "opentelekomcloud_identity_project_v3" "project_1" {
@@ -24,7 +34,7 @@ data "opentelekomcloud_identity_project_v3" "project_1" {
 
 ### Query Current Project details
 
-If `name` or `domain_id` are not provided, data source gets info about current project.
+If no filter arguments are provided, the data source gets information about the current project.
 
 ```hcl
 data "opentelekomcloud_identity_project_v3" "project_1" {
@@ -35,6 +45,8 @@ data "opentelekomcloud_identity_project_v3" "project_1" {
 ## Argument Reference
 
 The following arguments are supported:
+
+* `id` - (Optional) The ID of the project. When specified, the project is looked up directly by ID.
 
 * `domain_id` - (Optional) The domain this project belongs to.
 

--- a/opentelekomcloud/acceptance/iam/data_source_opentelekomcloud_identity_project_v3_test.go
+++ b/opentelekomcloud/acceptance/iam/data_source_opentelekomcloud_identity_project_v3_test.go
@@ -7,36 +7,29 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/identity/v3/projects"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 )
 
 func TestAccOpenStackIdentityV3ProjectDataSource_basic(t *testing.T) {
-	projectName := fmt.Sprintf("tf_test_%s", acctest.RandString(5))
-	projectDescription := acctest.RandString(20)
+	fallbackProjectName := fmt.Sprintf("tf_test_%s", acctest.RandString(5))
+	fallbackProjectDescription := acctest.RandString(20)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			common.TestAccPreCheck(t)
-			common.TestAccPreCheckAdminOnly(t)
+			testAccPreCheckIdentityProjectV3DataSource(t)
 		},
 		ProviderFactories: common.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccOpenStackIdentityProjectV3DataSource_project(projectName, projectDescription),
-			},
-			{
-				Config: testAccOpenStackIdentityProjectV3DataSource_basic(projectName, projectDescription),
+				Config: testAccOpenStackIdentityProjectV3DataSource_basic(fallbackProjectName, fallbackProjectDescription),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIdentityV3ProjectDataSourceID("data.opentelekomcloud_identity_project_v3.project_1"),
-					resource.TestCheckResourceAttr(
-						"data.opentelekomcloud_identity_project_v3.project_1", "name", projectName),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_identity_project_v3.project_1", "description", projectDescription),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_identity_project_v3.project_1", "enabled", "true"),
-					resource.TestCheckResourceAttr(
-						"opentelekomcloud_identity_project_v3.project_1", "is_domain", "false"),
+					resource.TestCheckResourceAttrSet("data.opentelekomcloud_identity_project_v3.project_1", "name"),
+					resource.TestCheckResourceAttrSet("data.opentelekomcloud_identity_project_v3.project_1", "domain_id"),
 				),
 			},
 		},
@@ -76,15 +69,6 @@ func testAccCheckIdentityV3ProjectDataSourceID(n string) resource.TestCheckFunc 
 	}
 }
 
-func testAccOpenStackIdentityProjectV3DataSource_project(name, description string) string {
-	return fmt.Sprintf(`
-resource "opentelekomcloud_identity_project_v3" "project_1" {
-  name        = "%s"
-  description = "%s"
-}
-`, name, description)
-}
-
 func testAccOpenStackIdentityProjectV3DataSource_project_empty() string {
 	return `
 data "opentelekomcloud_identity_project_v3" "project_1" {
@@ -94,51 +78,94 @@ data "opentelekomcloud_identity_project_v3" "project_1" {
 
 func testAccOpenStackIdentityProjectV3DataSource_basic(name, description string) string {
 	return fmt.Sprintf(`
-	%s
+data "opentelekomcloud_identity_projects_v3" "all" {}
+
+locals {
+	has_existing_project = length(data.opentelekomcloud_identity_projects_v3.all.projects) > 0
+	selected_project_name = local.has_existing_project ? data.opentelekomcloud_identity_projects_v3.all.projects[0].name : opentelekomcloud_identity_project_v3.project_1[0].name
+}
+
+resource "opentelekomcloud_identity_project_v3" "project_1" {
+	count       = local.has_existing_project ? 0 : 1
+	name        = "%s"
+	description = "%s"
+}
 
 data "opentelekomcloud_identity_project_v3" "project_1" {
-  name = opentelekomcloud_identity_project_v3.project_1.name
+	name = local.selected_project_name
 }
-`, testAccOpenStackIdentityProjectV3DataSource_project(name, description))
+`, name, description)
 }
 
 func testAccOpenStackIdentityProjectV3DataSource_byID(name, description string) string {
 	return fmt.Sprintf(`
-     %s
+data "opentelekomcloud_identity_projects_v3" "all" {}
+
+locals {
+	has_existing_project = length(data.opentelekomcloud_identity_projects_v3.all.projects) > 0
+	selected_project_id  = local.has_existing_project ? data.opentelekomcloud_identity_projects_v3.all.projects[0].project_id : opentelekomcloud_identity_project_v3.project_1[0].id
+}
+
+resource "opentelekomcloud_identity_project_v3" "project_1" {
+	count       = local.has_existing_project ? 0 : 1
+	name        = "%s"
+	description = "%s"
+}
  
  data "opentelekomcloud_identity_project_v3" "project_1" {
-   id = opentelekomcloud_identity_project_v3.project_1.id
+	 id = local.selected_project_id
  }
- `, testAccOpenStackIdentityProjectV3DataSource_project(name, description))
+ `, name, description)
 }
 
 func TestAccOpenStackIdentityV3ProjectDataSource_byID(t *testing.T) {
-	projectName := fmt.Sprintf("tf_test_%s", acctest.RandString(5))
-	projectDescription := acctest.RandString(20)
+	fallbackProjectName := fmt.Sprintf("tf_test_%s", acctest.RandString(5))
+	fallbackProjectDescription := acctest.RandString(20)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			common.TestAccPreCheck(t)
-			common.TestAccPreCheckAdminOnly(t)
+			testAccPreCheckIdentityProjectV3DataSource(t)
 		},
 		ProviderFactories: common.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccOpenStackIdentityProjectV3DataSource_project(projectName, projectDescription),
-			},
-			{
-				Config: testAccOpenStackIdentityProjectV3DataSource_byID(projectName, projectDescription),
+				Config: testAccOpenStackIdentityProjectV3DataSource_byID(fallbackProjectName, fallbackProjectDescription),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIdentityV3ProjectDataSourceID("data.opentelekomcloud_identity_project_v3.project_1"),
-					resource.TestCheckResourceAttr(
-						"data.opentelekomcloud_identity_project_v3.project_1", "name", projectName),
-					resource.TestCheckResourceAttr(
-						"data.opentelekomcloud_identity_project_v3.project_1", "description", projectDescription),
-					resource.TestCheckResourceAttrPair(
-						"data.opentelekomcloud_identity_project_v3.project_1", "id",
-						"opentelekomcloud_identity_project_v3.project_1", "id"),
+					resource.TestCheckResourceAttrSet("data.opentelekomcloud_identity_project_v3.project_1", "name"),
+					resource.TestCheckResourceAttrSet("data.opentelekomcloud_identity_project_v3.project_1", "id"),
 				),
 			},
 		},
 	})
+}
+
+func testAccPreCheckIdentityProjectV3DataSource(t *testing.T) {
+	common.TestAccPreCheck(t)
+
+	if testAccHasAnyIdentityProject(t) {
+		return
+	}
+
+	common.TestAccPreCheckAdminOnly(t)
+}
+
+func testAccHasAnyIdentityProject(t *testing.T) bool {
+	config := common.TestAccProvider.Meta().(*cfg.Config)
+	identityClient, err := config.IdentityV3Client(env.OS_REGION_NAME)
+	if err != nil {
+		t.Fatalf("error creating OpenStack identity client: %s", err)
+	}
+
+	allPages, err := projects.List(identityClient, projects.ListOpts{}).AllPages()
+	if err != nil {
+		t.Fatalf("unable to query projects: %s", err)
+	}
+
+	allProjects, err := projects.ExtractProjects(allPages)
+	if err != nil {
+		t.Fatalf("unable to retrieve projects: %s", err)
+	}
+
+	return len(allProjects) > 0
 }

--- a/opentelekomcloud/acceptance/iam/data_source_opentelekomcloud_identity_project_v3_test.go
+++ b/opentelekomcloud/acceptance/iam/data_source_opentelekomcloud_identity_project_v3_test.go
@@ -7,11 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/opentelekomcloud/gophertelekomcloud/openstack/identity/v3/projects"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
-	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
-	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 )
 
 func TestAccOpenStackIdentityV3ProjectDataSource_basic(t *testing.T) {
@@ -20,7 +17,7 @@ func TestAccOpenStackIdentityV3ProjectDataSource_basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheckIdentityProjectV3DataSource(t)
+			common.TestAccPreCheck(t)
 		},
 		ProviderFactories: common.TestAccProviderFactories,
 		Steps: []resource.TestStep{
@@ -124,7 +121,7 @@ func TestAccOpenStackIdentityV3ProjectDataSource_byID(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheckIdentityProjectV3DataSource(t)
+			common.TestAccPreCheck(t)
 		},
 		ProviderFactories: common.TestAccProviderFactories,
 		Steps: []resource.TestStep{
@@ -138,34 +135,4 @@ func TestAccOpenStackIdentityV3ProjectDataSource_byID(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccPreCheckIdentityProjectV3DataSource(t *testing.T) {
-	common.TestAccPreCheck(t)
-
-	if testAccHasAnyIdentityProject(t) {
-		return
-	}
-
-	common.TestAccPreCheckAdminOnly(t)
-}
-
-func testAccHasAnyIdentityProject(t *testing.T) bool {
-	config := common.TestAccProvider.Meta().(*cfg.Config)
-	identityClient, err := config.IdentityV3Client(env.OS_REGION_NAME)
-	if err != nil {
-		t.Fatalf("error creating OpenStack identity client: %s", err)
-	}
-
-	allPages, err := projects.List(identityClient, projects.ListOpts{}).AllPages()
-	if err != nil {
-		t.Fatalf("unable to query projects: %s", err)
-	}
-
-	allProjects, err := projects.ExtractProjects(allPages)
-	if err != nil {
-		t.Fatalf("unable to retrieve projects: %s", err)
-	}
-
-	return len(allProjects) > 0
 }

--- a/opentelekomcloud/acceptance/iam/data_source_opentelekomcloud_identity_project_v3_test.go
+++ b/opentelekomcloud/acceptance/iam/data_source_opentelekomcloud_identity_project_v3_test.go
@@ -101,3 +101,44 @@ data "opentelekomcloud_identity_project_v3" "project_1" {
 }
 `, testAccOpenStackIdentityProjectV3DataSource_project(name, description))
 }
+
+func testAccOpenStackIdentityProjectV3DataSource_byID(name, description string) string {
+	return fmt.Sprintf(`
+     %s
+ 
+ data "opentelekomcloud_identity_project_v3" "project_1" {
+   id = opentelekomcloud_identity_project_v3.project_1.id
+ }
+ `, testAccOpenStackIdentityProjectV3DataSource_project(name, description))
+}
+
+func TestAccOpenStackIdentityV3ProjectDataSource_byID(t *testing.T) {
+	projectName := fmt.Sprintf("tf_test_%s", acctest.RandString(5))
+	projectDescription := acctest.RandString(20)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+			common.TestAccPreCheckAdminOnly(t)
+		},
+		ProviderFactories: common.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOpenStackIdentityProjectV3DataSource_project(projectName, projectDescription),
+			},
+			{
+				Config: testAccOpenStackIdentityProjectV3DataSource_byID(projectName, projectDescription),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIdentityV3ProjectDataSourceID("data.opentelekomcloud_identity_project_v3.project_1"),
+					resource.TestCheckResourceAttr(
+						"data.opentelekomcloud_identity_project_v3.project_1", "name", projectName),
+					resource.TestCheckResourceAttr(
+						"data.opentelekomcloud_identity_project_v3.project_1", "description", projectDescription),
+					resource.TestCheckResourceAttrPair(
+						"data.opentelekomcloud_identity_project_v3.project_1", "id",
+						"opentelekomcloud_identity_project_v3.project_1", "id"),
+				),
+			},
+		},
+	})
+}

--- a/opentelekomcloud/acceptance/iam/data_source_opentelekomcloud_identity_project_v3_test.go
+++ b/opentelekomcloud/acceptance/iam/data_source_opentelekomcloud_identity_project_v3_test.go
@@ -81,18 +81,18 @@ func testAccOpenStackIdentityProjectV3DataSource_basic(name, description string)
 data "opentelekomcloud_identity_projects_v3" "all" {}
 
 locals {
-	has_existing_project = length(data.opentelekomcloud_identity_projects_v3.all.projects) > 0
-	selected_project_name = local.has_existing_project ? data.opentelekomcloud_identity_projects_v3.all.projects[0].name : opentelekomcloud_identity_project_v3.project_1[0].name
+  has_existing_project  = length(data.opentelekomcloud_identity_projects_v3.all.projects) > 0
+  selected_project_name = local.has_existing_project ? data.opentelekomcloud_identity_projects_v3.all.projects[0].name : opentelekomcloud_identity_project_v3.project_1[0].name
 }
 
 resource "opentelekomcloud_identity_project_v3" "project_1" {
-	count       = local.has_existing_project ? 0 : 1
-	name        = "%s"
-	description = "%s"
+  count       = local.has_existing_project ? 0 : 1
+  name        = "%s"
+  description = "%s"
 }
 
 data "opentelekomcloud_identity_project_v3" "project_1" {
-	name = local.selected_project_name
+  name = local.selected_project_name
 }
 `, name, description)
 }
@@ -102,20 +102,20 @@ func testAccOpenStackIdentityProjectV3DataSource_byID(name, description string) 
 data "opentelekomcloud_identity_projects_v3" "all" {}
 
 locals {
-	has_existing_project = length(data.opentelekomcloud_identity_projects_v3.all.projects) > 0
-	selected_project_id  = local.has_existing_project ? data.opentelekomcloud_identity_projects_v3.all.projects[0].project_id : opentelekomcloud_identity_project_v3.project_1[0].id
+  has_existing_project = length(data.opentelekomcloud_identity_projects_v3.all.projects) > 0
+  selected_project_id  = local.has_existing_project ? data.opentelekomcloud_identity_projects_v3.all.projects[0].project_id : opentelekomcloud_identity_project_v3.project_1[0].id
 }
 
 resource "opentelekomcloud_identity_project_v3" "project_1" {
-	count       = local.has_existing_project ? 0 : 1
-	name        = "%s"
-	description = "%s"
+  count       = local.has_existing_project ? 0 : 1
+  name        = "%s"
+  description = "%s"
 }
- 
- data "opentelekomcloud_identity_project_v3" "project_1" {
-	 id = local.selected_project_id
- }
- `, name, description)
+
+data "opentelekomcloud_identity_project_v3" "project_1" {
+  id = local.selected_project_id
+}
+`, name, description)
 }
 
 func TestAccOpenStackIdentityV3ProjectDataSource_byID(t *testing.T) {

--- a/opentelekomcloud/services/iam/data_source_opentelekomcloud_identity_project_v3.go
+++ b/opentelekomcloud/services/iam/data_source_opentelekomcloud_identity_project_v3.go
@@ -18,6 +18,11 @@ func DataSourceIdentityProjectV3() *schema.Resource {
 		ReadContext: dataSourceIdentityProjectV3Read,
 
 		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"description": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -61,70 +66,79 @@ func dataSourceIdentityProjectV3Read(_ context.Context, d *schema.ResourceData, 
 		return fmterr.Errorf(clientCreationFail, err)
 	}
 
-	var domainID string
-	rawDomainID, ok := d.GetOk("domain_id")
-	if ok {
-		domainID = rawDomainID.(string)
-	} else {
-		domainID = client.DomainID
-	}
-
-	listOpts := projects.ListOpts{
-		DomainID: domainID,
-		Name:     d.Get("name").(string),
-		ParentID: d.Get("parent_id").(string),
-	}
-
-	log.Printf("[DEBUG] List Options: %#v", listOpts)
-
 	var project projects.Project
-	allPages, err := projects.List(client, listOpts).AllPages()
-	if err != nil {
-		return fmterr.Errorf("unable to query projects: %s", err)
-	}
 
-	allProjects, err := projects.ExtractProjects(allPages)
-	if err != nil {
-		return fmterr.Errorf("unable to retrieve projects: %s", err)
-	}
-
-	var filteredProjects []projects.Project
-	var enabled bool
-	rawEnabled, eOk := d.GetOk("enabled")
-	if eOk {
-		enabled = rawEnabled.(bool)
-	}
-	var isDomain bool
-	rawIsDomain, dOk := d.GetOk("is_domain")
-	if dOk {
-		isDomain = rawIsDomain.(bool)
-	}
-	for _, v := range allProjects {
-		if eOk && v.Enabled != enabled {
-			continue
+	if v, ok := d.GetOk("id"); ok {
+		p, err := projects.Get(client, v.(string)).Extract()
+		if err != nil {
+			return fmterr.Errorf("unable to retrieve project %s: %s", v.(string), err)
 		}
-		if dOk && v.IsDomain != isDomain {
-			continue
+		project = *p
+	} else {
+		var domainID string
+		rawDomainID, ok := d.GetOk("domain_id")
+		if ok {
+			domainID = rawDomainID.(string)
+		} else {
+			domainID = client.DomainID
 		}
-		filteredProjects = append(filteredProjects, v)
-	}
 
-	if len(filteredProjects) < 1 {
-		return fmterr.Errorf("your query returned no results. " +
-			"Please change your search criteria and try again.")
-	}
+		listOpts := projects.ListOpts{
+			DomainID: domainID,
+			Name:     d.Get("name").(string),
+			ParentID: d.Get("parent_id").(string),
+		}
 
-	if len(filteredProjects) > 1 {
-		projectID := config.HwClient.ProjectID
-		for _, p := range filteredProjects {
-			if p.ID == projectID {
-				filteredProjects = []projects.Project{p}
-				break
+		log.Printf("[DEBUG] List Options: %#v", listOpts)
+
+		allPages, err := projects.List(client, listOpts).AllPages()
+		if err != nil {
+			return fmterr.Errorf("unable to query projects: %s", err)
+		}
+
+		allProjects, err := projects.ExtractProjects(allPages)
+		if err != nil {
+			return fmterr.Errorf("unable to retrieve projects: %s", err)
+		}
+
+		var filteredProjects []projects.Project
+		var enabled bool
+		rawEnabled, eOk := d.GetOk("enabled")
+		if eOk {
+			enabled = rawEnabled.(bool)
+		}
+		var isDomain bool
+		rawIsDomain, dOk := d.GetOk("is_domain")
+		if dOk {
+			isDomain = rawIsDomain.(bool)
+		}
+		for _, v := range allProjects {
+			if eOk && v.Enabled != enabled {
+				continue
+			}
+			if dOk && v.IsDomain != isDomain {
+				continue
+			}
+			filteredProjects = append(filteredProjects, v)
+		}
+
+		if len(filteredProjects) < 1 {
+			return fmterr.Errorf("your query returned no results. " +
+				"Please change your search criteria and try again.")
+		}
+
+		if len(filteredProjects) > 1 {
+			projectID := config.HwClient.ProjectID
+			for _, p := range filteredProjects {
+				if p.ID == projectID {
+					filteredProjects = []projects.Project{p}
+					break
+				}
 			}
 		}
-	}
 
-	project = filteredProjects[0]
+		project = filteredProjects[0]
+	}
 
 	log.Printf("[DEBUG] Single project found: %s", project.ID)
 

--- a/releasenotes/notes/iam-project-ds-id-lookup-3362.yaml
+++ b/releasenotes/notes/iam-project-ds-id-lookup-3362.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[IAM]** Add support for lookup by ``id`` in ``data_source/opentelekomcloud_identity_project_v3`` (`#3362 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/3362>`_)


### PR DESCRIPTION
## Summary of the Pull Request

This PR adds support for looking up `opentelekomcloud_identity_project_v3` by project ID.

It updates the IAM data source schema and read logic to allow direct lookup via `id`, adds acceptance coverage for that behavior, and updates the documentation with an example and argument reference for `id`.

## PR Checklist

* [x] Refers to: #3362
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```text
Running tool: go.exe test -test.fullpath=true -timeout 20m -run ^(TestAccOpenStackIdentityV3ProjectDataSource_basic|TestAccOpenStackIdentityV3ProjectDataSource_empty|TestAccOpenStackIdentityV3ProjectDataSource_byID)$ github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/iam -count=1

=== RUN   TestAccOpenStackIdentityV3ProjectDataSource_basic
--- PASS: TestAccOpenStackIdentityV3ProjectDataSource_basic (28.50s)
=== RUN   TestAccOpenStackIdentityV3ProjectDataSource_empty
--- PASS: TestAccOpenStackIdentityV3ProjectDataSource_empty (24.36s)
=== RUN   TestAccOpenStackIdentityV3ProjectDataSource_byID
--- PASS: TestAccOpenStackIdentityV3ProjectDataSource_byID (25.67s)
PASS
ok      github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/iam 79.431s