### PR TITLE
[Fix] Re-sign AKSK requests on retry

### DIFF
--- a/opentelekomcloud/common/cfg/config.go
+++ b/opentelekomcloud/common/cfg/config.go
@@ -530,18 +530,24 @@ func (c *Config) genClient(ao golangsdk.AuthOptionsProvider) (*golangsdk.Provide
 	defaultBackoffTimeout := time.Duration(c.BackoffRetryTimeout) * time.Second
 	client.BackoffRetryTimeout = &defaultBackoffTimeout
 
+	rt := &RoundTripper{
+		Rt:         transport,
+		OsDebug:    osDebug,
+		MaxRetries: c.MaxRetries,
+	}
+	if client.AKSKAuthOptions.AccessKey != "" {
+		signOpts := golangsdk.SignOptions{
+			AccessKey: client.AKSKAuthOptions.AccessKey,
+			SecretKey: client.AKSKAuthOptions.SecretKey,
+		}
+		rt.SignOptions = &signOpts
+	}
+
 	client.HTTPClient = http.Client{
-		Transport: &RoundTripper{
-			Rt:         transport,
-			OsDebug:    osDebug,
-			MaxRetries: c.MaxRetries,
-		},
+		Transport: rt,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			if client.AKSKAuthOptions.AccessKey != "" {
-				golangsdk.ReSign(req, golangsdk.SignOptions{
-					AccessKey: client.AKSKAuthOptions.AccessKey,
-					SecretKey: client.AKSKAuthOptions.SecretKey,
-				})
+			if rt.SignOptions != nil {
+				golangsdk.ReSign(req, *rt.SignOptions)
 			}
 			return nil
 		},

--- a/opentelekomcloud/common/cfg/logger.go
+++ b/opentelekomcloud/common/cfg/logger.go
@@ -8,31 +8,34 @@ import (
 	"io/ioutil"
 	"log"
 	"math"
+	"math/rand"
 	"net/http"
 	"sort"
 	"strings"
 	"time"
 
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/unknwon/com"
 )
 
-var maxTimeout = 10 * time.Minute
+var maxTimeout = 20 * time.Second
 
 // RoundTripper satisfies the http.RoundTripper interface and is used to
 // customize the default http client RoundTripper to allow for logging.
 type RoundTripper struct {
-	Rt         http.RoundTripper
-	OsDebug    bool
-	MaxRetries int
+	Rt          http.RoundTripper
+	OsDebug     bool
+	MaxRetries  int
+	SignOptions *golangsdk.SignOptions
 }
 
 func retryTimeout(count int) time.Duration {
-	seconds := math.Pow(2, float64(count))
-	timeout := time.Duration(seconds) * time.Second
-	if timeout > maxTimeout { // won't wait more than maxTimeout
+	timeout := time.Duration(math.Pow(2, float64(count))) * time.Second
+	if timeout > maxTimeout {
 		timeout = maxTimeout
 	}
-	return timeout
+	half := timeout / 2
+	return half + time.Duration(rand.Float64()*float64(half))
 }
 
 // RoundTrip performs a round-trip HTTP request and logs relevant information about it.
@@ -76,6 +79,9 @@ func (lrt *RoundTripper) RoundTrip(request *http.Request) (*http.Response, error
 			log.Printf("[DEBUG] OpenTelecomCloud connection error, retry number %d: %s", retry, err)
 		}
 		time.Sleep(retryTimeout(retry))
+		if lrt.SignOptions != nil {
+			golangsdk.ReSign(request, *lrt.SignOptions)
+		}
 		response, err = lrt.Rt.RoundTrip(request)
 		retry += 1
 	}

--- a/opentelekomcloud/common/cfg/transport_test.go
+++ b/opentelekomcloud/common/cfg/transport_test.go
@@ -57,6 +57,66 @@ const tokenOutput = `
 }
 `
 
+type recordingTransport struct {
+	failCount    int
+	maxFailures  int
+	sdkDates     []string
+	authHeaders  []string
+}
+
+func (rt *recordingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.sdkDates = append(rt.sdkDates, req.Header.Get("X-Sdk-Date"))
+	rt.authHeaders = append(rt.authHeaders, req.Header.Get("Authorization"))
+
+	if rt.failCount < rt.maxFailures {
+		rt.failCount++
+		return nil, fmt.Errorf("connection refused")
+	}
+	return &http.Response{
+		StatusCode: 200,
+		Body:       http.NoBody,
+	}, nil
+}
+
+func TestRoundTripperRetryResign(t *testing.T) {
+	inner := &recordingTransport{maxFailures: 1}
+
+	signOpts := golangsdk.SignOptions{
+		AccessKey: "test-ak",
+		SecretKey: "test-sk",
+	}
+
+	req, err := http.NewRequest("GET", "https://example.com/v1/resource", nil)
+	th.CheckNoErr(t, err)
+
+	// Set stale signature headers so that ReSign is guaranteed to produce different ones
+	staleDate := "20200101T000000Z"
+	staleAuth := "SDK-HMAC-SHA256 stale-signature"
+	req.Header.Set("Host", req.URL.Host)
+	req.Header.Set("X-Sdk-Date", staleDate)
+	req.Header.Set("Authorization", staleAuth)
+
+	rt := &RoundTripper{
+		Rt:          inner,
+		MaxRetries:  1,
+		SignOptions: &signOpts,
+	}
+
+	resp, err := rt.RoundTrip(req)
+	th.CheckNoErr(t, err)
+	th.AssertEquals(t, 200, resp.StatusCode)
+
+	th.AssertEquals(t, 2, len(inner.sdkDates))
+	th.AssertEquals(t, staleDate, inner.sdkDates[0])
+
+	if inner.sdkDates[1] == staleDate {
+		t.Error("X-Sdk-Date should be updated on retry, but was still stale")
+	}
+	if inner.authHeaders[1] == staleAuth {
+		t.Error("Authorization should be updated on retry, but was still stale")
+	}
+}
+
 func TestRoundTripperRetry(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()

--- a/opentelekomcloud/common/cfg/transport_test.go
+++ b/opentelekomcloud/common/cfg/transport_test.go
@@ -58,10 +58,10 @@ const tokenOutput = `
 `
 
 type recordingTransport struct {
-	failCount    int
-	maxFailures  int
-	sdkDates     []string
-	authHeaders  []string
+	failCount   int
+	maxFailures int
+	sdkDates    []string
+	authHeaders []string
 }
 
 func (rt *recordingTransport) RoundTrip(req *http.Request) (*http.Response, error) {

--- a/releasenotes/notes/aksk-retry-resign-68eb3928407e899d.yaml
+++ b/releasenotes/notes/aksk-retry-resign-68eb3928407e899d.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Re-sign AKSK requests on HTTP retry to prevent signature expired errors (`#3399 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3399>`_)
+enhancements:
+  - |
+    Improve HTTP retry backoff strategy: reduce max timeout from 10 minutes to 20 seconds and add jitter (`#3399 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3399>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Fix requests resign for AKSK auth during request retry.

## PR Checklist

* [x] Refers to: #3392
* [x] Tests added/passed.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestRoundTripperRetryResign
--- PASS: TestRoundTripperRetryResign (1.09s)
=== RUN   TestRoundTripperRetry
--- PASS: TestRoundTripperRetry (0.53s)
PASS

Process finished with the exit code 0

=== RUN   TestReadCloudsYaml
=== RUN   TestReadCloudsYaml/IdentityEndpoint
--- PASS: TestReadCloudsYaml/IdentityEndpoint (0.00s)
=== RUN   TestReadCloudsYaml/Region
--- PASS: TestReadCloudsYaml/Region (0.00s)
=== RUN   TestReadCloudsYaml/TenantName
--- PASS: TestReadCloudsYaml/TenantName (0.00s)
=== RUN   TestReadCloudsYaml/Username
--- PASS: TestReadCloudsYaml/Username (0.00s)
=== RUN   TestReadCloudsYaml/Password
--- PASS: TestReadCloudsYaml/Password (0.00s)
=== RUN   TestReadCloudsYaml/Insecure
--- PASS: TestReadCloudsYaml/Insecure (0.00s)
=== RUN   TestReadCloudsYaml/ClientCertFile
--- PASS: TestReadCloudsYaml/ClientCertFile (0.00s)
=== RUN   TestReadCloudsYaml/ClientKeyFile
--- PASS: TestReadCloudsYaml/ClientKeyFile (0.00s)
=== RUN   TestReadCloudsYaml/CACertFile
--- PASS: TestReadCloudsYaml/CACertFile (0.00s)
--- PASS: TestReadCloudsYaml (0.01s)
=== RUN   TestDomain
=== RUN   TestDomain/TenantID/DomainName/user_domain_name
--- PASS: TestDomain/TenantID/DomainName/user_domain_name (0.00s)
=== RUN   TestDomain/TenantID/DomainName/domain_name
--- PASS: TestDomain/TenantID/DomainName/domain_name (0.00s)
=== RUN   TestDomain/TenantID/DomainName/project_domain_name
--- PASS: TestDomain/TenantID/DomainName/project_domain_name (0.00s)
=== RUN   TestDomain/TenantID/DomainID/user_domain_id
--- PASS: TestDomain/TenantID/DomainID/user_domain_id (0.00s)
=== RUN   TestDomain/TenantID/DomainID/domain_id
--- PASS: TestDomain/TenantID/DomainID/domain_id (0.00s)
=== RUN   TestDomain/TenantID/DomainID/project_domain_id
--- PASS: TestDomain/TenantID/DomainID/project_domain_id (0.00s)
=== RUN   TestDomain/TenantID/DomainID/default_domain
--- PASS: TestDomain/TenantID/DomainID/default_domain (0.00s)
=== RUN   TestDomain/TenantName/DomainName/user_domain_name
--- PASS: TestDomain/TenantName/DomainName/user_domain_name (0.00s)
=== RUN   TestDomain/TenantName/DomainName/domain_name
--- PASS: TestDomain/TenantName/DomainName/domain_name (0.00s)
=== RUN   TestDomain/TenantName/DomainName/project_domain_name
--- PASS: TestDomain/TenantName/DomainName/project_domain_name (0.00s)
=== RUN   TestDomain/TenantName/DomainID/user_domain_id
--- PASS: TestDomain/TenantName/DomainID/user_domain_id (0.00s)
=== RUN   TestDomain/TenantName/DomainID/domain_id
--- PASS: TestDomain/TenantName/DomainID/domain_id (0.00s)
=== RUN   TestDomain/TenantName/DomainID/project_domain_id
--- PASS: TestDomain/TenantName/DomainID/project_domain_id (0.00s)
=== RUN   TestDomain/TenantName/DomainID/default_domain
--- PASS: TestDomain/TenantName/DomainID/default_domain (0.00s)
--- PASS: TestDomain (0.00s)
=== RUN   TestRequestRetry
=== RUN   TestRequestRetry/TestRequestMultipleRetries
2026/06/01 15:29:32 http: panic serving 127.0.0.1:53304: panic called with nil argument
goroutine 63 [running]:
net/http.(*conn).serve.func1()
	/usr/local/go/src/net/http/server.go:1947 +0xbe
panic({0x0?, 0x0?})
	/usr/local/go/src/runtime/panic.go:787 +0x132
github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg.testRequestRetry.func1({0x1005498, 0xc0000f6000}, 0xc0000a1b38?)
	/home/arti/projects/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg/config_test.go:182 +0x234
net/http.HandlerFunc.ServeHTTP(0xc000186240?, {0x1005498?, 0xc0000f6000?}, 0x791a36?)
	/usr/local/go/src/net/http/server.go:2294 +0x29
net/http.(*ServeMux).ServeHTTP(0x477d79?, {0x1005498, 0xc0000f6000}, 0xc000016140)
	/usr/local/go/src/net/http/server.go:2822 +0x1c4
net/http.serverHandler.ServeHTTP({0xc0004c40f0?}, {0x1005498?, 0xc0000f6000?}, 0x1?)
	/usr/local/go/src/net/http/server.go:3301 +0x8e
net/http.(*conn).serve(0xc0001aa3f0, {0x1006ec8, 0xc0004c5980})
	/usr/local/go/src/net/http/server.go:2102 +0x625
created by net/http.(*Server).Serve in goroutine 62
	/usr/local/go/src/net/http/server.go:3454 +0x485
2026/06/01 15:29:34 http: panic serving 127.0.0.1:32826: panic called with nil argument
goroutine 7 [running]:
net/http.(*conn).serve.func1()
	/usr/local/go/src/net/http/server.go:1947 +0xbe
panic({0x0?, 0x0?})
	/usr/local/go/src/runtime/panic.go:787 +0x132
github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg.testRequestRetry.func1({0x1005498, 0xc0001d6460}, 0xc0000a3b38?)
	/home/arti/projects/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg/config_test.go:182 +0x234
net/http.HandlerFunc.ServeHTTP(0xc000186240?, {0x1005498?, 0xc0001d6460?}, 0x791a36?)
	/usr/local/go/src/net/http/server.go:2294 +0x29
net/http.(*ServeMux).ServeHTTP(0x477d79?, {0x1005498, 0xc0001d6460}, 0xc000384280)
	/usr/local/go/src/net/http/server.go:2822 +0x1c4
net/http.serverHandler.ServeHTTP({0xc00012c6f0?}, {0x1005498?, 0xc0001d6460?}, 0x1?)
	/usr/local/go/src/net/http/server.go:3301 +0x8e
net/http.(*conn).serve(0xc0002cd830, {0x1006ec8, 0xc0004c5980})
	/usr/local/go/src/net/http/server.go:2102 +0x625
created by net/http.(*Server).Serve in goroutine 62
	/usr/local/go/src/net/http/server.go:3454 +0x485
--- PASS: TestRequestRetry/TestRequestMultipleRetries (4.40s)
=== RUN   TestRequestRetry/TestRequestSingleRetry
2026/06/01 15:29:36 http: panic serving 127.0.0.1:56068: panic called with nil argument
goroutine 121 [running]:
net/http.(*conn).serve.func1()
	/usr/local/go/src/net/http/server.go:1947 +0xbe
panic({0x0?, 0x0?})
	/usr/local/go/src/runtime/panic.go:787 +0x132
github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg.testRequestRetry.func1({0x1005498, 0xc0000f60e0}, 0xc0004d3b38?)
	/home/arti/projects/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg/config_test.go:182 +0x234
net/http.HandlerFunc.ServeHTTP(0xc00037a000?, {0x1005498?, 0xc0000f60e0?}, 0x791a36?)
	/usr/local/go/src/net/http/server.go:2294 +0x29
net/http.(*ServeMux).ServeHTTP(0x477d79?, {0x1005498, 0xc0000f60e0}, 0xc000016b40)
	/usr/local/go/src/net/http/server.go:2822 +0x1c4
net/http.serverHandler.ServeHTTP({0xc0004c4d20?}, {0x1005498?, 0xc0000f60e0?}, 0x1?)
	/usr/local/go/src/net/http/server.go:3301 +0x8e
net/http.(*conn).serve(0xc0001aac60, {0x1006ec8, 0xc0004c4990})
	/usr/local/go/src/net/http/server.go:2102 +0x625
created by net/http.(*Server).Serve in goroutine 114
	/usr/local/go/src/net/http/server.go:3454 +0x485
--- PASS: TestRequestRetry/TestRequestSingleRetry (1.08s)
=== RUN   TestRequestRetry/TestRequestZeroRetry
--- PASS: TestRequestRetry/TestRequestZeroRetry (0.00s)
--- PASS: TestRequestRetry (5.48s)
PASS

Process finished with the exit code 0
```
