### PR TITLE
[Fix] APIGW: Gateway `enterprise_project_id` fix

### DIFF
--- a/docs/resources/apigw_gateway_v2.md
+++ b/docs/resources/apigw_gateway_v2.md
@@ -66,7 +66,8 @@ The following arguments are supported:
   users can access resources on public networks.
 
 * `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID to which the dedicated
-  instance belongs. This parameter is required for enterprise users.
+  instance belongs. This parameter is required for enterprise ("eps") users. If it is not set here or at the
+  provider level (`OS_ENTERPRISE_PROJECT_ID`), the default enterprise project `0` is used.
 
 * `bandwidth_charging_mode` - (Optional, String, ForceNew) Billing type of the public outbound access bandwidth.
   The valid values are as follows:

--- a/opentelekomcloud/services/apigw/resource_opentelekomcloud_apigw_gateway_v2.go
+++ b/opentelekomcloud/services/apigw/resource_opentelekomcloud_apigw_gateway_v2.go
@@ -204,7 +204,7 @@ func buildInstanceAvailabilityZones(d *schema.ResourceData) ([]string, error) {
 	return nil, fmt.Errorf("the parameter 'availability_zones' must be specified")
 }
 
-func buildInstanceCreateOpts(d *schema.ResourceData) (gateway.CreateOpts, error) {
+func buildInstanceCreateOpts(d *schema.ResourceData, config *cfg.Config) (gateway.CreateOpts, error) {
 	var tagList []tags.ResourceTag
 
 	gwTags := d.Get("tags").(map[string]interface{})
@@ -227,7 +227,7 @@ func buildInstanceCreateOpts(d *schema.ResourceData) (gateway.CreateOpts, error)
 		LoadBalancerProvider:         d.Get("loadbalancer_provider").(string),
 		IngressBandwidthSize:         pointerto.Int(d.Get("ingress_bandwidth_size").(int)),
 		IngressBandwidthChargingMode: d.Get("ingress_bandwidth_charging_mode").(string),
-		EnterpriseProjectId:          d.Get("enterprise_project_id").(string),
+		EnterpriseProjectId:          config.GetEnterpriseProjectID(d, "0"),
 		Tags:                         tagList,
 	}
 
@@ -258,7 +258,7 @@ func resourceGatewayCreate(ctx context.Context, d *schema.ResourceData, meta int
 		return diag.Errorf("error creating APIGW v2 client: %s", err)
 	}
 
-	opts, err := buildInstanceCreateOpts(d)
+	opts, err := buildInstanceCreateOpts(d, config)
 	if err != nil {
 		return diag.Errorf("error creating the dedicated instance options: %s", err)
 	}
@@ -494,9 +494,6 @@ func resourceGatewayDelete(ctx context.Context, d *schema.ResourceData, meta int
 	}
 	if err = gateway.Delete(client, d.Id()); err != nil {
 		return diag.Errorf("error deleting the dedicated instance (%s): %s", d.Id(), err)
-	}
-	if err != nil {
-		return diag.FromErr(err)
 	}
 
 	stateConf := &resource.StateChangeConf{

--- a/releasenotes/notes/apigw-gateway-enterprise-project-id-375e61e04b8ddc9b.yaml
+++ b/releasenotes/notes/apigw-gateway-enterprise-project-id-375e61e04b8ddc9b.yaml
@@ -1,6 +1,4 @@
 ---
 fixes:
   - |
-    **[APIGW]** Fixed ``resource/opentelekomcloud_apigw_gateway_v2`` creation for
-    enterprise accounts by defaulting ``enterprise_project_id`` to ``"0"`` when it
-    is not set.
+    **[APIGW]** Fixed ``resource/opentelekomcloud_apigw_gateway_v2`` creation for enterprise accounts by defaulting ``enterprise_project_id`` to ``"0"`` when it is not set (`#3438 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3438>`_)

--- a/releasenotes/notes/apigw-gateway-enterprise-project-id-375e61e04b8ddc9b.yaml
+++ b/releasenotes/notes/apigw-gateway-enterprise-project-id-375e61e04b8ddc9b.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    **[APIGW]** Fixed ``resource/opentelekomcloud_apigw_gateway_v2`` creation for
+    enterprise accounts by defaulting ``enterprise_project_id`` to ``"0"`` when it
+    is not set.


### PR DESCRIPTION
## Summary of the Pull Request
Since all tenants are now enterprise ones, the `enterprise_project_id` field is required when creating an APIGW gateway. 
This PR fixes gateway creation by autofilling `enterprise_project_id` with the default project (`"0"`) when it's not provided by the user.

## PR Checklist

* [x] Refers to: #3427
* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccAPIGWv2Gateway_basic
=== PAUSE TestAccAPIGWv2Gateway_basic
=== CONT  TestAccAPIGWv2Gateway_basic
--- PASS: TestAccAPIGWv2Gateway_basic (574.79s)
PASS

Process finished with the exit code 0

```
