### PR TITLE
[Feat] CC: Add central network policy resources

### DIFF
--- a/docs/resources/cc_central_network_policy_apply_v3.md
+++ b/docs/resources/cc_central_network_policy_apply_v3.md
@@ -1,0 +1,76 @@
+---
+subcategory: "Cloud Connect (CC)"
+layout: "opentelekomcloud"
+page_title: "OpenTelekomCloud: opentelekomcloud_cc_central_network_policy_apply_v3"
+sidebar_current: "docs-opentelekomcloud-resource-cc-central-network-policy-apply-v3"
+description: |-
+  Applies a Cloud Connect Central Network Policy within OpenTelekomCloud.
+---
+
+Up-to-date reference of API arguments for Cloud Connect Central Network Policy you can get at
+[documentation portal](https://docs.otc.t-systems.com/cloud-connect/api-ref/api/central_network_policies/index.html)
+
+# opentelekomcloud_cc_central_network_policy_apply_v3
+
+Applies a Cloud Connect (CC) central network policy within OpenTelekomCloud.
+
+A central network can hold several policies, but only one can be active. This resource applies the policy
+referenced by `policy_id` to the central network and waits until it becomes effective.
+
+-> Deleting this resource does not delete the policy. Instead, it reverts the central network to its default
+policy (the initial policy with version `1`, which has no associated enterprise routers).
+
+## Example Usage
+
+```hcl
+variable "central_network_id" {}
+
+resource "opentelekomcloud_cc_central_network_policy_v3" "test" {
+  central_network_id = var.central_network_id
+
+  er_instances {
+    project_id           = var.project_id
+    region_id            = "eu-de"
+    enterprise_router_id = var.enterprise_router_id
+  }
+}
+
+resource "opentelekomcloud_cc_central_network_policy_apply_v3" "test" {
+  central_network_id = var.central_network_id
+  policy_id          = opentelekomcloud_cc_central_network_policy_v3.test.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `central_network_id` - (Required, String, ForceNew) The ID of the central network the policy is applied to.
+  Changing this parameter will create a new resource.
+
+* `policy_id` - (Required, String) The ID of the central network policy to apply.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID. Equal to the central network ID.
+
+* `region` - The region in which the central network policy is applied.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `update` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
+
+## Import
+
+The applied central network policy can be imported using the `central_network_id` and `policy_id`, separated by
+a slash, e.g.
+
+```sh
+$ terraform import opentelekomcloud_cc_central_network_policy_apply_v3.test <central_network_id>/<policy_id>
+```

--- a/docs/resources/cc_central_network_policy_v3.md
+++ b/docs/resources/cc_central_network_policy_v3.md
@@ -1,0 +1,142 @@
+---
+subcategory: "Cloud Connect (CC)"
+layout: "opentelekomcloud"
+page_title: "OpenTelekomCloud: opentelekomcloud_cc_central_network_policy_v3"
+sidebar_current: "docs-opentelekomcloud-resource-cc-central-network-policy-v3"
+description: |-
+  Manages a Cloud Connect Central Network Policy resource within OpenTelekomCloud.
+---
+
+Up-to-date reference of API arguments for Cloud Connect Central Network Policy you can get at
+[documentation portal](https://docs.otc.t-systems.com/cloud-connect/api-ref/api/central_network_policies/index.html)
+
+# opentelekomcloud_cc_central_network_policy_v3
+
+Manages a Cloud Connect (CC) central network policy resource within OpenTelekomCloud.
+
+A central network policy describes which enterprise routers belong to a central network and how their route
+tables are associated. Creating a policy only stages it; use `opentelekomcloud_cc_central_network_policy_apply_v3`
+to make it the active policy of the central network.
+
+-> Central network policies are immutable. Any change to the arguments forces a new policy to be created.
+
+## Example Usage
+
+```hcl
+variable "central_network_id" {}
+variable "project_id" {}
+variable "enterprise_router_a_id" {}
+variable "enterprise_router_a_table_id" {}
+variable "enterprise_router_b_id" {}
+variable "enterprise_router_b_table_id" {}
+
+resource "opentelekomcloud_cc_central_network_policy_v3" "test" {
+  central_network_id = var.central_network_id
+
+  er_instances {
+    project_id           = var.project_id
+    region_id            = "eu-de"
+    enterprise_router_id = var.enterprise_router_a_id
+  }
+
+  er_instances {
+    project_id           = var.project_id
+    region_id            = "eu-nl"
+    enterprise_router_id = var.enterprise_router_b_id
+  }
+
+  planes {
+    associate_er_tables {
+      project_id                 = var.project_id
+      region_id                  = "eu-de"
+      enterprise_router_id       = var.enterprise_router_a_id
+      enterprise_router_table_id = var.enterprise_router_a_table_id
+    }
+
+    associate_er_tables {
+      project_id                 = var.project_id
+      region_id                  = "eu-nl"
+      enterprise_router_id       = var.enterprise_router_b_id
+      enterprise_router_table_id = var.enterprise_router_b_table_id
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `central_network_id` - (Required, String, ForceNew) The ID of the central network the policy belongs to.
+  Changing this parameter will create a new resource.
+
+* `er_instances` - (Optional, List, ForceNew) The list of the enterprise routers on the central network policy.
+  Changing this parameter will create a new resource.
+  The [er_instances](#policy_er_instances) structure is documented below.
+
+* `planes` - (Optional, List, ForceNew) The list of the central network policy planes.
+  Changing this parameter will create a new resource.
+  The [planes](#policy_planes) structure is documented below.
+
+<a name="policy_er_instances"></a>
+The `er_instances` block supports:
+
+* `project_id` - (Required, String, ForceNew) The project ID of the enterprise router.
+
+* `region_id` - (Required, String, ForceNew) The region ID of the enterprise router.
+
+* `enterprise_router_id` - (Required, String, ForceNew) The ID of the enterprise router.
+
+<a name="policy_planes"></a>
+The `planes` block supports:
+
+* `associate_er_tables` - (Optional, List, ForceNew) The list of route tables associated with the central
+  network policy. The [associate_er_tables](#policy_associate_er_tables) structure is documented below.
+
+* `exclude_er_connections` - (Optional, List, ForceNew) The list of the enterprise router connections excluded
+  from the central network policy. The [exclude_er_connections](#policy_exclude_er_connections) structure is
+  documented below.
+
+<a name="policy_associate_er_tables"></a>
+The `associate_er_tables` block supports:
+
+* `project_id` - (Required, String, ForceNew) The project ID of the enterprise router.
+
+* `region_id` - (Required, String, ForceNew) The region ID of the enterprise router.
+
+* `enterprise_router_id` - (Required, String, ForceNew) The ID of the enterprise router.
+
+* `enterprise_router_table_id` - (Required, String, ForceNew) The ID of the enterprise router route table.
+
+<a name="policy_exclude_er_connections"></a>
+The `exclude_er_connections` block supports:
+
+* `exclude_er_instances` - (Required, List, ForceNew) The list of enterprise routers that will not establish a
+  connection with each other. The [exclude_er_instances](#policy_er_instances) structure is the same as the
+  `er_instances` structure documented above.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format. Equal to the central network policy ID.
+
+* `document_template_version` - The version of the central network policy document template.
+
+* `is_applied` - Whether the central network policy is applied.
+
+* `version` - The version of the central network policy.
+
+* `state` - The status of the central network policy. The value can be **AVAILABLE**, **CANCELING**,
+  **APPLYING**, **FAILED** or **DELETED**.
+
+* `region` - The region in which the central network policy is managed.
+
+## Import
+
+The central network policy can be imported using the `central_network_id` and `id` (policy ID), separated by a
+slash, e.g.
+
+```sh
+$ terraform import opentelekomcloud_cc_central_network_policy_v3.test <central_network_id>/<id>
+```

--- a/opentelekomcloud/acceptance/cc/resource_opentelekomcloud_cc_central_network_policy_apply_v3_test.go
+++ b/opentelekomcloud/acceptance/cc/resource_opentelekomcloud_cc_central_network_policy_apply_v3_test.go
@@ -1,0 +1,112 @@
+package cc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/cc/v3/policy"
+
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+)
+
+func getCentralNetworkPolicyApplyResourceFunc(conf *cfg.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.CcV3Client(env.OS_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating OpenTelekomCloud CC v3 client: %s", err)
+	}
+	policyId := state.Primary.Attributes["policy_id"]
+	resp, err := policy.List(client, policy.ListOpts{
+		CentralNetworkId: state.Primary.ID,
+		ID:               []string{policyId},
+	})
+	if err != nil {
+		return nil, err
+	}
+	for i := range resp.CentralNetworkPolicies {
+		if resp.CentralNetworkPolicies[i].ID == policyId && resp.CentralNetworkPolicies[i].IsApplied {
+			return resp.CentralNetworkPolicies[i], nil
+		}
+	}
+	return nil, fmt.Errorf("applied central network policy (%s) not found", policyId)
+}
+
+func TestAccCcCentralNetworkPolicyApplyV3_basic(t *testing.T) {
+	var obj interface{}
+
+	name := fmt.Sprintf("cc_acc_apply_%s", acctest.RandString(5))
+	asn := acctest.RandIntRange(64512, 65534)
+	rName := "opentelekomcloud_cc_central_network_policy_apply_v3.test"
+
+	rc := common.InitResourceCheck(
+		rName,
+		&obj,
+		getCentralNetworkPolicyApplyResourceFunc,
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+			testAccPreCheckCcProjectID(t)
+		},
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCcCentralNetworkPolicyApplyV3_basic(name, asn),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "central_network_id",
+						"opentelekomcloud_cc_central_network_v3.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "policy_id",
+						"opentelekomcloud_cc_central_network_policy_v3.test", "id"),
+					resource.TestCheckResourceAttrSet(rName, "region"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccCcCentralNetworkPolicyApplyImportStateIdFunc(rName),
+			},
+		},
+	})
+}
+
+func testAccCcCentralNetworkPolicyApplyImportStateIdFunc(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found", name)
+		}
+		if rs.Primary.ID == "" || rs.Primary.Attributes["policy_id"] == "" {
+			return "", fmt.Errorf("missing ID or policy_id for resource (%s)", name)
+		}
+		return rs.Primary.ID + "/" + rs.Primary.Attributes["policy_id"], nil
+	}
+}
+
+func testAccCcCentralNetworkPolicyApplyV3_basic(name string, asn int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "opentelekomcloud_cc_central_network_policy_v3" "test" {
+  central_network_id = opentelekomcloud_cc_central_network_v3.test.id
+
+  er_instances {
+    project_id           = "%[2]s"
+    region_id            = "%[3]s"
+    enterprise_router_id = opentelekomcloud_er_instance_v3.test.id
+  }
+}
+
+resource "opentelekomcloud_cc_central_network_policy_apply_v3" "test" {
+  central_network_id = opentelekomcloud_cc_central_network_v3.test.id
+  policy_id          = opentelekomcloud_cc_central_network_policy_v3.test.id
+}
+`, testAccCcCentralNetworkPolicyBase(name, asn), env.OS_PROJECT_ID, env.OS_REGION_NAME)
+}

--- a/opentelekomcloud/acceptance/cc/resource_opentelekomcloud_cc_central_network_policy_v3_test.go
+++ b/opentelekomcloud/acceptance/cc/resource_opentelekomcloud_cc_central_network_policy_v3_test.go
@@ -1,0 +1,137 @@
+package cc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/cc/v3/policy"
+
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+)
+
+func getCentralNetworkPolicyResourceFunc(conf *cfg.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.CcV3Client(env.OS_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating OpenTelekomCloud CC v3 client: %s", err)
+	}
+	resp, err := policy.List(client, policy.ListOpts{
+		CentralNetworkId: state.Primary.Attributes["central_network_id"],
+		ID:               []string{state.Primary.ID},
+	})
+	if err != nil {
+		return nil, err
+	}
+	for i := range resp.CentralNetworkPolicies {
+		if resp.CentralNetworkPolicies[i].ID == state.Primary.ID {
+			return resp.CentralNetworkPolicies[i], nil
+		}
+	}
+	return nil, fmt.Errorf("central network policy (%s) not found", state.Primary.ID)
+}
+
+func TestAccCcCentralNetworkPolicyV3_basic(t *testing.T) {
+	var obj interface{}
+
+	name := fmt.Sprintf("cc_acc_pol_%s", acctest.RandString(5))
+	asn := acctest.RandIntRange(64512, 65534)
+	rName := "opentelekomcloud_cc_central_network_policy_v3.test"
+
+	rc := common.InitResourceCheck(
+		rName,
+		&obj,
+		getCentralNetworkPolicyResourceFunc,
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+			testAccPreCheckCcProjectID(t)
+		},
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCcCentralNetworkPolicyV3_basic(name, asn),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "central_network_id",
+						"opentelekomcloud_cc_central_network_v3.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "er_instances.0.enterprise_router_id",
+						"opentelekomcloud_er_instance_v3.test", "id"),
+					resource.TestCheckResourceAttr(rName, "state", "AVAILABLE"),
+					resource.TestCheckResourceAttr(rName, "is_applied", "false"),
+					resource.TestCheckResourceAttrSet(rName, "document_template_version"),
+					resource.TestCheckResourceAttrSet(rName, "version"),
+					resource.TestCheckResourceAttrSet(rName, "region"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccCcCentralNetworkPolicyImportStateIdFunc(rName),
+			},
+		},
+	})
+}
+
+func testAccCcCentralNetworkPolicyImportStateIdFunc(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found", name)
+		}
+		centralNetworkId := rs.Primary.Attributes["central_network_id"]
+		if centralNetworkId == "" || rs.Primary.ID == "" {
+			return "", fmt.Errorf("missing central_network_id or ID for resource (%s)", name)
+		}
+		return centralNetworkId + "/" + rs.Primary.ID, nil
+	}
+}
+
+func testAccPreCheckCcProjectID(t *testing.T) {
+	if env.OS_PROJECT_ID == "" {
+		t.Skip("OS_PROJECT_ID must be set for CC central network policy acceptance tests")
+	}
+}
+
+func testAccCcCentralNetworkPolicyBase(name string, asn int) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_er_instance_v3" "test" {
+  availability_zones = ["eu-de-01", "eu-de-02"]
+
+  name = "%[1]s"
+  asn  = %[2]d
+
+  enable_default_propagation     = true
+  enable_default_association     = true
+  auto_accept_shared_attachments = true
+}
+
+resource "opentelekomcloud_cc_central_network_v3" "test" {
+  name        = "%[1]s"
+  description = "created by terraform acceptance test"
+}
+`, name, asn)
+}
+
+func testAccCcCentralNetworkPolicyV3_basic(name string, asn int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "opentelekomcloud_cc_central_network_policy_v3" "test" {
+  central_network_id = opentelekomcloud_cc_central_network_v3.test.id
+
+  er_instances {
+    project_id           = "%[2]s"
+    region_id            = "%[3]s"
+    enterprise_router_id = opentelekomcloud_er_instance_v3.test.id
+  }
+}
+`, testAccCcCentralNetworkPolicyBase(name, asn), env.OS_PROJECT_ID, env.OS_REGION_NAME)
+}

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -489,6 +489,8 @@ func Provider() *schema.Provider {
 			"opentelekomcloud_cbr_policy_v3":                             cbr.ResourceCBRPolicyV3(),
 			"opentelekomcloud_cbr_vault_v3":                              cbr.ResourceCBRVaultV3(),
 			"opentelekomcloud_cc_central_network_v3":                     cc.ResourceCcCentralNetworkV3(),
+			"opentelekomcloud_cc_central_network_policy_v3":              cc.ResourceCcCentralNetworkPolicyV3(),
+			"opentelekomcloud_cc_central_network_policy_apply_v3":        cc.ResourceCcCentralNetworkPolicyApplyV3(),
 			"opentelekomcloud_cce_addon_v3":                              cce.ResourceCCEAddonV3(),
 			"opentelekomcloud_cce_cluster_v3":                            cce.ResourceCCEClusterV3(),
 			"opentelekomcloud_cce_node_attach_v3":                        cce.ResourceCCENodeV3Attach(),

--- a/opentelekomcloud/services/cc/resource_opentelekomcloud_cc_central_network_policy_apply_v3.go
+++ b/opentelekomcloud/services/cc/resource_opentelekomcloud_cc_central_network_policy_apply_v3.go
@@ -1,0 +1,182 @@
+package cc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/cc/v3/policy"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
+)
+
+func ResourceCcCentralNetworkPolicyApplyV3() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceCcCentralNetworkPolicyApplyV3Create,
+		UpdateContext: resourceCcCentralNetworkPolicyApplyV3Create,
+		ReadContext:   resourceCcCentralNetworkPolicyApplyV3Read,
+		DeleteContext: resourceCcCentralNetworkPolicyApplyV3Delete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceCcCentralNetworkPolicyApplyV3ImportState,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"central_network_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"policy_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"region": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceCcCentralNetworkPolicyApplyV3Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, ccClientV3, func() (*golangsdk.ServiceClient, error) {
+		return config.CcV3Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV3Client, err)
+	}
+
+	centralNetworkId := d.Get("central_network_id").(string)
+	if err = applyCentralNetworkPolicy(ctx, client, centralNetworkId, d.Get("policy_id").(string), d.Timeout(schema.TimeoutCreate)); err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(centralNetworkId)
+
+	clientCtx := common.CtxWithClient(ctx, client, ccClientV3)
+	return resourceCcCentralNetworkPolicyApplyV3Read(clientCtx, d, meta)
+}
+
+func applyCentralNetworkPolicy(ctx context.Context, client *golangsdk.ServiceClient, centralNetworkId, policyId string, timeout time.Duration) error {
+	if _, err := policy.Apply(client, centralNetworkId, policyId); err != nil {
+		return fmt.Errorf("error applying OpenTelekomCloud CC central network policy: %s", err)
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      waitForCentralNetworkPolicyApplied(client, centralNetworkId, policyId),
+		Timeout:      timeout,
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+		return fmt.Errorf("error waiting for OpenTelekomCloud CC central network policy (%s) to be applied: %s", policyId, err)
+	}
+
+	return nil
+}
+
+func waitForCentralNetworkPolicyApplied(client *golangsdk.ServiceClient, centralNetworkId, policyId string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		pol, err := getCentralNetworkPolicy(client, centralNetworkId, policyId)
+		if err != nil {
+			return nil, "", err
+		}
+		if pol.IsApplied {
+			return pol, "COMPLETED", nil
+		}
+		return pol, "PENDING", nil
+	}
+}
+
+func resourceCcCentralNetworkPolicyApplyV3Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, ccClientV3, func() (*golangsdk.ServiceClient, error) {
+		return config.CcV3Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV3Client, err)
+	}
+
+	pol, err := getCentralNetworkPolicy(client, d.Id(), d.Get("policy_id").(string))
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving OpenTelekomCloud CC central network policy")
+	}
+	if !pol.IsApplied {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "OpenTelekomCloud CC central network policy is no longer applied")
+	}
+
+	mErr := multierror.Append(
+		nil,
+		d.Set("region", config.GetRegion(d)),
+		d.Set("central_network_id", pol.CentralNetworkId),
+		d.Set("policy_id", pol.ID),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+// resourceCcCentralNetworkPolicyApplyV3Delete reverts the central network to its default policy
+// (version 1, with no associated enterprise routers), since a policy cannot simply be "unapplied".
+func resourceCcCentralNetworkPolicyApplyV3Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, ccClientV3, func() (*golangsdk.ServiceClient, error) {
+		return config.CcV3Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV3Client, err)
+	}
+
+	centralNetworkId := d.Get("central_network_id").(string)
+	resp, err := policy.List(client, policy.ListOpts{CentralNetworkId: centralNetworkId})
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving OpenTelekomCloud CC central network policies")
+	}
+
+	var defaultPolicyId string
+	for _, pol := range resp.CentralNetworkPolicies {
+		if pol.Version == 1 {
+			defaultPolicyId = pol.ID
+			break
+		}
+	}
+	if defaultPolicyId == "" {
+		return diag.Errorf("error reverting OpenTelekomCloud CC central network policy: no default policy (version 1) found")
+	}
+
+	if err = applyCentralNetworkPolicy(ctx, client, centralNetworkId, defaultPolicyId, d.Timeout(schema.TimeoutDelete)); err != nil {
+		return diag.Errorf("error reverting OpenTelekomCloud CC central network to default policy: %s", err)
+	}
+
+	return nil
+}
+
+func resourceCcCentralNetworkPolicyApplyV3ImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.SplitN(d.Id(), "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import id, must be <central_network_id>/<policy_id>")
+	}
+
+	d.SetId(parts[0])
+	if err := d.Set("policy_id", parts[1]); err != nil {
+		return nil, err
+	}
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/opentelekomcloud/services/cc/resource_opentelekomcloud_cc_central_network_policy_v3.go
+++ b/opentelekomcloud/services/cc/resource_opentelekomcloud_cc_central_network_policy_v3.go
@@ -1,0 +1,379 @@
+package cc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/cc/v3/policy"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
+)
+
+// defaultPlaneName is the only plane name currently supported by the central network policy API.
+const defaultPlaneName = "default-plane"
+
+func ResourceCcCentralNetworkPolicyV3() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceCcCentralNetworkPolicyV3Create,
+		ReadContext:   resourceCcCentralNetworkPolicyV3Read,
+		DeleteContext: resourceCcCentralNetworkPolicyV3Delete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceCcCentralNetworkPolicyV3ImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"central_network_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"er_instances": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem:     centralNetworkPolicyErInstanceSchema(),
+			},
+			"planes": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem:     centralNetworkPolicyPlaneSchema(),
+			},
+			"document_template_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"is_applied": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"version": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"region": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func centralNetworkPolicyPlaneSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"associate_er_tables": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem:     centralNetworkPolicyAssociateErTableSchema(),
+			},
+			"exclude_er_connections": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem:     centralNetworkPolicyExcludeErConnectionsSchema(),
+			},
+		},
+	}
+}
+
+func centralNetworkPolicyAssociateErTableSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"project_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"region_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"enterprise_router_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"enterprise_router_table_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func centralNetworkPolicyExcludeErConnectionsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"exclude_er_instances": {
+				Type:     schema.TypeList,
+				Required: true,
+				ForceNew: true,
+				Elem:     centralNetworkPolicyErInstanceSchema(),
+			},
+		},
+	}
+}
+
+func centralNetworkPolicyErInstanceSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"project_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"region_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"enterprise_router_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceCcCentralNetworkPolicyV3Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, ccClientV3, func() (*golangsdk.ServiceClient, error) {
+		return config.CcV3Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV3Client, err)
+	}
+
+	createOpts := policy.CreateOpts{
+		CentralNetworkId: d.Get("central_network_id").(string),
+		DefaultPlane:     defaultPlaneName,
+		Planes:           buildCentralNetworkPolicyPlanes(d.Get("planes").([]interface{})),
+		ErInstances:      buildCentralNetworkPolicyErInstances(d.Get("er_instances").([]interface{})),
+	}
+
+	created, err := policy.Create(client, createOpts)
+	if err != nil {
+		return diag.Errorf("error creating OpenTelekomCloud CC central network policy: %s", err)
+	}
+
+	d.SetId(created.ID)
+
+	clientCtx := common.CtxWithClient(ctx, client, ccClientV3)
+	return resourceCcCentralNetworkPolicyV3Read(clientCtx, d, meta)
+}
+
+func buildCentralNetworkPolicyPlanes(rawPlanes []interface{}) []policy.PlaneDocument {
+	// The API always expects at least one plane carrying the default plane name.
+	if len(rawPlanes) == 0 {
+		return []policy.PlaneDocument{{Name: defaultPlaneName}}
+	}
+
+	planes := make([]policy.PlaneDocument, len(rawPlanes))
+	for i, v := range rawPlanes {
+		raw := v.(map[string]interface{})
+		planes[i] = policy.PlaneDocument{
+			Name:                 defaultPlaneName,
+			AssociateErTables:    buildCentralNetworkPolicyAssociateErTables(raw["associate_er_tables"].([]interface{})),
+			ExcludeErConnections: buildCentralNetworkPolicyExcludeErConnections(raw["exclude_er_connections"].([]interface{})),
+		}
+	}
+	return planes
+}
+
+func buildCentralNetworkPolicyAssociateErTables(rawTables []interface{}) []policy.AssociateErTable {
+	if len(rawTables) == 0 {
+		return nil
+	}
+	tables := make([]policy.AssociateErTable, len(rawTables))
+	for i, v := range rawTables {
+		raw := v.(map[string]interface{})
+		tables[i] = policy.AssociateErTable{
+			ProjectId:               raw["project_id"].(string),
+			RegionId:                raw["region_id"].(string),
+			EnterpriseRouterId:      raw["enterprise_router_id"].(string),
+			EnterpriseRouterTableId: raw["enterprise_router_table_id"].(string),
+		}
+	}
+	return tables
+}
+
+func buildCentralNetworkPolicyExcludeErConnections(rawConnections []interface{}) [][]policy.AssociateErInstance {
+	if len(rawConnections) == 0 {
+		return nil
+	}
+	connections := make([][]policy.AssociateErInstance, len(rawConnections))
+	for i, v := range rawConnections {
+		raw := v.(map[string]interface{})
+		connections[i] = buildCentralNetworkPolicyErInstances(raw["exclude_er_instances"].([]interface{}))
+	}
+	return connections
+}
+
+func buildCentralNetworkPolicyErInstances(rawInstances []interface{}) []policy.AssociateErInstance {
+	if len(rawInstances) == 0 {
+		return nil
+	}
+	instances := make([]policy.AssociateErInstance, len(rawInstances))
+	for i, v := range rawInstances {
+		raw := v.(map[string]interface{})
+		instances[i] = policy.AssociateErInstance{
+			ProjectId:          raw["project_id"].(string),
+			RegionId:           raw["region_id"].(string),
+			EnterpriseRouterId: raw["enterprise_router_id"].(string),
+		}
+	}
+	return instances
+}
+
+func resourceCcCentralNetworkPolicyV3Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, ccClientV3, func() (*golangsdk.ServiceClient, error) {
+		return config.CcV3Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV3Client, err)
+	}
+
+	pol, err := getCentralNetworkPolicy(client, d.Get("central_network_id").(string), d.Id())
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving OpenTelekomCloud CC central network policy")
+	}
+
+	mErr := multierror.Append(
+		nil,
+		d.Set("region", config.GetRegion(d)),
+		d.Set("central_network_id", pol.CentralNetworkId),
+		d.Set("document_template_version", pol.DocumentTemplateVersion),
+		d.Set("is_applied", pol.IsApplied),
+		d.Set("version", pol.Version),
+		d.Set("state", pol.State),
+		d.Set("er_instances", flattenCentralNetworkPolicyErInstances(pol.Document.ErInstances)),
+		d.Set("planes", flattenCentralNetworkPolicyPlanes(pol.Document.Planes)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+// getCentralNetworkPolicy looks up a single policy by ID. The API only exposes a list endpoint,
+// so we filter the result client-side and surface a 404 when the policy is gone.
+func getCentralNetworkPolicy(client *golangsdk.ServiceClient, centralNetworkId, policyId string) (*policy.CentralNetworkPolicy, error) {
+	resp, err := policy.List(client, policy.ListOpts{
+		CentralNetworkId: centralNetworkId,
+		ID:               []string{policyId},
+	})
+	if err != nil {
+		return nil, err
+	}
+	for i := range resp.CentralNetworkPolicies {
+		if resp.CentralNetworkPolicies[i].ID == policyId {
+			return &resp.CentralNetworkPolicies[i], nil
+		}
+	}
+	return nil, golangsdk.ErrDefault404{}
+}
+
+func flattenCentralNetworkPolicyPlanes(planes []policy.PlaneDocument) []interface{} {
+	if len(planes) == 0 {
+		return nil
+	}
+	rst := make([]interface{}, 0, len(planes))
+	for _, plane := range planes {
+		rst = append(rst, map[string]interface{}{
+			"associate_er_tables":    flattenCentralNetworkPolicyAssociateErTables(plane.AssociateErTables),
+			"exclude_er_connections": flattenCentralNetworkPolicyExcludeErConnections(plane.ExcludeErConnections),
+		})
+	}
+	return rst
+}
+
+func flattenCentralNetworkPolicyAssociateErTables(tables []policy.AssociateErTable) []interface{} {
+	if len(tables) == 0 {
+		return nil
+	}
+	rst := make([]interface{}, 0, len(tables))
+	for _, table := range tables {
+		rst = append(rst, map[string]interface{}{
+			"project_id":                 table.ProjectId,
+			"region_id":                  table.RegionId,
+			"enterprise_router_id":       table.EnterpriseRouterId,
+			"enterprise_router_table_id": table.EnterpriseRouterTableId,
+		})
+	}
+	return rst
+}
+
+func flattenCentralNetworkPolicyExcludeErConnections(connections [][]policy.AssociateErInstance) []interface{} {
+	if len(connections) == 0 {
+		return nil
+	}
+	rst := make([]interface{}, 0, len(connections))
+	for _, connection := range connections {
+		rst = append(rst, map[string]interface{}{
+			"exclude_er_instances": flattenCentralNetworkPolicyErInstances(connection),
+		})
+	}
+	return rst
+}
+
+func flattenCentralNetworkPolicyErInstances(instances []policy.AssociateErInstance) []interface{} {
+	if len(instances) == 0 {
+		return nil
+	}
+	rst := make([]interface{}, 0, len(instances))
+	for _, instance := range instances {
+		rst = append(rst, map[string]interface{}{
+			"project_id":           instance.ProjectId,
+			"region_id":            instance.RegionId,
+			"enterprise_router_id": instance.EnterpriseRouterId,
+		})
+	}
+	return rst
+}
+
+func resourceCcCentralNetworkPolicyV3Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, ccClientV3, func() (*golangsdk.ServiceClient, error) {
+		return config.CcV3Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV3Client, err)
+	}
+
+	if err = policy.Delete(client, d.Get("central_network_id").(string), d.Id()); err != nil {
+		return common.CheckDeletedDiag(d, err, "error deleting OpenTelekomCloud CC central network policy")
+	}
+
+	return nil
+}
+
+func resourceCcCentralNetworkPolicyV3ImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.SplitN(d.Id(), "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import id, must be <central_network_id>/<id>")
+	}
+
+	if err := d.Set("central_network_id", parts[0]); err != nil {
+		return nil, err
+	}
+	d.SetId(parts[1])
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/releasenotes/notes/cc-central-network-policy-resources-010e6e903b647e43.yaml
+++ b/releasenotes/notes/cc-central-network-policy-resources-010e6e903b647e43.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    **[Cloud Connect]** Added new resource ``opentelekomcloud_cc_central_network_policy_v3``
+  - |
+    **[Cloud Connect]** Added new resource ``opentelekomcloud_cc_central_network_policy_apply_v3``

--- a/releasenotes/notes/cc-central-network-policy-resources-010e6e903b647e43.yaml
+++ b/releasenotes/notes/cc-central-network-policy-resources-010e6e903b647e43.yaml
@@ -1,6 +1,6 @@
 ---
 features:
   - |
-    **[Cloud Connect]** Added new resource ``opentelekomcloud_cc_central_network_policy_v3``
+    **[Cloud Connect]** Added new resource ``opentelekomcloud_cc_central_network_policy_v3`` (`#3443 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3443>`_)
   - |
-    **[Cloud Connect]** Added new resource ``opentelekomcloud_cc_central_network_policy_apply_v3``
+    **[Cloud Connect]** Added new resource ``opentelekomcloud_cc_central_network_policy_apply_v3`` (`#3443 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3443>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Added two new resources:
- `opentelekomcloud_cc_central_network_policy_v3`
- `opentelekomcloud_cc_central_network_policy_apply_v3`

## PR Checklist

* [x] Refers to: #3341
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccCcCentralNetworkPolicyV3_basic
--- PASS: TestAccCcCentralNetworkPolicyV3_basic (111.93s)
PASS

Process finished with the exit code 0

=== RUN   TestAccCcCentralNetworkPolicyApplyV3_basic
--- PASS: TestAccCcCentralNetworkPolicyApplyV3_basic (123.46s)
PASS

Process finished with the exit code 0

```
