### PR TITLE
[Feat.] advanced mode support in `opentelekomcloud_waf_dedicated_cc_rule_v1`

### DIFF
--- a/docs/resources/waf_dedicated_cc_rule_v1.md
+++ b/docs/resources/waf_dedicated_cc_rule_v1.md
@@ -39,6 +39,33 @@ resource "opentelekomcloud_waf_dedicated_cc_rule_v1" "rule_1" {
 }
 ```
 
+### Advanced Mode with Logging
+
+```hcl
+resource "opentelekomcloud_waf_dedicated_policy_v1" "policy_1" {
+  name = "policy_cc_advanced_log"
+}
+
+resource "opentelekomcloud_waf_dedicated_cc_rule_v1" "rule_1" {
+  policy_id    = opentelekomcloud_waf_dedicated_policy_v1.policy_1.id
+  mode         = 1
+  limit_num    = 10
+  limit_period = 60
+  tag_type     = "ip"
+  description  = "advanced log rule"
+
+  conditions {
+    category        = "url"
+    logic_operation = "contain"
+    contents        = ["/url"]
+  }
+
+  action {
+    category = "log"
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -49,9 +76,11 @@ The following arguments are supported:
   * `0` - Standard. Only the protected paths of domain names can be specified.
   * `1` - The path, IP address, cookie, header, and params fields can all be set.
 
-* `url` - (Required, ForceNew, String) Path to be protected in the CC attack protection rule. Changing this creates a new rule.
+* `url` - (Optional, ForceNew, String) Path to be protected in the CC attack protection rule. This parameter is required
+  when `mode` is set to `0`. Changing this creates a new rule.
 
-* `conditions` - (Optional, ForceNew, List) Rate limit conditions of the CC protection rule. Changing this creates a new rule.
+* `conditions` - (Optional, ForceNew, List) Rate limit conditions of the CC protection rule. At least one block is required
+  when `mode` is set to `1`. Changing this creates a new rule.
     The `conditions` block supports:
 
   + `category` - (Required, ForceNew, String) Field type. The value can be `url`, `ip`, `params`, `cookie`, or `header`.

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.9.9-0.20260722110318-e272c83c3c8a
+	github.com/opentelekomcloud/gophertelekomcloud v0.9.9-0.20260727102019-5ac96946e868
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.52.0
 	golang.org/x/sync v0.20.0

--- a/go.sum
+++ b/go.sum
@@ -169,8 +169,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.9-0.20260722110318-e272c83c3c8a h1:yxp+CeCqpnfIB9rwSG5aQsMUbQIZVcRG+o5k24Rzmxc=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.9-0.20260722110318-e272c83c3c8a/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.9-0.20260727102019-5ac96946e868 h1:TDNOUxuiKdm303fHlq5l9V/FwaFkZqFvPe/5NAKGWdY=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.9-0.20260727102019-5ac96946e868/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/opentelekomcloud/acceptance/waf/resource_opentelekomcloud_waf_dedicated_cc_rule_v1_test.go
+++ b/opentelekomcloud/acceptance/waf/resource_opentelekomcloud_waf_dedicated_cc_rule_v1_test.go
@@ -40,6 +40,38 @@ func TestAccWafDedicatedCcAttackProtectionRuleV1_basic(t *testing.T) {
 	})
 }
 
+func TestAccWafDedicatedCcAttackProtectionRuleV1_advancedLog(t *testing.T) {
+	var rule rules.CcRule
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckWafDedicatedCcRuleV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafDedicatedCcAttackProtectionRuleV1AdvancedLog,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafDedicatedCcRuleV1Exists(wafdCCRuleName, &rule),
+					resource.TestCheckResourceAttr(wafdCCRuleName, "mode", "1"),
+					resource.TestCheckResourceAttr(wafdCCRuleName, "url", ""),
+					resource.TestCheckResourceAttr(wafdCCRuleName, "conditions.#", "1"),
+					resource.TestCheckResourceAttr(wafdCCRuleName, "conditions.0.category", "url"),
+					resource.TestCheckResourceAttr(wafdCCRuleName, "conditions.0.logic_operation", "contain"),
+					resource.TestCheckResourceAttr(wafdCCRuleName, "conditions.0.contents.0", "/url"),
+					resource.TestCheckResourceAttr(wafdCCRuleName, "action.#", "1"),
+					resource.TestCheckResourceAttr(wafdCCRuleName, "action.0.category", "log"),
+				),
+			},
+			{
+				ResourceName:      wafdCCRuleName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: dedicatedRuleImportStateIDFunc(wafdCCRuleName, wafdPolicyResourceName),
+			},
+		},
+	})
+}
+
 func testAccCheckWafDedicatedCcRuleV1Destroy(s *terraform.State) error {
 	config := common.TestAccProvider.Meta().(*cfg.Config)
 	client, err := config.WafDedicatedV1Client(env.OS_REGION_NAME)
@@ -112,6 +144,31 @@ resource "opentelekomcloud_waf_dedicated_cc_rule_v1" "rule_1" {
     category     = "block"
     content_type = "application/json"
     content      = "{\"error\":\"forbidden\"}"
+  }
+}
+`
+
+const testAccWafDedicatedCcAttackProtectionRuleV1AdvancedLog = `
+resource "opentelekomcloud_waf_dedicated_policy_v1" "policy_1" {
+  name = "policy_cc_advanced_log"
+}
+
+resource "opentelekomcloud_waf_dedicated_cc_rule_v1" "rule_1" {
+  policy_id    = opentelekomcloud_waf_dedicated_policy_v1.policy_1.id
+  mode         = 1
+  limit_num    = 10
+  limit_period = 60
+  tag_type     = "ip"
+  description  = "advanced log rule"
+
+  conditions {
+    category        = "url"
+    logic_operation = "contain"
+    contents        = ["/url"]
+  }
+
+  action {
+    category = "log"
   }
 }
 `

--- a/opentelekomcloud/services/waf/resource_opentelekomcloud_waf_dedicated_cc_rule_v1.go
+++ b/opentelekomcloud/services/waf/resource_opentelekomcloud_waf_dedicated_cc_rule_v1.go
@@ -2,6 +2,7 @@ package waf
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"time"
 
@@ -22,6 +23,7 @@ func ResourceWafDedicatedCcRuleV1() *schema.Resource {
 		CreateContext: resourceWafDedicatedCcRuleV1Create,
 		ReadContext:   resourceWafDedicatedCcRuleV1Read,
 		DeleteContext: resourceWafDedicatedCcRuleV1Delete,
+		CustomizeDiff: validateWafDedicatedCcRuleV1Mode,
 		Importer: &schema.ResourceImporter{
 			StateContext: common.ImportByPath("policy_id", "id"),
 		},
@@ -38,13 +40,14 @@ func ResourceWafDedicatedCcRuleV1() *schema.Resource {
 				ForceNew: true,
 			},
 			"mode": {
-				Type:     schema.TypeInt,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeInt,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IntInSlice([]int{0, 1}),
 			},
 			"url": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 			},
 			"conditions": {
@@ -194,6 +197,20 @@ func ResourceWafDedicatedCcRuleV1() *schema.Resource {
 	}
 }
 
+func validateWafDedicatedCcRuleV1Mode(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
+	switch d.Get("mode").(int) {
+	case 0:
+		if d.Get("url").(string) == "" {
+			return fmt.Errorf("url must be configured when mode is 0")
+		}
+	case 1:
+		if len(d.Get("conditions").([]interface{})) == 0 {
+			return fmt.Errorf("at least one conditions block must be configured when mode is 1")
+		}
+	}
+	return nil
+}
+
 func resourceWafDedicatedCcRuleV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
 	client, err := common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
@@ -220,12 +237,14 @@ func resourceWafDedicatedCcRuleV1Create(ctx context.Context, d *schema.ResourceD
 		rawAction := rawActionList[0].(map[string]interface{})
 		action = rules.CcActionObject{
 			Category: rawAction["category"].(string),
-			Detail: &rules.CcDetailObject{
+		}
+		if rawAction["content_type"].(string) != "" || rawAction["content"].(string) != "" {
+			action.Detail = &rules.CcDetailObject{
 				Response: &rules.CcResponseObject{
 					ContentType: rawAction["content_type"].(string),
 					Content:     rawAction["content"].(string),
 				},
-			},
+			}
 		}
 	}
 
@@ -242,10 +261,12 @@ func resourceWafDedicatedCcRuleV1Create(ctx context.Context, d *schema.ResourceD
 
 		condition := rules.CcConditionsObject{
 			Category:       cond["category"].(string),
-			Index:          cond["index"].(string),
 			LogicOperation: cond["logic_operation"].(string),
 			ValueListId:    cond["value_list_id"].(string),
 			Contents:       contents,
+		}
+		if index := cond["index"].(string); index != "" {
+			condition.Index = pointerto.String(index)
 		}
 		conditionList = append(conditionList, condition)
 	}
@@ -321,21 +342,24 @@ func resourceWafDedicatedCcRuleV1Read(ctx context.Context, d *schema.ResourceDat
 	for _, conditionObj := range rule.Conditions {
 		condition := map[string]interface{}{
 			"category":        conditionObj.Category,
-			"index":           conditionObj.Index,
 			"contents":        conditionObj.Contents,
 			"logic_operation": conditionObj.LogicOperation,
 			"value_list_id":   conditionObj.ValueListId,
 		}
+		if conditionObj.Index != nil {
+			condition["index"] = *conditionObj.Index
+		}
 		conditions = append(conditions, condition)
 	}
 
-	action := []map[string]interface{}{
-		{
-			"category":     rule.Action.Category,
-			"content_type": rule.Action.Detail.Response.ContentType,
-			"content":      rule.Action.Detail.Response.Content,
-		},
+	actionValue := map[string]interface{}{
+		"category": rule.Action.Category,
 	}
+	if rule.Action.Detail != nil && rule.Action.Detail.Response != nil {
+		actionValue["content_type"] = rule.Action.Detail.Response.ContentType
+		actionValue["content"] = rule.Action.Detail.Response.Content
+	}
+	action := []map[string]interface{}{actionValue}
 	mErr = multierror.Append(mErr,
 		d.Set("conditions", conditions),
 		d.Set("action", action),

--- a/releasenotes/notes/wafd-cc-rule-advanced-mode-4a10c257a1791088.yaml
+++ b/releasenotes/notes/wafd-cc-rule-advanced-mode-4a10c257a1791088.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  |
+  **[WAF]** Advanced mode support in ``resource/opentelekomcloud_waf_dedicated_cc_rule_v1`` (`#3491 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3491>`_)


### PR DESCRIPTION
## Summary of the Pull Request
mode = 1 now supported
example with only log action

## PR Checklist

* [ ] Refers to: #xxx
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccWafDedicatedCcAttackProtectionRuleV1_basic
--- PASS: TestAccWafDedicatedCcAttackProtectionRuleV1_basic (30.32s)
=== RUN   TestAccWafDedicatedCcAttackProtectionRuleV1_advancedLog
--- PASS: TestAccWafDedicatedCcAttackProtectionRuleV1_advancedLog (33.10s)
PASS

Process finished with the exit code 0
```
