### PR TITLE
[Feat] CCE: Support custom cluster IAM agencies

### DIFF
--- a/docs/resources/cce_cluster_v3.md
+++ b/docs/resources/cce_cluster_v3.md
@@ -132,6 +132,34 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
 }
 ```
 
+### Cluster with custom IAM agency
+
+```hcl
+variable "vpc_id" {}
+variable "subnet_id" {}
+
+resource "opentelekomcloud_identity_agency_v3" "cce_agency" {
+  name                  = "my_cce_agency"
+  description           = "Custom CCE agency"
+  delegated_domain_name = "op_svc_cce"
+
+  project_role {
+    project = "eu-de"
+    roles   = ["CCE Administrator"]
+  }
+}
+
+resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
+  name                   = "cluster-custom-agency"
+  cluster_type           = "VirtualMachine"
+  flavor_id              = "cce.s1.small"
+  vpc_id                 = var.vpc_id
+  subnet_id              = var.subnet_id
+  container_network_type = "overlay_l2"
+  agency_name            = opentelekomcloud_identity_agency_v3.cce_agency.name
+}
+```
+
 ### CCE HA cluster
 
 ```hcl
@@ -223,6 +251,12 @@ The following arguments are supported:
 * `cluster_type` - (Required, String, ForceNew) Cluster Type, possible values are `VirtualMachine` and `BareMetal`. Changing this parameter will create a new cluster resource.
 
 * `description` - (Optional, String) Cluster description.
+
+* `agency_name` - (Optional, String) Name of the custom IAM agency to use for this cluster.
+  The agency must be of the cloud service type, delegated to `op_svc_cce`,
+  and have any [available role](../data-sources/identity_role_v3.md) assigned for the target project.
+  Custom agencies are supported only in clusters of v1.27 or later (CCE Standard only).
+  Changing this updates the agency on the running cluster without recreation.
 
 * `ipv6_enable` - (Optional, Boolean, ForceNew) Specifies whether the cluster supports IPv6 addresses. This field is supported in clusters of v1.25 and later versions. Default: `false`. If `ipv6_enable` is true, subnet should have ipv6 enabled and `kube_proxy_mode` value can only be `ipvs`.
 
@@ -408,6 +442,8 @@ All above argument parameters can be exported as attribute parameters along with
 This resource provides the following timeouts configuration options:
 
 - `create` - Default is 30 minutes.
+
+- `update` - Default is 10 minutes.
 
 - `delete` - Default is 30 minutes.
 

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.9.9-0.20260727102019-5ac96946e868
+	github.com/opentelekomcloud/gophertelekomcloud v0.9.9-0.20260727150319-ce1e62bb18cc
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.52.0
 	golang.org/x/sync v0.20.0

--- a/go.sum
+++ b/go.sum
@@ -169,8 +169,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.9-0.20260727102019-5ac96946e868 h1:TDNOUxuiKdm303fHlq5l9V/FwaFkZqFvPe/5NAKGWdY=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.9-0.20260727102019-5ac96946e868/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.9-0.20260727150319-ce1e62bb18cc h1:J4wCg5DporkJtag4tHftZ85HEitD7PqQT5hq7TCKrt4=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.9-0.20260727150319-ce1e62bb18cc/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_cluster_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_cluster_v3_test.go
@@ -80,6 +80,86 @@ func TestAccCCEClusterV3_basic(t *testing.T) {
 	})
 }
 
+func TestAccCCEClusterV3_agencyName(t *testing.T) {
+	var cluster clusters.Clusters
+	rc := common.InitResourceCheck(
+		resourceClusterName,
+		&cluster,
+		getCceClusterResourceFunc,
+	)
+	clusterName := randClusterName()
+	agencyNameA := fmt.Sprintf("cce-agency-a-%s", acctest.RandString(5))
+	agencyNameB := fmt.Sprintf("cce-agency-b-%s", acctest.RandString(5))
+	t.Parallel()
+
+	quotas.BookOne(t, quotas.CCEClusterQuota)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			common.TestAccPreCheck(t)
+			common.TestAccPreCheckAdminOnly(t)
+			if env.OS_TENANT_NAME == "" {
+				t.Skip("OS_TENANT_NAME or OS_PROJECT_NAME must be set for CCE agency acceptance tests")
+			}
+		},
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCCEClusterV3AgencyName(clusterName, agencyNameA, agencyNameB, "agency_a"),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceClusterName, "agency_name", agencyNameA),
+					checkCCEClusterAgencyName(agencyNameA),
+				),
+			},
+			{
+				Config: testAccCCEClusterV3AgencyName(clusterName, agencyNameA, agencyNameB, "agency_b"),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceClusterName, "agency_name", agencyNameB),
+					checkCCEClusterAgencyName(agencyNameB),
+				),
+			},
+			{
+				Config:   testAccCCEClusterV3AgencyName(clusterName, agencyNameA, agencyNameB, "agency_b"),
+				PlanOnly: true,
+			},
+			{
+				ResourceName:      resourceClusterName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"cluster_version", "installed_addons", "ignore_addons",
+				},
+			},
+		},
+	})
+}
+
+func checkCCEClusterAgencyName(expected string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		state, ok := s.RootModule().Resources[resourceClusterName]
+		if !ok {
+			return fmt.Errorf("CCE cluster not found in state")
+		}
+
+		config := common.TestAccProvider.Meta().(*cfg.Config)
+		client, err := config.CceV3Client(env.OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("error creating CCE v3 client: %s", err)
+		}
+		cluster, err := clusters.Get(client, state.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("error retrieving CCE cluster: %s", err)
+		}
+		if cluster.Spec.AgencyName != expected {
+			return fmt.Errorf("expected CCE cluster agency name %q, got %q", expected, cluster.Spec.AgencyName)
+		}
+		return nil
+	}
+}
+
 func TestAccCCEClusterV3_turbo_basic(t *testing.T) {
 	var cluster clusters.Clusters
 	rc := common.InitResourceCheck(
@@ -450,6 +530,44 @@ resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
   }
 }
 `, common.DataSourceSubnet, clusterName)
+}
+
+func testAccCCEClusterV3AgencyName(clusterName, agencyNameA, agencyNameB, selectedAgency string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "opentelekomcloud_identity_agency_v3" "agency_a" {
+  name                  = "%s"
+  delegated_domain_name = "op_svc_cce"
+
+  project_role {
+    project = "%s"
+    roles   = ["CCE Administrator"]
+  }
+}
+
+resource "opentelekomcloud_identity_agency_v3" "agency_b" {
+  name                  = "%s"
+  delegated_domain_name = "op_svc_cce"
+
+  project_role {
+    project = "%s"
+    roles   = ["CCE Administrator"]
+  }
+}
+
+resource "opentelekomcloud_cce_cluster_v3" "cluster_1" {
+  name                    = "%s"
+  cluster_type            = "VirtualMachine"
+  flavor_id               = "cce.s1.small"
+  vpc_id                  = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.vpc_id
+  subnet_id               = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id
+  container_network_type  = "overlay_l2"
+  kubernetes_svc_ip_range = "10.247.0.0/16"
+  ignore_addons           = true
+  agency_name             = opentelekomcloud_identity_agency_v3.%s.name
+}
+`, common.DataSourceSubnet, agencyNameA, env.OS_TENANT_NAME, agencyNameB, env.OS_TENANT_NAME, clusterName, selectedAgency)
 }
 
 func testAccCCEClusterV3BasicSG(clusterName string) string {

--- a/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_cluster_v3.go
+++ b/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_cluster_v3.go
@@ -49,6 +49,7 @@ func ResourceCCEClusterV3() *schema.Resource {
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
 			Delete: schema.DefaultTimeout(30 * time.Minute),
 		},
 
@@ -106,6 +107,11 @@ func ResourceCCEClusterV3() *schema.Resource {
 				ForceNew: true,
 			},
 			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"agency_name": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
@@ -527,6 +533,7 @@ func resourceCCEClusterV3Create(ctx context.Context, d *schema.ResourceData, met
 			Version:     d.Get("cluster_version").(string),
 			Ipv6Enable:  d.Get("ipv6_enable").(bool),
 			Description: d.Get("description").(string),
+			AgencyName:  d.Get("agency_name").(string),
 			HostNetwork: clusters.HostNetworkSpec{
 				VpcId:           d.Get("vpc_id").(string),
 				SubnetId:        d.Get("subnet_id").(string),
@@ -663,6 +670,7 @@ func resourceCCEClusterV3Read(ctx context.Context, d *schema.ResourceData, meta 
 		d.Set("cluster_type", cluster.Spec.Type),
 		d.Set("cluster_version", cluster.Spec.Version),
 		d.Set("description", cluster.Spec.Description),
+		d.Set("agency_name", cluster.Spec.AgencyName),
 		d.Set("ipv6_enable", cluster.Spec.Ipv6Enable),
 		d.Set("billing_mode", cluster.Spec.BillingMode),
 		d.Set("vpc_id", cluster.Spec.HostNetwork.VpcId),
@@ -805,11 +813,29 @@ func resourceCCEClusterV3Update(ctx context.Context, d *schema.ResourceData, met
 
 	var updateOpts clusters.UpdateOpts
 
-	if d.HasChange("description") {
-		updateOpts.Spec.Description = d.Get("description").(string)
+	if d.HasChange("description") || d.HasChange("agency_name") {
+		if d.HasChange("description") {
+			updateOpts.Spec.Description = d.Get("description").(string)
+		}
+		if d.HasChange("agency_name") {
+			updateOpts.Spec.AgencyName = d.Get("agency_name").(string)
+		}
 		_, err = clusters.Update(client, d.Id(), updateOpts)
 		if err != nil {
 			return fmterr.Errorf("error updating opentelekomcloud CCE: %w", err)
+		}
+		if d.HasChange("agency_name") {
+			stateConf := &resource.StateChangeConf{
+				Pending:    []string{"pending"},
+				Target:     []string{"updated"},
+				Refresh:    waitForCCEClusterAgencyName(client, d.Id(), d.Get("agency_name").(string)),
+				Timeout:    d.Timeout(schema.TimeoutUpdate),
+				Delay:      5 * time.Second,
+				MinTimeout: 3 * time.Second,
+			}
+			if _, err = stateConf.WaitForStateContext(ctx); err != nil {
+				return fmterr.Errorf("error waiting for opentelekomcloud CCE agency name update: %w", err)
+			}
 		}
 	}
 
@@ -930,6 +956,19 @@ func WaitForCCEClusterActive(cceClient *golangsdk.ServiceClient, clusterId strin
 		}
 
 		return n, n.Status.Phase, nil
+	}
+}
+
+func waitForCCEClusterAgencyName(client *golangsdk.ServiceClient, clusterID, agencyName string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		cluster, err := clusters.Get(client, clusterID)
+		if err != nil {
+			return nil, "", fmt.Errorf("error retrieving CCE cluster: %w", err)
+		}
+		if cluster.Spec.AgencyName == agencyName {
+			return cluster, "updated", nil
+		}
+		return cluster, "pending", nil
 	}
 }
 

--- a/releasenotes/notes/cce_cluster_agency_name-2aabb30415a68cb3.yaml
+++ b/releasenotes/notes/cce_cluster_agency_name-2aabb30415a68cb3.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[CCE]** Add ``agency_name`` support for ``resource/opentelekomcloud_cce_cluster_v3`` (`#3493 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3493>`_)


### PR DESCRIPTION
## Summary of the Pull Request

* Add `agency_name` support to `opentelekomcloud_cce_cluster_v3` for custom IAM agencies delegated to `op_svc_cce`.
* Wait for CCE API readback to confirm asynchronous `agency_name` updates before updating Terraform state.
* Add custom-agency documentation and acceptance coverage for create, update, no-drift planning, and import.

## PR Checklist

* [x] Refers to: #3492 
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```text
=== RUN   TestAccCCEClusterV3_agencyName
=== PAUSE TestAccCCEClusterV3_agencyName
=== CONT  TestAccCCEClusterV3_agencyName
--- PASS: TestAccCCEClusterV3_agencyName (732.38s)
PASS
```

Closes #3492 