### PR TITLE
[Fix] server ID store during creation before wait function in `opentelekomcloud_compute_instance_v2`

### DIFF
--- a/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_instance_v2_test.go
+++ b/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_compute_instance_v2_test.go
@@ -3,6 +3,7 @@ package acceptance
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -66,6 +67,38 @@ func TestAccComputeV2Instance_basic(t *testing.T) {
 					"force_delete",
 					"image_name",
 				},
+			},
+		},
+	})
+}
+
+func TestAccComputeV2Instance_createErrorRetainsState(t *testing.T) {
+	flavorID := os.Getenv("OS_COMPUTE_BUILD_ERROR_FLAVOR_ID")
+	if flavorID == "" {
+		t.Skip("OS_COMPUTE_BUILD_ERROR_FLAVOR_ID must identify a non-abandoned flavor that is accepted by the create API but enters ERROR during scheduling")
+	}
+
+	var instance servers.Server
+	quotas.BookMany(t, serverQuotas(4, flavorID))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      TestAccCheckComputeV2InstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccComputeV2InstanceCreateError(flavorID),
+				ExpectError: regexp.MustCompile(`error waiting for instance \(.+\) to become ready`),
+			},
+			{
+				RefreshState:       true,
+				ExpectNonEmptyPlan: true,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeV2InstanceExists(resourceInstanceV2Name, &instance),
+					resource.TestCheckResourceAttrSet(resourceInstanceV2Name, "id"),
+					resource.TestCheckResourceAttr(resourceInstanceV2Name, "power_state", "error"),
+					testAccCheckComputeV2InstanceState(&instance, "error"),
+				),
 			},
 		},
 	})
@@ -584,6 +617,23 @@ resource "opentelekomcloud_compute_instance_v2" "instance_1" {
   stop_before_destroy = true
 }
 `, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE)
+
+func testAccComputeV2InstanceCreateError(flavorID string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "opentelekomcloud_compute_instance_v2" "instance_1" {
+  name              = "tf_acc_compute_instance_create_error"
+  availability_zone = %q
+  image_name        = %q
+  flavor_id         = %q
+
+  network {
+    uuid = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  }
+}
+`, common.DataSourceSubnet, env.OS_AVAILABILITY_ZONE, env.OsImageName, flavorID)
+}
 
 var testAccComputeV2InstanceImageByName = fmt.Sprintf(`
 %s

--- a/opentelekomcloud/services/ecs/resource_opentelekomcloud_compute_instance_v2.go
+++ b/opentelekomcloud/services/ecs/resource_opentelekomcloud_compute_instance_v2.go
@@ -475,6 +475,7 @@ func resourceComputeInstanceV2Create(ctx context.Context, d *schema.ResourceData
 		return fmterr.Errorf("error creating OpenTelekomCloud server: %w", err)
 	}
 	log.Printf("[INFO] Instance ID: %s", server.ID)
+	d.SetId(server.ID)
 
 	// Wait for the instance to become running so we can get some attributes
 	// that aren't available until later.
@@ -494,9 +495,6 @@ func resourceComputeInstanceV2Create(ctx context.Context, d *schema.ResourceData
 	if err != nil {
 		return fmterr.Errorf("error waiting for instance (%s) to become ready: %s", server.ID, err)
 	}
-
-	// Store the ID now
-	d.SetId(server.ID)
 
 	vmState := d.Get("power_state").(string)
 	if strings.ToLower(vmState) == "shutoff" {

--- a/releasenotes/notes/compute-instance-set-id-fix-a45e433f650a15c3.yaml
+++ b/releasenotes/notes/compute-instance-set-id-fix-a45e433f650a15c3.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[ECS]** Fixed ``id`` set during creation in ``resource/opentelekomcloud_compute_instance_v2`` (`#3483 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3483>`_)


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [x] Refers to: #3480
* [x] Tests added/passed.
* [ ] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccComputeV2Instance_basic
=== PAUSE TestAccComputeV2Instance_basic
=== CONT  TestAccComputeV2Instance_basic
--- PASS: TestAccComputeV2Instance_basic (118.54s)
=== RUN   TestAccComputeV2Instance_imageByName
--- PASS: TestAccComputeV2Instance_imageByName (108.49s)
=== RUN   TestAccComputeV2Instance_multiSecgroup
=== PAUSE TestAccComputeV2Instance_multiSecgroup
=== CONT  TestAccComputeV2Instance_multiSecgroup
--- PASS: TestAccComputeV2Instance_multiSecgroup (125.05s)
=== RUN   TestAccComputeV2Instance_bootFromImage
=== PAUSE TestAccComputeV2Instance_bootFromImage
=== CONT  TestAccComputeV2Instance_bootFromImage
--- PASS: TestAccComputeV2Instance_bootFromImage (106.44s)
=== RUN   TestAccComputeV2Instance_bootFromVolume
=== PAUSE TestAccComputeV2Instance_bootFromVolume
=== CONT  TestAccComputeV2Instance_bootFromVolume
--- PASS: TestAccComputeV2Instance_bootFromVolume (137.60s)
=== RUN   TestAccComputeV2Instance_importBootFromVolumeImage
=== PAUSE TestAccComputeV2Instance_importBootFromVolumeImage
=== CONT  TestAccComputeV2Instance_importBootFromVolumeImage
--- PASS: TestAccComputeV2Instance_importBootFromVolumeImage (99.57s)
=== RUN   TestAccComputeV2Instance_changeFixedIP
=== PAUSE TestAccComputeV2Instance_changeFixedIP
=== CONT  TestAccComputeV2Instance_changeFixedIP
--- PASS: TestAccComputeV2Instance_changeFixedIP (76.68s)
=== RUN   TestAccComputeV2Instance_bootFromVolumeVolume
=== PAUSE TestAccComputeV2Instance_bootFromVolumeVolume
=== CONT  TestAccComputeV2Instance_bootFromVolumeVolume
--- PASS: TestAccComputeV2Instance_bootFromVolumeVolume (98.03s)
=== RUN   TestAccComputeV2Instance_metadata
=== PAUSE TestAccComputeV2Instance_metadata
=== CONT  TestAccComputeV2Instance_metadata
--- PASS: TestAccComputeV2Instance_metadata (116.94s)
=== RUN   TestAccComputeV2Instance_timeout
=== PAUSE TestAccComputeV2Instance_timeout
=== CONT  TestAccComputeV2Instance_timeout
--- PASS: TestAccComputeV2Instance_timeout (329.00s)
=== RUN   TestAccComputeV2Instance_autoRecovery
=== PAUSE TestAccComputeV2Instance_autoRecovery
=== CONT  TestAccComputeV2Instance_autoRecovery
--- PASS: TestAccComputeV2Instance_autoRecovery (115.98s)
=== RUN   TestAccComputeV2Instance_crazyNICs
=== PAUSE TestAccComputeV2Instance_crazyNICs
=== CONT  TestAccComputeV2Instance_crazyNICs
--- PASS: TestAccComputeV2Instance_crazyNICs (162.95s)
=== RUN   TestAccComputeV2Instance_initialStateActive
=== PAUSE TestAccComputeV2Instance_initialStateActive
=== CONT  TestAccComputeV2Instance_initialStateActive
--- PASS: TestAccComputeV2Instance_initialStateActive (348.14s)
=== RUN   TestAccComputeV2Instance_initialStateShutoff
=== PAUSE TestAccComputeV2Instance_initialStateShutoff
=== CONT  TestAccComputeV2Instance_initialStateShutoff
--- PASS: TestAccComputeV2Instance_initialStateShutoff (418.70s)
PASS

Process finished with the exit code 0
```
