### PR TITLE
[Fix] resources now is optional for all_resources scoped namespace/type in opentelekomcloud_ces_alarm_rule_v2

### DIFF
--- a/docs/resources/ces_alarm_rule_v2.md
+++ b/docs/resources/ces_alarm_rule_v2.md
@@ -128,13 +128,6 @@ resource "opentelekomcloud_ces_alarm_rule_v2" "test" {
   notification_enabled = false
   alarm_enabled        = true
 
-  resources {
-    dimensions {
-      name  = "resource_id"
-      value = "all_instance"
-    }
-  }
-
   policies {
     metric_name         = "stopServer"
     period              = 0
@@ -160,13 +153,6 @@ resource "opentelekomcloud_ces_alarm_rule_v2" "test" {
   type                 = "EVENT.SYS"
   notification_enabled = true
   alarm_enabled        = true
-
-  resources {
-    dimensions {
-      name  = "resource_id"
-      value = "all_instance"
-    }
-  }
 
   policies {
     metric_name         = "stopServer"
@@ -378,8 +364,10 @@ The `policies` block supports:
 <a name="resources_struct"></a>
 The `resources` block supports:
 
-* `dimensions` - (Required, List) Specifies the list of metric dimensions.
+* `dimensions` - (Optional, List) Specifies the list of metric dimensions.
   The [dimensions](#dimensions_struct) structure is documented below.
+  This block can be omitted when the alarm scope applies to all resources, for example
+  project-wide `EVENT.SYS` or `EVENT.CUSTOM` alarms.
 
 <a name="dimensions_struct"></a>
 The `dimensions` block supports:
@@ -389,7 +377,7 @@ The `dimensions` block supports:
 
 * `value` - (Optional, String) Specifies the dimension value. The value can be a string of `1` to `64` characters
   that must start with a letter or a number and contain only letters, digits, underscores (_), and hyphens (-).
-  For **ALL_INSTANCE** type alarms, this field can be left empty.
+  This field can be left empty when the alarm scope applies to all resources.
 
 <a name="actions_struct"></a>
 The `alarm_actions` block supports:

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.9.7-0.20260506131623-10bb47fa3432
+	github.com/opentelekomcloud/gophertelekomcloud v0.9.7-0.20260514085017-8e26f666099b
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.46.0
 	golang.org/x/sync v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -171,6 +171,8 @@ github.com/opentelekomcloud/gophertelekomcloud v0.9.7-0.20260427110910-b87174af4
 github.com/opentelekomcloud/gophertelekomcloud v0.9.7-0.20260427110910-b87174af457e/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
 github.com/opentelekomcloud/gophertelekomcloud v0.9.7-0.20260506131623-10bb47fa3432 h1:GbuFtYWZGCTAU9cjTF2I1tUVcSo1i3B0j9gEHTPLric=
 github.com/opentelekomcloud/gophertelekomcloud v0.9.7-0.20260506131623-10bb47fa3432/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.7-0.20260514085017-8e26f666099b h1:kNGoJcSvNkprqxobNOhFK6fTtKPU8e1llFg3THC/OTo=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.7-0.20260514085017-8e26f666099b/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/go.sum
+++ b/go.sum
@@ -167,10 +167,6 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.7-0.20260427110910-b87174af457e h1:VyY7qOS0Lto/plvgwBdJr4cVTPIOjjwHbMEmLmGI1wc=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.7-0.20260427110910-b87174af457e/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.7-0.20260506131623-10bb47fa3432 h1:GbuFtYWZGCTAU9cjTF2I1tUVcSo1i3B0j9gEHTPLric=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.7-0.20260506131623-10bb47fa3432/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
 github.com/opentelekomcloud/gophertelekomcloud v0.9.7-0.20260514085017-8e26f666099b h1:kNGoJcSvNkprqxobNOhFK6fTtKPU8e1llFg3THC/OTo=
 github.com/opentelekomcloud/gophertelekomcloud v0.9.7-0.20260514085017-8e26f666099b/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/opentelekomcloud/acceptance/ces/data_source_opentelekomcloud_ces_alarm_rules_v2_test.go
+++ b/opentelekomcloud/acceptance/ces/data_source_opentelekomcloud_ces_alarm_rules_v2_test.go
@@ -51,13 +51,6 @@ resource "opentelekomcloud_ces_alarm_rule_v2" "test" {
   namespace = "SYS.ECS"
   type      = "EVENT.SYS"
 
-  resources {
-    dimensions {
-      name  = "resource_id"
-      value = "all_instance"
-    }
-  }
-
   policies {
     metric_name         = "stopServer"
     period              = 0

--- a/opentelekomcloud/acceptance/ces/resource_opentelekomcloud_ces_alarm_rule_v2_test.go
+++ b/opentelekomcloud/acceptance/ces/resource_opentelekomcloud_ces_alarm_rule_v2_test.go
@@ -831,13 +831,6 @@ resource "opentelekomcloud_ces_alarm_rule_v2" "test" {
   namespace = "SYS.ECS"
   type      = "EVENT.SYS"
 
-  resources {
-    dimensions {
-      name  = "resource_id"
-      value = "all_instance"
-    }
-  }
-
   policies {
     metric_name         = "stopServer"
     period              = 0
@@ -862,13 +855,6 @@ resource "opentelekomcloud_ces_alarm_rule_v2" "test" {
   name      = "%[1]s"
   namespace = "SYS.ECS"
   type      = "EVENT.SYS"
-
-  resources {
-    dimensions {
-      name  = "resource_id"
-      value = "all_instance"
-    }
-  }
 
   policies {
     metric_name         = "stopServer"
@@ -938,13 +924,6 @@ resource "opentelekomcloud_ces_alarm_rule_v2" "test" {
   name      = "%[1]s"
   namespace = "SYS.ECS"
   type      = "EVENT.SYS"
-
-  resources {
-    dimensions {
-      name  = "resource_id"
-      value = "all_instance"
-    }
-  }
 
   policies {
     metric_name         = "stopServer"

--- a/opentelekomcloud/acceptance/common/quotas/quotas.go
+++ b/opentelekomcloud/acceptance/common/quotas/quotas.go
@@ -118,7 +118,7 @@ var (
 	// Compute
 
 	// Server - shared compute instance quota (number of instances only)
-	Server = FromEnv("OS_SERVER_QUOTA", 10)
+	Server = FromEnv("OS_SERVER_QUOTA", 5)
 	CPU    = FromEnv("OS_CPU_QUOTA", 40)
 	RAM    = FromEnv("OS_RAM_QUOTA", 160*1024)
 

--- a/opentelekomcloud/services/ces/resource_opentelekomcloud_ces_alarm_rule_v2.go
+++ b/opentelekomcloud/services/ces/resource_opentelekomcloud_ces_alarm_rule_v2.go
@@ -145,7 +145,7 @@ func ResourceAlarmRuleV2() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"dimensions": {
 							Type:     schema.TypeList,
-							Required: true,
+							Optional: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"name": {
@@ -317,13 +317,22 @@ func buildPoliciesOptsV2(d *schema.ResourceData) []alarms.Policy {
 func buildResourcesOptsV2(d *schema.ResourceData) [][]alarms.Dimension {
 	rawResources := d.Get("resources").(*schema.Set).List()
 	if len(rawResources) == 0 {
+		resourceType := d.Get("type").(string)
+		if resourceType == "EVENT.SYS" || resourceType == "EVENT.CUSTOM" || resourceType == "RESOURCE_GROUP" {
+			return [][]alarms.Dimension{}
+		}
 		return nil
 	}
 
 	resourcesOpts := make([][]alarms.Dimension, len(rawResources))
 	for i, v := range rawResources {
 		resource := v.(map[string]interface{})
-		dimensionsRaw := resource["dimensions"].([]interface{})
+		dimensionsRaw, ok := resource["dimensions"].([]interface{})
+		if !ok || len(dimensionsRaw) == 0 {
+			resourcesOpts[i] = []alarms.Dimension{}
+			continue
+		}
+
 		dimensions := make([]alarms.Dimension, len(dimensionsRaw))
 		for j, dim := range dimensionsRaw {
 			dimension := dim.(map[string]interface{})

--- a/releasenotes/notes/ces-alarms-empty-resources-e892b062bee411dd.yaml
+++ b/releasenotes/notes/ces-alarms-empty-resources-e892b062bee411dd.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[CES]** `resources` `dimensions` parameter now optional in ``resource/opentelekomcloud_ces_alarm_rule_v2`` (`#3372 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3372>`_)


### PR DESCRIPTION
Now resources can be omitted

## Summary of the Pull Request


## PR Checklist

* [x] Refers to: #3350
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestCESAlarmRuleV2_basic
=== PAUSE TestCESAlarmRuleV2_basic
=== CONT  TestCESAlarmRuleV2_basic
--- PASS: TestCESAlarmRuleV2_basic (254.69s)
=== RUN   TestCESAlarmRuleV2_withNotification
=== PAUSE TestCESAlarmRuleV2_withNotification
=== CONT  TestCESAlarmRuleV2_withNotification
--- PASS: TestCESAlarmRuleV2_withNotification (382.16s)
=== RUN   TestCESAlarmRuleV2_multiplePolicies
=== PAUSE TestCESAlarmRuleV2_multiplePolicies
=== CONT  TestCESAlarmRuleV2_multiplePolicies
--- PASS: TestCESAlarmRuleV2_multiplePolicies (244.09s)
=== RUN   TestCESAlarmRuleV2_multipleResources
=== PAUSE TestCESAlarmRuleV2_multipleResources
=== CONT  TestCESAlarmRuleV2_multipleResources
--- PASS: TestCESAlarmRuleV2_multipleResources (483.82s)
=== RUN   TestCESAlarmRuleV2_multipleDimensions
=== PAUSE TestCESAlarmRuleV2_multipleDimensions
=== CONT  TestCESAlarmRuleV2_multipleDimensions
--- PASS: TestCESAlarmRuleV2_multipleDimensions (247.75s)
=== RUN   TestCESAlarmRuleV2_sysEvent
=== PAUSE TestCESAlarmRuleV2_sysEvent
=== CONT  TestCESAlarmRuleV2_sysEvent
--- PASS: TestCESAlarmRuleV2_sysEvent (50.69s)
=== RUN   TestCESAlarmRuleV2_sysEventWithNotification
=== PAUSE TestCESAlarmRuleV2_sysEventWithNotification
=== CONT  TestCESAlarmRuleV2_sysEventWithNotification
--- PASS: TestCESAlarmRuleV2_sysEventWithNotification (35.83s)
=== RUN   TestCESAlarmRuleV2_allInstance
=== PAUSE TestCESAlarmRuleV2_allInstance
=== CONT  TestCESAlarmRuleV2_allInstance
--- PASS: TestCESAlarmRuleV2_allInstance (34.84s)
=== RUN   TestCESAlarmRuleV2_withOkActions
=== PAUSE TestCESAlarmRuleV2_withOkActions
=== CONT  TestCESAlarmRuleV2_withOkActions
--- PASS: TestCESAlarmRuleV2_withOkActions (194.84s)
=== RUN   TestCESAlarmRuleV2_withAlarmTemplate
=== PAUSE TestCESAlarmRuleV2_withAlarmTemplate
=== CONT  TestCESAlarmRuleV2_withAlarmTemplate
--- PASS: TestCESAlarmRuleV2_withAlarmTemplate (452.10s)
PASS

Process finished with the exit code 0

```
