### PR TITLE
[Fix] FGS: Allow disabling function initialization

### DIFF
--- a/docs/resources/fgs_function_v2.md
+++ b/docs/resources/fgs_function_v2.md
@@ -295,6 +295,7 @@ The following arguments are supported:
 * `description` - (Optional, String) Specifies the description of the function.
 
 * `initializer_handler` - (Optional, String) Specifies the initializer of the function.
+  Removing this argument (together with `initializer_timeout`) disables the function initialization.
 
 * `initializer_timeout` - (Optional, Int) Specifies the maximum duration the function can be initialized. Value range:
   1s to 300s.

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.9.8-0.20260602172432-0f847c46a7f5
+	github.com/opentelekomcloud/gophertelekomcloud v0.9.8-0.20260605123338-3310648de98f
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.46.0
 	golang.org/x/sync v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -167,8 +167,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.8-0.20260602172432-0f847c46a7f5 h1:L2iH38hvMXxn9NmYial7kBGYvwSmNZCtqZgadznxt6Q=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.8-0.20260602172432-0f847c46a7f5/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.8-0.20260605123338-3310648de98f h1:BSvQwUCpVYQqIOmjwzUXZzl41aV8S7VyuPYuoCvJSSU=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.8-0.20260605123338-3310648de98f/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/opentelekomcloud/acceptance/fgs/resource_opentelekomcloud_fgs_function_v2_test.go
+++ b/opentelekomcloud/acceptance/fgs/resource_opentelekomcloud_fgs_function_v2_test.go
@@ -162,7 +162,7 @@ func TestAccFgsV2Function_createByImage(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc1.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName1, "name", randName+"_1"),
-					resource.TestCheckResourceAttr(rName1, "agency", "functiongraph_swr_trust"),
+					resource.TestCheckResourceAttr(rName1, "agency", "fg_agency"),
 					resource.TestCheckResourceAttr(rName1, "runtime", "Custom Image"),
 					resource.TestCheckResourceAttr(rName1, "handler", "-"),
 					resource.TestCheckResourceAttr(rName1, "custom_image.0.url", common.OTC_BUILD_IMAGE_URL),
@@ -171,7 +171,7 @@ func TestAccFgsV2Function_createByImage(t *testing.T) {
 					resource.TestCheckResourceAttrSet(rName1, "peering_cidr"),
 					rc2.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName2, "name", randName+"_2"),
-					resource.TestCheckResourceAttr(rName2, "agency", "functiongraph_swr_trust"),
+					resource.TestCheckResourceAttr(rName2, "agency", "fg_agency"),
 					resource.TestCheckResourceAttr(rName2, "runtime", "Custom Image"),
 					resource.TestCheckResourceAttr(rName2, "handler", "-"),
 					resource.TestCheckResourceAttr(rName2, "custom_image.0.url", common.OTC_BUILD_IMAGE_URL),
@@ -455,7 +455,7 @@ resource "opentelekomcloud_fgs_function_v2" "create_with_vpc_access" {
   memory_size = 128
   runtime     = "Custom Image"
   timeout     = 3
-  agency      = "functiongraph_swr_trust"
+  agency      = "fg_agency"
   code_type   = "Custom-Image-Swr"
 
   custom_image {
@@ -474,7 +474,7 @@ resource "opentelekomcloud_fgs_function_v2" "create_without_vpc_access" {
   memory_size = 128
   runtime     = "Custom Image"
   timeout     = 3
-  agency      = "functiongraph_swr_trust"
+  agency      = "fg_agency"
   code_type   = "Custom-Image-Swr"
 
   custom_image {
@@ -499,7 +499,7 @@ resource "opentelekomcloud_fgs_function_v2" "create_with_vpc_access" {
   memory_size = 128
   runtime     = "Custom Image"
   timeout     = 3
-  agency      = "functiongraph_swr_trust"
+  agency      = "fg_agency"
   code_type   = "Custom-Image-Swr"
 
   custom_image {
@@ -518,7 +518,7 @@ resource "opentelekomcloud_fgs_function_v2" "create_without_vpc_access" {
   memory_size = 128
   runtime     = "Custom Image"
   timeout     = 3
-  agency      = "functiongraph_swr_trust"
+  agency      = "fg_agency"
   code_type   = "Custom-Image-Swr"
 
   custom_image {
@@ -1111,4 +1111,116 @@ resource "opentelekomcloud_fgs_function_v2" "test" {
   enable_class_isolation = true
 }
 `, name)
+}
+
+func TestAccFgsV2Function_initializer(t *testing.T) {
+	var f function.FuncGraph
+	randName := fmt.Sprintf("fgs-acc-%s", acctest.RandString(5))
+	resourceName := "opentelekomcloud_fgs_function_v2.test"
+
+	rc := common.InitResourceCheck(
+		resourceName,
+		&f,
+		getResourceObj,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFgsV2Function_initializer(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "initializer_handler", "index.initializer"),
+					resource.TestCheckResourceAttr(resourceName, "initializer_timeout", "30"),
+				),
+			},
+			{
+				// Removing the initializer arguments must disable the function initialization.
+				Config: testAccFgsV2Function_initializerDisabled(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "initializer_handler", ""),
+					resource.TestCheckResourceAttr(resourceName, "initializer_timeout", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"app",
+					"func_code",
+				},
+			},
+		},
+	})
+}
+
+func testAccFgsV2Function_initializer(rName string) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_fgs_function_v2" "test" {
+  name                = "%s"
+  app                 = "default"
+  description         = "function initializer test"
+  handler             = "index.handler"
+  memory_size         = 128
+  timeout             = 3
+  runtime             = "Python2.7"
+  code_type           = "inline"
+  initializer_handler = "index.initializer"
+  initializer_timeout = 30
+
+  func_code = <<EOF
+# -*- coding:utf-8 -*-
+import json
+def initializer(context):
+    return
+
+def handler (event, context):
+    return {
+        "statusCode": 200,
+        "isBase64Encoded": False,
+        "body": json.dumps(event),
+        "headers": {
+            "Content-Type": "application/json"
+        }
+    }
+EOF
+}
+`, rName)
+}
+
+func testAccFgsV2Function_initializerDisabled(rName string) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_fgs_function_v2" "test" {
+  name        = "%s"
+  app         = "default"
+  description = "function initializer test"
+  handler     = "index.handler"
+  memory_size = 128
+  timeout     = 3
+  runtime     = "Python2.7"
+  code_type   = "inline"
+
+  func_code = <<EOF
+# -*- coding:utf-8 -*-
+import json
+def initializer(context):
+    return
+
+def handler (event, context):
+    return {
+        "statusCode": 200,
+        "isBase64Encoded": False,
+        "body": json.dumps(event),
+        "headers": {
+            "Content-Type": "application/json"
+        }
+    }
+EOF
+}
+`, rName)
 }

--- a/opentelekomcloud/services/fgs/resource_opentelekomcloud_fgs_function_v2.go
+++ b/opentelekomcloud/services/fgs/resource_opentelekomcloud_fgs_function_v2.go
@@ -130,12 +130,10 @@ func ResourceFgsFunctionV2() *schema.Resource {
 			"initializer_handler": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Computed: true,
 			},
 			"initializer_timeout": {
 				Type:     schema.TypeInt,
 				Optional: true,
-				Computed: true,
 			},
 			"enterprise_project_id": {
 				Type:     schema.TypeString,

--- a/releasenotes/notes/fgs-fix-disable-initializer-function-v2-c32141c29484ca52.yaml
+++ b/releasenotes/notes/fgs-fix-disable-initializer-function-v2-c32141c29484ca52.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    **[FGS]** Allow disabling function initialization by removing the `initializer_handler` and `initializer_timeout` arguments from
+    ``resource/opentelekomcloud_fgs_function_v2`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)

--- a/releasenotes/notes/fgs-fix-disable-initializer-function-v2-c32141c29484ca52.yaml
+++ b/releasenotes/notes/fgs-fix-disable-initializer-function-v2-c32141c29484ca52.yaml
@@ -2,4 +2,4 @@
 fixes:
   - |
     **[FGS]** Allow disabling function initialization by removing the `initializer_handler` and `initializer_timeout` arguments from
-    ``resource/opentelekomcloud_fgs_function_v2`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    ``resource/opentelekomcloud_fgs_function_v2`` (`#3413 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3413>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Fixes the inability to disable function initialization for `opentelekomcloud_fgs_function_v2`.

## PR Checklist

* [x] Refers to: #3403
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccFgsV2Function_basic
=== PAUSE TestAccFgsV2Function_basic
=== CONT  TestAccFgsV2Function_basic
--- PASS: TestAccFgsV2Function_basic (108.07s)
=== RUN   TestAccFgsV2Function_text
=== PAUSE TestAccFgsV2Function_text
=== CONT  TestAccFgsV2Function_text
--- PASS: TestAccFgsV2Function_text (36.40s)
=== RUN   TestAccFgsV2Function_createByImage
=== PAUSE TestAccFgsV2Function_createByImage
=== CONT  TestAccFgsV2Function_createByImage
--- PASS: TestAccFgsV2Function_createByImage (69.36s)
=== RUN   TestAccFgsV2Function_logConfig
=== PAUSE TestAccFgsV2Function_logConfig
=== CONT  TestAccFgsV2Function_logConfig
--- PASS: TestAccFgsV2Function_logConfig (54.18s)
=== RUN   TestAccFgsV2Function_strategy
=== PAUSE TestAccFgsV2Function_strategy
=== CONT  TestAccFgsV2Function_strategy
--- PASS: TestAccFgsV2Function_strategy (110.83s)
=== RUN   TestAccFgsV2Function_versions
=== PAUSE TestAccFgsV2Function_versions
=== CONT  TestAccFgsV2Function_versions
--- PASS: TestAccFgsV2Function_versions (75.79s)
=== RUN   TestAccFgsV2Function_reservedInstance_version
=== PAUSE TestAccFgsV2Function_reservedInstance_version
=== CONT  TestAccFgsV2Function_reservedInstance_version
--- PASS: TestAccFgsV2Function_reservedInstance_version (60.00s)
=== RUN   TestAccFgsV2Function_reservedInstance_alias
=== PAUSE TestAccFgsV2Function_reservedInstance_alias
=== CONT  TestAccFgsV2Function_reservedInstance_alias
--- PASS: TestAccFgsV2Function_reservedInstance_alias (59.22s)
=== RUN   TestAccFgsV2Function_EnableDynamicMemory
=== PAUSE TestAccFgsV2Function_EnableDynamicMemory
=== CONT  TestAccFgsV2Function_EnableDynamicMemory
--- PASS: TestAccFgsV2Function_EnableDynamicMemory (30.96s)
=== RUN   TestAccFgsV2Function_initializer
=== PAUSE TestAccFgsV2Function_initializer
=== CONT  TestAccFgsV2Function_initializer
--- PASS: TestAccFgsV2Function_initializer (58.38s)
PASS

Process finished with the exit code 0

```
