### PR TITLE
[Fix] RDS: Fix private domain implementation for MySQL instances

### DIFF
--- a/docs/resources/rds_instance_v3.md
+++ b/docs/resources/rds_instance_v3.md
@@ -351,7 +351,7 @@ For example, the parameter can be UTC+08:00 rather than UTC+08:30.
 
 * `private_domain_name` - (Optional) Specifies the prefix of the new domain name. The value contains `8` to `63` characters. Only uppercase letters, lowercase letters, and digits are allowed.
 
-~> **Warning** The argument `private_domain_name` not supported in `eu-ch2` region.
+~> **Warning** The argument `private_domain_name` not supported in `eu-ch2` region. The argument `private_domain_name` is only supported for `MySQL` and `PostgreSQL` database types.
 
 * `backup_strategy` - (Optional) Specifies the advanced backup policy. Structure is documented below.
 

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.9.9-0.20260824160243-de92ff34978f
+	github.com/opentelekomcloud/gophertelekomcloud v0.9.9-0.20260825122042-b2d050443dd9
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.52.0
 	golang.org/x/sync v0.20.0

--- a/go.sum
+++ b/go.sum
@@ -169,12 +169,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.9-0.20260819145922-554c8ed9cd75 h1:lQ+V5Vg+tM7/Rva1iJZJNVGAX+gC0VTLx+SNGbYdkD8=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.9-0.20260819145922-554c8ed9cd75/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.9-0.20260824105328-b5467d8fff9b h1:bWfSX8ljvvCijV07AZG8XwOC+8q1B1WrC+7AD97LQCs=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.9-0.20260824105328-b5467d8fff9b/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.9-0.20260824160243-de92ff34978f h1:3kmKr/4zVqVwhHD+SLhUnQTj7ghBnzH3XyPXmBSAPQY=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.9-0.20260824160243-de92ff34978f/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.9-0.20260825122042-b2d050443dd9 h1:60FNqOFvHEgxIeLYy5HJax57yx5sDd7EB/y0Kpee+4w=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.9-0.20260825122042-b2d050443dd9/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
+++ b/opentelekomcloud/acceptance/rds/resource_opentelekomcloud_rds_instance_v3_test.go
@@ -1390,8 +1390,8 @@ func testAccRdsInstanceV3PrivateDNS(postfix string) string {
 %[2]s
 
 data "opentelekomcloud_rds_flavors_v3" "flavor" {
-  db_type       = "PostgreSQL"
-  db_version    = "15"
+  db_type       = "MySQL"
+  db_version    = "8.0"
   instance_mode = "single"
 }
 
@@ -1407,9 +1407,9 @@ resource "opentelekomcloud_rds_instance_v3" "instance" {
   availability_zone = ["%[4]s"]
   db {
     password = "Postgres!120521"
-    type     = "PostgreSQL"
-    version  = "15"
-    port     = "8635"
+    type     = "MySQL"
+    version  = "8.0"
+    port     = "3306"
   }
   security_group_id   = data.opentelekomcloud_networking_secgroup_v2.default_secgroup.id
   subnet_id           = data.opentelekomcloud_vpc_subnet_v1.shared_subnet.network_id

--- a/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_instance_v3.go
+++ b/opentelekomcloud/services/rds/resource_opentelekomcloud_rds_instance_v3.go
@@ -642,6 +642,18 @@ func resourceRdsInstanceV3Create(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	if privateDomainName := d.Get("private_domain_name").(string); privateDomainName != "" {
+		if dbType := d.Get("db.0.type").(string); strings.ToLower(dbType) == "mysql" {
+			jobId, err := instances.ApplyForPrivateDomain(client, instances.ApplyForPrivateDomainOpts{
+				InstanceId: d.Id(),
+				DnsType:    "private",
+			})
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			if err := instances.WaitForJobCompleted(client, 600, *jobId); err != nil {
+				return fmterr.Errorf("error waiting while applying for private domain: %w", err)
+			}
+		}
 		jobId, err := instances.ModifyPrivateDomainName(client, instances.ModifyPrivateDomainNameOpts{
 			InstanceId: d.Id(),
 			DnsName:    privateDomainName,

--- a/releasenotes/notes/rds-fix-private-domain-07c800af2ef32f27.yaml
+++ b/releasenotes/notes/rds-fix-private-domain-07c800af2ef32f27.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    **[RDS]** Add db type check for private domain in `resource/opentelekomcloud_rds_instance_v3`` (`#3527 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3527>`_)


### PR DESCRIPTION
## Summary of the Pull Request

Private domain is not automatically enabled for MySQL instances. Add check to manually enable private domain in rds_instance_v3 resource.

## PR Checklist

* [x] Refers to: #3523 
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccRdsInstanceV3_PrivateDNS
--- PASS: TestAccRdsInstanceV3_PrivateDNS (404.47s)
PASS
```
