### PR TITLE
[Feat] VPC: Add option to delete default rules in vpc_secgroup_v3

### DIFF
--- a/docs/resources/vpc_secgroup_v3.md
+++ b/docs/resources/vpc_secgroup_v3.md
@@ -35,6 +35,8 @@ The following arguments are supported:
 
 * `tags` - (Optional, Map, ForceNew) Specifies the tags.
 
+* `delete_default_rules` - (Optional, Boolean, ForceNew) Specify whether to delete all default rules when security group is created. Default: `false`.
+
 ## Attributes Reference
 
 In addition to the arguments mentioned above, the following attributes are exported:
@@ -53,4 +55,20 @@ VPC Security Group V3 can be imported using the `id`, e.g.
 
 ```sh
 terraform import opentelekomcloud_vpc_secgroup_v3.secgroup_1 <id>
+```
+
+## Notes
+
+It is required to ignore changes as below:
+
+```hcl
+resource "opentelekomcloud_vpc_secgroup_v3" "group_1" {
+  # ...
+
+  lifecycle {
+    ignore_changes = [
+      delete_default_rules,
+    ]
+  }
+}
 ```

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_vpc_secgroup_v3_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_vpc_secgroup_v3_test.go
@@ -56,6 +56,9 @@ func TestAccVpcSecGroupV3_basic(t *testing.T) {
 				ResourceName:      vpcSecGroupResourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"delete_default_rules",
+				},
 			},
 		},
 	})
@@ -63,14 +66,16 @@ func TestAccVpcSecGroupV3_basic(t *testing.T) {
 
 var testAccVpcSecGroupV3Basic = `
 resource "opentelekomcloud_vpc_secgroup_v3" "group_1" {
-  name        = "test-acc-sec-group-v3"
-  description = "created"
+  name                 = "test-acc-sec-group-v3"
+  description          = "created"
+  delete_default_rules = true
 }
 `
 
 var testAccVpcSecGroupV3Update = `
 resource "opentelekomcloud_vpc_secgroup_v3" "group_1" {
-  name        = "test-acc-sec-group-v3"
-  description = "updated"
+  name                 = "test-acc-sec-group-v3"
+  description          = "updated"
+  delete_default_rules = true
 }
 `

--- a/opentelekomcloud/services/vpc/resource_opentelekomcloud_vpc_secgroup_v3.go
+++ b/opentelekomcloud/services/vpc/resource_opentelekomcloud_vpc_secgroup_v3.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/tags"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/vpc/v3/security/group"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/vpc/v3/security/rules"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
@@ -54,6 +55,12 @@ func ResourceVpcSecGroupV3() *schema.Resource {
 				ForceNew: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"delete_default_rules": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+				Default:  false,
+			},
 			"project_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -94,6 +101,15 @@ func resourceVpcSecGroupV3Create(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	d.SetId(securityGroup.ID)
+
+	if d.Get("delete_default_rules").(bool) {
+		for _, rule := range securityGroup.SecurityGroupRules {
+			err = rules.Delete(client, rule.ID)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
 
 	log.Printf("[DEBUG] OpenTelekomCloud VPC Security Group `%s` created: %#v", d.Id(), securityGroup)
 

--- a/releasenotes/notes/vpc-delete-def-rules-secgroup-v3-93b6d8a884649571.yaml
+++ b/releasenotes/notes/vpc-delete-def-rules-secgroup-v3-93b6d8a884649571.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    **[VPC]** Add argument `delete_default_rules` to ``resource/opentelekomcloud_vpc_secgroup_v3`` (`#3506 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3506>`_)


### PR DESCRIPTION
## Summary of the Pull Request

New parameter `delete_default_rules` added to resource `opentelekomcloud_vpc_secgroup_v3`

## PR Checklist

* [x] Refers to: #3471 
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccVpcSecGroupV3_basic
--- PASS: TestAccVpcSecGroupV3_basic (203.11s)
PASS
```
