### PR TITLE
[Feat.] IAM: Support user lookup by ID in data source identity_user_v3

### DIFF
--- a/docs/data-sources/identity_user_v3.md
+++ b/docs/data-sources/identity_user_v3.md
@@ -16,15 +16,28 @@ Use this data source to get the ID of an OpenTelekomCloud user.
 
 ## Example Usage
 
+### Query by name
+
 ```hcl
 data "opentelekomcloud_identity_user_v3" "user_1" {
   name = "user_1"
 }
 ```
 
+### Query by ID
+
+```hcl
+data "opentelekomcloud_identity_user_v3" "user_1" {
+  id = "0a54c86a-0b3c-4762-92cc-bdfb63c572e1"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
+
+* `id` - (Optional) The ID of the user. If set, it takes precedence over the arguments below
+  and the user is looked up by ID directly.
 
 * `domain_id` - (Optional) The domain this user belongs to.
 
@@ -36,6 +49,10 @@ The following arguments are supported:
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the user.
+
+* `name` - The name of the user.
 
 * `password_expires_at` - Password expiration date of the user.
 

--- a/opentelekomcloud/acceptance/iam/data_source_opentelekomcloud_identity_user_v3_test.go
+++ b/opentelekomcloud/acceptance/iam/data_source_opentelekomcloud_identity_user_v3_test.go
@@ -34,6 +34,19 @@ func TestAccOpenStackIdentityV3UserDataSource_basic(t *testing.T) {
 						"data.opentelekomcloud_identity_user_v3.user_1", "mfa_device", ""),
 					resource.TestCheckResourceAttr(
 						"data.opentelekomcloud_identity_user_v3.user_1", "enabled", "true"),
+					resource.TestCheckResourceAttrPair(
+						"data.opentelekomcloud_identity_user_v3.user_1", "id",
+						"opentelekomcloud_identity_user_v3.user_1", "id"),
+				),
+			},
+			{
+				Config: testAccOpenStackIdentityUserV3DataSource_byID(userName, userPassword),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIdentityUserV3DataSourceID("data.opentelekomcloud_identity_user_v3.user_1"),
+					resource.TestCheckResourceAttr(
+						"data.opentelekomcloud_identity_user_v3.user_1", "name", userName),
+					resource.TestCheckResourceAttr(
+						"data.opentelekomcloud_identity_user_v3.user_1", "enabled", "true"),
 				),
 			},
 		},
@@ -70,6 +83,16 @@ func testAccOpenStackIdentityUserV3DataSource_basic(name, password string) strin
 
 data "opentelekomcloud_identity_user_v3" "user_1" {
   name = opentelekomcloud_identity_user_v3.user_1.name
+}
+`, testAccOpenStackIdentityUserV3DataSource_user(name, password))
+}
+
+func testAccOpenStackIdentityUserV3DataSource_byID(name, password string) string {
+	return fmt.Sprintf(`
+	%s
+
+data "opentelekomcloud_identity_user_v3" "user_1" {
+  id = opentelekomcloud_identity_user_v3.user_1.id
 }
 `, testAccOpenStackIdentityUserV3DataSource_user(name, password))
 }

--- a/opentelekomcloud/services/iam/data_source_opentelekomcloud_identity_user_v3.go
+++ b/opentelekomcloud/services/iam/data_source_opentelekomcloud_identity_user_v3.go
@@ -22,6 +22,11 @@ func DataSourceIdentityUserV3() *schema.Resource {
 		ReadContext: dataSourceIdentityUserV3Read,
 
 		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"domain_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -56,36 +61,49 @@ func dataSourceIdentityUserV3Read(_ context.Context, d *schema.ResourceData, met
 		return fmterr.Errorf("error creating identity client: %s", err)
 	}
 
-	enabled := d.Get("enabled").(bool)
-	listOpts := users.ListOpts{
-		DomainID: d.Get("domain_id").(string),
-		Enabled:  &enabled,
-		Name:     d.Get("name").(string),
+	var user users.User
+	if userID := d.Get("id").(string); userID != "" {
+		userDetails, err := users.Get(client, userID).Extract()
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				return fmterr.Errorf("your query returned no results. " +
+					"Please change your search criteria and try again.")
+			}
+			return fmterr.Errorf("unable to get user %s: %s", userID, err)
+		}
+		user = *userDetails
+	} else {
+		enabled := d.Get("enabled").(bool)
+		listOpts := users.ListOpts{
+			DomainID: d.Get("domain_id").(string),
+			Enabled:  &enabled,
+			Name:     d.Get("name").(string),
+		}
+
+		log.Printf("[DEBUG] List Options: %#v", listOpts)
+
+		allPages, err := users.List(client, listOpts).AllPages()
+		if err != nil {
+			return fmterr.Errorf("unable to query users: %s", err)
+		}
+
+		allUsers, err := users.ExtractUsers(allPages)
+		if err != nil {
+			return fmterr.Errorf("unable to retrieve users: %s", err)
+		}
+
+		if len(allUsers) < 1 {
+			return fmterr.Errorf("your query returned no results. " +
+				"Please change your search criteria and try again.")
+		}
+
+		if len(allUsers) > 1 {
+			log.Printf("[DEBUG] Multiple results found: %#v", allUsers)
+			return fmterr.Errorf("your query returned more than one result")
+		}
+
+		user = allUsers[0]
 	}
-
-	log.Printf("[DEBUG] List Options: %#v", listOpts)
-
-	allPages, err := users.List(client, listOpts).AllPages()
-	if err != nil {
-		return fmterr.Errorf("unable to query users: %s", err)
-	}
-
-	allUsers, err := users.ExtractUsers(allPages)
-	if err != nil {
-		return fmterr.Errorf("unable to retrieve users: %s", err)
-	}
-
-	if len(allUsers) < 1 {
-		return fmterr.Errorf("your query returned no results. " +
-			"Please change your search criteria and try again.")
-	}
-
-	if len(allUsers) > 1 {
-		log.Printf("[DEBUG] Multiple results found: %#v", allUsers)
-		return fmterr.Errorf("your query returned more than one result")
-	}
-
-	user := allUsers[0]
 
 	log.Printf("[DEBUG] Single user found: %s", user.ID)
 

--- a/releasenotes/notes/identity_user_v3_lookup_by_id-b04b24fc9791856e.yaml
+++ b/releasenotes/notes/identity_user_v3_lookup_by_id-b04b24fc9791856e.yaml
@@ -1,4 +1,4 @@
 ---
 enhancements:
   - |
-    **[IAM]** Support user lookup by ``id`` in ``data/opentelekomcloud_identity_user_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_).
+    **[IAM]** Support user lookup by ``id`` in ``data/opentelekomcloud_identity_user_v3`` (`#3475 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3475>`_).

--- a/releasenotes/notes/identity_user_v3_lookup_by_id-b04b24fc9791856e.yaml
+++ b/releasenotes/notes/identity_user_v3_lookup_by_id-b04b24fc9791856e.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[IAM]** Support user lookup by ``id`` in ``data/opentelekomcloud_identity_user_v3`` (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_).


### PR DESCRIPTION
## Summary of the Pull Request
Enhances the `opentelekomcloud_identity_user_v3` data source to support bidirectional lookups:
- New optional `id` argument: when set, the user is fetched by ID directly (takes precedence over `name`/`domain_id`/`enabled` filters).
- The `id` attribute is now explicitly documented as exported, enabling name → ID reverse lookups.

## PR Checklist

* [x] Refers to: #3469
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed
```
  === RUN   TestAccOpenStackIdentityV3UserDataSource_basic
  --- PASS: TestAccOpenStackIdentityV3UserDataSource_basic (69.27s)
  PASS

  Process finished with exit code 0
```
