### PR TITLE
[Fix] OBS: Enable SSL verification for internal OBS client

### DIFF
--- a/opentelekomcloud/common/cfg/config.go
+++ b/opentelekomcloud/common/cfg/config.go
@@ -664,7 +664,7 @@ func (c *Config) NewObjectStorageClient(region string) (*obs.ObsClient, error) {
 
 	return obs.New(
 		cred.AccessKey, cred.SecretKey, client.Endpoint,
-		obs.WithSecurityToken(cred.SecurityToken), obs.WithSignature(obs.SignatureObs), proxyConfigure,
+		obs.WithSecurityToken(cred.SecurityToken), obs.WithSignature(obs.SignatureObs), obs.WithSslVerify(!c.Insecure), proxyConfigure,
 	)
 }
 

--- a/releasenotes/notes/obs-ssl-verify-57466ef04cd4b0be.yaml
+++ b/releasenotes/notes/obs-ssl-verify-57466ef04cd4b0be.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **OBS:** Enable SSL verification for internal OBS client based on provider ``insecure`` setting (`#3404 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3404>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Internal OBS client was created without specifying `sslVerify` which defaults to `false`, meaning SSL certificates were silently skipped for all OBS operations.

This change passes existing provider setting `insecure` to OBS client aligning its behaviour with all provider clients.

## PR Checklist

* [x] Refers to: #3390
* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccOBSBucketAcl_basic
=== PAUSE TestAccOBSBucketAcl_basic
=== CONT  TestAccOBSBucketAcl_basic
--- PASS: TestAccOBSBucketAcl_basic (58.34s)
PASS

Process finished with the exit code 0
```
