### PR TITLE
[Feat] IAM: Add xuser_type and xuser_id arguments to identity_user_v3

### DIFF
--- a/docs/resources/identity_user_v3.md
+++ b/docs/resources/identity_user_v3.md
@@ -43,6 +43,18 @@ resource "opentelekomcloud_identity_user_v3" "user_1" {
 }
 ```
 
+## Example with external identity
+
+```hcl
+resource "opentelekomcloud_identity_user_v3" "user_1" {
+  name       = "user_external"
+  password   = "password123@!"
+  enabled    = true
+  xuser_type = "TenantIdp"
+  xuser_id   = "external-system-user-id"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -83,6 +95,12 @@ The following arguments are supported:
   + `enabled` - (Required, Bool) Indicates whether login protection has been enabled for the user. The value can be `true` or `false`.
   + `verification_method` - (Required, String) Login authentication method of the user. Options: `sms`, `email`, and `vmfa`.
 
+* `xuser_type` - (Optional, String) Specifies the type of the IAM user in the external system.
+  Must be used together with `xuser_id`. Currently, the only supported value is `TenantIdp`.
+
+* `xuser_id` - (Optional, String) Specifies the ID of the IAM user in the external system.
+  Must be used together with `xuser_type`. The ID can contain a maximum of 128 characters.
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -96,10 +114,6 @@ In addition to all arguments above, the following attributes are exported:
 * `last_login` - The time when the IAM user last login.
 
 * `domain_id` - The domain user belongs to.
-
-* `xuser_type` - Type of the user in the external system.
-
-* `xuser_id` - ID of the user in the external system.
 
 ## Import
 

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.9.7-0.20260514085017-8e26f666099b
+	github.com/opentelekomcloud/gophertelekomcloud v0.9.7-0.20260526101807-2a7f3cd46004
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.46.0
 	golang.org/x/sync v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -167,8 +167,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.7-0.20260514085017-8e26f666099b h1:kNGoJcSvNkprqxobNOhFK6fTtKPU8e1llFg3THC/OTo=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.7-0.20260514085017-8e26f666099b/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.7-0.20260526101807-2a7f3cd46004 h1:zpda19oY7zLwc6JpfWwrzMQeaJtgiXEQtTjMEIens4E=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.7-0.20260526101807-2a7f3cd46004/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/opentelekomcloud/acceptance/iam/resource_opentelekomcloud_identity_user_v3_test.go
+++ b/opentelekomcloud/acceptance/iam/resource_opentelekomcloud_identity_user_v3_test.go
@@ -294,3 +294,62 @@ resource "opentelekomcloud_identity_user_v3" "user_1" {
 }
   `, userName)
 }
+
+func TestAccIdentityV3User_externalIdentity(t *testing.T) {
+	var user users.User
+	userName := acctest.RandomWithPrefix("tf-user")
+	xuserID := acctest.RandString(16)
+	xuserIDUpdated := acctest.RandString(16)
+	rc := common.InitResourceCheck(
+		resourceName,
+		&user,
+		getIdentityUserResourceFunc,
+	)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+			common.TestAccPreCheckAdminOnly(t)
+		},
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIdentityV3UserExternalIdentity(userName, xuserID),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "xuser_type", "TenantIdp"),
+					resource.TestCheckResourceAttr(resourceName, "xuser_id", xuserID),
+				),
+			},
+			{
+				Config: testAccIdentityV3UserExternalIdentity(userName, xuserIDUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "xuser_type", "TenantIdp"),
+					resource.TestCheckResourceAttr(resourceName, "xuser_id", xuserIDUpdated),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"password",
+					"send_welcome_email",
+				},
+			},
+		},
+	})
+}
+
+func testAccIdentityV3UserExternalIdentity(userName, xuserID string) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_identity_user_v3" "user_1" {
+  name       = "%s"
+  password   = "password123@!"
+  enabled    = true
+  xuser_type = "TenantIdp"
+  xuser_id   = "%s"
+}
+  `, userName, xuserID)
+}

--- a/opentelekomcloud/services/iam/resource_opentelekomcloud_identity_user_v3.go
+++ b/opentelekomcloud/services/iam/resource_opentelekomcloud_identity_user_v3.go
@@ -128,12 +128,18 @@ func ResourceIdentityUserV3() *schema.Resource {
 				Computed: true,
 			},
 			"xuser_type": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				RequiredWith: []string{"xuser_id"},
+				ValidateFunc: validation.StringInSlice([]string{"TenantIdp"}, false),
 			},
 			"xuser_id": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				RequiredWith: []string{"xuser_type"},
+				ValidateFunc: validation.StringLenBetween(1, 128),
 			},
 		},
 	}
@@ -165,6 +171,8 @@ func resourceIdentityUserV3Create(ctx context.Context, d *schema.ResourceData, m
 		Enabled:       &enabled,
 		PasswordReset: &reset,
 		DomainID:      domainId,
+		XuserType:     d.Get("xuser_type").(string),
+		XuserID:       d.Get("xuser_id").(string),
 	}
 
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)
@@ -362,6 +370,17 @@ func resourceIdentityUserV3Update(ctx context.Context, d *schema.ResourceData, m
 	_, err = users.ModifyUser(client, d.Id(), updateOpts)
 	if err != nil {
 		return diag.Errorf("error updating IAM user: %s", err)
+	}
+
+	if d.HasChanges("xuser_type", "xuser_id") {
+		_, err = users.ModifyUserAdmin(client, users.UpdateAdminOpts{
+			XuserType: d.Get("xuser_type").(string),
+			XuserId:   d.Get("xuser_id").(string),
+			Id:        d.Id(),
+		})
+		if err != nil {
+			return diag.Errorf("error updating xuser fields for IAM user: %s", err)
+		}
 	}
 
 	if hasChange {

--- a/releasenotes/notes/identity_user_external_identity-7de5d8c2fcd74579.yaml
+++ b/releasenotes/notes/identity_user_external_identity-7de5d8c2fcd74579.yaml
@@ -1,0 +1,7 @@
+---
+enhancements:
+  - |
+    **[IAM]** Added ``xuser_type`` and ``xuser_id`` arguments to
+    ``resource/opentelekomcloud_identity_user_v3`` to support external identity
+    provider user mapping
+    (`#3388 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3388>`_)


### PR DESCRIPTION
## Summary of the Pull Request

Add `xuser_type` and `xuser_id` as configurable arguments to `opentelekomcloud_identity_user_v3`.

Both fields were previously Computed-only. Users can now set them to map an IAM user to an external identity provider system (e.g. `TenantIdp`).

### Changes

- Schema: `xuser_type` and `xuser_id` changed from `Computed`-only to `Optional + Computed` with mutual `RequiredWith` dependency `xuser_type` accepts only `"TenantIdp"` (current API constraint). `xuser_id` is validated to 1–128 characters.
- Create: `xuser_type` and `xuser_id` are passed in `CreateOpts` atomically (requires SDK change: `XuserType`/`XuserID` added to `CreateOpts` in [gophertelekomcloud](https://github.com/opentelekomcloud/gophertelekomcloud/pull/938)).
- Update: `xuser_type`/`xuser_id` changes are applied via `ModifyUserAdmin`.
- Delete: no change
- Acceptance test `TestAccIdentityV3User_externalIdentity` added: covers create, update of `xuser_id`, and import.
- Documentation updated with argument descriptions and usage example.
- Release note added.

## SDK Dependency

Present at https://github.com/opentelekomcloud/gophertelekomcloud/pull/938

## PR Checklist

- [x] Refers to: #3386
- [x] Tests added/passed.
- [x] Documentation updated.
- [x] Schema updated.
- [x] Release notes added.

## Acceptance Steps Performed

```text
=== RUN   TestAccIdentityV3User_basic
--- PASS: TestAccIdentityV3User_basic (125.12s)
=== RUN   TestAccIdentityV3User_protection
--- PASS: TestAccIdentityV3User_protection (199.07s)
=== RUN   TestAccIdentityV3User_externalIdentity
--- PASS: TestAccIdentityV3User_externalIdentity (104.83s)
PASS
```