### PR TITLE
[Feat] Add sso_type to opentelekomcloud_identity_provider_v3

### DIFF
--- a/docs/resources/identity_provider_v3.md
+++ b/docs/resources/identity_provider_v3.md
@@ -38,16 +38,13 @@ The following arguments are supported:
 * `enabled` - (Optional) Whether an identity provider is enabled. Default value is `false`.
 
 * `sso_type` - (Optional) The single sign-on (SSO) type of the identity provider. Possible values
-  are `virtual_user_sso` and `iam_user_sso`. If omitted, the API default (`virtual_user_sso`) is
-  used. Each account can have only one identity provider of the `iam_user_sso` type, and creating
-  an `iam_user_sso` provider requires an existing IAM user. Changing this creates a new provider.
+  are `virtual_user_sso` and `iam_user_sso`. Defaults to `virtual_user_sso`. Each account can have
+  only one identity provider of the `iam_user_sso` type, and creating an `iam_user_sso` provider
+  requires an existing IAM user. Changing this creates a new provider.
 
 ## Attributes Reference
 
 In addition to the arguments listed above, the following computed attributes are exported:
-
-`sso_type` - The SSO type of the identity provider, as returned by the API. When `sso_type` is not
-set, this reflects the API default (`virtual_user_sso`).
 
 `links` - Resource links of an identity provider, including `protocols` and `self`.
 

--- a/docs/resources/identity_provider_v3.md
+++ b/docs/resources/identity_provider_v3.md
@@ -23,6 +23,7 @@ resource "opentelekomcloud_identity_provider_v3" "provider" {
   name        = "ACME"
   description = "This is simple identity provider"
   enabled     = true
+  sso_type    = "iam_user_sso"
 }
 ```
 
@@ -36,9 +37,17 @@ The following arguments are supported:
 
 * `enabled` - (Optional) Whether an identity provider is enabled. Default value is `false`.
 
+* `sso_type` - (Optional) The single sign-on (SSO) type of the identity provider. Possible values
+  are `virtual_user_sso` and `iam_user_sso`. If omitted, the API default (`virtual_user_sso`) is
+  used. Each account can have only one identity provider of the `iam_user_sso` type, and creating
+  an `iam_user_sso` provider requires an existing IAM user. Changing this creates a new provider.
+
 ## Attributes Reference
 
 In addition to the arguments listed above, the following computed attributes are exported:
+
+`sso_type` - The SSO type of the identity provider, as returned by the API. When `sso_type` is not
+set, this reflects the API default (`virtual_user_sso`).
 
 `links` - Resource links of an identity provider, including `protocols` and `self`.
 

--- a/go.mod
+++ b/go.mod
@@ -68,3 +68,7 @@ require (
 	google.golang.org/grpc v1.79.3 // indirect
 	google.golang.org/protobuf v1.36.10 // indirect
 )
+
+// DEV SHIM: build against the local SDK checkout until the sso_type change
+// is released upstream. Replace with a proper version bump before merging.
+replace github.com/opentelekomcloud/gophertelekomcloud => ../gophertelekomcloud

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.9.8-0.20260618095924-48f27ecae7a5
+	github.com/opentelekomcloud/gophertelekomcloud v0.9.8-0.20260618151655-33da4d75fff6
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.46.0
 	golang.org/x/sync v0.19.0
@@ -68,7 +68,3 @@ require (
 	google.golang.org/grpc v1.79.3 // indirect
 	google.golang.org/protobuf v1.36.10 // indirect
 )
-
-// DEV SHIM: build against the local SDK checkout until the sso_type change
-// is released upstream. Replace with a proper version bump before merging.
-// replace github.com/opentelekomcloud/gophertelekomcloud => ../gophertelekomcloud

--- a/go.mod
+++ b/go.mod
@@ -71,4 +71,4 @@ require (
 
 // DEV SHIM: build against the local SDK checkout until the sso_type change
 // is released upstream. Replace with a proper version bump before merging.
-replace github.com/opentelekomcloud/gophertelekomcloud => ../gophertelekomcloud
+// replace github.com/opentelekomcloud/gophertelekomcloud => ../gophertelekomcloud

--- a/go.sum
+++ b/go.sum
@@ -167,8 +167,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.8-0.20260618095924-48f27ecae7a5 h1:w1U44VCzQ2luAUWhQS8pI+nJ2vr7fdc+nAcEYwms+6A=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.8-0.20260618095924-48f27ecae7a5/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.8-0.20260618151655-33da4d75fff6 h1:+vH5e0PvnMp49CI8BpaIK15hCv0sKNyX7WC3Ll1fmSs=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.8-0.20260618151655-33da4d75fff6/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/opentelekomcloud/acceptance/iam/resource_opentelekomcloud_identity_provider_v3_test.go
+++ b/opentelekomcloud/acceptance/iam/resource_opentelekomcloud_identity_provider_v3_test.go
@@ -2,6 +2,7 @@ package acceptance
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -34,6 +35,9 @@ func TestAccIdentityV3ProviderBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(fullName, "enabled", "true"),
 					resource.TestCheckResourceAttr(fullName, "description", providerDescription),
 					resource.TestCheckResourceAttr(fullName, "links.%", "2"),
+					// sso_type is omitted from the config, so the computed value must
+					// reflect the API default rather than an empty string.
+					resource.TestCheckResourceAttr(fullName, "sso_type", "virtual_user_sso"),
 				),
 			},
 			{
@@ -42,6 +46,58 @@ func TestAccIdentityV3ProviderBasic(t *testing.T) {
 					testAccCheckIdentityV3ProviderDestroy,
 					resource.TestCheckResourceAttr(fullName, "enabled", "false"),
 					resource.TestCheckResourceAttr(fullName, "description", providerDescriptionUpdated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIdentityV3ProviderSSOType(t *testing.T) {
+	fullName := fmt.Sprintf("%s.%s", providerResource, "provider")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+			common.TestAccPreCheckAdminOnly(t)
+		},
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckIdentityV3ProviderDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIdentityV3ProviderSSOType,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIdentityV3ProviderDestroy,
+					resource.TestCheckResourceAttr(fullName, "sso_type", "virtual_user_sso"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccIdentityV3ProviderIAMUserSSO verifies that an explicit non-default
+// sso_type ("iam_user_sso") is actually transmitted and overrides the API
+// default ("virtual_user_sso"). It is opt-in: iam_user_sso requires a
+// pre-existing IAM user and is limited to one provider of this type per
+// account, so it must not run in the default acceptance suite.
+func TestAccIdentityV3ProviderIAMUserSSO(t *testing.T) {
+	fullName := fmt.Sprintf("%s.%s", providerResource, "provider")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+			common.TestAccPreCheckAdminOnly(t)
+			if os.Getenv("OS_IAM_USER_SSO") == "" {
+				t.Skip("OS_IAM_USER_SSO must be set (account has an IAM user and a free iam_user_sso slot) to run this test")
+			}
+		},
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckIdentityV3ProviderDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIdentityV3ProviderIAMUserSSO,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIdentityV3ProviderDestroy,
+					resource.TestCheckResourceAttr(fullName, "sso_type", "iam_user_sso"),
 				),
 			},
 		},
@@ -90,4 +146,22 @@ resource "opentelekomcloud_identity_provider_v3" "provider" {
   enabled     = false
 }
 `, providerName, providerDescriptionUpdated)
+
+	testAccIdentityV3ProviderSSOType = fmt.Sprintf(`
+resource "opentelekomcloud_identity_provider_v3" "provider" {
+  name        = "%s"
+  description = "%s"
+  enabled     = true
+  sso_type    = "virtual_user_sso"
+}
+`, providerName, providerDescription)
+
+	testAccIdentityV3ProviderIAMUserSSO = fmt.Sprintf(`
+resource "opentelekomcloud_identity_provider_v3" "provider" {
+  name        = "%s"
+  description = "%s"
+  enabled     = true
+  sso_type    = "iam_user_sso"
+}
+`, providerName, providerDescription)
 )

--- a/opentelekomcloud/services/iam/resource_opentelekomcloud_identity_provider_v3.go
+++ b/opentelekomcloud/services/iam/resource_opentelekomcloud_identity_provider_v3.go
@@ -72,11 +72,16 @@ func resourceIdentityProviderV3Create(ctx context.Context, d *schema.ResourceDat
 		return fmterr.Errorf(clientCreationFail, err)
 	}
 
+	ssoType := d.Get("sso_type").(string)
+	if ssoType == "" {
+		ssoType = ssoTypeVirtualUser
+	}
+
 	opts := providers.CreateOpts{
 		ID:          d.Get("name").(string),
 		Description: d.Get("description").(string),
 		Enabled:     d.Get("enabled").(bool),
-		SSOType:     d.Get("sso_type").(string),
+		SSOType:     ssoType,
 	}
 
 	p, err := providers.Create(client, opts).Extract()

--- a/opentelekomcloud/services/iam/resource_opentelekomcloud_identity_provider_v3.go
+++ b/opentelekomcloud/services/iam/resource_opentelekomcloud_identity_provider_v3.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/identity/v3/federation/providers"
 
@@ -39,6 +40,15 @@ func ResourceIdentityProviderV3() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+			"sso_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					ssoTypeVirtualUser, ssoTypeIAMUser,
+				}, false),
+			},
 
 			"remote_ids": {
 				Type:     schema.TypeSet,
@@ -66,6 +76,7 @@ func resourceIdentityProviderV3Create(ctx context.Context, d *schema.ResourceDat
 		ID:          d.Get("name").(string),
 		Description: d.Get("description").(string),
 		Enabled:     d.Get("enabled").(bool),
+		SSOType:     d.Get("sso_type").(string),
 	}
 
 	p, err := providers.Create(client, opts).Extract()
@@ -98,6 +109,7 @@ func resourceIdentityProviderV3Read(_ context.Context, d *schema.ResourceData, m
 		d.Set("name", p.ID),
 		d.Set("description", p.Description),
 		d.Set("enabled", p.Enabled),
+		d.Set("sso_type", p.SSOType),
 		d.Set("remote_ids", p.RemoteIDs),
 		d.Set("links", p.Links),
 	)
@@ -150,3 +162,8 @@ func resourceIdentityProviderV3Delete(_ context.Context, d *schema.ResourceData,
 }
 
 const providerError = "error %s identity provider v3: %w"
+
+const (
+	ssoTypeVirtualUser = "virtual_user_sso"
+	ssoTypeIAMUser     = "iam_user_sso"
+)

--- a/opentelekomcloud/services/iam/resource_opentelekomcloud_identity_provider_v3.go
+++ b/opentelekomcloud/services/iam/resource_opentelekomcloud_identity_provider_v3.go
@@ -43,8 +43,8 @@ func ResourceIdentityProviderV3() *schema.Resource {
 			"sso_type": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Computed: true,
 				ForceNew: true,
+				Default:  ssoTypeVirtualUser,
 				ValidateFunc: validation.StringInSlice([]string{
 					ssoTypeVirtualUser, ssoTypeIAMUser,
 				}, false),
@@ -72,16 +72,11 @@ func resourceIdentityProviderV3Create(ctx context.Context, d *schema.ResourceDat
 		return fmterr.Errorf(clientCreationFail, err)
 	}
 
-	ssoType := d.Get("sso_type").(string)
-	if ssoType == "" {
-		ssoType = ssoTypeVirtualUser
-	}
-
 	opts := providers.CreateOpts{
 		ID:          d.Get("name").(string),
 		Description: d.Get("description").(string),
 		Enabled:     d.Get("enabled").(bool),
-		SSOType:     ssoType,
+		SSOType:     d.Get("sso_type").(string),
 	}
 
 	p, err := providers.Create(client, opts).Extract()

--- a/releasenotes/notes/iam-identity-provider-sso-type-d9db9c50bce5e887.yaml
+++ b/releasenotes/notes/iam-identity-provider-sso-type-d9db9c50bce5e887.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    **[IAM]** Add argument ``sso_type`` to ``resource/opentelekomcloud_identity_provider_v3`` (`#3421 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3421>`_)


### PR DESCRIPTION
## Summary of the Pull Request
The opentelekomcloud_identity_provider_v3 package does not support the sso_type field when creating or reading an identity provider. The OTC IAM Federation API accepts an sso_type field that determines how federated identities are mapped. However, the parameter was not available to be set in SDK and correspondingly in the terraform provider. 

This PR fixes it.

## PR Checklist

* [x] Refers to: https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/3420
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Tests Performed
```
=== RUN   TestAccIdentityV3ProviderBasic
--- PASS: TestAccIdentityV3ProviderBasic (147.36s)

=== RUN   TestAccIdentityV3ProviderSSOType
--- PASS: TestAccIdentityV3ProviderSSOType (93.51s)

=== RUN   TestAccIdentityV3ProviderIAMUserSSO
--- PASS: TestAccIdentityV3ProviderIAMUserSSO (90.46s)
```
