### PR TITLE
[Fix] `secondary_cidr` removal in `resource/opentelecomcloud_vpc_v1`

### DIFF
--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_vpc_v1_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_vpc_v1_test.go
@@ -211,10 +211,10 @@ resource "opentelekomcloud_vpc_v1" "vpc_1" {
 
 const testAccVpcV3RemoveCidr = `
 resource "opentelekomcloud_vpc_v1" "vpc_1" {
-  name           = "tf_acc_test_v3"
-  description    = "simple description updated"
-  cidr           = "192.168.0.0/16"
-  shared         = false
+  name        = "tf_acc_test_v3"
+  description = "simple description updated"
+  cidr        = "192.168.0.0/16"
+  shared      = false
 
   tags = {
     foo = "bar"

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_vpc_v1_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_vpc_v1_test.go
@@ -6,31 +6,39 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
-
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v1/vpcs"
-
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 )
 
 const resourceVPCName = "opentelekomcloud_vpc_v1.vpc_1"
 
+func getVpcV1ResourceFunc(conf *cfg.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.NetworkingV1Client(env.OS_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating OpenTelekomCloud NetworkingV1 client: %w", err)
+	}
+
+	return vpcs.Get(client, state.Primary.ID).Extract()
+}
+
 func TestAccVpcV1_basic(t *testing.T) {
 	var vpc vpcs.Vpc
 	t.Parallel()
 	quotas.BookOne(t, quotas.Router)
+	rc := common.InitResourceCheck(resourceVPCName, &vpc, getVpcV1ResourceFunc)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
-		CheckDestroy:      testAccCheckVpcV1Destroy,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVpcV1Basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckVpcV1Exists(resourceVPCName, &vpc),
+					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceVPCName, "name", "terraform_provider_test"),
 					resource.TestCheckResourceAttr(resourceVPCName, "description", "simple description"),
 					resource.TestCheckResourceAttr(resourceVPCName, "cidr", "192.168.0.0/16"),
@@ -43,12 +51,17 @@ func TestAccVpcV1_basic(t *testing.T) {
 			{
 				Config: testAccVpcV1Update,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckVpcV1Exists(resourceVPCName, &vpc),
+					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceVPCName, "name", "terraform_provider_test1"),
 					resource.TestCheckResourceAttr(resourceVPCName, "description", "simple description updated"),
 					resource.TestCheckResourceAttr(resourceVPCName, "shared", "false"),
 					resource.TestCheckResourceAttr(resourceVPCName, "tags.key", "value_update"),
 				),
+			},
+			{
+				ResourceName:      resourceVPCName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -58,16 +71,17 @@ func TestAccVpcV1_secondaryCidr(t *testing.T) {
 	var vpc vpcs.Vpc
 	t.Parallel()
 	quotas.BookOne(t, quotas.Router)
+	rc := common.InitResourceCheck(resourceVPCName, &vpc, getVpcV1ResourceFunc)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
-		CheckDestroy:      testAccCheckVpcV1Destroy,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVpcV3BasicCidr,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckVpcV1Exists(resourceVPCName, &vpc),
+					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceVPCName, "name", "tf_acc_test_v3"),
 					resource.TestCheckResourceAttr(resourceVPCName, "description", "simple description"),
 					resource.TestCheckResourceAttr(resourceVPCName, "cidr", "192.168.0.0/16"),
@@ -81,10 +95,21 @@ func TestAccVpcV1_secondaryCidr(t *testing.T) {
 			{
 				Config: testAccVpcV3UpdateCidr,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckVpcV1Exists(resourceVPCName, &vpc),
+					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceVPCName, "name", "tf_acc_test_v3"),
 					resource.TestCheckResourceAttr(resourceVPCName, "description", "simple description updated"),
 					resource.TestCheckResourceAttr(resourceVPCName, "secondary_cidr", "23.8.0.0/16"),
+					resource.TestCheckResourceAttr(resourceVPCName, "shared", "false"),
+					resource.TestCheckResourceAttr(resourceVPCName, "tags.key", "value_update"),
+				),
+			},
+			{
+				Config: testAccVpcV3RemoveCidr,
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceVPCName, "name", "tf_acc_test_v3"),
+					resource.TestCheckResourceAttr(resourceVPCName, "description", "simple description updated"),
+					resource.TestCheckResourceAttr(resourceVPCName, "secondary_cidr", ""),
 					resource.TestCheckResourceAttr(resourceVPCName, "shared", "false"),
 					resource.TestCheckResourceAttr(resourceVPCName, "tags.key", "value_update"),
 				),
@@ -97,94 +122,21 @@ func TestAccVpcV1_timeout(t *testing.T) {
 	var vpc vpcs.Vpc
 	t.Parallel()
 	quotas.BookOne(t, quotas.Router)
+	rc := common.InitResourceCheck(resourceVPCName, &vpc, getVpcV1ResourceFunc)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
 		ProviderFactories: common.TestAccProviderFactories,
-		CheckDestroy:      testAccCheckVpcV1Destroy,
+		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVpcV1Timeout,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckVpcV1Exists(resourceVPCName, &vpc),
+					rc.CheckResourceExists(),
 				),
 			},
 		},
 	})
-}
-
-func TestAccVpcV1_import(t *testing.T) {
-	t.Parallel()
-	quotas.BookOne(t, quotas.Router)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { common.TestAccPreCheck(t) },
-		ProviderFactories: common.TestAccProviderFactories,
-		CheckDestroy:      testAccCheckVpcV1Destroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccVpcV1Import,
-			},
-			{
-				ResourceName:      resourceVPCName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func testAccCheckVpcV1Destroy(s *terraform.State) error {
-	config := common.TestAccProvider.Meta().(*cfg.Config)
-	client, err := config.NetworkingV1Client(env.OS_REGION_NAME)
-	if err != nil {
-		return fmt.Errorf("error creating OpenTelekomCloud NetworkingV1 client: %w", err)
-	}
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "opentelekomcloud_vpc_v1" {
-			continue
-		}
-
-		_, err := vpcs.Get(client, rs.Primary.ID).Extract()
-		if err == nil {
-			return fmt.Errorf("vpc still exists")
-		}
-	}
-
-	return nil
-}
-
-func testAccCheckVpcV1Exists(n string, vpc *vpcs.Vpc) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("not found: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no ID is set")
-		}
-
-		config := common.TestAccProvider.Meta().(*cfg.Config)
-		client, err := config.NetworkingV1Client(env.OS_REGION_NAME)
-		if err != nil {
-			return fmt.Errorf("error creating OpenTelekomCloud NetworkingV1 client: %w", err)
-		}
-
-		found, err := vpcs.Get(client, rs.Primary.ID).Extract()
-		if err != nil {
-			return err
-		}
-
-		if found.ID != rs.Primary.ID {
-			return fmt.Errorf("vpc not found")
-		}
-
-		*vpc = *found
-
-		return nil
-	}
 }
 
 const testAccVpcV1Basic = `
@@ -227,19 +179,6 @@ resource "opentelekomcloud_vpc_v1" "vpc_1" {
 }
 `
 
-const testAccVpcV1Import = `
-resource "opentelekomcloud_vpc_v1" "vpc_1" {
-  name   = "terraform_provider_test-imp"
-  cidr   = "192.168.0.0/16"
-  shared = true
-
-  tags = {
-    foo = "bar"
-    key = "value"
-  }
-}
-`
-
 const testAccVpcV3BasicCidr = `
 resource "opentelekomcloud_vpc_v1" "vpc_1" {
   name           = "tf_acc_test_v3"
@@ -261,6 +200,20 @@ resource "opentelekomcloud_vpc_v1" "vpc_1" {
   description    = "simple description updated"
   cidr           = "192.168.0.0/16"
   secondary_cidr = "23.8.0.0/16"
+  shared         = false
+
+  tags = {
+    foo = "bar"
+    key = "value_update"
+  }
+}
+`
+
+const testAccVpcV3RemoveCidr = `
+resource "opentelekomcloud_vpc_v1" "vpc_1" {
+  name           = "tf_acc_test_v3"
+  description    = "simple description updated"
+  cidr           = "192.168.0.0/16"
   shared         = false
 
   tags = {

--- a/opentelekomcloud/services/vpc/resource_opentelekomcloud_vpc_v1.go
+++ b/opentelekomcloud/services/vpc/resource_opentelekomcloud_vpc_v1.go
@@ -94,35 +94,6 @@ func addSecondaryCidr(d *schema.ResourceData, config *cfg.Config) error {
 	return nil
 }
 
-func updateSecondaryCidr(d *schema.ResourceData, config *cfg.Config) error {
-	vpcV3Client, err := config.NetworkingV3Client(config.GetRegion(d))
-	if err != nil {
-		return fmt.Errorf(errCreationV3Client, err)
-	}
-	vpcV3Get, err := VpcV3.Get(vpcV3Client, d.Id())
-	if err != nil {
-		return fmt.Errorf("error fetching vpc: %s", err)
-	}
-	cidrOpts := VpcV3.CidrOpts{
-		Vpc: &VpcV3.AddExtendCidrOption{
-			ExtendCidrs: []string{vpcV3Get.SecondaryCidrs[0]}},
-	}
-	_, err = VpcV3.RemoveSecondaryCidr(vpcV3Client, d.Id(), cidrOpts)
-	if err != nil {
-		return fmt.Errorf("error removing old secondary cidr of VirtualPrivateCloud %s: %s", d.Id(), vpcV3Get.SecondaryCidrs[0])
-	}
-	cidr := d.Get("secondary_cidr").(string)
-	cidrAddOpts := VpcV3.CidrOpts{
-		Vpc: &VpcV3.AddExtendCidrOption{
-			ExtendCidrs: []string{cidr}},
-	}
-	_, err = VpcV3.AddSecondaryCidr(vpcV3Client, d.Id(), cidrAddOpts)
-	if err != nil {
-		return fmt.Errorf("error setting new secondary cidr of VirtualPrivateCloud %s: %s", d.Id(), cidr)
-	}
-	return nil
-}
-
 func readSecondaryCidr(d *schema.ResourceData, config *cfg.Config) error {
 	vpcV3Client, err := config.NetworkingV3Client(config.GetRegion(d))
 	if err != nil {
@@ -323,8 +294,30 @@ func resourceVirtualPrivateCloudV1Update(ctx context.Context, d *schema.Resource
 
 	// update secondary cidr
 	if d.HasChange("secondary_cidr") {
-		if err := updateSecondaryCidr(d, config); err != nil {
-			return diag.FromErr(err)
+		vpcV3Client, err := config.NetworkingV3Client(config.GetRegion(d))
+		if err != nil {
+			return fmterr.Errorf(errCreationV3Client, err)
+		}
+		oldValue, newValue := d.GetChange("secondary_cidr")
+		preExtendCidr := oldValue.(string)
+		newExtendCidr := newValue.(string)
+		if preExtendCidr != "" {
+			cidrRemoveOpts := VpcV3.CidrOpts{
+				Vpc: &VpcV3.AddExtendCidrOption{
+					ExtendCidrs: []string{preExtendCidr}},
+			}
+			if _, err := VpcV3.RemoveSecondaryCidr(vpcV3Client, d.Id(), cidrRemoveOpts); err != nil {
+				return diag.Errorf("error deleting VPC secondary CIDR: %s", err)
+			}
+		}
+		if newExtendCidr != "" {
+			cidrAddOpts := VpcV3.CidrOpts{
+				Vpc: &VpcV3.AddExtendCidrOption{
+					ExtendCidrs: []string{newExtendCidr}},
+			}
+			if _, err := VpcV3.AddSecondaryCidr(vpcV3Client, d.Id(), cidrAddOpts); err != nil {
+				return diag.Errorf("error adding VPC secondary CIDR: %s", err)
+			}
 		}
 	}
 

--- a/releasenotes/notes/fix-rm-secondary-cidr-5cc3b13712d6d0b6.yaml
+++ b/releasenotes/notes/fix-rm-secondary-cidr-5cc3b13712d6d0b6.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[VPC]** Fix removal if ``secondary_cidr`` in resource/opentelekomcloud_vpc_v1`` (`#3373 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/3373>`_)


### PR DESCRIPTION
## Summary of the Pull Request
We need to fix it first, next step gracefull deprecation of this attribute, because of changes in API
Tests was refactored
## PR Checklist

* [ ] Refers to: #xxx
* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccVpcV1_basic
=== PAUSE TestAccVpcV1_basic
=== CONT  TestAccVpcV1_basic
--- PASS: TestAccVpcV1_basic (71.96s)
=== RUN   TestAccVpcV1_secondaryCidr
=== PAUSE TestAccVpcV1_secondaryCidr
=== CONT  TestAccVpcV1_secondaryCidr
--- PASS: TestAccVpcV1_secondaryCidr (86.85s)
=== RUN   TestAccVpcV1_timeout
=== PAUSE TestAccVpcV1_timeout
=== CONT  TestAccVpcV1_timeout
--- PASS: TestAccVpcV1_timeout (39.81s)
PASS

Process finished with the exit code 0
```
