### PR TITLE
[Feat] VPC: Add attr subnet_id_v6 to subnets

### DIFF
--- a/docs/data-sources/vpc_subnet_v1.md
+++ b/docs/data-sources/vpc_subnet_v1.md
@@ -67,4 +67,6 @@ the selected subnet.
 
 * `subnet_id` - Specifies the OpenStack subnet ID.
 
+* `subnet_id_v6` - Specifies the OpenStack IPv6 subnet ID. Only returned if subnet is IPV6 enabled.
+
 * `network_id` - Specifies the OpenStack network ID.

--- a/docs/resources/vpc_subnet_v1.md
+++ b/docs/resources/vpc_subnet_v1.md
@@ -127,6 +127,8 @@ All the argument attributes are also exported as result attributes:
 
 * `subnet_id` - Specifies the OpenStack subnet ID.
 
+* `subnet_id_v6` - Specifies the OpenStack IPv6 subnet ID. Only returned if subnet is IPV6 enabled.
+
 * `network_id` - Specifies the OpenStack network ID.
 
 * `cidr_v6` - Specifies the IPv6 subnet CIDR block. If the subnet is an IPv4 subnet, this parameter is not returned.

--- a/opentelekomcloud/acceptance/vpc/data_source_opentelekomcloud_vpc_subnet_v1_test.go
+++ b/opentelekomcloud/acceptance/vpc/data_source_opentelekomcloud_vpc_subnet_v1_test.go
@@ -37,6 +37,8 @@ func TestAccVpcSubnetV1DataSource_basic(t *testing.T) {
 						"10.0.1.1", "eu-de-02"),
 					resource.TestCheckResourceAttr(dataSourceNameByID, "status", "ACTIVE"),
 					resource.TestCheckResourceAttr(dataSourceNameByID, "dhcp_enable", "true"),
+					resource.TestCheckResourceAttr(dataSourceNameByID, "ipv6_enable", "true"),
+					resource.TestCheckResourceAttrSet(dataSourceNameByID, "subnet_id_v6"),
 				),
 			},
 		},
@@ -90,6 +92,7 @@ resource "opentelekomcloud_vpc_subnet_v1" "subnet_1" {
   gateway_ip        = "10.0.1.1"
   vpc_id            = opentelekomcloud_vpc_v1.vpc_1.id
   availability_zone = "eu-de-02"
+  ipv6_enable       = true
 }
 
 data "opentelekomcloud_vpc_subnet_v1" "by_id" {

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_vpc_subnet_v1_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_vpc_subnet_v1_test.go
@@ -115,6 +115,7 @@ func TestAccVpcSubnetV1Ipv6(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVpcSubnetV1Exists(resourceVPCSubnetName, &subnet),
 					resource.TestCheckResourceAttr(resourceVPCSubnetName, "ipv6_enable", "true"),
+					resource.TestCheckResourceAttrSet(resourceVPCSubnetName, "subnet_id_v6"),
 				),
 			},
 		},

--- a/opentelekomcloud/services/vpc/data_source_opentelekomcloud_vpc_subnet_v1.go
+++ b/opentelekomcloud/services/vpc/data_source_opentelekomcloud_vpc_subnet_v1.go
@@ -96,6 +96,10 @@ func DataSourceVpcSubnetV1() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"subnet_id_v6": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"network_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -153,6 +157,7 @@ func dataSourceVpcSubnetV1Read(_ context.Context, d *schema.ResourceData, meta i
 		d.Set("availability_zone", subnet.AvailabilityZone),
 		d.Set("vpc_id", subnet.VpcID),
 		d.Set("subnet_id", subnet.SubnetID),
+		d.Set("subnet_id_v6", subnet.SubnetIDV6),
 		d.Set("network_id", subnet.NetworkID),
 		d.Set("ipv6_enable", subnet.EnableIpv6),
 		d.Set("cidr_ipv6", subnet.CidrV6),

--- a/opentelekomcloud/services/vpc/resource_opentelekomcloud_vpc_subnet_v1.go
+++ b/opentelekomcloud/services/vpc/resource_opentelekomcloud_vpc_subnet_v1.go
@@ -78,7 +78,6 @@ func ResourceVpcSubnetV1() *schema.Resource {
 			"ipv6_enable": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				ForceNew: true,
 			},
 			"primary_dns": {
 				Type:         schema.TypeString,
@@ -114,6 +113,10 @@ func ResourceVpcSubnetV1() *schema.Resource {
 				Optional: true,
 			},
 			"subnet_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"subnet_id_v6": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -234,6 +237,7 @@ func resourceVpcSubnetV1Read(ctx context.Context, d *schema.ResourceData, meta i
 		d.Set("availability_zone", subnet.AvailabilityZone),
 		d.Set("vpc_id", subnet.VpcID),
 		d.Set("subnet_id", subnet.SubnetID),
+		d.Set("subnet_id_v6", subnet.SubnetIDV6),
 		d.Set("network_id", subnet.NetworkID),
 		d.Set("status", subnet.Status),
 		d.Set("region", config.GetRegion(d)),
@@ -287,6 +291,10 @@ func resourceVpcSubnetV1Update(ctx context.Context, d *schema.ResourceData, meta
 	if d.HasChange("dhcp_enable") {
 		enableDHCP := d.Get("dhcp_enable").(bool)
 		updateOpts.EnableDHCP = &enableDHCP
+	}
+	if d.HasChange("ipv6_enable") {
+		enableIPV6 := d.Get("ipv6_enable").(bool)
+		updateOpts.EnableIpv6 = &enableIPV6
 	}
 	if d.HasChange("ntp_addresses") {
 		var extraDhcpRequests []subnets.ExtraDHCPOpt

--- a/releasenotes/notes/vpc-update-subnet-v1-attr-3d285b3f2cbfb0e4.yaml
+++ b/releasenotes/notes/vpc-update-subnet-v1-attr-3d285b3f2cbfb0e4.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    **[VPC]** Add `subnet_id_v6` attribute in ``resource/opentelekomcloud_vpc_subnet_v1`` (`#3412 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3412>`_)
+  - |
+    **[VPC]** Add `subnet_id_v6` attribute in ``data/opentelekomcloud_vpc_subnet_v1`` (`#3412 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3412>`_)


### PR DESCRIPTION
## Summary of the Pull Request

Added attribute `subnet_id_v6` to
- `data_opentelekomcloud_vpc_subnet_v1`
- `resource_opentelekomcloud_vpc_subnet_v1` 

## PR Checklist

* [x] Refers to: #3377 
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccVpcSubnetV1Ipv6
=== PAUSE TestAccVpcSubnetV1Ipv6
=== CONT  TestAccVpcSubnetV1Ipv6
--- PASS: TestAccVpcSubnetV1Ipv6 (70.71s)
PASS
=== RUN   TestAccVpcSubnetV1DataSource_basic
=== PAUSE TestAccVpcSubnetV1DataSource_basic
=== CONT  TestAccVpcSubnetV1DataSource_basic
--- PASS: TestAccVpcSubnetV1DataSource_basic (75.14s)
PASS
```
