### PR TITLE
[Fix] extra dhcp opts and ntp example for `opentelekomcloud_networking_port_v2`

### DIFF
--- a/docs/resources/networking_port_v2.md
+++ b/docs/resources/networking_port_v2.md
@@ -41,6 +41,28 @@ resource "opentelekomcloud_networking_subnet_v2" "subnet_1" {
 }
 ```
 
+### Configure NTP for a Port
+
+Use the Neutron `ntp-server` extra DHCP option to configure an NTP server for a specific port:
+
+```hcl
+resource "opentelekomcloud_networking_port_v2" "port_ntp" {
+  name       = "port_ntp"
+  network_id = opentelekomcloud_networking_network_v2.network_1.id
+
+  fixed_ip {
+    subnet_id = opentelekomcloud_networking_subnet_v2.subnet_1.id
+  }
+
+  extra_dhcp_option {
+    name  = "ntp-server"
+    value = "10.100.0.33"
+  }
+}
+```
+
+The option applies only to this port. Existing guests may need to renew their DHCP lease to receive the updated NTP configuration.
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -92,7 +114,7 @@ The following arguments are supported:
   * `ip_address` - (Required, String) The additional IP address.
   * `mac_address` - (Optional, String) The additional MAC address.
 
-* `extra_dhcp_option` - (Optional, Map) Specifies the extended DHCP option. This is an extended attribute.
+* `extra_dhcp_option` - (Optional, Set) Specifies the extended DHCP option. This is an extended attribute.
   The `extra_dhcp_option` block supports:
   * `name` - (Required, String) Specifies the option name.
   * `value` - (Required, String) Specifies the option value.

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_port_v2_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_networking_port_v2_test.go
@@ -155,7 +155,7 @@ func TestAccNetworkingV2Port_portSecurity_enabled(t *testing.T) {
 	})
 }
 
-func TestAccNetworkingV2Port_extendedDhcpOpts(t *testing.T) {
+func TestAccNetworkingV2Port_ntpDhcpOption(t *testing.T) {
 	var port ports.Port
 	resourceName := "opentelekomcloud_networking_port_v2.port_1"
 	t.Parallel()
@@ -168,21 +168,31 @@ func TestAccNetworkingV2Port_extendedDhcpOpts(t *testing.T) {
 		CheckDestroy:      testAccCheckNetworkingV2PortDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkingV2PortExtendedDHCPOpts,
+				Config: testAccNetworkingV2PortNTPDHCPOption,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkingV2PortWithExtensionsExists(resourceName, &port),
 					resource.TestCheckResourceAttr(resourceName, "extra_dhcp_option.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "extra_dhcp_option.0.name", "A"),
-					resource.TestCheckResourceAttr(resourceName, "extra_dhcp_option.0.value", "MY_VAL"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "extra_dhcp_option.*", map[string]string{
+						"name":  "ntp-server",
+						"value": "10.100.0.33",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "port_security_enabled", "false"),
+					testAccCheckNetworkingV2PortPortSecurity(&port, false),
+					testAccCheckNetworkingV2PortDHCPOption(&port, "ntp-server", "10.100.0.33"),
 				),
 			},
 			{
-				Config: testAccNetworkingV2PortExtendedDHCPOptsUpdate,
+				Config: testAccNetworkingV2PortNTPDHCPOptionUpdate,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkingV2PortWithExtensionsExists(resourceName, &port),
 					resource.TestCheckResourceAttr(resourceName, "extra_dhcp_option.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "extra_dhcp_option.0.name", "B"),
-					resource.TestCheckResourceAttr(resourceName, "extra_dhcp_option.0.value", "MY_VAL_UPDATED"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "extra_dhcp_option.*", map[string]string{
+						"name":  "ntp-server",
+						"value": "10.100.0.34",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "port_security_enabled", "false"),
+					testAccCheckNetworkingV2PortPortSecurity(&port, false),
+					testAccCheckNetworkingV2PortDHCPOption(&port, "ntp-server", "10.100.0.34"),
 				),
 			},
 		},
@@ -342,6 +352,18 @@ func testAccCheckNetworkingV2PortPortSecurity(port *ports.Port, expected bool) r
 		}
 
 		return nil
+	}
+}
+
+func testAccCheckNetworkingV2PortDHCPOption(port *ports.Port, name, value string) resource.TestCheckFunc {
+	return func(_ *terraform.State) error {
+		for _, option := range port.ExtraDhcpOpts {
+			if option.OptName == name && option.OptValue == value {
+				return nil
+			}
+		}
+
+		return fmt.Errorf("port DHCP option %q with value %q not found", name, value)
 	}
 }
 
@@ -543,7 +565,7 @@ resource "opentelekomcloud_networking_port_v2" "port_1" {
 }
 `
 
-const testAccNetworkingV2PortExtendedDHCPOpts = `
+const testAccNetworkingV2PortNTPDHCPOption = `
 resource "opentelekomcloud_networking_network_v2" "network_1" {
   name = "network_1"
 }
@@ -555,20 +577,22 @@ resource "opentelekomcloud_networking_subnet_v2" "subnet_1" {
 }
 
 resource "opentelekomcloud_networking_port_v2" "port_1" {
-  name       = "port_1"
-  network_id = opentelekomcloud_networking_network_v2.network_1.id
+  name                  = "port_1"
+  network_id            = opentelekomcloud_networking_network_v2.network_1.id
+  port_security_enabled = false
+  no_security_groups    = true
   fixed_ip {
     subnet_id  = opentelekomcloud_networking_subnet_v2.subnet_1.id
     ip_address = "192.168.199.23"
   }
   extra_dhcp_option {
-    name  = "A"
-    value = "MY_VAL"
+    name  = "ntp-server"
+    value = "10.100.0.33"
   }
 }
 `
 
-const testAccNetworkingV2PortExtendedDHCPOptsUpdate = `
+const testAccNetworkingV2PortNTPDHCPOptionUpdate = `
 resource "opentelekomcloud_networking_network_v2" "network_1" {
   name = "network_1"
 }
@@ -580,15 +604,17 @@ resource "opentelekomcloud_networking_subnet_v2" "subnet_1" {
 }
 
 resource "opentelekomcloud_networking_port_v2" "port_1" {
-  name       = "port_1"
-  network_id = opentelekomcloud_networking_network_v2.network_1.id
+  name                  = "port_1"
+  network_id            = opentelekomcloud_networking_network_v2.network_1.id
+  port_security_enabled = false
+  no_security_groups    = true
   fixed_ip {
     subnet_id  = opentelekomcloud_networking_subnet_v2.subnet_1.id
     ip_address = "192.168.199.23"
   }
   extra_dhcp_option {
-    name  = "B"
-    value = "MY_VAL_UPDATED"
+    name  = "ntp-server"
+    value = "10.100.0.34"
   }
 }
 `

--- a/opentelekomcloud/services/vpc/resource_opentelekomcloud_networking_port_v2.go
+++ b/opentelekomcloud/services/vpc/resource_opentelekomcloud_networking_port_v2.go
@@ -220,7 +220,7 @@ func resourceNetworkingPortV2Create(ctx context.Context, d *schema.ResourceData,
 	dhcpOpts := d.Get("extra_dhcp_option").(*schema.Set)
 	if dhcpOpts.Len() > 0 {
 		extendedCreateOpts = extradhcpopts.CreateOptsExt{
-			CreateOptsBuilder: createOpts,
+			CreateOptsBuilder: extendedCreateOpts,
 			ExtraDHCPOpts:     expandNetworkingPortDHCPOptsV2Create(dhcpOpts),
 		}
 	}

--- a/releasenotes/notes/networking-port-ntp-example-ad6fe5a2e90870cd.yaml
+++ b/releasenotes/notes/networking-port-ntp-example-ad6fe5a2e90870cd.yaml
@@ -1,0 +1,7 @@
+---
+other:
+  - |
+    **[VPC]** NTP server example for ``resource/opentelekomcloud_networking_port_v2`` (`#3477 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3477>`_)
+fixes:
+  - |
+    **[VPC]** fix ``extra_dhcp_option`` setup while create for ``resource/opentelekomcloud_networking_port_v2`` (`#3477 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3477>`_)


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [x] Refers to: #3473
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccNetworkingV2Port_basic
=== PAUSE TestAccNetworkingV2Port_basic
=== CONT  TestAccNetworkingV2Port_basic
--- PASS: TestAccNetworkingV2Port_basic (70.93s)
=== RUN   TestAccNetworkingV2Port_importBasic
=== PAUSE TestAccNetworkingV2Port_importBasic
=== CONT  TestAccNetworkingV2Port_importBasic
--- PASS: TestAccNetworkingV2Port_importBasic (76.26s)
=== RUN   TestAccNetworkingV2Port_noip
=== PAUSE TestAccNetworkingV2Port_noip
=== CONT  TestAccNetworkingV2Port_noip
--- PASS: TestAccNetworkingV2Port_noip (70.92s)
=== RUN   TestAccNetworkingV2Port_allowedAddressPairs
=== PAUSE TestAccNetworkingV2Port_allowedAddressPairs
=== CONT  TestAccNetworkingV2Port_allowedAddressPairs
--- PASS: TestAccNetworkingV2Port_allowedAddressPairs (89.40s)
=== RUN   TestAccNetworkingV2Port_portSecurity_enabled
=== PAUSE TestAccNetworkingV2Port_portSecurity_enabled
=== CONT  TestAccNetworkingV2Port_portSecurity_enabled
--- PASS: TestAccNetworkingV2Port_portSecurity_enabled (90.88s)
=== RUN   TestAccNetworkingV2Port_ntpDhcpOption
=== PAUSE TestAccNetworkingV2Port_ntpDhcpOption
=== CONT  TestAccNetworkingV2Port_ntpDhcpOption
--- PASS: TestAccNetworkingV2Port_ntpDhcpOption (91.90s)
=== RUN   TestAccNetworkingV2Port_noPortSecurityNoSecurityGroups
=== PAUSE TestAccNetworkingV2Port_noPortSecurityNoSecurityGroups
=== CONT  TestAccNetworkingV2Port_noPortSecurityNoSecurityGroups
--- PASS: TestAccNetworkingV2Port_noPortSecurityNoSecurityGroups (71.09s)
=== RUN   TestAccNetworkingV2Port_timeout
=== PAUSE TestAccNetworkingV2Port_timeout
=== CONT  TestAccNetworkingV2Port_timeout
--- PASS: TestAccNetworkingV2Port_timeout (71.48s)
PASS

Process finished with the exit code 0

```
