### PR TITLE
[Feat] VPC: Add `opentelekomcloud_vpc_secondary_cidr_v3`

### DIFF
--- a/docs/resources/vpc_secondary_cidr_v3.md
+++ b/docs/resources/vpc_secondary_cidr_v3.md
@@ -1,0 +1,73 @@
+---
+subcategory: "Virtual Private Cloud (VPC)"
+layout: "opentelekomcloud"
+page_title: "OpenTelekomCloud: opentelekomcloud_vpc_secondary_cidr_v3"
+sidebar_current: "docs-opentelekomcloud-resource-vpc-secondary-cidr-v3"
+description: |-
+  Manages secondary CIDR blocks for a VPC within OpenTelekomCloud.
+---
+
+Up-to-date reference of API arguments for VPC secondary CIDR block management you can get at
+[documentation portal](https://docs.otc.t-systems.com/virtual-private-cloud/api-ref/apis/virtual_private_cloud)
+
+# opentelekomcloud_vpc_secondary_cidr_v3
+
+Manages up to 5 secondary CIDR blocks attached to an existing VPC via the VPC v3 API.
+
+~> **Warning:** Each VPC has a single shared `extend_cidrs` list in the cloud.
+Define **at most one** `opentelekomcloud_vpc_secondary_cidr_v3` resource per
+VPC, and do **not** combine it with the `secondary_cidr` attribute on
+[`opentelekomcloud_vpc_v1`](vpc_v1.md) against the same VPC which will be soon
+deprecated. Multiple resources targeting the same `vpc_id` will fight on every
+plan, because each resource reads back the full cloud-side list and tries to
+reconcile it to its own subset.
+
+## Example Usage
+
+```hcl
+resource "opentelekomcloud_vpc_v1" "vpc" {
+  name = "tf_vpc"
+  cidr = "192.168.0.0/16"
+}
+
+resource "opentelekomcloud_vpc_secondary_cidr_v3" "secondary" {
+  vpc_id = opentelekomcloud_vpc_v1.vpc.id
+  cidrs = [
+    "23.9.0.0/16",
+    "23.10.0.0/16",
+    "23.11.0.0/16",
+  ]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `vpc_id` - (Required, ForceNew) The ID of the VPC to which the secondary CIDR
+  blocks are attached. Changing this forces a new resource to be created.
+
+- `cidrs` - (Required) Set of secondary CIDR blocks to attach to the VPC.
+  At least 1 and at most 5 entries are supported. Each entry must be a valid
+  IPv4 CIDR. The cloud rejects reserved ranges (for example
+  `100.64.0.0/10`, `214.0.0.0/7`, `198.18.0.0/15`, `169.254.0.0/16`,
+  `0.0.0.0/8`, `127.0.0.0/8`, `240.0.0.0/4`, `172.31.0.0/16`,
+  `192.168.0.0/16`); these checks are enforced server-side.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+- `id` - The ID of the resource. Equal to the `vpc_id` because each VPC has a
+  single set of secondary CIDR blocks.
+
+- `region` - The region in which the secondary CIDRs are managed. Inherited
+  from the provider configuration.
+
+## Import
+
+VPC secondary CIDR resources can be imported using the parent VPC `id`, e.g.
+
+```sh
+terraform import opentelekomcloud_vpc_secondary_cidr_v3.secondary 7117d38e-4c8f-4624-a505-bd96b97d024c
+```

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_vpc_secondary_cidr_v3_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_vpc_secondary_cidr_v3_test.go
@@ -1,0 +1,158 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	VpcV3 "github.com/opentelekomcloud/gophertelekomcloud/openstack/vpc/v3/vpcs"
+
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+)
+
+const resourceVpcSecondaryCidrV3Name = "opentelekomcloud_vpc_secondary_cidr_v3.test"
+
+func getVpcSecondaryCidrFunc(c *cfg.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := c.NetworkingV3Client(env.OS_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating OpenTelekomCloud NetworkingV3 client: %w", err)
+	}
+	vpc, err := VpcV3.Get(client, state.Primary.ID)
+	if err != nil {
+		return nil, err
+	}
+	if len(vpc.SecondaryCidrs) == 0 {
+		return nil, fmt.Errorf("vpc %s has no secondary CIDRs", state.Primary.ID)
+	}
+	return vpc, nil
+}
+
+func TestAccVpcSecondaryCidrV3_basic(t *testing.T) {
+	t.Parallel()
+	quotas.BookOne(t, quotas.Router)
+	vpcName := tools.RandomString("tf-acc-sec-cidr-", 5)
+
+	var vpc VpcV3.Vpc
+	rc := common.InitResourceCheck(resourceVpcSecondaryCidrV3Name, &vpc, getVpcSecondaryCidrFunc)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVpcSecondaryCidrV3OneCidr(vpcName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceVpcSecondaryCidrV3Name, "cidrs.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceVpcSecondaryCidrV3Name, "cidrs.*", "23.9.0.0/16"),
+				),
+			},
+			{
+				Config: testAccVpcSecondaryCidrV3ThreeCidrs(vpcName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceVpcSecondaryCidrV3Name, "cidrs.#", "3"),
+					resource.TestCheckTypeSetElemAttr(resourceVpcSecondaryCidrV3Name, "cidrs.*", "23.9.0.0/16"),
+					resource.TestCheckTypeSetElemAttr(resourceVpcSecondaryCidrV3Name, "cidrs.*", "23.10.0.0/16"),
+					resource.TestCheckTypeSetElemAttr(resourceVpcSecondaryCidrV3Name, "cidrs.*", "23.11.0.0/16"),
+				),
+			},
+			{
+				Config: testAccVpcSecondaryCidrV3TwoCidrs(vpcName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceVpcSecondaryCidrV3Name, "cidrs.#", "2"),
+					resource.TestCheckTypeSetElemAttr(resourceVpcSecondaryCidrV3Name, "cidrs.*", "23.9.0.0/16"),
+					resource.TestCheckTypeSetElemAttr(resourceVpcSecondaryCidrV3Name, "cidrs.*", "23.11.0.0/16"),
+				),
+			},
+			{
+				Config: testAccVpcSecondaryCidrV3MaxCidrs(vpcName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceVpcSecondaryCidrV3Name, "cidrs.#", "5"),
+				),
+			},
+			{
+				ResourceName:      resourceVpcSecondaryCidrV3Name,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccVpcSecondaryCidrV3OneCidr(vpcName string) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_vpc_v1" "test" {
+  name = "%s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "opentelekomcloud_vpc_secondary_cidr_v3" "test" {
+  vpc_id = opentelekomcloud_vpc_v1.test.id
+  cidrs  = ["23.9.0.0/16"]
+}
+`, vpcName)
+}
+
+func testAccVpcSecondaryCidrV3ThreeCidrs(vpcName string) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_vpc_v1" "test" {
+  name = "%s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "opentelekomcloud_vpc_secondary_cidr_v3" "test" {
+  vpc_id = opentelekomcloud_vpc_v1.test.id
+  cidrs = [
+    "23.9.0.0/16",
+    "23.10.0.0/16",
+    "23.11.0.0/16",
+  ]
+}
+`, vpcName)
+}
+
+func testAccVpcSecondaryCidrV3TwoCidrs(vpcName string) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_vpc_v1" "test" {
+  name = "%s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "opentelekomcloud_vpc_secondary_cidr_v3" "test" {
+  vpc_id = opentelekomcloud_vpc_v1.test.id
+  cidrs = [
+    "23.9.0.0/16",
+    "23.11.0.0/16",
+  ]
+}
+`, vpcName)
+}
+
+func testAccVpcSecondaryCidrV3MaxCidrs(vpcName string) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_vpc_v1" "test" {
+  name = "%s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "opentelekomcloud_vpc_secondary_cidr_v3" "test" {
+  vpc_id = opentelekomcloud_vpc_v1.test.id
+  cidrs = [
+    "23.9.0.0/16",
+    "23.10.0.0/16",
+    "23.11.0.0/16",
+    "23.12.0.0/16",
+    "23.13.0.0/16",
+  ]
+}
+`, vpcName)
+}

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -719,6 +719,7 @@ func Provider() *schema.Provider {
 			"opentelekomcloud_vpc_bandwidth_v2":                          vpc.ResourceBandwidthV2(),
 			"opentelekomcloud_vpc_eip_v1":                                vpc.ResourceVpcEIPV1(),
 			"opentelekomcloud_vpc_v1":                                    vpc.ResourceVirtualPrivateCloudV1(),
+			"opentelekomcloud_vpc_secondary_cidr_v3":                     vpc.ResourceVpcSecondaryCidrV3(),
 			"opentelekomcloud_vpc_peering_connection_v2":                 vpc.ResourceVpcPeeringConnectionV2(),
 			"opentelekomcloud_vpc_peering_connection_accepter_v2":        vpc.ResourceVpcPeeringConnectionAccepterV2(),
 			"opentelekomcloud_vpc_route_table_v1":                        vpc.ResourceVPCRouteTableV1(),

--- a/opentelekomcloud/services/vpc/resource_opentelekomcloud_vpc_secondary_cidr_v3.go
+++ b/opentelekomcloud/services/vpc/resource_opentelekomcloud_vpc_secondary_cidr_v3.go
@@ -1,0 +1,158 @@
+package vpc
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	VpcV3 "github.com/opentelekomcloud/gophertelekomcloud/openstack/vpc/v3/vpcs"
+
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
+)
+
+func ResourceVpcSecondaryCidrV3() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceVpcSecondaryCidrV3Create,
+		ReadContext:   resourceVpcSecondaryCidrV3Read,
+		UpdateContext: resourceVpcSecondaryCidrV3Update,
+		DeleteContext: resourceVpcSecondaryCidrV3Delete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"cidrs": {
+				Type:     schema.TypeSet,
+				Required: true,
+				MinItems: 1,
+				MaxItems: 5,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.IsCIDR,
+				},
+			},
+		},
+	}
+}
+
+func resourceVpcSecondaryCidrV3Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, keyClientV3, func() (*golangsdk.ServiceClient, error) {
+		return config.NetworkingV3Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV3Client, err)
+	}
+
+	vpcID := d.Get("vpc_id").(string)
+	cidrs := common.ExpandToStringListBySet(d.Get("cidrs").(*schema.Set))
+
+	if _, err := VpcV3.AddSecondaryCidr(client, vpcID, VpcV3.CidrOpts{
+		Vpc: &VpcV3.AddExtendCidrOption{ExtendCidrs: cidrs},
+	}); err != nil {
+		return fmterr.Errorf("error adding secondary CIDRs to VPC %s: %w", vpcID, err)
+	}
+
+	d.SetId(vpcID)
+
+	clientCtx := common.CtxWithClient(ctx, client, keyClientV3)
+	return resourceVpcSecondaryCidrV3Read(clientCtx, d, meta)
+}
+
+func resourceVpcSecondaryCidrV3Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, keyClientV3, func() (*golangsdk.ServiceClient, error) {
+		return config.NetworkingV3Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV3Client, err)
+	}
+
+	vpcInfo, err := VpcV3.Get(client, d.Id())
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "vpc_secondary_cidr_v3")
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", config.GetRegion(d)),
+		d.Set("vpc_id", d.Id()),
+		d.Set("cidrs", vpcInfo.SecondaryCidrs),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return fmterr.Errorf("error setting vpc_secondary_cidr_v3 fields: %w", err)
+	}
+
+	return nil
+}
+
+func resourceVpcSecondaryCidrV3Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, keyClientV3, func() (*golangsdk.ServiceClient, error) {
+		return config.NetworkingV3Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV3Client, err)
+	}
+
+	removed, added := common.GetSetChanges(d, "cidrs")
+
+	if removed.Len() > 0 {
+		if _, err := VpcV3.RemoveSecondaryCidr(client, d.Id(), VpcV3.CidrOpts{
+			Vpc: &VpcV3.AddExtendCidrOption{ExtendCidrs: common.ExpandToStringListBySet(removed)},
+		}); err != nil {
+			return fmterr.Errorf("error removing secondary CIDRs from VPC %s: %w", d.Id(), err)
+		}
+	}
+
+	if added.Len() > 0 {
+		if _, err := VpcV3.AddSecondaryCidr(client, d.Id(), VpcV3.CidrOpts{
+			Vpc: &VpcV3.AddExtendCidrOption{ExtendCidrs: common.ExpandToStringListBySet(added)},
+		}); err != nil {
+			return fmterr.Errorf("error adding secondary CIDRs to VPC %s: %w", d.Id(), err)
+		}
+	}
+
+	clientCtx := common.CtxWithClient(ctx, client, keyClientV3)
+	return resourceVpcSecondaryCidrV3Read(clientCtx, d, meta)
+}
+
+func resourceVpcSecondaryCidrV3Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, keyClientV3, func() (*golangsdk.ServiceClient, error) {
+		return config.NetworkingV3Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV3Client, err)
+	}
+
+	cidrs := common.ExpandToStringListBySet(d.Get("cidrs").(*schema.Set))
+	if len(cidrs) == 0 {
+		return nil
+	}
+
+	if _, err := VpcV3.RemoveSecondaryCidr(client, d.Id(), VpcV3.CidrOpts{
+		Vpc: &VpcV3.AddExtendCidrOption{ExtendCidrs: cidrs},
+	}); err != nil {
+		if _, ok := err.(golangsdk.ErrDefault404); ok {
+			return nil
+		}
+		return fmterr.Errorf("error removing secondary CIDRs from VPC %s: %w", d.Id(), err)
+	}
+
+	return nil
+}

--- a/releasenotes/notes/vpc-secondary-cidr-v3-873242fc5f9102f5.yaml
+++ b/releasenotes/notes/vpc-secondary-cidr-v3-873242fc5f9102f5.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    **New Resource:** ``opentelekomcloud_vpc_secondary_cidr_v3`` for managing
+    up to 5 secondary CIDR blocks on a VPC via the v3 API
+    (`#3371 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3371>`_)


### PR DESCRIPTION
## Summary of the Pull Request

Add a new resource `opentelekomcloud_vpc_secondary_cidr_v3` for managing up to 5 secondary CIDR blocks attached to an existing VPC via the v3 API endpoints (`PUT /v3/{project_id}/vpc/vpcs/{vpc_id}/{add,remove}-extend-cidr`).

The `secondary_cidr` attribute on `opentelekomcloud_vpc_v1` is not removed in this PR. Its graceful deprecation and removal will follow in a separate PR.

### New resource: `opentelekomcloud_vpc_secondary_cidr_v3`

- Schema: `vpc_id` (`Required + ForceNew`), `cidrs` (`TypeSet`, `MinItems=1`, `MaxItems=5`, IsCIDR), `region` (computed/optional). Resource ID is the parent VPC ID. This is exactly one resource per VPC.
- **Update** computes the set difference via `common.GetSetChanges` and issues at most one `RemoveSecondaryCidr` and one `AddSecondaryCidr` per change.
- **Read** uses `common.CheckDeletedDiag` for VPC-deleted, and overwrites `cidrs` from the live API response so external mutations are detected as drift.
- **Delete** issues a single `RemoveSecondaryCidr` with the full set; 404 is treated as already-gone.
- **Import** via `schema.ImportStatePassthroughContext` using the VPC ID.

### Related bug fixes (separate PRs)

Two bugs in `opentelekomcloud_vpc_v1` had to be fixed before this resource can coexist safely with a VPC managed by `vpc_v1`:

- **#3373**: Fixed the destructive update path: `secondary_cidr = "x" → ""` was removing the cloud-side CIDR and then calling `AddSecondaryCidr("")`, losing the CIDR and erroring mid-apply.
- **#3375**: Fixed `readSecondaryCidr` state pollution: The function was running unconditionally on every refresh and writing any CIDR it found into `secondary_cidr`, even when the user never set the field. CIDRs added by this new resource were silently claimed by `vpc_v1` state, triggering a removal on the next apply.

### Why a sub-resource and not a full `vpc_v3`

The v3 SDK has only `Get`, `List`, `AddSecondaryCidr`, `RemoveSecondaryCidr`. No `Create`, `Update`, or `Delete` functionality present. The OTC v3 API exposes no general PUT-on-VPC endpoint either; v1 still owns name/description/cidr updates. A full `vpc_v3` resource would add SDK code that calls v1 internally for half its operations and would invite users to manage one cloud entity through two parallel resources. The sub-resource approach mirrors the API shape (set-style add/remove against a parent VPC) and reuses the established provider pattern from `opentelekomcloud_vpc_bandwidth_associate_v2`.

## PR Checklist

- [x] Refers to: #3370
- [x] Tests added/passed.
- [x] Documentation updated.
- [ ] Schema updated. (N/A)
- [x] Release notes added.

## Acceptance Steps Performed

```text
=== RUN   TestAccVpcSecondaryCidrV3_basic
=== PAUSE TestAccVpcSecondaryCidrV3_basic
=== CONT  TestAccVpcSecondaryCidrV3_basic
--- PASS: TestAccVpcSecondaryCidrV3_basic (241.37s)
PASS
```

`TestAccVpcSecondaryCidrV3_basic` covers create, update (adding/removing CIDRs), and import in a single test suite using `common.InitResourceCheck`. Acceptance tests for `opentelekomcloud_vpc_v1` were updated and verified in #3373 and #3375.