### PR TITLE
[Fix] VPC: vpc_v1 readSecondaryCidr leaks out-of-band CIDRs into state

### DIFF
--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_vpc_v1_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_vpc_v1_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v1/vpcs"
+	VpcV3 "github.com/opentelekomcloud/gophertelekomcloud/openstack/vpc/v3/vpcs"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
@@ -118,6 +119,54 @@ func TestAccVpcV1_secondaryCidr(t *testing.T) {
 	})
 }
 
+func TestAccVpcV1_readIgnoresExternalCidrs(t *testing.T) {
+	const injectedCidr = "23.9.0.0/16"
+
+	var vpc vpcs.Vpc
+	t.Parallel()
+	quotas.BookOne(t, quotas.Router)
+	rc := common.InitResourceCheck(resourceVPCName, &vpc, getVpcV1ResourceFunc)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVpcV1ReadIsolation,
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					injectSecondaryCidr(resourceVPCName, injectedCidr),
+				),
+			},
+			{
+				Config:   testAccVpcV1ReadIsolation,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func injectSecondaryCidr(resourceName, cidr string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found in state: %s", resourceName)
+		}
+		client, err := common.TestAccProvider.Meta().(*cfg.Config).NetworkingV3Client(env.OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("error creating NetworkingV3 client: %w", err)
+		}
+		_, err = VpcV3.AddSecondaryCidr(client, rs.Primary.ID, VpcV3.CidrOpts{
+			Vpc: &VpcV3.AddExtendCidrOption{ExtendCidrs: []string{cidr}},
+		})
+		if err != nil {
+			return fmt.Errorf("error injecting secondary CIDR %s on VPC %s: %w", cidr, rs.Primary.ID, err)
+		}
+		return nil
+	}
+}
+
 func TestAccVpcV1_timeout(t *testing.T) {
 	var vpc vpcs.Vpc
 	t.Parallel()
@@ -220,5 +269,12 @@ resource "opentelekomcloud_vpc_v1" "vpc_1" {
     foo = "bar"
     key = "value_update"
   }
+}
+`
+
+const testAccVpcV1ReadIsolation = `
+resource "opentelekomcloud_vpc_v1" "vpc_1" {
+  name = "tf_acc_test_read_isolation"
+  cidr = "192.168.0.0/16"
 }
 `

--- a/opentelekomcloud/services/vpc/resource_opentelekomcloud_vpc_v1.go
+++ b/opentelekomcloud/services/vpc/resource_opentelekomcloud_vpc_v1.go
@@ -95,6 +95,10 @@ func addSecondaryCidr(d *schema.ResourceData, config *cfg.Config) error {
 }
 
 func readSecondaryCidr(d *schema.ResourceData, config *cfg.Config) error {
+	if d.Get("secondary_cidr").(string) == "" {
+		return nil
+	}
+
 	vpcV3Client, err := config.NetworkingV3Client(config.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf(errCreationV3Client, err)

--- a/releasenotes/notes/fix-vpc-v1-secondary-cidr-read-8d14b7dbcd3f2825.yaml
+++ b/releasenotes/notes/fix-vpc-v1-secondary-cidr-read-8d14b7dbcd3f2825.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    **[VPC]** Fixed ``readSecondaryCidr`` on ``resource/opentelekomcloud_vpc_v1``
+    so it no longer claims out-of-band secondary CIDRs into state when the
+    ``secondary_cidr`` attribute is unset in HCL. Previously, any secondary CIDR
+    added to the VPC by another tool (console, module, or
+    ``opentelekomcloud_vpc_secondary_cidr_v3``) would be written into ``vpc_v1``
+    state on refresh and then proposed for removal on the next plan.
+    (`#3375 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3375>`_)


### PR DESCRIPTION
## Summary of the Pull Request

Fix a Read-side state pollution bug on `opentelekomcloud_vpc_v1`. `readSecondaryCidr` in `opentelekomcloud/services/vpc/resource_opentelekomcloud_vpc_v1.go` always hits the v3 API and writes any `extend_cidrs[0]` it finds into the `secondary_cidr` attribute, even when the user did not set the field in HCL. Any CIDR added to the same VPC by another tool (console, module, or `opentelekomcloud_vpc_secondary_cidr_v3`) is silently claimed by `vpc_v1` state. The next `terraform plan` proposes removing it, and `terraform apply` issues `RemoveSecondaryCidr` against the cloud, fighting the other tool.

The fix is an early-return guard at the top of `readSecondaryCidr`:

```go
if d.Get("secondary_cidr").(string) == "" {
    return nil
}
```

Users who set the field see no behaviour change. The v3 API is still consulted, state is still updated, and the existing Update path (fixed in #3373) still runs. Users who do not set the field keep `secondary_cidr` as `""` in state regardless of cloud-side `extend_cidrs`.

This unblocks PR #3371's `TestAccVpcSecondaryCidrV3_basic`, which was failing because of this Read-side pollution when the new resource adds a CIDR to a VPC managed by `vpc_v1`.

The change is intentionally minimal. It does not pre-empt the planned deprecation of `secondary_cidr` on `vpc_v1`, which will follow in a separate PR.

## PR Checklist

* [x] Refers to: #3374 
* [x] Tests added/passed.
* [ ] Documentation updated. (N/A — no schema or user-visible behaviour change for users who set the field; the fixed behaviour matches what the doc already implies)
* [ ] Schema updated. (N/A)
* [x] Release notes added.

## Acceptance Steps Performed

```text
=== RUN   TestAccVpcV1_basic
=== PAUSE TestAccVpcV1_basic
=== RUN   TestAccVpcV1_secondaryCidr
=== PAUSE TestAccVpcV1_secondaryCidr
=== RUN   TestAccVpcV1_readIgnoresExternalCidrs
=== PAUSE TestAccVpcV1_readIgnoresExternalCidrs
=== RUN   TestAccVpcV1_timeout
=== PAUSE TestAccVpcV1_timeout
=== CONT  TestAccVpcV1_basic
=== CONT  TestAccVpcV1_readIgnoresExternalCidrs
=== CONT  TestAccVpcV1_timeout
=== CONT  TestAccVpcV1_secondaryCidr
--- PASS: TestAccVpcV1_timeout (88.86s)
--- PASS: TestAccVpcV1_readIgnoresExternalCidrs (112.54s)
--- PASS: TestAccVpcV1_basic (156.84s)
--- PASS: TestAccVpcV1_secondaryCidr (182.50s)
PASS
```

The new `TestAccVpcV1_readIgnoresExternalCidrs` is a regression test for this bug. It applies a `vpc_v1` block without `secondary_cidr`, calls `VpcV3.AddSecondaryCidr` directly to inject an out-of-band CIDR, then runs `PlanOnly: true` and expects an empty plan. Without the fix the plan proposes removing the injected CIDR.