### PR TITLE
deps: pin gophertelekomcloud to fork commit for CCE API fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -68,3 +68,5 @@ require (
 	google.golang.org/grpc v1.79.3 // indirect
 	google.golang.org/protobuf v1.36.10 // indirect
 )
+
+replace github.com/opentelekomcloud/gophertelekomcloud => github.com/DKSR-Data-Competence-for-Cities-Regions/gophertelekomcloud v0.0.0-20260702185825-f56b69a6f110

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+github.com/DKSR-Data-Competence-for-Cities-Regions/gophertelekomcloud v0.0.0-20260702185825-f56b69a6f110 h1:LNsP8m2y5BM9nk7Sc43NepcxeTic00V2cykiEOLtgHo=
+github.com/DKSR-Data-Competence-for-Cities-Regions/gophertelekomcloud v0.0.0-20260702185825-f56b69a6f110/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
 github.com/GehirnInc/crypt v0.0.0-20230320061759-8cc1b52080c5 h1:IEjq88XO4PuBDcvmjQJcQGg+w+UaafSy8G5Kcb5tBhI=
 github.com/GehirnInc/crypt v0.0.0-20230320061759-8cc1b52080c5/go.mod h1:exZ0C/1emQJAw5tHOaUDyY1ycttqBAPcxuzf7QbY6ec=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
@@ -167,8 +169,6 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.8-0.20260619093052-c1120d6d0559 h1:CupbcYUCWb9lylq+TiICIT6uIVcocAetQdG3fotx6IU=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.8-0.20260619093052-c1120d6d0559/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
## Summary of the Pull Request
Use DKSR fork of gophertelekomcloud via go.mod replace, pinned to commit f56b69a6f110 (pseudo-version v0.0.0-20260702185825-f56b69a6f110), to include the CCE API response change fix until upstream is merged.

Upstream PR: https://github.com/opentelekomcloud/gophertelekomcloud/pull/957
Fork branch: fix/cce_api_response_change

Closes: #3450 (Temporary fix until PR is merged in SDK)


## PR Checklist

* [x] Refers to: #3450
* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (101.71s)
=== RUN   TestAccSomethingV0_timeout
--- PASS: TestAccSomethingV0_timeout (128.67s)
PASS

Process finished with exit code 0
```
