### PR TITLE
[Fix] VPC: Retry in-use error on secondary CIDR delete

### DIFF
--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_vpc_secondary_cidr_v3_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_vpc_secondary_cidr_v3_test.go
@@ -88,6 +88,34 @@ func TestAccVpcSecondaryCidrV3_basic(t *testing.T) {
 	})
 }
 
+func TestAccVpcSecondaryCidrV3_subnetOnSecondaryCidr(t *testing.T) {
+	t.Parallel()
+	quotas.BookOne(t, quotas.Router)
+	vpcName := tools.RandomString("tf-acc-sec-cidr-sub-", 5)
+
+	var vpc VpcV3.Vpc
+	rc := common.InitResourceCheck(resourceVpcSecondaryCidrV3Name, &vpc, getVpcSecondaryCidrFunc)
+
+	// The destroy is the assertion: removing the secondary CIDR while the subnet carved
+	// from it is still draining returns 409, which the delete must wait out.
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVpcSecondaryCidrV3WithSubnet(vpcName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceVpcSecondaryCidrV3Name, "cidrs.#", "1"),
+					resource.TestCheckResourceAttr(
+						"opentelekomcloud_vpc_subnet_v1.test", "cidr", "23.9.0.0/24"),
+				),
+			},
+		},
+	})
+}
+
 func testAccVpcSecondaryCidrV3OneCidr(vpcName string) string {
 	return fmt.Sprintf(`
 resource "opentelekomcloud_vpc_v1" "test" {
@@ -100,6 +128,29 @@ resource "opentelekomcloud_vpc_secondary_cidr_v3" "test" {
   cidrs  = ["23.9.0.0/16"]
 }
 `, vpcName)
+}
+
+func testAccVpcSecondaryCidrV3WithSubnet(vpcName string) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_vpc_v1" "test" {
+  name = "%s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "opentelekomcloud_vpc_secondary_cidr_v3" "test" {
+  vpc_id = opentelekomcloud_vpc_v1.test.id
+  cidrs  = ["23.9.0.0/16"]
+}
+
+resource "opentelekomcloud_vpc_subnet_v1" "test" {
+  name       = "%s-sub"
+  cidr       = "23.9.0.0/24"
+  gateway_ip = "23.9.0.1"
+  vpc_id     = opentelekomcloud_vpc_v1.test.id
+
+  depends_on = [opentelekomcloud_vpc_secondary_cidr_v3.test]
+}
+`, vpcName, vpcName)
 }
 
 func testAccVpcSecondaryCidrV3ThreeCidrs(vpcName string) string {

--- a/opentelekomcloud/services/vpc/resource_opentelekomcloud_vpc_secondary_cidr_v3.go
+++ b/opentelekomcloud/services/vpc/resource_opentelekomcloud_vpc_secondary_cidr_v3.go
@@ -1,10 +1,13 @@
 package vpc
 
 import (
+	"bytes"
 	"context"
+	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
@@ -24,6 +27,10 @@ func ResourceVpcSecondaryCidrV3() *schema.Resource {
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -145,14 +152,49 @@ func resourceVpcSecondaryCidrV3Delete(ctx context.Context, d *schema.ResourceDat
 		return nil
 	}
 
-	if _, err := VpcV3.RemoveSecondaryCidr(client, d.Id(), VpcV3.CidrOpts{
-		Vpc: &VpcV3.AddExtendCidrOption{ExtendCidrs: cidrs},
-	}); err != nil {
-		if _, ok := err.(golangsdk.ErrDefault404); ok {
-			return nil
-		}
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"IN_USE"},
+		Target:     []string{"REMOVED"},
+		Refresh:    waitForVpcSecondaryCidrRemoved(client, d.Id(), cidrs),
+		Timeout:    d.Timeout(schema.TimeoutDelete),
+		Delay:      5 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
 		return fmterr.Errorf("error removing secondary CIDRs from VPC %s: %w", d.Id(), err)
 	}
 
 	return nil
+}
+
+// cidrInUseErrCode is returned by OTC while a subnet carved from the secondary CIDR is
+// still being released. It arrives as HTTP 400, not 409.
+const cidrInUseErrCode = "VPC.0602"
+
+// waitForVpcSecondaryCidrRemoved retries the removal while OTC reports the CIDR as still
+// in use, which happens while a subnet carved from it is still being released.
+func waitForVpcSecondaryCidrRemoved(client *golangsdk.ServiceClient, vpcID string, cidrs []string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		vpc, err := VpcV3.RemoveSecondaryCidr(client, vpcID, VpcV3.CidrOpts{
+			Vpc: &VpcV3.AddExtendCidrOption{ExtendCidrs: cidrs},
+		})
+		if err != nil {
+			switch e := err.(type) {
+			case golangsdk.ErrDefault404:
+				return struct{}{}, "REMOVED", nil
+			case golangsdk.ErrDefault400:
+				if bytes.Contains(e.Body, []byte(cidrInUseErrCode)) {
+					return struct{}{}, "IN_USE", nil
+				}
+				return nil, "", err
+			case golangsdk.ErrDefault409:
+				return struct{}{}, "IN_USE", nil
+			default:
+				return nil, "", err
+			}
+		}
+
+		return vpc, "REMOVED", nil
+	}
 }

--- a/releasenotes/notes/fix-vpc-secondary-cidr-delete-retry-4f1c8a2b6d9e30f5.yaml
+++ b/releasenotes/notes/fix-vpc-secondary-cidr-delete-retry-4f1c8a2b6d9e30f5.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    **[VPC]** Fix ``resource/opentelekomcloud_vpc_secondary_cidr_v3`` failing to delete
+    with ``cidr is used by subnets`` (``VPC.0602``) when a subnet carved from the
+    secondary CIDR is still being released. The removal is now retried until it succeeds
+    or the delete timeout expires
+    (`#3513 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3513>`_)


### PR DESCRIPTION
## Summary of the Pull Request

`opentelekomcloud_vpc_secondary_cidr_v3` failed to delete with `error removing secondary CIDRs from VPC ...: cidr is used by subnets` (`VPC.0602`) when a subnet carved from that secondary CIDR was still being released.

The delete issued a single, unretried `RemoveSecondaryCidr` call and tolerated only a 404, so the transient in-use error aborted the destroy. Re-running `terraform destroy` normally succeeded, because the subnet finished releasing in the meantime.

* Wrap the removal in a `resource.StateChangeConf` loop that retries while the API returns `VPC.0602`, mirroring `waitForVpcSubnetDelete` in the same package. A 404 is still treated as already removed; any other error fails immediately.
* Add a `Timeouts` block with a 10 minute delete timeout — the resource previously had none — matching `opentelekomcloud_vpc_subnet_v1`.
* Add an acceptance test creating a VPC, a secondary CIDR, and a subnet carved from that CIDR in one apply. The destroy at test end is the assertion.

Note on the status code: OTC returns `VPC.0602` as **HTTP 400**, not 409 as the error text might suggest. The retry matches on the error code in the response body rather than on 400 alone, so unrelated bad requests still fail fast. A 409 is also treated as retryable defensively, but is not the code observed in practice.

### Known related defect, not fixed here

`opentelekomcloud_vpc_subnet_v1` treats HTTP 400 on the delete call as successful deletion and drops a live subnet from state, which makes this failure more likely to be hit. Reclassifying that 400 affects every subnet delete in the provider and its original motivation is undocumented, so it is left for a separate PR. The retry added here makes it non-fatal for teardown.

## PR Checklist

* [x] Refers to: #3512 
* [x] Tests added/passed.
* [x] Documentation updated. (N/A — no user-facing schema or behavior change)
* [x] Schema updated. (`Timeouts` block added)
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccVpcSecondaryCidrV3_basic
=== PAUSE TestAccVpcSecondaryCidrV3_basic
=== RUN   TestAccVpcSecondaryCidrV3_subnetOnSecondaryCidr
=== PAUSE TestAccVpcSecondaryCidrV3_subnetOnSecondaryCidr
=== CONT  TestAccVpcSecondaryCidrV3_basic
=== CONT  TestAccVpcSecondaryCidrV3_subnetOnSecondaryCidr
--- PASS: TestAccVpcSecondaryCidrV3_subnetOnSecondaryCidr (87.81s)
--- PASS: TestAccVpcSecondaryCidrV3_basic (209.93s)
=== RUN   TestAccVpcSecondaryCidrV3_basic
=== PAUSE TestAccVpcSecondaryCidrV3_basic
=== RUN   TestAccVpcSecondaryCidrV3_subnetOnSecondaryCidr
=== PAUSE TestAccVpcSecondaryCidrV3_subnetOnSecondaryCidr
=== CONT  TestAccVpcSecondaryCidrV3_basic
=== CONT  TestAccVpcSecondaryCidrV3_subnetOnSecondaryCidr
--- PASS: TestAccVpcSecondaryCidrV3_subnetOnSecondaryCidr (92.91s)
--- PASS: TestAccVpcSecondaryCidrV3_basic (206.64s)
=== RUN   TestAccVpcSecondaryCidrV3_basic
=== PAUSE TestAccVpcSecondaryCidrV3_basic
=== RUN   TestAccVpcSecondaryCidrV3_subnetOnSecondaryCidr
=== PAUSE TestAccVpcSecondaryCidrV3_subnetOnSecondaryCidr
=== CONT  TestAccVpcSecondaryCidrV3_basic
=== CONT  TestAccVpcSecondaryCidrV3_subnetOnSecondaryCidr
--- PASS: TestAccVpcSecondaryCidrV3_subnetOnSecondaryCidr (92.01s)
--- PASS: TestAccVpcSecondaryCidrV3_basic (209.12s)
PASS
```

Run with `-count=3`, since a single green run does not prove a race is fixed.

Closes #3512 