### PR TITLE
[Fix] DCS: Retry SSL enablement for Redis Cluster instances

### DIFF
--- a/opentelekomcloud/acceptance/dcs/resource_opentelekomcloud_dcs_instance_v2_test.go
+++ b/opentelekomcloud/acceptance/dcs/resource_opentelekomcloud_dcs_instance_v2_test.go
@@ -260,6 +260,41 @@ func TestAccDcsInstancesV2_SSL(t *testing.T) {
 	})
 }
 
+func TestAccDcsInstancesV2_SSLCluster(t *testing.T) {
+	var (
+		dcsInstance  instance.DcsInstance
+		instanceName = fmt.Sprintf("dcs_instance_%s", acctest.RandString(5))
+
+		rc = common.InitResourceCheck(
+			dcsV2InstanceName,
+			&dcsInstance,
+			getFunctionTriggerFunc,
+		)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDcsV2InstanceSSLCluster(instanceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDcsV2InstanceExists(dcsV2InstanceName, dcsInstance),
+					resource.TestCheckResourceAttr(dcsV2InstanceName, "name", instanceName),
+					resource.TestCheckResourceAttr(dcsV2InstanceName, "engine", "Redis"),
+					resource.TestCheckResourceAttr(dcsV2InstanceName, "engine_version", "6.0"),
+					resource.TestCheckResourceAttr(dcsV2InstanceName, "capacity", "4"),
+					resource.TestCheckResourceAttr(dcsV2InstanceName, "flavor", "redis.cluster.xu1.large.r2.4"),
+					resource.TestCheckResourceAttr(dcsV2InstanceName, "ssl_enable", "true"),
+					resource.TestCheckResourceAttrSet(dcsV2InstanceName, "private_ip"),
+					resource.TestCheckResourceAttrSet(dcsV2InstanceName, "port"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDCSInstanceV2_importBasic(t *testing.T) {
 	var (
 		dcsInstance  instance.DcsInstance
@@ -633,6 +668,25 @@ resource "opentelekomcloud_dcs_instance_v2" "instance_1" {
   flavor             = "redis.ha.xu1.tiny.r2.128"
   ssl_enable         = true
 
+}
+`, testBase, instanceName)
+}
+
+func testAccDcsV2InstanceSSLCluster(instanceName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "opentelekomcloud_dcs_instance_v2" "instance_1" {
+  name               = "%s"
+  engine_version     = "6.0"
+  password           = "Hungarian_rapsody"
+  engine             = "Redis"
+  capacity           = 4
+  vpc_id             = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  subnet_id          = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  availability_zones = [data.opentelekomcloud_compute_availability_zones_v2.zones.names[0]]
+  flavor             = "redis.cluster.xu1.large.r2.4"
+  ssl_enable         = true
 }
 `, testBase, instanceName)
 }

--- a/opentelekomcloud/acceptance/dcs/resource_opentelekomcloud_dcs_instance_v2_test.go
+++ b/opentelekomcloud/acceptance/dcs/resource_opentelekomcloud_dcs_instance_v2_test.go
@@ -126,36 +126,6 @@ func TestAccDcsInstancesV2_basicSingleInstance(t *testing.T) {
 	})
 }
 
-func TestAccDcsInstancesV2_basicEngineV3Instance(t *testing.T) {
-	var (
-		dcsInstance  instance.DcsInstance
-		instanceName = fmt.Sprintf("dcs_instance_%s", acctest.RandString(5))
-
-		rc = common.InitResourceCheck(
-			dcsV2InstanceName,
-			&dcsInstance,
-			getFunctionTriggerFunc,
-		)
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { common.TestAccPreCheck(t) },
-		ProviderFactories: common.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDcsV2InstanceEngineV3(instanceName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDcsV2InstanceExists(dcsV2InstanceName, dcsInstance),
-					resource.TestCheckResourceAttr(dcsV2InstanceName, "name", instanceName),
-					resource.TestCheckResourceAttr(dcsV2InstanceName, "engine", "Redis"),
-					resource.TestCheckResourceAttr(dcsV2InstanceName, "flavor", "dcs.master_standby"),
-				),
-			},
-		},
-	})
-}
-
 func TestAccDcsInstancesV2_Whitelist(t *testing.T) {
 	var (
 		dcsInstance  instance.DcsInstance
@@ -454,27 +424,6 @@ resource "opentelekomcloud_dcs_instance_v2" "instance_1" {
   subnet_id          = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
   availability_zones = [data.opentelekomcloud_compute_availability_zones_v2.zones.names[0]]
   flavor             = "redis.single.xu1.tiny.128"
-}
-`, testBase, instanceName)
-}
-
-func testAccDcsV2InstanceEngineV3(instanceName string) string {
-	return fmt.Sprintf(`
-
-
-%s
-
-resource "opentelekomcloud_dcs_instance_v2" "instance_1" {
-  name               = "%s"
-  engine_version     = "3.0"
-  password           = "Hungarian_rapsody"
-  engine             = "Redis"
-  capacity           = 2
-  vpc_id             = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
-  subnet_id          = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
-  security_group_id  = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
-  availability_zones = [data.opentelekomcloud_compute_availability_zones_v2.zones.names[0]]
-  flavor             = "dcs.master_standby"
 }
 `, testBase, instanceName)
 }

--- a/opentelekomcloud/services/dcs/common.go
+++ b/opentelekomcloud/services/dcs/common.go
@@ -38,6 +38,8 @@ var (
 		"DCS.4118": true,
 		// freeze
 		"DCS.4120": true,
+		// instance is recovering from an internal fault, retry later
+		"DCS.4104": true,
 		// creating/restarting
 		"DCS.4975": true,
 	}

--- a/opentelekomcloud/services/dcs/resource_opentelekomcloud_dcs_instance_v2.go
+++ b/opentelekomcloud/services/dcs/resource_opentelekomcloud_dcs_instance_v2.go
@@ -572,17 +572,9 @@ func resourceDcsInstancesV2Create(ctx context.Context, d *schema.ResourceData, m
 		}
 	}
 
-	if sslEnabled := d.Get("ssl_enable").(bool); sslEnabled {
-		sslOpts := buildSslParam(sslEnabled)
-		sslOpts.InstanceId = id
-		_, err := ssl.Update(client, sslOpts)
-		if err != nil {
-			return diag.Errorf("error updating SSL for the instance (%s): %s", id, err)
-		}
-
-		err = waitForSslCompleted(ctx, client, d)
-		if err != nil {
-			return diag.Errorf("error waiting for updating SSL to complete: %s", err)
+	if d.Get("ssl_enable").(bool) {
+		if err := updateInstanceSsl(ctx, client, d, d.Timeout(schema.TimeoutCreate)); err != nil {
+			return diag.FromErr(err)
 		}
 	}
 
@@ -949,17 +941,8 @@ func resourceDcsInstancesV2Update(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	if d.HasChange("ssl_enable") {
-		sslOpts := buildSslParam(d.Get("ssl_enable").(bool))
-		sslOpts.InstanceId = d.Id()
-		_, err = ssl.Update(client, sslOpts)
-		if err != nil {
-			return diag.Errorf("error updating SSL for the instance (%s): %s", d.Id(), err)
-		}
-
-		// wait for SSL updated
-		err = waitForSslCompleted(ctx, client, d)
-		if err != nil {
-			return diag.Errorf("error waiting for updating SSL to complete: %s", err)
+		if err = updateInstanceSsl(ctx, client, d, d.Timeout(schema.TimeoutUpdate)); err != nil {
+			return diag.FromErr(err)
 		}
 	}
 
@@ -1118,19 +1101,31 @@ func handleOperationError(err error) (bool, error) {
 	if err == nil {
 		return false, nil
 	}
-	if errCode, ok := err.(golangsdk.ErrDefault400); ok {
-		var apiError interface{}
-		if jsonErr := json.Unmarshal(errCode.Body, &apiError); jsonErr != nil {
-			return false, jsonErr
-		}
-		errorCode, errorCodeErr := jmespath.Search("error_code", apiError)
-		if errorCodeErr != nil {
-			return false, fmt.Errorf("error parse errorCode from response body: %s", errorCodeErr)
-		}
-		// CBC.99003651: Another operation is being performed.
-		if operateErrorCode[errorCode.(string)] || errorCode == "CBC.99003651" {
-			return true, err
-		}
+
+	var body []byte
+	switch e := err.(type) {
+	case golangsdk.ErrDefault400:
+		body = e.Body
+	case golangsdk.ErrDefault409:
+		body = e.Body
+	case golangsdk.ErrDefault500:
+		body = e.Body
+	case golangsdk.ErrDefault503:
+		body = e.Body
+	default:
+		return false, err
+	}
+	var apiError interface{}
+	if jsonErr := json.Unmarshal(body, &apiError); jsonErr != nil {
+		return false, jsonErr
+	}
+	errorCode, errorCodeErr := jmespath.Search("error_code", apiError)
+	if errorCodeErr != nil {
+		return false, fmt.Errorf("error parse errorCode from response body: %s", errorCodeErr)
+	}
+	// CBC.99003651: Another operation is being performed.
+	if code, ok := errorCode.(string); ok && (operateErrorCode[code] || code == "CBC.99003651") {
+		return true, err
 	}
 	return false, err
 }
@@ -1180,6 +1175,34 @@ func getAzCode(d *schema.ResourceData, client *golangsdk.ServiceClient) ([]strin
 	azCodes = common.ExpandToStringList(availabilityZones.([]interface{}))
 
 	return azCodes, nil
+}
+
+func updateInstanceSsl(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData,
+	timeout time.Duration) error {
+	sslOpts := buildSslParam(d.Get("ssl_enable").(bool))
+	sslOpts.InstanceId = d.Id()
+	retryFunc := func() (interface{}, bool, error) {
+		_, err := ssl.Update(client, sslOpts)
+		retry, err := handleOperationError(err)
+		return nil, retry, err
+	}
+	_, err := common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
+		Ctx:          ctx,
+		RetryFunc:    retryFunc,
+		WaitFunc:     refreshDcsInstanceState(client, d.Id()),
+		WaitTarget:   []string{"RUNNING"},
+		Timeout:      timeout,
+		DelayTimeout: 1 * time.Second,
+		PollInterval: 10 * time.Second,
+	})
+	if err != nil {
+		return fmt.Errorf("error updating SSL for the instance (%s): %s", d.Id(), err)
+	}
+
+	if err := waitForSslCompleted(ctx, client, d); err != nil {
+		return fmt.Errorf("error waiting for updating SSL to complete: %s", err)
+	}
+	return nil
 }
 
 func waitForSslCompleted(ctx context.Context, c *golangsdk.ServiceClient, d *schema.ResourceData) error {

--- a/releasenotes/notes/dcs-instance-v2-ssl-cluster-retry-cdf2297233d33040.yaml
+++ b/releasenotes/notes/dcs-instance-v2-ssl-cluster-retry-cdf2297233d33040.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   |
-  **[DCS]** Fix ``resource/opentelekomcloud_dcs_instance_v2`` failing to create a Redis Cluster instance with ``ssl_enable = true`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+  **[DCS]** Fix ``resource/opentelekomcloud_dcs_instance_v2`` failing to create a Redis Cluster instance with ``ssl_enable = true`` (`#3448 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3448>`_)

--- a/releasenotes/notes/dcs-instance-v2-ssl-cluster-retry-cdf2297233d33040.yaml
+++ b/releasenotes/notes/dcs-instance-v2-ssl-cluster-retry-cdf2297233d33040.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  |
+  **[DCS]** Fix ``resource/opentelekomcloud_dcs_instance_v2`` failing to create a Redis Cluster instance with ``ssl_enable = true`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Creating a Redis Cluster with `ssl_enable = true` failed with `DCS.4104` because the SSL call after creation had no retry.
Now retries until the instance is ready.

## PR Checklist

* [x] Refers to: #3446
* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccDcsInstancesV2_basic
=== PAUSE TestAccDcsInstancesV2_basic
=== CONT  TestAccDcsInstancesV2_basic
--- PASS: TestAccDcsInstancesV2_basic (147.59s)
=== RUN   TestAccDcsInstancesV2_privateIPs
=== PAUSE TestAccDcsInstancesV2_privateIPs
=== CONT  TestAccDcsInstancesV2_privateIPs
--- PASS: TestAccDcsInstancesV2_privateIPs (114.23s)
=== RUN   TestAccDcsInstancesV2_basicSingleInstance
=== PAUSE TestAccDcsInstancesV2_basicSingleInstance
=== CONT  TestAccDcsInstancesV2_basicSingleInstance
--- PASS: TestAccDcsInstancesV2_basicSingleInstance (102.18s)
=== RUN   TestAccDcsInstancesV2_Whitelist
=== PAUSE TestAccDcsInstancesV2_Whitelist
=== CONT  TestAccDcsInstancesV2_Whitelist
=== RUN   TestAccDcsInstancesV2_SSL
=== PAUSE TestAccDcsInstancesV2_SSL
=== CONT  TestAccDcsInstancesV2_SSL
=== RUN   TestAccDcsInstancesV2_SSLCluster
=== PAUSE TestAccDcsInstancesV2_SSLCluster
=== CONT  TestAccDcsInstancesV2_SSLCluster
=== RUN   TestAccDCSInstanceV2_importBasic
--- PASS: TestAccDCSInstanceV2_importBasic (121.36s)
--- PASS: TestAccDcsInstancesV2_SSL (154.54s)
--- PASS: TestAccDcsInstancesV2_SSLCluster (205.61s)
--- PASS: TestAccDcsInstancesV2_Whitelist (239.03s)
PASS

Process finished with the exit code 0

```
