### PR TITLE
Add name-based lookup to data-source direct_connect_v2

### DIFF
--- a/docs/data-sources/direct_connect_v2.md
+++ b/docs/data-sources/direct_connect_v2.md
@@ -18,15 +18,26 @@ Example usage
 -----------------
 
 ```hcl
+# Look up by ID
 data "opentelekomcloud_direct_connect_v2" "direct_connect" {
   id = "direct_connect_id"
+}
+
+# Look up by name
+data "opentelekomcloud_direct_connect_v2" "direct_connect" {
+  name = "direct_connect_name"
 }
 ```
 
 
 ## Argument Reference
 
-- `id` (String) - Specifies the direct connection ID.
+The following arguments are supported. Exactly one of `id` or `name` must be specified.
+
+* `id` - (Optional, String) Specifies the direct connection ID.
+* `name` - (Optional, String) Specifies the connection name. The lookup fails if the name does not
+  match exactly one connection: an error is returned when no connection matches and when more than
+  one connection shares the name.
 
 ## Attributes Reference
 * `bandwidth` (Number) - Specifies the bandwidth of the connection in Mbit/s.
@@ -39,7 +50,6 @@ data "opentelekomcloud_direct_connect_v2" "direct_connect" {
 * `device_id` (String) - Specifies the gateway device ID of the connection.
 * `hosting_id` (String) - Specifies the ID of the operations connection on which the hosted connection is created.
 * `interface_name` (String) - Specifies the name of the interface accessed by the connection.
-* `name` (String) - Specifies the connection name.
 * `order_id` (String) - Specifies the connection order ID, which is used to support duration-based billing and identify user orders.
 * `peer_location` (String) - Specifies the physical location of the peer device accessed by the connection, specific to the street or data center name.
 * `product_id` (String) - Specifies the product ID corresponding to the connection's order, which is used to custom billing policies such as duration-based packages.
@@ -57,7 +67,6 @@ data "opentelekomcloud_direct_connect_v2" "direct_connect" {
 * `create_time` (String) - Specifies the time when the connection is created.
 * `delete_time` (String) - Specifies the time when the connection was deleted.
 * `email` (String) - This is a reserved field, which is not used currently.
-* `id` (String) - Specifies the connection ID.
 * `lag_id` (String) - This is a reserved field, which is not used currently.
 * `last_onestop_product_id` (String) - This is a reserved field, which is not used currently.
 * `mobile` (String) - This is a reserved field, which is not used currently.

--- a/opentelekomcloud/acceptance/dcaas/datasource_opentelekomcloud_direct_connect_v2_test.go
+++ b/opentelekomcloud/acceptance/dcaas/datasource_opentelekomcloud_direct_connect_v2_test.go
@@ -2,6 +2,7 @@ package dcaas
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -41,5 +42,137 @@ resource "opentelekomcloud_direct_connect_v2" "direct_connect" {
 data "opentelekomcloud_direct_connect_v2" "direct_connect" {
   id = opentelekomcloud_direct_connect_v2.direct_connect.id
 }
-`, directConnectName)
+	`, directConnectName)
+}
+
+func TestDirectConnectV2Datasource_byName(t *testing.T) {
+	var directConnectName = fmt.Sprintf("dc-%s", acctest.RandString(5))
+	const dc = "data.opentelekomcloud_direct_connect_v2.by_name"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDirectConnectV2Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDirectConnectV2Datasource_byName(directConnectName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dc, "name", directConnectName),
+					resource.TestCheckResourceAttr(dc, "bandwidth", "100"),
+					resource.TestCheckResourceAttrPair(dc, "id",
+						"opentelekomcloud_direct_connect_v2.direct_connect", "id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDirectConnectV2Datasource_byName(directConnectName string) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_direct_connect_v2" "direct_connect" {
+  name          = "%s"
+  port_type     = "1G"
+  location      = "Biere"
+  bandwidth     = 100
+  provider_name = "OTC"
+}
+
+data "opentelekomcloud_direct_connect_v2" "by_name" {
+  name = opentelekomcloud_direct_connect_v2.direct_connect.name
+}
+		`, directConnectName)
+}
+
+func TestDirectConnectV2Datasource_byNameMultiple(t *testing.T) {
+	var directConnectName = fmt.Sprintf("dc-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDirectConnectV2Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDirectConnectV2Datasource_byNameMultiple(directConnectName),
+				ExpectError: regexp.MustCompile(`your query returned more than one result: 2 direct connects match name .* \(IDs: [^)]+\)\. Please query by .id.`),
+			},
+		},
+	})
+}
+
+func testAccDirectConnectV2Datasource_byNameMultiple(directConnectName string) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_direct_connect_v2" "dc1" {
+  name          = "%[1]s"
+  port_type     = "1G"
+  location      = "Biere"
+  bandwidth     = 100
+  provider_name = "OTC"
+}
+
+resource "opentelekomcloud_direct_connect_v2" "dc2" {
+  name          = "%[1]s"
+  port_type     = "1G"
+  location      = "Biere"
+  bandwidth     = 100
+  provider_name = "OTC"
+}
+
+data "opentelekomcloud_direct_connect_v2" "by_name" {
+  name = "%[1]s"
+  depends_on = [
+    opentelekomcloud_direct_connect_v2.dc1,
+    opentelekomcloud_direct_connect_v2.dc2,
+  ]
+}
+			`, directConnectName)
+}
+
+func TestDirectConnectV2Datasource_nameNotFound(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDirectConnectV2Datasource_nameNotFound(),
+				ExpectError: regexp.MustCompile(`your query returned no results\. Please change your search criteria`),
+			},
+		},
+	})
+}
+
+func testAccDirectConnectV2Datasource_nameNotFound() string {
+	return fmt.Sprintf(`
+data "opentelekomcloud_direct_connect_v2" "by_name" {
+  name = "nonexistent-dc-%s"
+}
+	`, acctest.RandString(8))
+}
+
+func TestDirectConnectV2Datasource_idAndName(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `data "opentelekomcloud_direct_connect_v2" "test" {
+  id   = "any-value"
+  name = "any-value"
+}`,
+				ExpectError: regexp.MustCompile("only one of `id` or `name` can be specified"),
+			},
+		},
+	})
+}
+
+func TestDirectConnectV2Datasource_noFilter(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      `data "opentelekomcloud_direct_connect_v2" "test" {}`,
+				ExpectError: regexp.MustCompile("one of `id` or `name` must be specified"),
+			},
+		},
+	})
 }

--- a/opentelekomcloud/services/dcaas/data_source_opentelekomcloud_direct_connect_v2.go
+++ b/opentelekomcloud/services/dcaas/data_source_opentelekomcloud_direct_connect_v2.go
@@ -3,6 +3,7 @@ package dcaas
 import (
 	"context"
 	"log"
+	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -200,20 +201,58 @@ func DataSourceDirectConnectV2() *schema.Resource {
 }
 
 func dataSourceDirectConnectV2Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	idVal, idSet := d.GetOk("id")
+	nameVal, nameSet := d.GetOk("name")
+	switch {
+	case idSet && nameSet:
+		return fmterr.Errorf("only one of `id` or `name` can be specified")
+	case !idSet && !nameSet:
+		return fmterr.Errorf("one of `id` or `name` must be specified")
+	}
+
 	config := meta.(*cfg.Config)
 	client, err := config.DCaaSV2Client(config.GetRegion(d))
 	if err != nil {
 		return fmterr.Errorf(errCreateClientV2, err)
 	}
 
-	var ID string
-	if v, ok := d.GetOk("id"); ok {
-		ID = v.(string)
-	}
+	var directConnect *dcaas.DirectConnect
+	if idSet {
+		directConnect, err = dcaas.Get(client, idVal.(string))
+		if err != nil {
+			return fmterr.Errorf("error reading direct connect: %s", err)
+		}
+	} else {
+		name := nameVal.(string)
+		// dcaas.List hardcodes a `?id=` query parameter; calling it with an empty
+		// id filters on id == "" and returns nothing. Query the collection endpoint
+		// without that filter so the name match below sees every direct connect.
+		var listResp struct {
+			DirectConnects []dcaas.DirectConnect `json:"direct_connects"`
+		}
+		if _, err = client.Get(client.ServiceURL("dcaas", "direct-connects"), &listResp, nil); err != nil {
+			return fmterr.Errorf("error listing direct connects: %s", err)
+		}
 
-	directConnect, err := dcaas.Get(client, ID)
-	if err != nil {
-		return fmterr.Errorf("error reading direct connect: %s", err)
+		var filtered []dcaas.DirectConnect
+		for _, connection := range listResp.DirectConnects {
+			if connection.Name == name {
+				filtered = append(filtered, connection)
+			}
+		}
+
+		if len(filtered) < 1 {
+			return fmterr.Errorf("your query returned no results. Please change your search criteria and try again")
+		}
+		if len(filtered) > 1 {
+			ids := make([]string, len(filtered))
+			for i, connection := range filtered {
+				ids[i] = connection.ID
+			}
+			return fmterr.Errorf("your query returned more than one result: %d direct connects match name %q (IDs: %s). "+
+				"Please query by `id` to select a specific one", len(filtered), name, strings.Join(ids, ", "))
+		}
+		directConnect = &filtered[0]
 	}
 	log.Printf("[DEBUG] Direct Connect read result: %#v", directConnect)
 

--- a/releasenotes/notes/dcaas-direct-connect-name-lookup-375cf2d4e11a7094.yaml
+++ b/releasenotes/notes/dcaas-direct-connect-name-lookup-375cf2d4e11a7094.yaml
@@ -1,0 +1,8 @@
+---
+enhancements:
+  - |
+    **[DCAAS]** Data source ``opentelekomcloud_direct_connect_v2`` now supports
+    looking up a connection by ``name`` as an alternative to ``id``. Exactly one
+    of the two must be specified, and the lookup returns an error when no
+    connection matches the name or when more than one connection shares it.
+    (`#3402 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3402>`_)


### PR DESCRIPTION
## Summary of the Pull Request

The opentelekomcloud_direct_connect_v2 data source currently only supports lookup by id. There is no way to reference an existing Direct Connect connection by its name, which is the more common identifier in Terraform configurations across environments.


Issue for this PR #3401 
 
## PR Checklist

* [x] Refers to: #3401
* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestDirectConnectV2Datasource_basic
--- PASS: TestDirectConnectV2Datasource_basic (76.43s)
=== RUN   TestDirectConnectV2Datasource_byName
--- PASS: TestDirectConnectV2Datasource_byName (81.26s)
=== RUN   TestDirectConnectV2Datasource_byNameMultiple
--- PASS: TestDirectConnectV2Datasource_byNameMultiple (48.85s)
=== RUN   TestDirectConnectV2Datasource_nameNotFound
--- PASS: TestDirectConnectV2Datasource_nameNotFound (21.75s)
=== RUN   TestDirectConnectV2Datasource_idAndName
--- PASS: TestDirectConnectV2Datasource_idAndName (21.05s)
=== RUN   TestDirectConnectV2Datasource_noFilter
--- PASS: TestDirectConnectV2Datasource_noFilter (20.12s)
PASS
```
