### PR TITLE
[Fix] `enable_auth_in_header` update in `opentelekomcloud_fgs_function_v2`

### DIFF
--- a/opentelekomcloud/acceptance/fgs/resource_opentelekomcloud_fgs_function_v2_test.go
+++ b/opentelekomcloud/acceptance/fgs/resource_opentelekomcloud_fgs_function_v2_test.go
@@ -174,6 +174,40 @@ func TestAccFgsV2Function_dependList(t *testing.T) {
 	})
 }
 
+func TestAccFgsV2Function_enableAuthInHeader(t *testing.T) {
+	var f function.FuncGraph
+	randName := fmt.Sprintf("fgs-acc-%s", acctest.RandString(5))
+	resourceName := "opentelekomcloud_fgs_function_v2.test"
+
+	rc := common.InitResourceCheck(
+		resourceName,
+		&f,
+		getResourceObj,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFgsV2Function_enableAuthInHeader(randName, true),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "enable_auth_in_header", "true"),
+				),
+			},
+			{
+				Config: testAccFgsV2Function_enableAuthInHeader(randName, false),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "enable_auth_in_header", "false"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccFgsV2Function_createByImage(t *testing.T) {
 	var f function.FuncGraph
 	randName := fmt.Sprintf("fgs-acc-%s", acctest.RandString(5))
@@ -516,6 +550,27 @@ resource "opentelekomcloud_fgs_function_v2" "test" {
   %[3]s
 }
 `, rName, description, dependListConfig)
+}
+
+func testAccFgsV2Function_enableAuthInHeader(rName string, enabled bool) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_fgs_function_v2" "test" {
+  name                  = "%[1]s"
+  app                   = "default"
+  description           = "function auth in header test"
+  handler               = "-"
+  memory_size           = 128
+  timeout               = 3
+  runtime               = "Custom Image"
+  agency                = "fg_agency"
+  code_type             = "Custom-Image-Swr"
+  enable_auth_in_header = %[2]t
+
+  custom_image {
+    url = "%[3]s"
+  }
+}
+`, rName, enabled, common.OTC_BUILD_IMAGE_URL)
 }
 
 func testAccFgsV2Function_createByImage_step_1(rName string) string {

--- a/opentelekomcloud/services/fgs/resource_opentelekomcloud_fgs_function_v2.go
+++ b/opentelekomcloud/services/fgs/resource_opentelekomcloud_fgs_function_v2.go
@@ -651,7 +651,7 @@ func resourceFgsFunctionV2Create(ctx context.Context, d *schema.ResourceData, me
 	urn := resourceFgsFunctionUrn(d.Id())
 	if d.HasChanges("vpc_id", "network_id", "peering_cidr", "func_mounts", "app_agency", "initializer_handler",
 		"initializer_timeout", "enable_class_isolation", "concurrency_num", "ephemeral_storage", "lts_custom_tag",
-		"restore_hook_timeout", "restore_hook_handler", "heartbeat_handler") {
+		"restore_hook_timeout", "restore_hook_handler", "heartbeat_handler", "enable_auth_in_header") {
 		err := resourceFgsFunctionMetadataUpdate(config, fgsClient, urn, d)
 		if err != nil {
 			return diag.FromErr(err)
@@ -1259,7 +1259,8 @@ func resourceFgsFunctionV2Update(ctx context.Context, d *schema.ResourceData, me
 		"user_data", "agency", "app_agency", "description", "initializer_handler", "initializer_timeout",
 		"vpc_id", "network_controller", "network_id", "mount_user_id", "mount_user_group_id", "func_mounts", "custom_image",
 		"log_group_id", "log_topic_id", "log_group_name", "log_topic_name", "gpu_memory", "gpu_type",
-		"pre_stop_handler", "pre_stop_timeout", "enable_dynamic_memory", "enable_lts_log", "concurrency_num") {
+		"pre_stop_handler", "pre_stop_timeout", "enable_dynamic_memory", "enable_lts_log", "concurrency_num",
+		"enable_auth_in_header") {
 		err := resourceFgsFunctionMetadataUpdate(config, fgsClient, urn, d)
 		if err != nil {
 			return diag.FromErr(err)

--- a/releasenotes/notes/fix-fgs-enable-auth-in-header-update-f96b58fde577fc24.yaml
+++ b/releasenotes/notes/fix-fgs-enable-auth-in-header-update-f96b58fde577fc24.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[FGS]** Update for attribute `enable_auth_in_header` in ``resource/opentelekomcloud_fgs_function_v2`` (`#3432 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3432>`_)


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [x] Refers to: #3429
* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccFgsV2Function_basic
=== PAUSE TestAccFgsV2Function_basic
=== CONT  TestAccFgsV2Function_basic
--- PASS: TestAccFgsV2Function_basic (107.52s)
=== RUN   TestAccFgsV2Function_text
=== PAUSE TestAccFgsV2Function_text
=== CONT  TestAccFgsV2Function_text
--- PASS: TestAccFgsV2Function_text (35.89s)
=== RUN   TestAccFgsV2Function_dependList
=== PAUSE TestAccFgsV2Function_dependList
=== CONT  TestAccFgsV2Function_dependList
--- PASS: TestAccFgsV2Function_dependList (71.10s)
=== RUN   TestAccFgsV2Function_enableAuthInHeader
=== PAUSE TestAccFgsV2Function_enableAuthInHeader
=== CONT  TestAccFgsV2Function_enableAuthInHeader
--- PASS: TestAccFgsV2Function_enableAuthInHeader (45.24s)
=== RUN   TestAccFgsV2Function_logConfig
=== PAUSE TestAccFgsV2Function_logConfig
=== CONT  TestAccFgsV2Function_logConfig
--- PASS: TestAccFgsV2Function_logConfig (51.51s)
=== RUN   TestAccFgsV2Function_strategy
=== PAUSE TestAccFgsV2Function_strategy
=== CONT  TestAccFgsV2Function_strategy
--- PASS: TestAccFgsV2Function_strategy (115.50s)
=== RUN   TestAccFgsV2Function_versions
=== PAUSE TestAccFgsV2Function_versions
=== CONT  TestAccFgsV2Function_versions
--- PASS: TestAccFgsV2Function_versions (78.21s)
=== RUN   TestAccFgsV2Function_reservedInstance_version
=== PAUSE TestAccFgsV2Function_reservedInstance_version
=== CONT  TestAccFgsV2Function_reservedInstance_version
--- PASS: TestAccFgsV2Function_reservedInstance_version (57.04s)
=== RUN   TestAccFgsV2Function_reservedInstance_alias
=== PAUSE TestAccFgsV2Function_reservedInstance_alias
=== CONT  TestAccFgsV2Function_reservedInstance_alias
--- PASS: TestAccFgsV2Function_reservedInstance_alias (54.35s)
=== RUN   TestAccFgsV2Function_EnableDynamicMemory
=== PAUSE TestAccFgsV2Function_EnableDynamicMemory
=== CONT  TestAccFgsV2Function_EnableDynamicMemory
--- PASS: TestAccFgsV2Function_EnableDynamicMemory (25.73s)
=== RUN   TestAccFgsV2Function_initializer
=== PAUSE TestAccFgsV2Function_initializer
=== CONT  TestAccFgsV2Function_initializer
--- PASS: TestAccFgsV2Function_initializer (51.45s)
PASS

Process finished with the exit code 0
```
