### PR TITLE
[Feat] CC: Add opentelekomcloud_cc_central_network_v3 resource

### DIFF
--- a/docs/resources/cc_central_network_v3.md
+++ b/docs/resources/cc_central_network_v3.md
@@ -1,0 +1,79 @@
+---
+subcategory: "Cloud Connect (CC)"
+layout: "opentelekomcloud"
+page_title: "OpenTelekomCloud: opentelekomcloud_cc_central_network_v3"
+sidebar_current: "docs-opentelekomcloud-resource-cc-central-network-v3"
+description: |-
+  Manages a Cloud Connect Central Network resource within OpenTelekomCloud.
+---
+
+Up-to-date reference of API arguments for Cloud Connect Central Network you can get at
+[documentation portal](https://docs.otc.t-systems.com/cloud-connect/api-ref/api/central_networks/index.html)
+
+# opentelekomcloud_cc_central_network_v3
+
+Manages a Cloud Connect (CC) central network resource within OpenTelekomCloud.
+
+A central network lets you connect enterprise routers from different regions and accounts so that they can
+communicate over a fully meshed network. It is the top-level container for central network policies and
+connections.
+
+-> The central network APIs are account-level (domain-scoped). Make sure the credentials used by the provider
+have permission to manage Cloud Connect resources.
+
+## Example Usage
+
+```hcl
+resource "opentelekomcloud_cc_central_network_v3" "test" {
+  name        = "central-network-demo"
+  description = "managed by terraform"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required, String) The name of the central network.
+  The name can contain 1 to 64 characters, only letters, digits, underscores (_) and hyphens (-) are allowed.
+
+* `description` - (Optional, String) The description of the central network.
+  The description can contain a maximum of 255 characters, and the angle brackets (`<` and `>`) are not allowed.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) The ID of the enterprise project that the central
+  network belongs to. Changing this parameter will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format. Equal to the central network ID.
+
+* `state` - The status of the central network. The value can be **AVAILABLE**, **CREATING**, **UPDATING**,
+  **FAILED**, **DELETING**, **DELETED** or **RESTORING**.
+
+* `default_plane_id` - The ID of the default central network plane.
+
+* `domain_id` - The ID of the account that the central network belongs to.
+
+* `created_at` - The creation time of the central network.
+
+* `updated_at` - The latest update time of the central network.
+
+* `region` - The region in which the central network is managed.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `update` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
+
+## Import
+
+The central network can be imported using the `id`, e.g.
+
+```
+$ terraform import opentelekomcloud_cc_central_network_v3.test 0ce123456a00f2591fabc00385ff1234
+```

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.9.8-0.20260618095924-48f27ecae7a5
+	github.com/opentelekomcloud/gophertelekomcloud v0.9.8-0.20260619093052-c1120d6d0559
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.46.0
 	golang.org/x/sync v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -167,8 +167,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.8-0.20260618095924-48f27ecae7a5 h1:w1U44VCzQ2luAUWhQS8pI+nJ2vr7fdc+nAcEYwms+6A=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.8-0.20260618095924-48f27ecae7a5/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.8-0.20260619093052-c1120d6d0559 h1:CupbcYUCWb9lylq+TiICIT6uIVcocAetQdG3fotx6IU=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.8-0.20260619093052-c1120d6d0559/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/opentelekomcloud/acceptance/cc/resource_opentelekomcloud_cc_central_network_v3_test.go
+++ b/opentelekomcloud/acceptance/cc/resource_opentelekomcloud_cc_central_network_v3_test.go
@@ -1,0 +1,88 @@
+package cc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/cc/v3/central_network"
+
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+)
+
+func getCentralNetworkResourceFunc(conf *cfg.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.CcV3Client(env.OS_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating OpenTelekomCloud CC v3 client: %s", err)
+	}
+	return central_network.Get(client, state.Primary.ID)
+}
+
+func TestAccCcCentralNetworkV3_basic(t *testing.T) {
+	var obj interface{}
+
+	name := fmt.Sprintf("cc_acc_cn_%s", acctest.RandString(5))
+	updateName := name + "_updated"
+	rName := "opentelekomcloud_cc_central_network_v3.test"
+
+	rc := common.InitResourceCheck(
+		rName,
+		&obj,
+		getCentralNetworkResourceFunc,
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCcCentralNetworkV3_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "created by terraform acceptance test"),
+					resource.TestCheckResourceAttr(rName, "state", "AVAILABLE"),
+					resource.TestCheckResourceAttrSet(rName, "domain_id"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "region"),
+				),
+			},
+			{
+				Config: testAccCcCentralNetworkV3_update(updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", updateName),
+					resource.TestCheckResourceAttr(rName, "description", "updated by terraform acceptance test"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCcCentralNetworkV3_basic(name string) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_cc_central_network_v3" "test" {
+  name        = "%s"
+  description = "created by terraform acceptance test"
+}
+`, name)
+}
+
+func testAccCcCentralNetworkV3_update(name string) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_cc_central_network_v3" "test" {
+  name        = "%s"
+  description = "updated by terraform acceptance test"
+}
+`, name)
+}

--- a/opentelekomcloud/common/cfg/config.go
+++ b/opentelekomcloud/common/cfg/config.go
@@ -1290,6 +1290,38 @@ func (c *Config) ErV3Client(region string) (*golangsdk.ServiceClient, error) {
 	})
 }
 
+func (c *Config) CcV3Client(_ string) (*golangsdk.ServiceClient, error) {
+	client, err := c.IdentityV3Client()
+	if err != nil {
+		return nil, err
+	}
+
+	parsedURL, err := url.Parse(client.Endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse IAM endpoint: %w", err)
+	}
+	re := regexp.MustCompile(`^[^.]+`)
+	parsedURL.Host = re.ReplaceAllString(parsedURL.Host, "cc")
+
+	client.Endpoint = parsedURL.String()
+	client.ResourceBase = client.Endpoint
+	client.Type = "cc"
+
+	domainID := c.DomainID
+	if domainID == "" {
+		domainID = c.DomainClient.DomainID
+	}
+	if domainID == "" {
+		domainID = c.DomainClient.AKSKAuthOptions.DomainID
+	}
+	if domainID == "" {
+		domainID = c.HwClient.DomainID
+	}
+	client.DomainID = domainID
+
+	return client, nil
+}
+
 func (c *Config) DwsV2Client(region string) (*golangsdk.ServiceClient, error) {
 	service, err := openstack.NewDWSV1(c.HwClient, golangsdk.EndpointOpts{
 		Region:       region,

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -13,6 +13,7 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/services/asm"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/services/bms"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/services/cbr"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/services/cc"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/services/cce"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/services/cci"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/services/ces"
@@ -487,6 +488,7 @@ func Provider() *schema.Provider {
 			"opentelekomcloud_blockstorage_volume_v2":                    evs.ResourceBlockStorageVolumeV2(),
 			"opentelekomcloud_cbr_policy_v3":                             cbr.ResourceCBRPolicyV3(),
 			"opentelekomcloud_cbr_vault_v3":                              cbr.ResourceCBRVaultV3(),
+			"opentelekomcloud_cc_central_network_v3":                     cc.ResourceCcCentralNetworkV3(),
 			"opentelekomcloud_cce_addon_v3":                              cce.ResourceCCEAddonV3(),
 			"opentelekomcloud_cce_cluster_v3":                            cce.ResourceCCEClusterV3(),
 			"opentelekomcloud_cce_node_attach_v3":                        cce.ResourceCCENodeV3Attach(),

--- a/opentelekomcloud/services/cc/common.go
+++ b/opentelekomcloud/services/cc/common.go
@@ -1,0 +1,6 @@
+package cc
+
+const (
+	errCreationV3Client = "error creating OpenTelekomCloud Cloud Connect v3 client: %w"
+	ccClientV3          = "cc-v3-client"
+)

--- a/opentelekomcloud/services/cc/resource_opentelekomcloud_cc_central_network_v3.go
+++ b/opentelekomcloud/services/cc/resource_opentelekomcloud_cc_central_network_v3.go
@@ -1,0 +1,237 @@
+package cc
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/cc/v3/central_network"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/pointerto"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
+)
+
+func ResourceCcCentralNetworkV3() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceCcCentralNetworkV3Create,
+		ReadContext:   resourceCcCentralNetworkV3Read,
+		UpdateContext: resourceCcCentralNetworkV3Update,
+		DeleteContext: resourceCcCentralNetworkV3Delete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"default_plane_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"domain_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"region": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceCcCentralNetworkV3Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, ccClientV3, func() (*golangsdk.ServiceClient, error) {
+		return config.CcV3Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV3Client, err)
+	}
+
+	createOpts := central_network.CreateOpts{
+		Name:                d.Get("name").(string),
+		Description:         d.Get("description").(string),
+		EnterpriseProjectId: d.Get("enterprise_project_id").(string),
+	}
+
+	created, err := central_network.Create(client, createOpts)
+	if err != nil {
+		return diag.Errorf("error creating OpenTelekomCloud CC central network: %s", err)
+	}
+
+	d.SetId(created.ID)
+
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      waitForCentralNetworkActive(client, d.Id()),
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		Delay:        5 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	if _, err = stateConf.WaitForStateContext(ctx); err != nil {
+		return fmterr.Errorf("error waiting for CC central network (%s) to become available: %s", d.Id(), err)
+	}
+
+	clientCtx := common.CtxWithClient(ctx, client, ccClientV3)
+	return resourceCcCentralNetworkV3Read(clientCtx, d, meta)
+}
+
+func resourceCcCentralNetworkV3Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, ccClientV3, func() (*golangsdk.ServiceClient, error) {
+		return config.CcV3Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV3Client, err)
+	}
+
+	cn, err := central_network.Get(client, d.Id())
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving OpenTelekomCloud CC central network")
+	}
+
+	mErr := multierror.Append(
+		nil,
+		d.Set("region", config.GetRegion(d)),
+		d.Set("name", cn.Name),
+		d.Set("description", cn.Description),
+		d.Set("enterprise_project_id", cn.EnterpriseProjectId),
+		d.Set("state", cn.State),
+		d.Set("default_plane_id", cn.DefaultPlaneId),
+		d.Set("domain_id", cn.DomainId),
+		d.Set("created_at", cn.CreatedAt),
+		d.Set("updated_at", cn.UpdatedAt),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceCcCentralNetworkV3Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, ccClientV3, func() (*golangsdk.ServiceClient, error) {
+		return config.CcV3Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV3Client, err)
+	}
+
+	if d.HasChanges("name", "description") {
+		updateOpts := central_network.UpdateOpts{
+			CentralNetworkId: d.Id(),
+			Name:             d.Get("name").(string),
+			Description:      pointerto.String(d.Get("description").(string)),
+		}
+		if _, err = central_network.Update(client, updateOpts); err != nil {
+			return diag.Errorf("error updating OpenTelekomCloud CC central network (%s): %s", d.Id(), err)
+		}
+	}
+
+	clientCtx := common.CtxWithClient(ctx, client, ccClientV3)
+	return resourceCcCentralNetworkV3Read(clientCtx, d, meta)
+}
+
+func resourceCcCentralNetworkV3Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, ccClientV3, func() (*golangsdk.ServiceClient, error) {
+		return config.CcV3Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV3Client, err)
+	}
+
+	if err = central_network.Delete(client, d.Id()); err != nil {
+		return common.CheckDeletedDiag(d, err, "error deleting OpenTelekomCloud CC central network")
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      waitForCentralNetworkDeleted(client, d.Id()),
+		Timeout:      d.Timeout(schema.TimeoutDelete),
+		Delay:        5 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	if _, err = stateConf.WaitForStateContext(ctx); err != nil {
+		return fmterr.Errorf("error waiting for CC central network (%s) to be deleted: %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func waitForCentralNetworkActive(client *golangsdk.ServiceClient, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		cn, err := central_network.Get(client, id)
+		if err != nil {
+			return nil, "", err
+		}
+		switch cn.State {
+		case "AVAILABLE":
+			return cn, "COMPLETED", nil
+		case "FAILED", "DELETED":
+			return cn, cn.State, fmt.Errorf("unexpected status (%s) for CC central network (%s)", cn.State, id)
+		default:
+			return cn, "PENDING", nil
+		}
+	}
+}
+
+func waitForCentralNetworkDeleted(client *golangsdk.ServiceClient, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		cn, err := central_network.Get(client, id)
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				log.Printf("[DEBUG] OpenTelekomCloud CC central network (%s) has been deleted", id)
+				return "deleted", "COMPLETED", nil
+			}
+			return nil, "", err
+		}
+		if cn.State == "DELETED" {
+			return cn, "COMPLETED", nil
+		}
+		if cn.State == "FAILED" {
+			return cn, cn.State, fmt.Errorf("unexpected status (%s) while deleting CC central network (%s)", cn.State, id)
+		}
+		return cn, "PENDING", nil
+	}
+}

--- a/releasenotes/notes/cc-central-network-v3-96ed35391551c938.yaml
+++ b/releasenotes/notes/cc-central-network-v3-96ed35391551c938.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   - |
-    **[Cloud Connect]** Added new resource ``opentelekomcloud_cc_central_network_v3``
+    **[Cloud Connect]** Added new resource ``opentelekomcloud_cc_central_network_v3`` (`#3433 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3433>`_)

--- a/releasenotes/notes/cc-central-network-v3-96ed35391551c938.yaml
+++ b/releasenotes/notes/cc-central-network-v3-96ed35391551c938.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    **[Cloud Connect]** Added new resource ``opentelekomcloud_cc_central_network_v3``


### PR DESCRIPTION
## Summary of the Pull Request
Adds the first Cloud Connect (CC) resource `opentelekomcloud_cc_central_network_v3` which manages account-level central networks.

## PR Checklist

* [x] Refers to: #3341
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccCcCentralNetworkV3_basic
--- PASS: TestAccCcCentralNetworkV3_basic (69.37s)
PASS

Process finished with the exit code 0

```
