### PR TITLE
[Fix] LTS: fix tags update for `opentelekomcloud_lts_host_group_v3`

### DIFF
--- a/opentelekomcloud/acceptance/lts/resource_opentelekomcloud_lts_host_group_v3_test.go
+++ b/opentelekomcloud/acceptance/lts/resource_opentelekomcloud_lts_host_group_v3_test.go
@@ -2,6 +2,7 @@ package acceptance
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -94,6 +95,72 @@ func TestAccHostGroup_basic(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccHostGroup_labelUpdateTags(t *testing.T) {
+	clusterID := os.Getenv("OS_CLUSTER_ID")
+	if clusterID == "" {
+		t.Skip("OS_CLUSTER_ID must be set for this acceptance test")
+	}
+	var (
+		group hg.HostGroupResponse
+		rName = "opentelekomcloud_lts_host_group_v3.hg"
+		name  = fmt.Sprintf("lts_group%s", acctest.RandString(3))
+		rc    = common.InitResourceCheck(rName, &group, getHostGroupResourceFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+		},
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testHostGroup_labelWithHosts(name, clusterID, "dev"),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "type", "linux"),
+					resource.TestCheckResourceAttr(rName, "agent_access_type", "LABEL"),
+					resource.TestCheckResourceAttr(rName, "tags.Environment", "dev"),
+				),
+			},
+			{
+				Config: testHostGroup_labelWithHosts(name, clusterID, "prod"),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "tags.Environment", "prod"),
+				),
+			},
+		},
+	})
+}
+
+func testHostGroup_labelWithHosts(name, clusterID, env string) string {
+	return fmt.Sprintf(`
+variable "tags" {
+  type = map(string)
+  default = {
+    Environment  = "%[3]s"
+    ManagedBy    = "terraform"
+    Project      = "test"
+    Purpose      = "development"
+    Team         = "terraform"
+  }
+}
+
+resource "opentelekomcloud_lts_host_group_v3" "hg" {
+  name              = "k8s-log-%[2]s"
+  type              = "linux"
+  agent_access_type = "LABEL"
+  labels            = toset(["k8s-log-%[2]s"])
+  tags              = var.tags
+
+  lifecycle {
+    ignore_changes = [host_ids]
+  }
+}
+`, name, clusterID, env)
 }
 
 func testHostGroup_basic(name string) string {

--- a/opentelekomcloud/acceptance/lts/resource_opentelekomcloud_lts_host_group_v3_test.go
+++ b/opentelekomcloud/acceptance/lts/resource_opentelekomcloud_lts_host_group_v3_test.go
@@ -141,11 +141,11 @@ func testHostGroup_labelWithHosts(name, clusterID, env string) string {
 variable "tags" {
   type = map(string)
   default = {
-    Environment  = "%[3]s"
-    ManagedBy    = "terraform"
-    Project      = "test"
-    Purpose      = "development"
-    Team         = "terraform"
+    Environment = "%[3]s"
+    ManagedBy   = "terraform"
+    Project     = "test"
+    Purpose     = "development"
+    Team        = "terraform"
   }
 }
 

--- a/opentelekomcloud/services/lts/resource_opentelekomcloud_lts_host_group_v3.go
+++ b/opentelekomcloud/services/lts/resource_opentelekomcloud_lts_host_group_v3.go
@@ -202,34 +202,40 @@ func resourceHostGroupV3Update(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	if d.HasChanges(updateHostGroupChanges...) {
-		if v, ok := d.GetOk("host_ids"); ok {
-			stateConf := &resource.StateChangeConf{
-				Pending: []string{"pending"},
-				Target:  []string{"running"},
-				Refresh: waitForHostActive(client, common.ExpandToStringListBySet(v.(*schema.Set))),
-				Timeout: d.Timeout(schema.TimeoutCreate),
-				Delay:   10 * time.Second,
-			}
-
-			_, err := stateConf.WaitForStateContext(ctx)
-			if err != nil {
-				return fmterr.Errorf("error waiting for OpenTelekomCloud ECS host icagent to be active: %w", err)
-			}
-		}
-		h := common.ExpandToStringListBySet(d.Get("host_ids").(*schema.Set))
-		tagSlice := ltsTags(d)
-		if tagSlice == nil {
-			tagSlice = []tags.ResourceTag{}
-		}
-		l := common.ExpandToStringListBySet(d.Get("labels").(*schema.Set))
 		updateOpts := hg.UpdateLogGroupOpts{
-			ID:         d.Id(),
-			HostIdList: &h,
-			Labels:     &l,
-			Tags:       &tagSlice,
+			ID: d.Id(),
+		}
+		if d.HasChange("host_ids") {
+			if v, ok := d.GetOk("host_ids"); ok {
+				stateConf := &resource.StateChangeConf{
+					Pending: []string{"pending"},
+					Target:  []string{"running"},
+					Refresh: waitForHostActive(client, common.ExpandToStringListBySet(v.(*schema.Set))),
+					Timeout: d.Timeout(schema.TimeoutCreate),
+					Delay:   10 * time.Second,
+				}
+
+				_, err := stateConf.WaitForStateContext(ctx)
+				if err != nil {
+					return fmterr.Errorf("error waiting for OpenTelekomCloud ECS host icagent to be active: %w", err)
+				}
+			}
+			h := common.ExpandToStringListBySet(d.Get("host_ids").(*schema.Set))
+			updateOpts.HostIdList = &h
 		}
 		if d.HasChange("name") {
 			updateOpts.Name = d.Get("name").(string)
+		}
+		if d.HasChange("tags") {
+			tagSlice := ltsTags(d)
+			if tagSlice == nil {
+				tagSlice = []tags.ResourceTag{}
+			}
+			updateOpts.Tags = &tagSlice
+		}
+		if d.HasChange("labels") || d.Get("agent_access_type").(string) == "LABEL" {
+			l := common.ExpandToStringListBySet(d.Get("labels").(*schema.Set))
+			updateOpts.Labels = &l
 		}
 		_, err = hg.Update(client, updateOpts)
 		if err != nil {

--- a/releasenotes/notes/lts-host-group-label-update-fix-6adf76bf19794994.yaml
+++ b/releasenotes/notes/lts-host-group-label-update-fix-6adf76bf19794994.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[LTS]** Fix tags update for ``resource/opentelekomcloud_lts_host_group_v3`` when ``agent_access_type`` is ``LABEL`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)

--- a/releasenotes/notes/lts-host-group-label-update-fix-6adf76bf19794994.yaml
+++ b/releasenotes/notes/lts-host-group-label-update-fix-6adf76bf19794994.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    **[LTS]** Fix tags update for ``resource/opentelekomcloud_lts_host_group_v3`` when ``agent_access_type`` is ``LABEL`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[LTS]** Fix tags update for ``resource/opentelekomcloud_lts_host_group_v3`` when ``agent_access_type`` is ``LABEL`` (`#3419 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3419>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Fix tags update for `opentelekomcloud_lts_host_group_v3` by sending only changed fields in update request.

## PR Checklist

* [x] Refers to: #3397
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```

2026/06/09 17:06:10 [INFO] Building Swift S3 auth structure
2026/06/09 17:06:10 [INFO] Setting AWS metadata API timeout to 100ms
2026/06/09 17:06:12 [INFO] Ignoring AWS metadata API endpoint at default location as it doesn't return any instance-id
2026/06/09 17:06:12 [INFO] Swift S3 Auth provider used: "StaticProvider"
=== RUN   TestAccHostGroup_basic
=== PAUSE TestAccHostGroup_basic
=== CONT  TestAccHostGroup_basic
--- PASS: TestAccHostGroup_basic (321.77s)
PASS

Process finished with the exit code 0

=== RUN   TestAccHostGroup_labelUpdateTags
=== PAUSE TestAccHostGroup_labelUpdateTags
=== CONT  TestAccHostGroup_labelUpdateTags
--- PASS: TestAccHostGroup_labelUpdateTags (47.37s)
PASS

Process finished with the exit code 0
```
