### PR TITLE
[Doc] Update docs and deprecation of config_drive

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
     <img src=".github/terraform_logo.svg" alt="Terraform logo" title="Terraform" align="right" height="50" />
 </a>
 
-Terraform Open Telekom Cloud Provider
+Terraform T-Cloud Public (former OpenTelekomCloud) Provider
 =====================================
 [![Documentation](https://img.shields.io/badge/documentation-blue)](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs)
 
 Quick Start
 -----------
-> When using the OpenTelekomCloud Provider with Terraform 0.13 and later, the recommended approach is to declare Provider versions in the root module Terraform configuration, using a `required_providers` block as per the following example. For previous versions, please continue to pin the version within the provider block.
+> When using the T-Cloud Public (former OpenTelekomCloud) Provider with Terraform 0.13 and later, the recommended approach is to declare Provider versions in the root module Terraform configuration, using a `required_providers` block as per the following example. For previous versions, please continue to pin the version within the provider block.
 
 1. Add [opentelekomcloud/opentelekomcloud](https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs) to your `required_providers`.
 ```hcl
@@ -27,7 +27,7 @@ terraform {
 ```hcl
 # provider.tf
 provider "opentelekomcloud" {
-   # OpenTelekomCloud Provider Documentation:
+   # T-Cloud Public (former OpenTelekomCloud) Provider Documentation:
    # https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs
    # domain_name = "..."
    # tenant_name = "..."

--- a/docs/guides/backends.md
+++ b/docs/guides/backends.md
@@ -25,9 +25,9 @@ The local backend configuration is different and entirely separate from the `ter
 
 When you change backends, Terraform gives you the option to migrate your state to the new backend. This lets you adopt backends without losing any existing state.
 
-## Using a OpenTelekomCloud S3 Backend Block
+## Using a T-Cloud Public (former OpenTelekomCloud) S3 Backend Block
 To configure a backend, add a nested backend block within the top-level terraform block. The following example configures the remote backend for S3.
-OpenTelekomCloud S3 endpoints:
+T-Cloud Public (former OpenTelekomCloud) S3 endpoints:
  - `https://obs.eu-de.otc.t-systems.com/`
  - `https://obs.eu-nl.otc.t-systems.com/`
  - `https://obs.eu-ch2.sc.otc.t-systems.com/`

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,13 +3,13 @@ layout: "opentelekomcloud"
 page_title: "Provider: OpenTelekomCloud"
 sidebar_current: "docs-opentelekomcloud-index"
 description: |-
-  The OpenTelekomCloud provider is used to interact with the many resources supported by OpenTelekomCloud. The provider needs to be configured with the proper credentials before it can be used.
+  The T-Cloud Public (former OpenTelekomCloud) provider is used to interact with the many resources supported by T-Cloud Public (former OpenTelekomCloud). The provider needs to be configured with the proper credentials before it can be used.
 ---
 
-# Open Telekom Cloud Provider
+# T-Cloud Public (former OpenTelekomCloud) Provider
 
-The Open Telekom Cloud provider is used to interact with the
-many resources supported by OpenTelekomCloud. The provider needs to be configured
+The T-Cloud Public (former OpenTelekomCloud) provider is used to interact with the
+many resources supported by T-Cloud Public (former OpenTelekomCloud). The provider needs to be configured
 with the proper credentials before it can be used.
 
 Use the navigation to the left to read about the available resources.
@@ -17,7 +17,7 @@ Use the navigation to the left to read about the available resources.
 ## Example Usage
 
 ```hcl
-# Configure the OpenTelekomCloud Provider
+# Configure the T-Cloud Public (former OpenTelekomCloud) Provider
 provider "opentelekomcloud" {
   user_name   = var.user_name
   password    = var.password
@@ -207,10 +207,10 @@ See [OpenStack configuration documentation](https://docs.openstack.org/python-op
 
 The following arguments are supported:
 
-* `access_key` - (Optional) The access key of the OpenTelekomCloud cloud to use.
+* `access_key` - (Optional) The access key of the T-Cloud Public (former OpenTelekomCloud) cloud to use.
   If omitted, the `OS_ACCESS_KEY` environment variable is used.
 
-* `secret_key` - (Optional) The secret key of the OpenTelekomCloud cloud to use.
+* `secret_key` - (Optional) The secret key of the T-Cloud Public (former OpenTelekomCloud) cloud to use.
   If omitted, the `OS_SECRET_KEY` environment variable is used.
 
 * `auth_url` - (Optional; required if `cloud` is not specified) The Identity
@@ -283,7 +283,7 @@ The following arguments are supported:
   such as `username:project`. Set the `password` to the Swauth/Swift key.
   Finally, set `auth_url` as the location of the Swift service.
 
--> This will only work when used with the OpenTelekomCloud Object Storage resources.
+-> This will only work when used with the T-Cloud Public (former OpenTelekomCloud) Object Storage resources.
 
 * `agency_name` - (Optional) if authorized by assume role, it must be set. The
   name of agency.
@@ -350,7 +350,7 @@ variables must also be set:
 
 * `OS_EXTGW_ID` - The UUID of the external gateway.
 
-You should be able to use any OpenTelekomCloud environment to develop on as long as the
+You should be able to use any T-Cloud Public (former OpenTelekomCloud) environment to develop on as long as the
 above environment variables are set.
 
 <div style="visibility:hidden">

--- a/docs/resources/compute_instance_v2.md
+++ b/docs/resources/compute_instance_v2.md
@@ -337,7 +337,7 @@ error.
 * `metadata` - (Optional) Metadata key/value pairs to make available from within the instance. Changing this updates the
   existing server metadata.
 
-* `config_drive` - (Optional) Whether to use the config_drive feature to configure the instance. Changing this creates a
+* `config_drive` **DEPRECATED** - (Optional) Whether to use the config_drive feature to configure the instance. Changing this creates a
   new server.
 
 * `admin_pass` - (Optional) The administrative password to assign to the server. Changing this changes the root password

--- a/docs/resources/evs_snapshot_v2.md
+++ b/docs/resources/evs_snapshot_v2.md
@@ -4,7 +4,7 @@ layout: "opentelekomcloud"
 page_title: "OpenTelekomCloud: opentelekomcloud_evs_snapshot_v2"
 sidebar_current: "docs-opentelekomcloud-resource-evs-snapshot-v2"
 description: |-
-Manages an EVS snapshot resource within OpenTelekomCloud.
+  Manages an EVS snapshot resource within OpenTelekomCloud.
 ---
 
 # opentelekomcloud_evs_snapshot_v2

--- a/opentelekomcloud/services/ecs/resource_opentelekomcloud_compute_instance_v2.go
+++ b/opentelekomcloud/services/ecs/resource_opentelekomcloud_compute_instance_v2.go
@@ -186,9 +186,10 @@ func ResourceComputeInstanceV2() *schema.Resource {
 				ForceNew: false,
 			},
 			"config_drive": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				ForceNew: true,
+				Type:       schema.TypeBool,
+				Optional:   true,
+				ForceNew:   true,
+				Deprecated: "This parameter is no longer available after an API update.",
 			},
 			"password": {
 				Type:      schema.TypeString,

--- a/releasenotes/notes/doc-update-config-drv-deprecation-3f48e8c7c18b391f.yaml
+++ b/releasenotes/notes/doc-update-config-drv-deprecation-3f48e8c7c18b391f.yaml
@@ -1,0 +1,5 @@
+other:
+  - |
+    **[DOC]** Deprecate ``config_drive`` in ``resource/opentelekomcloud_compute_instance_v2`` (`#3394 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3394>`_)
+  - |
+    **[DOC]** Rebranding changes in documentation (`#3394 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3394>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Deprecated `config_drive` in `opentelekomcloud_compute_instance_v2`:
https://docs.otc.t-systems.com/elastic-cloud-server/api-ref/native_openstack_nova_apis/lifecycle_management/creating_an_ecs.html#en-us-topic-0068473331:~:text=available%20for%20BMSs.-,config_drive,-No

Rebranding updates in docs
## PR Checklist

* [ ] Refers to: #xxx
* [ ] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.
* [x] Release notes added.

