### PR TITLE
[Feat.] Css update security mode update

### DIFF
--- a/docs/resources/css_cluster_v1.md
+++ b/docs/resources/css_cluster_v1.md
@@ -102,12 +102,10 @@ The following arguments are supported:
   By default, communication encryption is disabled.
   Value `true` indicates that communication encryption is performed on the cluster.
   Value `false` indicates that communication encryption is not performed on the cluster.
-  Changing this parameter will create a new resource.
 
 * `enable_authority` - (Optional, Bool) Whether to enable authentication.
   Authentication is disabled by default.
   When authentication is enabled, `enable_https` must be set to `true`.
-  Changing this parameter will create a new resource.
 
 * `admin_pass` - (Optional, String) Password of the cluster user admin in security mode.
   This parameter is mandatory only when `enable_authority` is set to `true`.

--- a/opentelekomcloud/acceptance/css/resource_opentelekomcloud_css_cluster_v1_test.go
+++ b/opentelekomcloud/acceptance/css/resource_opentelekomcloud_css_cluster_v1_test.go
@@ -114,7 +114,29 @@ func TestAccCssClusterV1_Opensearch(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCssClusterV1Exists(resourceClusterName, &cluster),
 					resource.TestCheckResourceAttr(resourceClusterName, "nodes.#", "1"),
-					resource.TestCheckResourceAttr(resourceClusterName, "datastore.0.version", "Opensearch_1.3.6"),
+					resource.TestCheckResourceAttr(resourceClusterName, "datastore.0.version", "2.19.0"),
+					resource.TestCheckResourceAttr(resourceClusterName, "enable_authority", "false"),
+					resource.TestCheckResourceAttr(resourceClusterName, "enable_https", "false"),
+				),
+			},
+			{
+				Config: testAccCssClusterV1Opensearch_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCssClusterV1Exists(resourceClusterName, &cluster),
+					resource.TestCheckResourceAttr(resourceClusterName, "nodes.#", "1"),
+					resource.TestCheckResourceAttr(resourceClusterName, "datastore.0.version", "2.19.0"),
+					resource.TestCheckResourceAttr(resourceClusterName, "enable_authority", "true"),
+					resource.TestCheckResourceAttr(resourceClusterName, "enable_https", "true"),
+				),
+			},
+			{
+				Config: testAccCssClusterV1Opensearch_update2(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCssClusterV1Exists(resourceClusterName, &cluster),
+					resource.TestCheckResourceAttr(resourceClusterName, "nodes.#", "1"),
+					resource.TestCheckResourceAttr(resourceClusterName, "datastore.0.version", "2.19.0"),
+					resource.TestCheckResourceAttr(resourceClusterName, "enable_authority", "true"),
+					resource.TestCheckResourceAttr(resourceClusterName, "enable_https", "false"),
 				),
 			},
 		},
@@ -264,14 +286,14 @@ resource "opentelekomcloud_css_cluster_v1" "cluster" {
   expect_node_num = 1
   name            = "%s"
   node_config {
-    flavor = "css.medium.8"
+    flavor = "css.xlarge.2"
     network_info {
       security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
       network_id        = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
       vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
     }
     volume {
-      volume_type = "COMMON"
+      volume_type = "HIGH"
       size        = 40
     }
 
@@ -295,21 +317,21 @@ resource "opentelekomcloud_css_cluster_v1" "cluster" {
   expect_node_num = 1
   name            = "%s"
   node_config {
-    flavor = "css.medium.8"
+    flavor = "css.xlarge.2"
     network_info {
       security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
       network_id        = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
       vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
     }
     volume {
-      volume_type = "COMMON"
+      volume_type = "HIGH"
       size        = 40
     }
 
     availability_zone = "%s"
   }
   datastore {
-    version = "7.6.2"
+    version = "7.10.2"
   }
   enable_https     = true
   enable_authority = true
@@ -338,21 +360,21 @@ resource "opentelekomcloud_css_cluster_v1" "cluster" {
   expect_node_num = 1
   name            = "%s"
   node_config {
-    flavor = "css.medium.8"
+    flavor = "css.xlarge.2"
     network_info {
       security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
       network_id        = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
       vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
     }
     volume {
-      volume_type = "COMMON"
+      volume_type = "HIGH"
       size        = 40
     }
 
     availability_zone = "%s"
   }
   datastore {
-    version = "7.6.2"
+    version = "7.10.2"
   }
   enable_https     = true
   enable_authority = true
@@ -382,21 +404,21 @@ resource "opentelekomcloud_css_cluster_v1" "cluster" {
   expect_node_num = 1
   name            = "%s"
   node_config {
-    flavor = "css.medium.8"
+    flavor = "css.xlarge.2"
     network_info {
       security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
       network_id        = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
       vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
     }
     volume {
-      volume_type = "COMMON"
+      volume_type = "HIGH"
       size        = 1
     }
 
     availability_zone = "%s"
   }
   datastore {
-    version = "7.6.2"
+    version = "7.10.2"
   }
   enable_https     = true
   enable_authority = true
@@ -415,21 +437,21 @@ resource "opentelekomcloud_css_cluster_v1" "cluster" {
   expect_node_num = 1
   name            = "%s"
   node_config {
-    flavor = "css.medium.8"
+    flavor = "css.xlarge.2"
     network_info {
       security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
       network_id        = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
       vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
     }
     volume {
-      volume_type = "COMMON"
+      volume_type = "HIGH"
       size        = 10000000
     }
 
     availability_zone = "%s"
   }
   datastore {
-    version = "7.6.2"
+    version = "7.10.2"
   }
   enable_https     = true
   enable_authority = true
@@ -455,14 +477,14 @@ resource "opentelekomcloud_css_cluster_v1" "cluster" {
       vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
     }
     volume {
-      volume_type = "COMMON"
+      volume_type = "HIGH"
       size        = 20
     }
 
     availability_zone = "%s"
   }
   datastore {
-    version = "7.6.2"
+    version = "7.10.2"
   }
   enable_https     = true
   enable_authority = true
@@ -481,21 +503,22 @@ resource "opentelekomcloud_css_cluster_v1" "cluster" {
   expect_node_num = 2
   name            = "%s"
   node_config {
-    flavor = "css.medium.8"
+    flavor = "css.xlarge.2"
     network_info {
       security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
       network_id        = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
       vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
     }
     volume {
-      volume_type = "COMMON"
+      volume_type = "HIGH"
       size        = 40
     }
 
     availability_zone = "%s"
   }
   datastore {
-    version = "7.6.2"
+    type    = "elasticsearch"
+    version = "7.10.2"
   }
   enable_https     = true
   enable_authority = true
@@ -514,21 +537,22 @@ resource "opentelekomcloud_css_cluster_v1" "cluster" {
   expect_node_num = 2
   name            = "%s"
   node_config {
-    flavor = "css.medium.8"
+    flavor = "css.xlarge.2"
     network_info {
       security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
       network_id        = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
       vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
     }
     volume {
-      volume_type = "COMMON"
+      volume_type = "HIGH"
       size        = 200
     }
 
     availability_zone = "%s"
   }
   datastore {
-    version = "7.6.2"
+    type    = "elasticsearch"
+    version = "7.10.2"
   }
   enable_https     = true
   enable_authority = true
@@ -554,7 +578,7 @@ resource "opentelekomcloud_css_cluster_v1" "cluster" {
       vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
     }
     volume {
-      volume_type    = "COMMON"
+      volume_type    = "HIGH"
       size           = 40
       encryption_key = "%s"
     }
@@ -562,7 +586,8 @@ resource "opentelekomcloud_css_cluster_v1" "cluster" {
     availability_zone = "%s"
   }
   datastore {
-    version = "7.6.2"
+    type    = "elasticsearch"
+    version = "7.10.2"
   }
   enable_https     = true
   enable_authority = true
@@ -581,23 +606,89 @@ resource "opentelekomcloud_css_cluster_v1" "cluster" {
   expect_node_num = 1
   name            = "%s"
   node_config {
-    flavor = "css.medium.8"
+    flavor = "css.xlarge.2"
     network_info {
       security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
       network_id        = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
       vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
     }
     volume {
-      volume_type = "COMMON"
+      volume_type = "HIGH"
       size        = 40
     }
 
     availability_zone = "%s"
   }
   datastore {
-    version = "Opensearch_1.3.6"
+    type    = "opensearch"
+    version = "2.19.0"
+  }
+}
+`, common.DataSourceSecGroupDefault, common.DataSourceSubnet, name, env.OS_AVAILABILITY_ZONE)
+}
+
+func testAccCssClusterV1Opensearch_update(name string) string {
+	return fmt.Sprintf(`
+%s
+
+%s
+
+resource "opentelekomcloud_css_cluster_v1" "cluster" {
+  expect_node_num = 1
+  name            = "%s"
+  node_config {
+    flavor = "css.xlarge.2"
+    network_info {
+      security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
+      network_id        = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+      vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+    }
+    volume {
+      volume_type = "HIGH"
+      size        = 40
+    }
+
+    availability_zone = "%s"
+  }
+  datastore {
+    type    = "opensearch"
+    version = "2.19.0"
   }
   enable_https     = true
+  enable_authority = true
+  admin_pass       = "QwertyUI!"
+}
+`, common.DataSourceSecGroupDefault, common.DataSourceSubnet, name, env.OS_AVAILABILITY_ZONE)
+}
+
+func testAccCssClusterV1Opensearch_update2(name string) string {
+	return fmt.Sprintf(`
+%s
+
+%s
+
+resource "opentelekomcloud_css_cluster_v1" "cluster" {
+  expect_node_num = 1
+  name            = "%s"
+  node_config {
+    flavor = "css.xlarge.2"
+    network_info {
+      security_group_id = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
+      network_id        = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+      vpc_id            = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+    }
+    volume {
+      volume_type = "HIGH"
+      size        = 40
+    }
+
+    availability_zone = "%s"
+  }
+  datastore {
+    type    = "opensearch"
+    version = "2.19.0"
+  }
+  enable_https     = false
   enable_authority = true
   admin_pass       = "QwertyUI!"
 }

--- a/opentelekomcloud/services/css/resource_opentelekomcloud_css_cluster_v1.go
+++ b/opentelekomcloud/services/css/resource_opentelekomcloud_css_cluster_v1.go
@@ -119,19 +119,16 @@ func ResourceCssClusterV1() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 				Optional: true,
-				ForceNew: true,
 			},
 			"enable_authority": {
 				Type:     schema.TypeBool,
 				Computed: true,
 				Optional: true,
-				ForceNew: true,
 			},
 			"admin_pass": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				RequiredWith: []string{"enable_authority"},
-				ForceNew:     true,
 			},
 			"public_access": {
 				Type:         schema.TypeList,
@@ -499,6 +496,32 @@ func resourceCssClusterV1Update(ctx context.Context, d *schema.ResourceData, met
 		err := updateCssPublicAccess(d, client)
 		if err != nil {
 			return fmterr.Errorf("error updating public access for CSS cluster %s: %s", d.Id(), err)
+		}
+	}
+
+	// update security mode (enable_https, enable_authority, admin_pass)
+	if d.HasChanges("enable_https", "enable_authority", "admin_pass") {
+		if d.Get("enable_authority").(bool) {
+			if adminPass, ok := d.GetOk("admin_pass"); !ok || adminPass.(string) == "" {
+				return fmterr.Errorf("admin_pass is required when enable_authority is true")
+			}
+		}
+
+		httpsEnabled := d.Get("enable_https").(bool)
+		authorityEnabled := d.Get("enable_authority").(bool)
+
+		err = clusters.UpdateSecurityMode(client, d.Id(), clusters.SecurityModeOpts{
+			AuthorityEnabled: &authorityEnabled,
+			AdminPassword:    d.Get("admin_pass").(string),
+			HttpsEnabled:     &httpsEnabled,
+		})
+		if err != nil {
+			return fmterr.Errorf("error updating security mode for CSS cluster %s: %s", d.Id(), err)
+		}
+
+		secondsWait := int(math.Round(d.Timeout(schema.TimeoutUpdate).Seconds()))
+		if err = checkClusterOperationCompleted(client, d.Id(), secondsWait); err != nil {
+			return fmterr.Errorf("error waiting for CSS cluster security mode update: %s", d.Id(), err)
 		}
 	}
 

--- a/opentelekomcloud/services/css/resource_opentelekomcloud_css_cluster_v1.go
+++ b/opentelekomcloud/services/css/resource_opentelekomcloud_css_cluster_v1.go
@@ -499,8 +499,8 @@ func resourceCssClusterV1Update(ctx context.Context, d *schema.ResourceData, met
 		}
 	}
 
-	// update security mode (enable_https, enable_authority, admin_pass)
-	if d.HasChanges("enable_https", "enable_authority", "admin_pass") {
+	// update security mode (enable_https, enable_authority)
+	if d.HasChanges("enable_https", "enable_authority") {
 		if d.Get("enable_authority").(bool) {
 			if adminPass, ok := d.GetOk("admin_pass"); !ok || adminPass.(string) == "" {
 				return fmterr.Errorf("admin_pass is required when enable_authority is true")
@@ -521,7 +521,7 @@ func resourceCssClusterV1Update(ctx context.Context, d *schema.ResourceData, met
 
 		secondsWait := int(math.Round(d.Timeout(schema.TimeoutUpdate).Seconds()))
 		if err = checkClusterOperationCompleted(client, d.Id(), secondsWait); err != nil {
-			return fmterr.Errorf("error waiting for CSS cluster security mode update: %s", d.Id(), err)
+			return fmterr.Errorf("error waiting for CSS cluster %s security mode update: %s", d.Id(), err)
 		}
 	}
 

--- a/releasenotes/notes/css-security-mode-update-4e0a18bf94f64237.yaml
+++ b/releasenotes/notes/css-security-mode-update-4e0a18bf94f64237.yaml
@@ -1,0 +1,5 @@
+---
+upgrade:
+  - |
+    **[CSS]** Updating the `enable_https` or `enable_authority` attributes in `resource/opentelekomcloud_css_cluster_v1` no longer forces cluster recreation.
+    (`#3437 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3437>`_)


### PR DESCRIPTION
## Summary of the Pull Request

Updating the `enable_https` or `enable_authority` attributes in `resource/opentelekomcloud_css_cluster_v1` will no longer forces cluster recreation.

## PR Checklist

* [ ] Refers to: #xxx
* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (101.71s)
=== RUN   TestAccSomethingV0_timeout
--- PASS: TestAccSomethingV0_timeout (128.67s)
PASS

Process finished with exit code 0
```
