### PR TITLE
[Feat.] CC: Add `opentelekomcloud_cc_global_connection_bandwidth_v3` resource

### DIFF
--- a/docs/resources/cc_global_connection_bandwidth_v3.md
+++ b/docs/resources/cc_global_connection_bandwidth_v3.md
@@ -1,0 +1,136 @@
+---
+subcategory: "Cloud Connect (CC)"
+layout: "opentelekomcloud"
+page_title: "OpenTelekomCloud: opentelekomcloud_cc_global_connection_bandwidth_v3"
+sidebar_current: "docs-opentelekomcloud-resource-cc-global-connection-bandwidth-v3"
+description: |-
+  Manages a Cloud Connect Global Connection Bandwidth resource within OpenTelekomCloud.
+---
+
+Up-to-date reference of API arguments for Cloud Connect Global Connection Bandwidth you can get at
+[documentation portal](https://docs.otc.t-systems.com/cloud-connect/api-ref/api/global_connection_bandwidths/index.html)
+
+# opentelekomcloud_cc_global_connection_bandwidth_v3
+
+Manages a Cloud Connect (CC) global connection bandwidth resource within OpenTelekomCloud.
+
+A global connection bandwidth provides the network capacity that connects instances (such as cloud connections,
+global EIPs, and central networks) across regions. It can be dedicated to a single instance or shared by
+multiple instances.
+
+-> The global connection bandwidth APIs are account-level (domain-scoped). Make sure the credentials used by the
+provider have permission to manage Cloud Connect resources.
+
+## Example Usage
+
+```hcl
+resource "opentelekomcloud_cc_global_connection_bandwidth_v3" "test" {
+  name        = "gcb-demo"
+  description = "managed by terraform"
+  type        = "Region"
+  bordercross = false
+  charge_mode = "bwd"
+  size        = 5
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required, String) The name of the global connection bandwidth.
+
+* `bordercross` - (Required, Bool, ForceNew) Whether the bandwidth is used for cross-border connections.
+  Changing this parameter will create a new resource.
+
+* `type` - (Required, String, ForceNew) The bandwidth type. The value can be **Area**, **TrsArea**,
+  **SubArea** or **Region**. Changing this parameter will create a new resource.
+
+* `charge_mode` - (Required, String) The billing option. The value can be **bwd** (billing by bandwidth),
+  **95** (standard 95th percentile billing) or **95avr** (enhanced 95th percentile billing).
+
+* `size` - (Required, Int) The bandwidth capacity, in Mbit/s. The value ranges from **2** to **300**.
+
+* `description` - (Optional, String) The description of the global connection bandwidth.
+  The angle brackets (`<` and `>`) are not allowed.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) The ID of the enterprise project that the global
+  connection bandwidth belongs to. Changing this parameter will create a new resource.
+
+* `sla_level` - (Optional, String) The service class of the bandwidth. The value can be **Pt** (Platinum),
+  **Au** (Gold) or **Ag** (Silver).
+
+* `local_area` - (Optional, String, ForceNew) The local access point. The value can contain 1 to 64
+  characters, only letters, digits, underscores (_), hyphens (-) and periods (.) are allowed.
+  Changing this parameter will create a new resource.
+
+* `remote_area` - (Optional, String, ForceNew) The remote access point. The value can contain 1 to 64
+  characters, only letters, digits, underscores (_), hyphens (-) and periods (.) are allowed.
+  Changing this parameter will create a new resource.
+
+* `spec_code_id` - (Optional, String) The UUID of the line specification code.
+
+* `binding_service` - (Optional, String) The service binding type. The value can be **CC**, **GEIP**,
+  **GCN**, **GSN** or **ALL**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format. Equal to the global connection bandwidth ID.
+
+* `domain_id` - The ID of the account that the global connection bandwidth belongs to.
+
+* `local_site_code` - The local access point code.
+
+* `remote_site_code` - The remote access point code.
+
+* `admin_state` - The status of the global connection bandwidth. The value can be **NORMAL** or **FREEZED**.
+
+* `frozen` - Whether the global connection bandwidth is frozen.
+
+* `enable_share` - Whether the bandwidth can be shared by multiple instances.
+
+* `eps_id` - The ID of the enterprise project that the global connection bandwidth belongs to.
+
+* `created_at` - The creation time of the global connection bandwidth.
+
+* `updated_at` - The latest update time of the global connection bandwidth.
+
+* `instances` - The instances associated with the global connection bandwidth.
+  The [instances](#gcb_instances) structure is documented below.
+
+* `directional_connections` - The directional connections of the global connection bandwidth.
+  The [directional_connections](#gcb_directional_connections) structure is documented below.
+
+* `region` - The region in which the global connection bandwidth is managed.
+
+<a name="gcb_instances"></a>
+The `instances` block supports:
+
+* `id` - The instance ID.
+
+* `type` - The instance type.
+
+* `region_id` - The region ID of the instance.
+
+* `project_id` - The project ID of the instance.
+
+<a name="gcb_directional_connections"></a>
+The `directional_connections` block supports:
+
+* `id` - The connection ID.
+
+* `name` - The connection name.
+
+* `local_site_code` - The local access point code.
+
+* `remote_site_code` - The remote access point code.
+
+## Import
+
+The global connection bandwidth can be imported using the `id`, e.g.
+
+```
+$ terraform import opentelekomcloud_cc_global_connection_bandwidth_v3.test 0ce123456a00f2591fabc00385ff1234
+```

--- a/opentelekomcloud/acceptance/cc/resource_opentelekomcloud_cc_global_connection_bandwidth_v3_test.go
+++ b/opentelekomcloud/acceptance/cc/resource_opentelekomcloud_cc_global_connection_bandwidth_v3_test.go
@@ -1,0 +1,103 @@
+package cc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	gcb "github.com/opentelekomcloud/gophertelekomcloud/openstack/cc/v3/global_connection_bandwidth"
+
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+)
+
+func getGlobalConnectionBandwidthResourceFunc(conf *cfg.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.CcV3Client(env.OS_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating OpenTelekomCloud CC v3 client: %s", err)
+	}
+	return gcb.Get(client, state.Primary.ID)
+}
+
+func TestAccCcGlobalConnectionBandwidthV3_basic(t *testing.T) {
+	var obj interface{}
+
+	name := fmt.Sprintf("cc_acc_gcb_%s", acctest.RandString(5))
+	updateName := name + "_updated"
+	rName := "opentelekomcloud_cc_global_connection_bandwidth_v3.test"
+
+	rc := common.InitResourceCheck(
+		rName,
+		&obj,
+		getGlobalConnectionBandwidthResourceFunc,
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCcGlobalConnectionBandwidthV3_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "created by terraform acceptance test"),
+					resource.TestCheckResourceAttr(rName, "type", "Region"),
+					resource.TestCheckResourceAttr(rName, "bordercross", "false"),
+					resource.TestCheckResourceAttr(rName, "charge_mode", "bwd"),
+					resource.TestCheckResourceAttr(rName, "size", "5"),
+					resource.TestCheckResourceAttrSet(rName, "domain_id"),
+					resource.TestCheckResourceAttrSet(rName, "admin_state"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "region"),
+				),
+			},
+			{
+				Config: testAccCcGlobalConnectionBandwidthV3_update(updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", updateName),
+					resource.TestCheckResourceAttr(rName, "description", "updated by terraform acceptance test"),
+					resource.TestCheckResourceAttr(rName, "size", "10"),
+					resource.TestCheckResourceAttr(rName, "sla_level", "Au"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCcGlobalConnectionBandwidthV3_basic(name string) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_cc_global_connection_bandwidth_v3" "test" {
+  name        = "%s"
+  description = "created by terraform acceptance test"
+  type        = "Region"
+  bordercross = false
+  charge_mode = "bwd"
+  size        = 5
+}
+`, name)
+}
+
+func testAccCcGlobalConnectionBandwidthV3_update(name string) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_cc_global_connection_bandwidth_v3" "test" {
+  name        = "%s"
+  description = "updated by terraform acceptance test"
+  type        = "Region"
+  bordercross = false
+  charge_mode = "bwd"
+  size        = 10
+  sla_level   = "Au"
+}
+`, name)
+}

--- a/opentelekomcloud/provider.go
+++ b/opentelekomcloud/provider.go
@@ -497,6 +497,7 @@ func Provider() *schema.Provider {
 			"opentelekomcloud_cc_central_network_v3":                     cc.ResourceCcCentralNetworkV3(),
 			"opentelekomcloud_cc_central_network_policy_v3":              cc.ResourceCcCentralNetworkPolicyV3(),
 			"opentelekomcloud_cc_central_network_policy_apply_v3":        cc.ResourceCcCentralNetworkPolicyApplyV3(),
+			"opentelekomcloud_cc_global_connection_bandwidth_v3":         cc.ResourceCcGlobalConnectionBandwidthV3(),
 			"opentelekomcloud_cce_addon_v3":                              cce.ResourceCCEAddonV3(),
 			"opentelekomcloud_cce_cluster_v3":                            cce.ResourceCCEClusterV3(),
 			"opentelekomcloud_cce_node_attach_v3":                        cce.ResourceCCENodeV3Attach(),

--- a/opentelekomcloud/services/cc/resource_opentelekomcloud_cc_global_connection_bandwidth_v3.go
+++ b/opentelekomcloud/services/cc/resource_opentelekomcloud_cc_global_connection_bandwidth_v3.go
@@ -1,0 +1,335 @@
+package cc
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	gcb "github.com/opentelekomcloud/gophertelekomcloud/openstack/cc/v3/global_connection_bandwidth"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/pointerto"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
+	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
+)
+
+func ResourceCcGlobalConnectionBandwidthV3() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceCcGlobalConnectionBandwidthV3Create,
+		ReadContext:   resourceCcGlobalConnectionBandwidthV3Read,
+		UpdateContext: resourceCcGlobalConnectionBandwidthV3Update,
+		DeleteContext: resourceCcGlobalConnectionBandwidthV3Delete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"bordercross": {
+				Type:     schema.TypeBool,
+				Required: true,
+				ForceNew: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"charge_mode": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"size": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"sla_level": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"local_area": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"remote_area": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"spec_code_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"binding_service": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"domain_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"local_site_code": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"remote_site_code": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"admin_state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"frozen": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"enable_share": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"eps_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"instances": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"region_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"project_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"directional_connections": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"local_site_code": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"remote_site_code": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"region": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceCcGlobalConnectionBandwidthV3Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, ccClientV3, func() (*golangsdk.ServiceClient, error) {
+		return config.CcV3Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV3Client, err)
+	}
+
+	createOpts := gcb.CreateOpts{
+		Name:                d.Get("name").(string),
+		Description:         d.Get("description").(string),
+		Bordercross:         pointerto.Bool(d.Get("bordercross").(bool)),
+		Type:                d.Get("type").(string),
+		EnterpriseProjectId: d.Get("enterprise_project_id").(string),
+		ChargeMode:          d.Get("charge_mode").(string),
+		Size:                d.Get("size").(int),
+		SlaLevel:            d.Get("sla_level").(string),
+		LocalArea:           d.Get("local_area").(string),
+		RemoteArea:          d.Get("remote_area").(string),
+		SpecCodeId:          d.Get("spec_code_id").(string),
+	}
+
+	created, err := gcb.Create(client, createOpts)
+	if err != nil {
+		return diag.Errorf("error creating OpenTelekomCloud CC global connection bandwidth: %s", err)
+	}
+
+	d.SetId(created.ID)
+
+	clientCtx := common.CtxWithClient(ctx, client, ccClientV3)
+	return resourceCcGlobalConnectionBandwidthV3Read(clientCtx, d, meta)
+}
+
+func resourceCcGlobalConnectionBandwidthV3Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, ccClientV3, func() (*golangsdk.ServiceClient, error) {
+		return config.CcV3Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV3Client, err)
+	}
+
+	bandwidth, err := gcb.Get(client, d.Id())
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving OpenTelekomCloud CC global connection bandwidth")
+	}
+
+	mErr := multierror.Append(
+		nil,
+		d.Set("region", config.GetRegion(d)),
+		d.Set("name", bandwidth.Name),
+		d.Set("description", bandwidth.Description),
+		d.Set("bordercross", bandwidth.Bordercross),
+		d.Set("type", bandwidth.Type),
+		d.Set("charge_mode", bandwidth.ChargeMode),
+		d.Set("size", bandwidth.Size),
+		d.Set("enterprise_project_id", bandwidth.EnterpriseProjectId),
+		d.Set("sla_level", bandwidth.SlaLevel),
+		d.Set("local_area", bandwidth.LocalArea),
+		d.Set("remote_area", bandwidth.RemoteArea),
+		d.Set("spec_code_id", bandwidth.SpecCodeId),
+		d.Set("binding_service", bandwidth.BindingService),
+		d.Set("domain_id", bandwidth.DomainId),
+		d.Set("local_site_code", bandwidth.LocalSiteCode),
+		d.Set("remote_site_code", bandwidth.RemoteSiteCode),
+		d.Set("admin_state", bandwidth.AdminState),
+		d.Set("frozen", bandwidth.Frozen),
+		d.Set("enable_share", bandwidth.EnableShare),
+		d.Set("eps_id", bandwidth.EpsId),
+		d.Set("created_at", bandwidth.CreatedAt),
+		d.Set("updated_at", bandwidth.UpdatedAt),
+		d.Set("instances", flattenGcbInstances(bandwidth.Instances)),
+		d.Set("directional_connections", flattenGcbDirectionalConnections(bandwidth.DirectionalConnections)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenGcbInstances(instances []gcb.AssociatedInstance) []map[string]interface{} {
+	if len(instances) == 0 {
+		return nil
+	}
+	result := make([]map[string]interface{}, len(instances))
+	for i, instance := range instances {
+		result[i] = map[string]interface{}{
+			"id":         instance.ID,
+			"type":       instance.Type,
+			"region_id":  instance.RegionId,
+			"project_id": instance.ProjectId,
+		}
+	}
+	return result
+}
+
+func flattenGcbDirectionalConnections(connections []gcb.DirectionalConnection) []map[string]interface{} {
+	if len(connections) == 0 {
+		return nil
+	}
+	result := make([]map[string]interface{}, len(connections))
+	for i, connection := range connections {
+		result[i] = map[string]interface{}{
+			"id":               connection.ID,
+			"name":             connection.Name,
+			"local_site_code":  connection.LocalSiteCode,
+			"remote_site_code": connection.RemoteSiteCode,
+		}
+	}
+	return result
+}
+
+func resourceCcGlobalConnectionBandwidthV3Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, ccClientV3, func() (*golangsdk.ServiceClient, error) {
+		return config.CcV3Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV3Client, err)
+	}
+
+	if d.HasChanges("name", "description", "size", "charge_mode", "sla_level", "binding_service", "spec_code_id") {
+		updateOpts := gcb.UpdateOpts{
+			ID:             d.Id(),
+			Name:           d.Get("name").(string),
+			Description:    pointerto.String(d.Get("description").(string)),
+			Size:           d.Get("size").(int),
+			ChargeMode:     d.Get("charge_mode").(string),
+			SlaLevel:       d.Get("sla_level").(string),
+			BindingService: d.Get("binding_service").(string),
+			SpecCodeId:     d.Get("spec_code_id").(string),
+		}
+		if _, err = gcb.Update(client, updateOpts); err != nil {
+			return diag.Errorf("error updating OpenTelekomCloud CC global connection bandwidth (%s): %s", d.Id(), err)
+		}
+	}
+
+	clientCtx := common.CtxWithClient(ctx, client, ccClientV3)
+	return resourceCcGlobalConnectionBandwidthV3Read(clientCtx, d, meta)
+}
+
+func resourceCcGlobalConnectionBandwidthV3Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*cfg.Config)
+	client, err := common.ClientFromCtx(ctx, ccClientV3, func() (*golangsdk.ServiceClient, error) {
+		return config.CcV3Client(config.GetRegion(d))
+	})
+	if err != nil {
+		return fmterr.Errorf(errCreationV3Client, err)
+	}
+
+	if err = gcb.Delete(client, d.Id()); err != nil {
+		return common.CheckDeletedDiag(d, err, "error deleting OpenTelekomCloud CC global connection bandwidth")
+	}
+
+	return nil
+}

--- a/releasenotes/notes/cc-global-connection-bandwidth-v3-911bcd1cd21d8dad.yaml
+++ b/releasenotes/notes/cc-global-connection-bandwidth-v3-911bcd1cd21d8dad.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   - |
-    **[Cloud Connect]** Added new resource ``opentelekomcloud_cc_global_connection_bandwidth_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[Cloud Connect]** Added new resource ``opentelekomcloud_cc_global_connection_bandwidth_v3`` (`#3449 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3449>`_)

--- a/releasenotes/notes/cc-global-connection-bandwidth-v3-911bcd1cd21d8dad.yaml
+++ b/releasenotes/notes/cc-global-connection-bandwidth-v3-911bcd1cd21d8dad.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    **[Cloud Connect]** Added new resource ``opentelekomcloud_cc_global_connection_bandwidth_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Adds a new resource `opentelekomcloud_cc_global_connection_bandwidth_v3` for managing Cloud Connect (CC) global connection bandwidths.

## PR Checklist

* [x] Refers to: #3341
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccCcGlobalConnectionBandwidthV3_basic
--- PASS: TestAccCcGlobalConnectionBandwidthV3_basic (53.89s)
PASS

Process finished with the exit code 0

```
