### PR TITLE
[Fix] CCE: Update dependencies to fix breaking changes in API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.9.8-0.20260619093052-c1120d6d0559
+	github.com/opentelekomcloud/gophertelekomcloud v0.9.8-0.20260703083050-9dec68a8dcf7
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.46.0
 	golang.org/x/sync v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -167,8 +167,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.8-0.20260619093052-c1120d6d0559 h1:CupbcYUCWb9lylq+TiICIT6uIVcocAetQdG3fotx6IU=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.8-0.20260619093052-c1120d6d0559/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.8-0.20260703083050-9dec68a8dcf7 h1:cf2lqasnVIqrFz+DW0m4gH79pdkYXlX00Lsuhi7dsek=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.8-0.20260703083050-9dec68a8dcf7/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/releasenotes/notes/cce-update-mod-fix-api-changes-cebb4126be5eacec.yaml
+++ b/releasenotes/notes/cce-update-mod-fix-api-changes-cebb4126be5eacec.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[CCE]** Updating go mod fixes ``resource/opentelekomcloud_cce_cluster_v3`` error caused by api change (`#3453 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3453>`_)


### PR DESCRIPTION
## Summary of the Pull Request

Fixes breaking API changes in cce clusters.
The field `conditions` were removed from `status` in gophertelekomcloud. Update the go mod to reflect changes from gopher  in T cloud Public TF provider. 
No changes need in the provider itself. 

## PR Checklist

* [x] Refers to: #3450 
* [x] Tests added/passed.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccCCEClusterV3_basic
=== PAUSE TestAccCCEClusterV3_basic
=== CONT  TestAccCCEClusterV3_basic
--- PASS: TestAccCCEClusterV3_basic (569.53s)
PASS
```
