### PR TITLE
[Fix] Provider: include enterprise_project_id

### DIFF
--- a/opentelekomcloud/common/cfg/config.go
+++ b/opentelekomcloud/common/cfg/config.go
@@ -1464,10 +1464,8 @@ func SetOptionalEndpoint(cfg *aws.Config) string {
 // either be set by the `enterprise_project_id` argument or by OS_ENTERPRISE_PROJECT_ID.
 // If the provider-level value
 func (c *Config) GetEnterpriseProjectID(d *schema.ResourceData, defaultEps ...string) string {
-	if d != nil {
-		if v, ok := d.GetOk("enterprise_project_id"); ok {
-			return v.(string)
-		}
+	if v, ok := d.GetOk("enterprise_project_id"); ok {
+		return v.(string)
 	}
 
 	if c.EnterpriseProjectID != "" {

--- a/opentelekomcloud/common/cfg/config.go
+++ b/opentelekomcloud/common/cfg/config.go
@@ -1464,8 +1464,10 @@ func SetOptionalEndpoint(cfg *aws.Config) string {
 // either be set by the `enterprise_project_id` argument or by OS_ENTERPRISE_PROJECT_ID.
 // If the provider-level value
 func (c *Config) GetEnterpriseProjectID(d *schema.ResourceData, defaultEps ...string) string {
-	if v, ok := d.GetOk("enterprise_project_id"); ok {
-		return v.(string)
+	if d != nil {
+		if v, ok := d.GetOk("enterprise_project_id"); ok {
+			return v.(string)
+		}
 	}
 
 	if c.EnterpriseProjectID != "" {

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -819,6 +819,7 @@ func providerConfigure(_ context.Context, d *schema.ResourceData, p *schema.Prov
 		MaxRetries:          d.Get("max_retries").(int),
 		MaxBackoffRetries:   d.Get("max_backoff_retries").(int),
 		BackoffRetryTimeout: d.Get("backoff_retry_timeout").(int),
+		EnterpriseProjectID: d.Get("enterprise_project_id").(string),
 		UserAgent:           p.UserAgent("terraform-provider-opentelekomcloud", version.ProviderVersion),
 	}
 

--- a/releasenotes/notes/provider-enterprise_project_id-948734480761c171.yaml
+++ b/releasenotes/notes/provider-enterprise_project_id-948734480761c171.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[Provider]** Fix to include enterprise_project_id setting (`#3427 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/3427>`_)


### PR DESCRIPTION
## Summary of the Pull Request

Fixes missing enterprise_project_id from the provider config.

## PR Checklist

* [x] Refers to: https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/3427
* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (101.71s)
=== RUN   TestAccSomethingV0_timeout
--- PASS: TestAccSomethingV0_timeout (128.67s)
PASS

Process finished with exit code 0
```
