### PR TITLE
[Fix] remove alarm rule v2 notification type validation

### DIFF
--- a/docs/resources/ces_alarm_rule_v2.md
+++ b/docs/resources/ces_alarm_rule_v2.md
@@ -385,6 +385,7 @@ The `alarm_actions` block supports:
 * `type` - (Required, String) Specifies the type of action triggered by an alarm. The value can be:
   + **notification**: indicates that a notification will be sent to the user.
   + **autoscaling**: indicates that a scaling action will be triggered.
+  + **contact**: indicates that a notification will be sent to the mobile number and email address registered for your account.
 
 * `notification_list` - (Required, List) Specifies the list of objects to be notified if the alarm status changes.
   The maximum length is `5`. If `type` is set to **notification**, the value of `notification_list` cannot be empty.
@@ -399,6 +400,7 @@ The `ok_actions` block supports:
   The value can be:
   + **notification**: indicates that a notification will be sent to the user.
   + **autoscaling**: indicates that a scaling action will be triggered.
+  + **contact**: indicates that a notification will be sent to the mobile number and email address registered for your account.
 
 * `notification_list` - (Required, List) Specifies the list of objects to be notified if the alarm status changes.
   The maximum length is `5`.

--- a/opentelekomcloud/acceptance/ces/resource_opentelekomcloud_ces_alarm_rule_v2_test.go
+++ b/opentelekomcloud/acceptance/ces/resource_opentelekomcloud_ces_alarm_rule_v2_test.go
@@ -122,7 +122,7 @@ func TestCESAlarmRuleV2_withNotification(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "name", "alarm_rule_v2_1"),
 					resource.TestCheckResourceAttr(rName, "notification_enabled", "true"),
 					resource.TestCheckResourceAttr(rName, "alarm_actions.#", "1"),
-					resource.TestCheckResourceAttr(rName, "alarm_actions.0.type", "notification"),
+					resource.TestCheckResourceAttr(rName, "alarm_actions.0.type", "contact"),
 				),
 			},
 		},
@@ -224,11 +224,6 @@ resource "opentelekomcloud_compute_instance_v2" "vm_1" {
   }
 }
 
-resource "opentelekomcloud_smn_topic_v2" "topic_1" {
-  name         = "topic_1"
-  display_name = "The display name of topic_1"
-}
-
 resource "opentelekomcloud_ces_alarm_rule_v2" "alarmrule_1" {
   name      = "alarm_rule_v2_1"
   namespace = "SYS.ECS"
@@ -256,10 +251,8 @@ resource "opentelekomcloud_ces_alarm_rule_v2" "alarmrule_1" {
   alarm_enabled        = true
 
   alarm_actions {
-    type = "notification"
-    notification_list = [
-      opentelekomcloud_smn_topic_v2.topic_1.topic_urn
-    ]
+    type              = "contact"
+    notification_list = []
   }
 }
 `, common.DataSourceSubnet)
@@ -1067,9 +1060,9 @@ func TestCESAlarmRuleV2_withOkActions(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "name", name),
 					resource.TestCheckResourceAttr(rName, "notification_enabled", "true"),
 					resource.TestCheckResourceAttr(rName, "alarm_actions.#", "1"),
-					resource.TestCheckResourceAttr(rName, "alarm_actions.0.type", "notification"),
+					resource.TestCheckResourceAttr(rName, "alarm_actions.0.type", "contact"),
 					resource.TestCheckResourceAttr(rName, "ok_actions.#", "1"),
-					resource.TestCheckResourceAttr(rName, "ok_actions.0.type", "notification"),
+					resource.TestCheckResourceAttr(rName, "ok_actions.0.type", "contact"),
 				),
 			},
 			{
@@ -1093,11 +1086,6 @@ resource "opentelekomcloud_compute_instance_v2" "test" {
   network {
     uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   }
-}
-
-resource "opentelekomcloud_smn_topic_v2" "test" {
-  name         = "smn-%[2]s"
-  display_name = "The display name of smn topic"
 }
 
 resource "opentelekomcloud_ces_alarm_rule_v2" "test" {
@@ -1127,17 +1115,13 @@ resource "opentelekomcloud_ces_alarm_rule_v2" "test" {
   alarm_enabled        = true
 
   alarm_actions {
-    type = "notification"
-    notification_list = [
-      opentelekomcloud_smn_topic_v2.test.topic_urn
-    ]
+    type              = "contact"
+    notification_list = []
   }
 
   ok_actions {
-    type = "notification"
-    notification_list = [
-      opentelekomcloud_smn_topic_v2.test.topic_urn
-    ]
+    type              = "contact"
+    notification_list = []
   }
 }
 `, common.DataSourceSubnet, name)

--- a/opentelekomcloud/services/ces/resource_opentelekomcloud_ces_alarm_rule_v2.go
+++ b/opentelekomcloud/services/ces/resource_opentelekomcloud_ces_alarm_rule_v2.go
@@ -182,9 +182,6 @@ func ResourceAlarmRuleV2() *schema.Resource {
 						"type": {
 							Type:     schema.TypeString,
 							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								"notification", "autoscaling",
-							}, false),
 						},
 						"notification_list": {
 							Type:     schema.TypeList,
@@ -205,9 +202,6 @@ func ResourceAlarmRuleV2() *schema.Resource {
 						"type": {
 							Type:     schema.TypeString,
 							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								"notification", "autoscaling",
-							}, false),
 						},
 						"notification_list": {
 							Type:     schema.TypeList,

--- a/releasenotes/notes/ces-alarm-rule-v2-notification-validation-38b7be47a82d22dc.yaml
+++ b/releasenotes/notes/ces-alarm-rule-v2-notification-validation-38b7be47a82d22dc.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    **[CES]** Removed ``type`` validation for ``alarm_actions`` and ``ok_actions`` in ``resource/opentelekomcloud_ces_alarm_rule_v2`` (`#3376 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3376>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Omitted extra validation

## PR Checklist

* [x] Refers to: #3352
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestCESAlarmRuleV2_basic
=== PAUSE TestCESAlarmRuleV2_basic
=== CONT  TestCESAlarmRuleV2_basic
--- PASS: TestCESAlarmRuleV2_basic (225.16s)
=== RUN   TestCESAlarmRuleV2_withNotification
=== PAUSE TestCESAlarmRuleV2_withNotification
=== CONT  TestCESAlarmRuleV2_withNotification
--- PASS: TestCESAlarmRuleV2_withNotification (203.72s)
=== RUN   TestCESAlarmRuleV2_multiplePolicies
=== PAUSE TestCESAlarmRuleV2_multiplePolicies
=== CONT  TestCESAlarmRuleV2_multiplePolicies
--- PASS: TestCESAlarmRuleV2_multiplePolicies (240.28s)
=== RUN   TestCESAlarmRuleV2_multipleResources
=== PAUSE TestCESAlarmRuleV2_multipleResources
=== CONT  TestCESAlarmRuleV2_multipleResources
--- PASS: TestCESAlarmRuleV2_multipleResources (242.37s)
=== RUN   TestCESAlarmRuleV2_multipleDimensions
=== PAUSE TestCESAlarmRuleV2_multipleDimensions
=== CONT  TestCESAlarmRuleV2_multipleDimensions
--- PASS: TestCESAlarmRuleV2_multipleDimensions (483.46s)
=== RUN   TestCESAlarmRuleV2_sysEvent
=== PAUSE TestCESAlarmRuleV2_sysEvent
=== CONT  TestCESAlarmRuleV2_sysEvent
--- PASS: TestCESAlarmRuleV2_sysEvent (53.79s)
=== RUN   TestCESAlarmRuleV2_sysEventWithNotification
=== PAUSE TestCESAlarmRuleV2_sysEventWithNotification
=== CONT  TestCESAlarmRuleV2_sysEventWithNotification
--- PASS: TestCESAlarmRuleV2_sysEventWithNotification (36.46s)
=== RUN   TestCESAlarmRuleV2_allInstance
=== PAUSE TestCESAlarmRuleV2_allInstance
=== CONT  TestCESAlarmRuleV2_allInstance
--- PASS: TestCESAlarmRuleV2_allInstance (35.74s)
=== RUN   TestCESAlarmRuleV2_withOkActions
=== PAUSE TestCESAlarmRuleV2_withOkActions
=== CONT  TestCESAlarmRuleV2_withOkActions
--- PASS: TestCESAlarmRuleV2_withOkActions (403.80s)
=== RUN   TestCESAlarmRuleV2_withAlarmTemplate
=== PAUSE TestCESAlarmRuleV2_withAlarmTemplate
=== CONT  TestCESAlarmRuleV2_withAlarmTemplate
--- PASS: TestCESAlarmRuleV2_withAlarmTemplate (473.34s)
PASS

Process finished with the exit code 0

```
