### PR TITLE
[Fix] data-source missing attributes in `opentelekomcloud_obs_bucket`

### DIFF
--- a/docs/data-sources/obs_bucket.md
+++ b/docs/data-sources/obs_bucket.md
@@ -40,6 +40,8 @@ The following attributes are exported:
 * `storage_class` - Specifies the storage class of the bucket. OBS provides three storage classes:
   `STANDARD`, `WARM` (Infrequent Access) and `COLD` (Archive).
 
+* `versioning` - Indicates whether bucket versioning is enabled.
+
 * `tags` - A mapping of tags to assign to the bucket. Each tag is represented by one key-value pair.
 
 * `logging` - A settings of bucket logging (documented below).
@@ -49,8 +51,6 @@ The following attributes are exported:
 * `website` - A website object (documented below).
 
 * `cors_rule` - A rule of Cross-Origin Resource Sharing (documented below).
-
-* `lifecycle_rule` - A configuration of object lifecycle management (documented below).
 
 * `server_side_encryption` - A configuration of server side encryption (documented below).
 
@@ -83,6 +83,8 @@ The `lifecycle_rule` object supports the following:
 
 * `prefix` - Object key prefix identifying one or more objects to which the rule applies.
 
+* `tag` - A list of tags used to filter objects covered by the lifecycle rule (documented below).
+
 * `expiration` - Specifies a period when objects that have been last updated are automatically
   deleted. (documented below).
 
@@ -94,6 +96,15 @@ The `lifecycle_rule` object supports the following:
 
 * `noncurrent_version_transition` - Specifies a period when noncurrent object versions are
   automatically transitioned to `WARM` or `COLD` storage class (documented below).
+
+* `abort_incomplete_multipart_upload` - Specifies when parts from incomplete multipart uploads are
+  automatically deleted (documented below).
+
+The `tag` object supports the following:
+
+* `key` - The lifecycle filter tag key.
+
+* `value` - The lifecycle filter tag value.
 
 The `expiration` object supports the following
 
@@ -117,3 +128,8 @@ The `noncurrent_version_transition` object supports the following
   transitioned to the specified storage class.
 
 * `storage_class` - The class of storage used to store the object.
+
+The `abort_incomplete_multipart_upload` object supports the following:
+
+* `days` - The number of days after an incomplete multipart upload is initiated before OBS deletes
+  its unmerged parts.

--- a/opentelekomcloud/acceptance/obs/data_source_opentelekomcloud_obs_bucket_test.go
+++ b/opentelekomcloud/acceptance/obs/data_source_opentelekomcloud_obs_bucket_test.go
@@ -35,6 +35,14 @@ func TestAccDataSourceObsBucket_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckObsBucketDataSourceExists(dataSourceName, bucket),
 					resource.TestCheckResourceAttr(dataSourceName, "bucket", randomName),
+					resource.TestCheckResourceAttr(dataSourceName, "lifecycle_rule.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "lifecycle_rule.0.noncurrent_version_expiration.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "lifecycle_rule.0.abort_incomplete_multipart_upload.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(
+						dataSourceName,
+						"lifecycle_rule.0.abort_incomplete_multipart_upload.*",
+						map[string]string{"days": "7"},
+					),
 				),
 			},
 		},
@@ -74,6 +82,21 @@ resource "opentelekomcloud_obs_bucket" "bucket" {
   bucket        = "%s"
   storage_class = "STANDARD"
   acl           = "public-read"
+  region        = "eu-de"
+  versioning    = true
+  force_destroy = true
+
+  lifecycle_rule {
+    name    = "purge1y"
+    enabled = true
+
+    noncurrent_version_expiration {
+      days = 365
+    }
+    abort_incomplete_multipart_upload {
+      days = 7
+    }
+  }
 }
 `, name)
 }
@@ -84,10 +107,25 @@ resource "opentelekomcloud_obs_bucket" "bucket" {
   bucket        = "%[1]s"
   storage_class = "STANDARD"
   acl           = "public-read"
+  region        = "eu-de"
+  versioning    = true
+  force_destroy = true
+
+  lifecycle_rule {
+    name    = "purge1y"
+    enabled = true
+
+    noncurrent_version_expiration {
+      days = 365
+    }
+    abort_incomplete_multipart_upload {
+      days = 7
+    }
+  }
 }
 
 data "opentelekomcloud_obs_bucket" "bucket" {
-  bucket = "%[1]s"
+  bucket = opentelekomcloud_obs_bucket.bucket.bucket
 }
 `, name)
 }

--- a/opentelekomcloud/services/obs/data_source_opentelekomcloud_obs_bucket.go
+++ b/opentelekomcloud/services/obs/data_source_opentelekomcloud_obs_bucket.go
@@ -116,7 +116,7 @@ func DataSourceObsBucket() *schema.Resource {
 						},
 						"noncurrent_version_transition": {
 							Type:     schema.TypeList,
-							Optional: true,
+							Computed: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"days": {
@@ -124,6 +124,34 @@ func DataSourceObsBucket() *schema.Resource {
 										Computed: true,
 									},
 									"storage_class": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"abort_incomplete_multipart_upload": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"days": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"tag": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"value": {
 										Type:     schema.TypeString,
 										Computed: true,
 									},

--- a/releasenotes/notes/fix-obs-bucket-ds-19d0a8e8d541e6d5.yaml
+++ b/releasenotes/notes/fix-obs-bucket-ds-19d0a8e8d541e6d5.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[OBS]** Fix ``data_source/opentelekomcloud_obs_bucket`` failing with missing ``lifecycle_rule`` attributes (`#3485 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3485>`_)


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [x] Refers to: #3484
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccDataSourceObsBucket_basic
=== PAUSE TestAccDataSourceObsBucket_basic
=== CONT  TestAccDataSourceObsBucket_basic
--- PASS: TestAccDataSourceObsBucket_basic (51.05s)
PASS

Process finished with the exit code 0
```
