### PR TITLE
[Sec] ELB: Mark certificate `private_key` as sensitive

### DIFF
--- a/opentelekomcloud/services/elb/v2/resource_opentelekomcloud_lb_certificate_v2.go
+++ b/opentelekomcloud/services/elb/v2/resource_opentelekomcloud_lb_certificate_v2.go
@@ -64,6 +64,7 @@ func ResourceCertificateV2() *schema.Resource {
 			"private_key": {
 				Type:             schema.TypeString,
 				Optional:         true,
+				Sensitive:        true,
 				DiffSuppressFunc: common.SuppressStrippedNewLines,
 			},
 

--- a/opentelekomcloud/services/elb/v3/data_source_opentelekomcloud_lb_certificate_v3.go
+++ b/opentelekomcloud/services/elb/v3/data_source_opentelekomcloud_lb_certificate_v3.go
@@ -39,8 +39,9 @@ func DataSourceCertificateV3() *schema.Resource {
 				Computed: true,
 			},
 			"private_key": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
 			},
 			"certificate": {
 				Type:     schema.TypeString,

--- a/opentelekomcloud/services/elb/v3/resource_opentelekomcloud_lb_certificate_v3.go
+++ b/opentelekomcloud/services/elb/v3/resource_opentelekomcloud_lb_certificate_v3.go
@@ -51,6 +51,7 @@ func ResourceCertificateV3() *schema.Resource {
 			"private_key": {
 				Type:             schema.TypeString,
 				Optional:         true,
+				Sensitive:        true,
 				DiffSuppressFunc: common.SuppressStrippedNewLines,
 			},
 			"certificate": {

--- a/releasenotes/notes/lb-certificate-private-key-sensitive-d3f7109cc1a42802.yaml
+++ b/releasenotes/notes/lb-certificate-private-key-sensitive-d3f7109cc1a42802.yaml
@@ -3,12 +3,12 @@ security:
   - |
     **[ELB]** Mark ``private_key`` as ``sensitive`` in
     ``resource/opentelekomcloud_lb_certificate_v2`` so the TLS private key is no
-    longer exposed in ``plan``/``apply`` output
+    longer exposed in ``plan``/``apply`` output (`#3459 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3459>`_)
   - |
     **[ELB]** Mark ``private_key`` as ``sensitive`` in
     ``resource/opentelekomcloud_lb_certificate_v3`` so the TLS private key is no
-    longer exposed in ``plan``/``apply`` output
+    longer exposed in ``plan``/``apply`` output (`#3459 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3459>`_)
   - |
     **[ELB]** Mark ``private_key`` as ``sensitive`` in
     ``data/opentelekomcloud_lb_certificate_v3`` so the TLS private key is no
-    longer exposed in ``plan``/``apply`` output
+    longer exposed in ``plan``/``apply`` output (`#3459 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3459>`_)

--- a/releasenotes/notes/lb-certificate-private-key-sensitive-d3f7109cc1a42802.yaml
+++ b/releasenotes/notes/lb-certificate-private-key-sensitive-d3f7109cc1a42802.yaml
@@ -1,0 +1,14 @@
+---
+security:
+  - |
+    **[ELB]** Mark ``private_key`` as ``sensitive`` in
+    ``resource/opentelekomcloud_lb_certificate_v2`` so the TLS private key is no
+    longer exposed in ``plan``/``apply`` output
+  - |
+    **[ELB]** Mark ``private_key`` as ``sensitive`` in
+    ``resource/opentelekomcloud_lb_certificate_v3`` so the TLS private key is no
+    longer exposed in ``plan``/``apply`` output
+  - |
+    **[ELB]** Mark ``private_key`` as ``sensitive`` in
+    ``data/opentelekomcloud_lb_certificate_v3`` so the TLS private key is no
+    longer exposed in ``plan``/``apply`` output


### PR DESCRIPTION
## Summary of the Pull Request
Adds `Sensitive: true` to the `private_key` field in `opentelekomcloud_lb_certificate_v2`, `opentelekomcloud_lb_certificate_v3` and the `opentelekomcloud_lb_certificate_v3` data source, so the TLS private key is no longer exposed in plan/apply output.

## PR Checklist

* [ ] Refers to: #xxx
* [x] Tests added/passed.
* [ ] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccLBV2Certificate_basic
=== PAUSE TestAccLBV2Certificate_basic
=== CONT  TestAccLBV2Certificate_basic
--- PASS: TestAccLBV2Certificate_basic (79.16s)
=== RUN   TestAccLBV2Certificate_import
=== PAUSE TestAccLBV2Certificate_import
=== CONT  TestAccLBV2Certificate_import
--- PASS: TestAccLBV2Certificate_import (32.35s)
PASS

Process finished with the exit code 0

=== RUN   TestAccLBV3Certificate_basic
=== PAUSE TestAccLBV3Certificate_basic
=== CONT  TestAccLBV3Certificate_basic
--- PASS: TestAccLBV3Certificate_basic (87.28s)
=== RUN   TestAccLBv3Certificate_importBasic
=== PAUSE TestAccLBv3Certificate_importBasic
=== CONT  TestAccLBv3Certificate_importBasic
--- PASS: TestAccLBv3Certificate_importBasic (32.29s)
PASS

Process finished with the exit code 0

=== RUN   TestAccLBCertificateV3_basic
=== PAUSE TestAccLBCertificateV3_basic
=== CONT  TestAccLBCertificateV3_basic
--- PASS: TestAccLBCertificateV3_basic (42.38s)
PASS

Process finished with the exit code 0

```
