### PR TITLE
[Fix] nil pointer dereference panic when content is empty

### DIFF
--- a/opentelekomcloud/acceptance/obs/resource_opentelekomcloud_obs_bucket_object_test.go
+++ b/opentelekomcloud/acceptance/obs/resource_opentelekomcloud_obs_bucket_object_test.go
@@ -87,6 +87,28 @@ func TestAccObsBucketObject_content(t *testing.T) {
 	})
 }
 
+func TestAccObsBucketObject_emptyContent(t *testing.T) {
+	rInt := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckObsBucketObjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccObsBucketObject_configEmptyContent(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketObjectExists("opentelekomcloud_obs_bucket_object.object"),
+					resource.TestCheckResourceAttr(
+						"opentelekomcloud_obs_bucket_object.object", "key", "test-key"),
+					resource.TestCheckResourceAttr(
+						"opentelekomcloud_obs_bucket_object.object", "size", "0"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccObsBucketObject_withVersionedContent(t *testing.T) {
 	rInt := acctest.RandInt()
 
@@ -243,6 +265,19 @@ resource "opentelekomcloud_obs_bucket_object" "object" {
   bucket  = opentelekomcloud_obs_bucket.object_bucket.bucket
   key     = "test-key"
   content = "some_bucket_content"
+}
+`, randInt)
+}
+
+func testAccObsBucketObject_configEmptyContent(randInt int) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_obs_bucket" "object_bucket" {
+  bucket = "tf-object-test-bucket-%d"
+}
+resource "opentelekomcloud_obs_bucket_object" "object" {
+  bucket  = opentelekomcloud_obs_bucket.object_bucket.bucket
+  key     = "test-key"
+  content = ""
 }
 `, randInt)
 }

--- a/opentelekomcloud/common/utils.go
+++ b/opentelekomcloud/common/utils.go
@@ -726,3 +726,19 @@ func StringifyAny(v interface{}) string {
 		return string(b)
 	}
 }
+
+// IsAttrSet returns true if an attribute was explicitly set in configuration.
+func IsAttrSet(d *schema.ResourceData, key string) bool {
+	rc := d.GetRawConfig()
+	// If raw config is unknown or null, nothing is set.
+	if !rc.IsKnown() || rc.IsNull() {
+		return false
+	}
+	// Ensure the attribute exists on the object type before accessing it.
+	t := rc.Type()
+	if !t.HasAttribute(key) {
+		return false
+	}
+	attr := rc.GetAttr(key)
+	return attr.IsKnown() && !attr.IsNull()
+}

--- a/opentelekomcloud/services/fgs/resource_opentelekomcloud_fgs_function_v2.go
+++ b/opentelekomcloud/services/fgs/resource_opentelekomcloud_fgs_function_v2.go
@@ -509,22 +509,6 @@ func buildCustomImage(imageConfig []interface{}) *function.CustomImage {
 	}
 }
 
-// isAttrSet returns true if an attribute was explicitly set in configuration.
-func isAttrSet(d *schema.ResourceData, key string) bool {
-	rc := d.GetRawConfig()
-	// If raw config is unknown or null, nothing is set.
-	if !rc.IsKnown() || rc.IsNull() {
-		return false
-	}
-	// Ensure the attribute exists on the object type before accessing it.
-	t := rc.Type()
-	if !t.HasAttribute(key) {
-		return false
-	}
-	attr := rc.GetAttr(key)
-	return attr.IsKnown() && !attr.IsNull()
-}
-
 func buildFgsFunctionParameters(config *cfg.Config, d *schema.ResourceData) (function.CreateOpts, error) {
 	// check app
 	app, appOk := d.GetOk("app")
@@ -576,7 +560,7 @@ func buildFgsFunctionParameters(config *cfg.Config, d *schema.ResourceData) (fun
 		LtsCustomTag:        ltsTags,
 		EnterpriseProjectId: config.GetEnterpriseProjectID(d),
 	}
-	if isAttrSet(d, "enable_lts_log") {
+	if common.IsAttrSet(d, "enable_lts_log") {
 		result.EnableLtsLog = pointerto.Bool(d.Get("enable_lts_log").(bool))
 	}
 	if v, ok := d.GetOk("func_code"); ok {
@@ -1406,7 +1390,7 @@ func resourceFgsFunctionMetadataUpdate(config *cfg.Config, fgsClient *golangsdk.
 		}
 		updateMetadateOpts.LogConfig = &logConfig
 	}
-	if isAttrSet(d, "enable_lts_log") {
+	if common.IsAttrSet(d, "enable_lts_log") {
 		updateMetadateOpts.EnableLtsLog = pointerto.Bool(d.Get("enable_lts_log").(bool))
 	}
 

--- a/opentelekomcloud/services/obs/resource_opentelekomcloud_obs_bucket_object.go
+++ b/opentelekomcloud/services/obs/resource_opentelekomcloud_obs_bucket_object.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/obs"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
@@ -117,7 +118,7 @@ func resourceObsBucketObjectPut(ctx context.Context, d *schema.ResourceData, met
 		}
 	}
 
-	if _, ok := d.GetOk("content"); ok {
+	if common.IsAttrSet(d, "content") {
 		// put content
 		resp, err = putContentToObject(client, d)
 		if err != nil {
@@ -129,6 +130,9 @@ func resourceObsBucketObjectPut(ctx context.Context, d *schema.ResourceData, met
 	key := d.Get("key").(string)
 	if err != nil {
 		return diag.FromErr(GetObsError("error putting object to OBS bucket", bucket, err))
+	}
+	if resp == nil {
+		return fmterr.Errorf("either `source` or `content` must be configured for OBS object upload")
 	}
 
 	log.Printf("[DEBUG] Response of putting %s to OBS Bucket %s: %#v", key, bucket, resp)

--- a/releasenotes/notes/obs-empty-content-fix-40ca534939e52045.yaml
+++ b/releasenotes/notes/obs-empty-content-fix-40ca534939e52045.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[OBS]** Fix empty string `content` put for ``resource/opentelekomcloud_obs_bucket_object`` (`#3369 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3369>`_)


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [x] Refers to: #3367
* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccObsBucketObject_source
=== PAUSE TestAccObsBucketObject_source
=== CONT  TestAccObsBucketObject_source
--- PASS: TestAccObsBucketObject_source (59.78s)
=== RUN   TestAccObsBucketObject_content
=== PAUSE TestAccObsBucketObject_content
=== CONT  TestAccObsBucketObject_content
--- PASS: TestAccObsBucketObject_content (30.02s)
=== RUN   TestAccObsBucketObject_emptyContent
=== PAUSE TestAccObsBucketObject_emptyContent
=== CONT  TestAccObsBucketObject_emptyContent
--- PASS: TestAccObsBucketObject_emptyContent (30.10s)
=== RUN   TestAccObsBucketObject_withVersionedContent
=== PAUSE TestAccObsBucketObject_withVersionedContent
=== CONT  TestAccObsBucketObject_withVersionedContent
--- PASS: TestAccObsBucketObject_withVersionedContent (30.21s)
=== RUN   TestAccObsBucketObject_nothing
=== PAUSE TestAccObsBucketObject_nothing
=== CONT  TestAccObsBucketObject_nothing
--- PASS: TestAccObsBucketObject_nothing (3.67s)
PASS

Process finished with the exit code 0
```
