### PR TITLE
[Fix] Provider: Re-sign AK/SK requests on retry (init SignOptions after auth)

### DIFF
--- a/opentelekomcloud/common/cfg/config.go
+++ b/opentelekomcloud/common/cfg/config.go
@@ -535,13 +535,6 @@ func (c *Config) genClient(ao golangsdk.AuthOptionsProvider) (*golangsdk.Provide
 		OsDebug:    osDebug,
 		MaxRetries: c.MaxRetries,
 	}
-	if client.AKSKAuthOptions.AccessKey != "" {
-		signOpts := golangsdk.SignOptions{
-			AccessKey: client.AKSKAuthOptions.AccessKey,
-			SecretKey: client.AKSKAuthOptions.SecretKey,
-		}
-		rt.SignOptions = &signOpts
-	}
 
 	client.HTTPClient = http.Client{
 		Transport: rt,
@@ -558,6 +551,15 @@ func (c *Config) genClient(ao golangsdk.AuthOptionsProvider) (*golangsdk.Provide
 		err = openstack.Authenticate(client, ao)
 		if err != nil {
 			return nil, err
+		}
+	}
+
+	// AK/SK credentials are populated by openstack.Authenticate, so SignOptions
+	// must be set after it to re-sign requests on retry/redirect (#3392).
+	if client.AKSKAuthOptions.AccessKey != "" {
+		rt.SignOptions = &golangsdk.SignOptions{
+			AccessKey: client.AKSKAuthOptions.AccessKey,
+			SecretKey: client.AKSKAuthOptions.SecretKey,
 		}
 	}
 

--- a/opentelekomcloud/common/cfg/config_test.go
+++ b/opentelekomcloud/common/cfg/config_test.go
@@ -199,3 +199,37 @@ func TestRequestRetry(t *testing.T) {
 	t.Run("TestRequestSingleRetry", func(t *testing.T) { testRequestRetry(t, 1) })
 	t.Run("TestRequestZeroRetry", func(t *testing.T) { testRequestRetry(t, 0) })
 }
+
+// TestGenClientAKSKReSignOptions checks that SignOptions is set after AK/SK
+// authentication, so retried requests are re-signed instead of reusing a stale
+// signature (#3392).
+func TestGenClientAKSKReSignOptions(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	// AK/SK authentication lists the service catalog; an empty catalog is enough.
+	th.Mux.HandleFunc("/v3/auth/catalog", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, `{"catalog": []}`)
+	})
+
+	cfg := &Config{MaxRetries: 1}
+	// Ending the endpoint with /v3/ lets ChooseVersion skip version negotiation.
+	client, err := cfg.genClient(golangsdk.AKSKAuthOptions{
+		IdentityEndpoint: fmt.Sprintf("%sv3/", th.Endpoint()),
+		AccessKey:        "test-ak",
+		SecretKey:        "test-sk",
+		ProjectId:        "test-project-id",
+	})
+	th.CheckNoErr(t, err)
+
+	rt, ok := client.HTTPClient.Transport.(*RoundTripper)
+	th.AssertEquals(t, true, ok)
+
+	if rt.SignOptions == nil {
+		t.Fatal("expected RoundTripper.SignOptions to be set for AK/SK auth, got nil")
+	}
+	th.AssertEquals(t, "test-ak", rt.SignOptions.AccessKey)
+	th.AssertEquals(t, "test-sk", rt.SignOptions.SecretKey)
+}

--- a/releasenotes/notes/aksk-resign-after-auth-e6846421cdde9427.yaml
+++ b/releasenotes/notes/aksk-resign-after-auth-e6846421cdde9427.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    Fix AK/SK requests not being re-signed on retry, which caused ``signature expired`` errors when a request was retried after a connection timeout (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    Fix AK/SK requests not being re-signed on retry, which caused ``signature expired`` errors when a request was retried after a connection timeout (`#3422 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3422>`_)

--- a/releasenotes/notes/aksk-resign-after-auth-e6846421cdde9427.yaml
+++ b/releasenotes/notes/aksk-resign-after-auth-e6846421cdde9427.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix AK/SK requests not being re-signed on retry, which caused ``signature expired`` errors when a request was retried after a connection timeout (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Follow-up to #3399, which added re-signing of AK/SK requests on retry/redirect but never actually took effect.

`RoundTripper.SignOptions` was initialized from `client.AKSKAuthOptions` in `genClient` **before** `openstack.Authenticate()` was called. For AK/SK auth the credentials are only populated on the client *during* `Authenticate` (`v3AKSKAuth`), so at that point `AccessKey` was empty, `SignOptions` stayed `nil`, and the re-sign logic never ran.

## PR Checklist

* [x] Refers to: #3392
* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestGenClientAKSKReSignOptions
--- PASS: TestGenClientAKSKReSignOptions (0.00s)
PASS

Process finished with the exit code 0

```
