### PR TITLE
[Feat.] migrate subnet v1 to modern sdk

### DIFF
--- a/docs/data-sources/vpc_subnet_ids_v1.md
+++ b/docs/data-sources/vpc_subnet_ids_v1.md
@@ -12,9 +12,7 @@ Up-to-date reference of API arguments for VPC subnet you can get at
 
 # opentelekomcloud_vpc_subnet_ids_v1
 
-Use this data source to get a list of subnet ids for a vpc_id
-
-This resource can be useful for getting back a list of subnet ids for a VPC.
+Use this data source to get a list of subnet IDs for a VPC.
 
 ## Example Usage
 
@@ -45,4 +43,4 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `ids` - A list of all the subnet ids found. This data source will fail if none are found.
+* `ids` - A set of all subnet IDs found. This data source will fail if none are found.

--- a/docs/data-sources/vpc_subnet_v1.md
+++ b/docs/data-sources/vpc_subnet_v1.md
@@ -8,7 +8,7 @@ description: |-
 ---
 
 Up-to-date reference of API arguments for VPC subnet you can get at
-[documentation portal](https://docs.otc.t-systems.com/virtual-private-cloud/api-ref/apis/subnet/querying_subnets.html#vpc-subnet01-0003)
+[documentation portal](https://docs.otc.t-systems.com/virtual-private-cloud/api-ref/vpc_apis_v1_v2/subnet/querying_subnets.html#vpc-subnet01-0003)
 
 # opentelekomcloud_vpc_subnet_v1
 
@@ -40,6 +40,8 @@ subnet whose data will be exported as attributes.
 
 * `name` - (Optional) The name of the specific subnet to retrieve.
 
+* `description` - (Optional) The description of the specific subnet to retrieve.
+
 * `cidr` - (Optional) The network segment of specific subnet to retrieve. The value must be in CIDR format.
 
 * `status` - (Optional) The value can be ACTIVE, DOWN, UNKNOWN, or ERROR.
@@ -53,6 +55,10 @@ subnet whose data will be exported as attributes.
 * `secondary_dns` - (Optional) The IP address of DNS server 2 on the specific subnet.
 
 * `availability_zone` - (Optional) The availability zone (AZ) to which the subnet should belong.
+
+* `ntp_addresses` - (Optional) The comma-separated NTP server addresses configured for the subnet.
+
+* `scope` - (Optional) The subnet usage scope, such as `center`.
 
 ## Attributes Reference
 
@@ -70,3 +76,9 @@ the selected subnet.
 * `subnet_id_v6` - Specifies the OpenStack IPv6 subnet ID. Only returned if subnet is IPV6 enabled.
 
 * `network_id` - Specifies the OpenStack network ID.
+
+* `tenant_id` - The project ID that owns the subnet.
+
+* `created_at` - The UTC creation timestamp.
+
+* `updated_at` - The UTC last-update timestamp.

--- a/docs/resources/vpc_subnet_v1.md
+++ b/docs/resources/vpc_subnet_v1.md
@@ -8,7 +8,7 @@ description: |-
 ---
 
 Up-to-date reference of API arguments for VPC subnet you can get at
-[documentation portal](https://docs.otc.t-systems.com/virtual-private-cloud/api-ref/apis/subnet)
+[documentation portal](https://docs.otc.t-systems.com/virtual-private-cloud/api-ref/vpc_apis_v1_v2/subnet/index.html)
 
 # opentelekomcloud_vpc_subnet_v1
 
@@ -77,7 +77,7 @@ resource "opentelekomcloud_vpc_subnet_v1" "subnet_v6" {
 The following arguments are supported:
 
 * `name` - (Required) The subnet name. The value is a string of `1` to `64` characters that can contain letters,
-  digits, underscores (`_`), and hyphens (`-`).
+  digits, underscores (`_`), hyphens (`-`), and periods (`.`).
 
 * `description` - (Optional) A description of the VPC subnet.
 
@@ -131,9 +131,17 @@ All the argument attributes are also exported as result attributes:
 
 * `network_id` - Specifies the OpenStack network ID.
 
-* `cidr_v6` - Specifies the IPv6 subnet CIDR block. If the subnet is an IPv4 subnet, this parameter is not returned.
+* `cidr_ipv6` - Specifies the IPv6 subnet CIDR block. If the subnet is an IPv4 subnet, this parameter is not returned.
 
-* `gateway_ip_v6` - Specifies the IPv6 subnet gateway. If the subnet is an IPv4 subnet, this parameter is not returned.
+* `gateway_ipv6` - Specifies the IPv6 subnet gateway. If the subnet is an IPv4 subnet, this parameter is not returned.
+
+* `scope` - Specifies where the subnet is used in an edge-cloud scenario.
+
+* `tenant_id` - The project ID that owns the subnet.
+
+* `created_at` - The UTC creation timestamp.
+
+* `updated_at` - The UTC last-update timestamp.
 
 ## Import
 

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.9.9-0.20260831085549-3aac627f4d8b
+	github.com/opentelekomcloud/gophertelekomcloud v0.9.9-0.20260831145652-3f8eb888697f
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.52.0
 	golang.org/x/sync v0.20.0

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/opentelekomcloud/gophertelekomcloud v0.9.9-0.20260831145652-3f8eb888697f
+	github.com/opentelekomcloud/gophertelekomcloud v0.9.9-0.20260901104958-3bfaa8b781ed
 	github.com/unknwon/com v1.0.1
 	golang.org/x/crypto v0.52.0
 	golang.org/x/sync v0.20.0

--- a/go.sum
+++ b/go.sum
@@ -175,6 +175,8 @@ github.com/opentelekomcloud/gophertelekomcloud v0.9.9-0.20260826145728-e49b564f4
 github.com/opentelekomcloud/gophertelekomcloud v0.9.9-0.20260826145728-e49b564f4cba/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
 github.com/opentelekomcloud/gophertelekomcloud v0.9.9-0.20260831085549-3aac627f4d8b h1:1ogiOgqtN7kvqPqrSjwQ2GGyMUVHC7BaiIZFuD0k8LY=
 github.com/opentelekomcloud/gophertelekomcloud v0.9.9-0.20260831085549-3aac627f4d8b/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.9-0.20260831145652-3f8eb888697f h1:OEUFvR3O85wAXQKM1xxqlqJHBlqERaQfL/J+yFqyn8g=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.9-0.20260831145652-3f8eb888697f/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/go.sum
+++ b/go.sum
@@ -169,14 +169,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.9-0.20260825122042-b2d050443dd9 h1:60FNqOFvHEgxIeLYy5HJax57yx5sDd7EB/y0Kpee+4w=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.9-0.20260825122042-b2d050443dd9/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.9-0.20260826145728-e49b564f4cba h1:LYp5x7ZUQeu7e9QCI2rNkfTqGMCyIrnkwfOXQJmq0Ag=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.9-0.20260826145728-e49b564f4cba/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.9-0.20260831085549-3aac627f4d8b h1:1ogiOgqtN7kvqPqrSjwQ2GGyMUVHC7BaiIZFuD0k8LY=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.9-0.20260831085549-3aac627f4d8b/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.9-0.20260831145652-3f8eb888697f h1:OEUFvR3O85wAXQKM1xxqlqJHBlqERaQfL/J+yFqyn8g=
-github.com/opentelekomcloud/gophertelekomcloud v0.9.9-0.20260831145652-3f8eb888697f/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.9-0.20260901104958-3bfaa8b781ed h1:O+5atkN5e9Opn3uE25dc9S0CKnOXB2+oFDGQDT5j5K4=
+github.com/opentelekomcloud/gophertelekomcloud v0.9.9-0.20260901104958-3bfaa8b781ed/go.mod h1:la8cQVYopRoEbNe2L7HlGTdLxUQOwIqHp1VHtjE/5qA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/opentelekomcloud/acceptance/vpc/data_source_opentelekomcloud_vpc_subnet_ids_v1_test.go
+++ b/opentelekomcloud/acceptance/vpc/data_source_opentelekomcloud_vpc_subnet_ids_v1_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
 )
 
-func TestAccVpcSubnetIdsV2DataSource_basic(t *testing.T) {
+func TestAccVpcSubnetIdsV1DataSource_basic(t *testing.T) {
 	t.Parallel()
 	qts := vpcSubnetQuotas()
 	quotas.BookMany(t, qts)
@@ -26,14 +26,21 @@ func TestAccVpcSubnetIdsV2DataSource_basic(t *testing.T) {
 			{
 				Config: testAccSubnetIdV2DataSourceBasic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccSubnetIdV2DataSourceID("data.opentelekomcloud_vpc_subnet_ids_v1.subnet_ids"),
+					testAccSubnetIdV1DataSourceID("data.opentelekomcloud_vpc_subnet_ids_v1.subnet_ids"),
 					resource.TestCheckResourceAttr("data.opentelekomcloud_vpc_subnet_ids_v1.subnet_ids", "ids.#", "1"),
+					resource.TestCheckTypeSetElemAttrPair(
+						"data.opentelekomcloud_vpc_subnet_ids_v1.subnet_ids",
+						"ids.*",
+						"opentelekomcloud_vpc_subnet_v1.subnet_1",
+						"id",
+					),
 				),
 			},
 		},
 	})
 }
-func testAccSubnetIdV2DataSourceID(n string) resource.TestCheckFunc {
+
+func testAccSubnetIdV1DataSourceID(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {

--- a/opentelekomcloud/acceptance/vpc/data_source_opentelekomcloud_vpc_subnet_v1_test.go
+++ b/opentelekomcloud/acceptance/vpc/data_source_opentelekomcloud_vpc_subnet_v1_test.go
@@ -39,6 +39,12 @@ func TestAccVpcSubnetV1DataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceNameByID, "dhcp_enable", "true"),
 					resource.TestCheckResourceAttr(dataSourceNameByID, "ipv6_enable", "true"),
 					resource.TestCheckResourceAttrSet(dataSourceNameByID, "subnet_id_v6"),
+					resource.TestCheckResourceAttr(dataSourceNameByID, "description", "data source description"),
+					resource.TestCheckResourceAttr(dataSourceNameByID, "ntp_addresses", "10.100.0.33"),
+					resource.TestCheckResourceAttrSet(dataSourceNameByID, "scope"),
+					resource.TestCheckResourceAttrSet(dataSourceNameByID, "tenant_id"),
+					resource.TestCheckResourceAttrSet(dataSourceNameByID, "created_at"),
+					resource.TestCheckResourceAttrSet(dataSourceNameByID, "updated_at"),
 				),
 			},
 		},
@@ -88,11 +94,13 @@ resource "opentelekomcloud_vpc_v1" "vpc_1" {
 
 resource "opentelekomcloud_vpc_subnet_v1" "subnet_1" {
   name              = "test_subnet_ds_sn"
+  description       = "data source description"
   cidr              = "10.0.1.0/24"
   gateway_ip        = "10.0.1.1"
   vpc_id            = opentelekomcloud_vpc_v1.vpc_1.id
   availability_zone = "eu-de-02"
   ipv6_enable       = true
+  ntp_addresses     = "10.100.0.33"
 }
 
 data "opentelekomcloud_vpc_subnet_v1" "by_id" {

--- a/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_vpc_subnet_v1_test.go
+++ b/opentelekomcloud/acceptance/vpc/resource_opentelekomcloud_vpc_subnet_v1_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common/quotas"
 
-	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v1/subnets"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/vpc/v1/subnets"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/common"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/env"
@@ -41,6 +41,10 @@ func TestAccVpcSubnetV1Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceVPCSubnetName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceVPCSubnetName, "tags.key", "value"),
 					resource.TestCheckResourceAttr(resourceVPCSubnetName, "status", "ACTIVE"),
+					resource.TestCheckResourceAttrSet(resourceVPCSubnetName, "scope"),
+					resource.TestCheckResourceAttrSet(resourceVPCSubnetName, "tenant_id"),
+					resource.TestCheckResourceAttrSet(resourceVPCSubnetName, "created_at"),
+					resource.TestCheckResourceAttrSet(resourceVPCSubnetName, "updated_at"),
 				),
 			},
 			{
@@ -155,9 +159,9 @@ func TestAccVpcSubnetV1DnsList(t *testing.T) {
 
 func testAccCheckVpcSubnetV1Destroy(s *terraform.State) error {
 	config := common.TestAccProvider.Meta().(*cfg.Config)
-	client, err := config.NetworkingV1Client(env.OS_REGION_NAME)
+	client, err := config.VpcV1Client(env.OS_REGION_NAME)
 	if err != nil {
-		return fmt.Errorf("error creating OpenTelekomCloud NetworkingV1 client: %w", err)
+		return fmt.Errorf("error creating OpenTelekomCloud VPC v1 client: %w", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -165,7 +169,7 @@ func testAccCheckVpcSubnetV1Destroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := subnets.Get(client, rs.Primary.ID).Extract()
+		_, err := subnets.Get(client, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("subnet still exists")
 		}
@@ -185,12 +189,12 @@ func testAccCheckVpcSubnetV1Exists(n string, subnet *subnets.Subnet) resource.Te
 		}
 
 		config := common.TestAccProvider.Meta().(*cfg.Config)
-		client, err := config.NetworkingV1Client(env.OS_REGION_NAME)
+		client, err := config.VpcV1Client(env.OS_REGION_NAME)
 		if err != nil {
-			return fmt.Errorf("error creating OpenTelekomCloud NetworkingV1 client: %w", err)
+			return fmt.Errorf("error creating OpenTelekomCloud VPC v1 client: %w", err)
 		}
 
-		found, err := subnets.Get(client, rs.Primary.ID).Extract()
+		found, err := subnets.Get(client, rs.Primary.ID)
 		if err != nil {
 			return err
 		}

--- a/opentelekomcloud/services/vpc/data_source_opentelekomcloud_vpc_subnet_ids_v1.go
+++ b/opentelekomcloud/services/vpc/data_source_opentelekomcloud_vpc_subnet_ids_v1.go
@@ -48,12 +48,13 @@ func dataSourceVpcSubnetIdsV1Read(_ context.Context, d *schema.ResourceData, met
 	}
 
 	vpcID := d.Get("vpc_id").(string)
-	// The API can repeat a page when vpc_id and marker are combined, so filter the complete result locally.
-	allSubnets, err := subnets.List(client, subnets.ListOpts{})
+	listOpts := subnets.ListOpts{
+		VpcID: vpcID,
+	}
+	refinedSubnets, err := subnets.List(client, listOpts)
 	if err != nil {
 		return fmterr.Errorf("unable to retrieve subnets: %w", err)
 	}
-	refinedSubnets := filterSubnets(allSubnets, subnetFilters{VpcID: vpcID})
 
 	if len(refinedSubnets) == 0 {
 		return fmterr.Errorf("no matching subnet found for vpc with id %s", vpcID)

--- a/opentelekomcloud/services/vpc/data_source_opentelekomcloud_vpc_subnet_ids_v1.go
+++ b/opentelekomcloud/services/vpc/data_source_opentelekomcloud_vpc_subnet_ids_v1.go
@@ -5,8 +5,8 @@ import (
 	"sort"
 
 	"github.com/hashicorp/go-multierror"
-	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v1/subnets"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/networkipavailabilities"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/vpc/v1/subnets"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -42,20 +42,18 @@ func DataSourceVpcSubnetIdsV1() *schema.Resource {
 
 func dataSourceVpcSubnetIdsV1Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	client, err := config.NetworkingV1Client(config.GetRegion(d))
+	client, err := config.VpcV1Client(config.GetRegion(d))
 	if err != nil {
-		return fmterr.Errorf("error creating OpenTelekomCloud NetworkingV1 client: %w", err)
+		return fmterr.Errorf("error creating OpenTelekomCloud VPC v1 client: %w", err)
 	}
 
 	vpcID := d.Get("vpc_id").(string)
-	listOpts := subnets.ListOpts{
-		VpcID: vpcID,
-	}
-
-	refinedSubnets, err := subnets.List(client, listOpts)
+	// The API can repeat a page when vpc_id and marker are combined, so filter the complete result locally.
+	allSubnets, err := subnets.List(client, subnets.ListOpts{})
 	if err != nil {
 		return fmterr.Errorf("unable to retrieve subnets: %w", err)
 	}
+	refinedSubnets := filterSubnets(allSubnets, subnetFilters{VpcID: vpcID})
 
 	if len(refinedSubnets) == 0 {
 		return fmterr.Errorf("no matching subnet found for vpc with id %s", vpcID)
@@ -71,6 +69,9 @@ func dataSourceVpcSubnetIdsV1Read(_ context.Context, d *schema.ResourceData, met
 		net, err := networkipavailabilities.Get(networkingClient, subnet.ID).Extract()
 		if err != nil {
 			return fmterr.Errorf("error retrieving NetworkIP availabilities: %w", err)
+		}
+		if len(net.SubnetIPAvailabilities) == 0 {
+			return fmterr.Errorf("no NetworkIP availability found for subnet %s", subnet.ID)
 		}
 		subnetIPAvail := net.SubnetIPAvailabilities[0]
 		newSubnet := SubnetIP{

--- a/opentelekomcloud/services/vpc/data_source_opentelekomcloud_vpc_subnet_v1.go
+++ b/opentelekomcloud/services/vpc/data_source_opentelekomcloud_vpc_subnet_v1.go
@@ -148,8 +148,10 @@ func dataSourceVpcSubnetV1Read(_ context.Context, d *schema.ResourceData, meta i
 		return fmterr.Errorf("error creating OpenTelekomCloud VPC v1 client: %w", err)
 	}
 
-	// The API can repeat a page when vpc_id and marker are combined, so apply all filters client-side.
-	allSubnets, err := subnets.List(client, subnets.ListOpts{})
+	listOpts := subnets.ListOpts{
+		VpcID: d.Get("vpc_id").(string),
+	}
+	allSubnets, err := subnets.List(client, listOpts)
 	if err != nil {
 		return fmterr.Errorf("unable to retrieve subnets: %w", err)
 	}
@@ -165,7 +167,6 @@ func dataSourceVpcSubnetV1Read(_ context.Context, d *schema.ResourceData, meta i
 		AvailabilityZone: d.Get("availability_zone").(string),
 		NtpAddresses:     d.Get("ntp_addresses").(string),
 		Scope:            d.Get("scope").(string),
-		VpcID:            d.Get("vpc_id").(string),
 	})
 
 	if len(refinedSubnets) == 0 {
@@ -225,7 +226,6 @@ type subnetFilters struct {
 	AvailabilityZone string
 	NtpAddresses     string
 	Scope            string
-	VpcID            string
 }
 
 func filterSubnets(allSubnets []subnets.Subnet, filters subnetFilters) []subnets.Subnet {
@@ -262,9 +262,6 @@ func filterSubnets(allSubnets []subnets.Subnet, filters subnetFilters) []subnets
 			continue
 		}
 		if filters.Scope != "" && subnet.Scope != filters.Scope {
-			continue
-		}
-		if filters.VpcID != "" && subnet.VpcID != filters.VpcID {
 			continue
 		}
 		refined = append(refined, subnet)

--- a/opentelekomcloud/services/vpc/data_source_opentelekomcloud_vpc_subnet_v1.go
+++ b/opentelekomcloud/services/vpc/data_source_opentelekomcloud_vpc_subnet_v1.go
@@ -3,12 +3,13 @@ package vpc
 import (
 	"context"
 	"log"
+	"regexp"
 
 	"github.com/hashicorp/go-multierror"
-	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v1/subnets"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/vpc/v1/subnets"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
@@ -34,6 +35,16 @@ func DataSourceVpcSubnetV1() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(0, 255),
+					validation.StringMatch(regexp.MustCompile("^[^<>]*$"),
+						"description cannot contain angle brackets"),
+				),
 			},
 			"cidr": {
 				Type:     schema.TypeString,
@@ -104,33 +115,58 @@ func DataSourceVpcSubnetV1() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"ntp_addresses": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"scope": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"tenant_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
 
 func dataSourceVpcSubnetV1Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
-	client, err := config.NetworkingV1Client(config.GetRegion(d))
+	client, err := config.VpcV1Client(config.GetRegion(d))
 	if err != nil {
-		return fmterr.Errorf(errCreationV1Client, err)
+		return fmterr.Errorf("error creating OpenTelekomCloud VPC v1 client: %w", err)
 	}
 
-	listOpts := subnets.ListOpts{
+	// The API can repeat a page when vpc_id and marker are combined, so apply all filters client-side.
+	allSubnets, err := subnets.List(client, subnets.ListOpts{})
+	if err != nil {
+		return fmterr.Errorf("unable to retrieve subnets: %w", err)
+	}
+	refinedSubnets := filterSubnets(allSubnets, subnetFilters{
 		ID:               d.Get("id").(string),
 		Name:             d.Get("name").(string),
+		Description:      d.Get("description").(string),
 		CIDR:             d.Get("cidr").(string),
 		Status:           d.Get("status").(string),
 		GatewayIP:        d.Get("gateway_ip").(string),
 		PrimaryDNS:       d.Get("primary_dns").(string),
 		SecondaryDNS:     d.Get("secondary_dns").(string),
 		AvailabilityZone: d.Get("availability_zone").(string),
+		NtpAddresses:     d.Get("ntp_addresses").(string),
+		Scope:            d.Get("scope").(string),
 		VpcID:            d.Get("vpc_id").(string),
-	}
-
-	refinedSubnets, err := subnets.List(client, listOpts)
-	if err != nil {
-		return fmterr.Errorf("unable to retrieve subnets: %w", err)
-	}
+	})
 
 	if len(refinedSubnets) == 0 {
 		return fmterr.Errorf("no matching subnet found. Please change your search criteria and try again")
@@ -147,6 +183,7 @@ func dataSourceVpcSubnetV1Read(_ context.Context, d *schema.ResourceData, meta i
 
 	mErr := multierror.Append(
 		d.Set("name", subnet.Name),
+		d.Set("description", subnet.Description),
 		d.Set("cidr", subnet.CIDR),
 		d.Set("dns_list", subnet.DNSList),
 		d.Set("status", subnet.Status),
@@ -162,6 +199,11 @@ func dataSourceVpcSubnetV1Read(_ context.Context, d *schema.ResourceData, meta i
 		d.Set("ipv6_enable", subnet.EnableIpv6),
 		d.Set("cidr_ipv6", subnet.CidrV6),
 		d.Set("gateway_ipv6", subnet.GatewayIpV6),
+		d.Set("ntp_addresses", subnetNtpAddresses(subnet.ExtraDHCPOpts)),
+		d.Set("scope", subnet.Scope),
+		d.Set("tenant_id", subnet.TenantID),
+		d.Set("created_at", subnet.CreatedAt),
+		d.Set("updated_at", subnet.UpdatedAt),
 		d.Set("region", config.GetRegion(d)),
 	)
 	if mErr.ErrorOrNil() != nil {
@@ -169,4 +211,63 @@ func dataSourceVpcSubnetV1Read(_ context.Context, d *schema.ResourceData, meta i
 	}
 
 	return nil
+}
+
+type subnetFilters struct {
+	ID               string
+	Name             string
+	Description      string
+	CIDR             string
+	Status           string
+	GatewayIP        string
+	PrimaryDNS       string
+	SecondaryDNS     string
+	AvailabilityZone string
+	NtpAddresses     string
+	Scope            string
+	VpcID            string
+}
+
+func filterSubnets(allSubnets []subnets.Subnet, filters subnetFilters) []subnets.Subnet {
+	refined := make([]subnets.Subnet, 0, len(allSubnets))
+	for _, subnet := range allSubnets {
+		if filters.ID != "" && subnet.ID != filters.ID {
+			continue
+		}
+		if filters.Name != "" && subnet.Name != filters.Name {
+			continue
+		}
+		if filters.Description != "" && subnet.Description != filters.Description {
+			continue
+		}
+		if filters.CIDR != "" && subnet.CIDR != filters.CIDR {
+			continue
+		}
+		if filters.Status != "" && subnet.Status != filters.Status {
+			continue
+		}
+		if filters.GatewayIP != "" && subnet.GatewayIP != filters.GatewayIP {
+			continue
+		}
+		if filters.PrimaryDNS != "" && subnet.PrimaryDNS != filters.PrimaryDNS {
+			continue
+		}
+		if filters.SecondaryDNS != "" && subnet.SecondaryDNS != filters.SecondaryDNS {
+			continue
+		}
+		if filters.AvailabilityZone != "" && subnet.AvailabilityZone != filters.AvailabilityZone {
+			continue
+		}
+		if filters.NtpAddresses != "" && subnetNtpAddresses(subnet.ExtraDHCPOpts) != filters.NtpAddresses {
+			continue
+		}
+		if filters.Scope != "" && subnet.Scope != filters.Scope {
+			continue
+		}
+		if filters.VpcID != "" && subnet.VpcID != filters.VpcID {
+			continue
+		}
+		refined = append(refined, subnet)
+	}
+	return refined
 }

--- a/opentelekomcloud/services/vpc/resource_opentelekomcloud_vpc_subnet_v1.go
+++ b/opentelekomcloud/services/vpc/resource_opentelekomcloud_vpc_subnet_v1.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"regexp"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -12,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
-	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v1/subnets"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/vpc/v1/subnets"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
@@ -48,6 +49,11 @@ func ResourceVpcSubnetV1() *schema.Resource {
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(0, 255),
+					validation.StringMatch(regexp.MustCompile("^[^<>]*$"),
+						"description cannot contain angle brackets"),
+				),
 			},
 			"cidr": {
 				Type:         schema.TypeString,
@@ -132,6 +138,22 @@ func ResourceVpcSubnetV1() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"scope": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tenant_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -139,10 +161,10 @@ func ResourceVpcSubnetV1() *schema.Resource {
 func resourceVpcSubnetV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
 	client, err := common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
-		return config.NetworkingV1Client(config.GetRegion(d))
+		return config.VpcV1Client(config.GetRegion(d))
 	})
 	if err != nil {
-		return fmterr.Errorf(errCreationV1Client, err)
+		return fmterr.Errorf("error creating OpenTelekomCloud VPC v1 client: %w", err)
 	}
 
 	primaryDNS := d.Get("primary_dns").(string)
@@ -179,10 +201,11 @@ func resourceVpcSubnetV1Create(ctx context.Context, d *schema.ResourceData, meta
 		createOpts.ExtraDHCPOpts = extraDhcpRequests
 	}
 
-	subnet, err := subnets.Create(client, createOpts).Extract()
+	subnet, err := subnets.Create(client, createOpts)
 	if err != nil {
 		return fmterr.Errorf("error creating OpenTelekomCloud VPC subnet: %w", err)
 	}
+	d.SetId(subnet.ID)
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"CREATING"},
@@ -198,8 +221,6 @@ func resourceVpcSubnetV1Create(ctx context.Context, d *schema.ResourceData, meta
 		return fmterr.Errorf("error waiting for Subnet (%s) to become ACTIVE: %w", subnet.ID, err)
 	}
 
-	d.SetId(subnet.ID)
-
 	if err := addNetworkingTags(d, config, "subnets"); err != nil {
 		return diag.FromErr(err)
 	}
@@ -211,13 +232,13 @@ func resourceVpcSubnetV1Create(ctx context.Context, d *schema.ResourceData, meta
 func resourceVpcSubnetV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
 	client, err := common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
-		return config.NetworkingV1Client(config.GetRegion(d))
+		return config.VpcV1Client(config.GetRegion(d))
 	})
 	if err != nil {
-		return fmterr.Errorf(errCreationV1Client, err)
+		return fmterr.Errorf("error creating OpenTelekomCloud VPC v1 client: %w", err)
 	}
 
-	subnet, err := subnets.Get(client, d.Id()).Extract()
+	subnet, err := subnets.Get(client, d.Id())
 	if err != nil {
 		return common.CheckDeletedDiag(d, err, "vpc subnet")
 	}
@@ -240,15 +261,13 @@ func resourceVpcSubnetV1Read(ctx context.Context, d *schema.ResourceData, meta i
 		d.Set("subnet_id_v6", subnet.SubnetIDV6),
 		d.Set("network_id", subnet.NetworkID),
 		d.Set("status", subnet.Status),
+		d.Set("ntp_addresses", subnetNtpAddresses(subnet.ExtraDHCPOpts)),
+		d.Set("scope", subnet.Scope),
+		d.Set("tenant_id", subnet.TenantID),
+		d.Set("created_at", subnet.CreatedAt),
+		d.Set("updated_at", subnet.UpdatedAt),
 		d.Set("region", config.GetRegion(d)),
 	)
-
-	for _, opt := range subnet.ExtraDHCPOpts {
-		if opt.OptName == "ntp" {
-			mErr = multierror.Append(mErr, d.Set("ntp_addresses", opt.OptValue))
-			break
-		}
-	}
 
 	if mErr.ErrorOrNil() != nil {
 		return fmterr.Errorf("error setting subnet fields: %w", mErr)
@@ -264,10 +283,10 @@ func resourceVpcSubnetV1Read(ctx context.Context, d *schema.ResourceData, meta i
 func resourceVpcSubnetV1Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
 	client, err := common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
-		return config.NetworkingV1Client(config.GetRegion(d))
+		return config.VpcV1Client(config.GetRegion(d))
 	})
 	if err != nil {
-		return fmterr.Errorf(errCreationV1Client, err)
+		return fmterr.Errorf("error creating OpenTelekomCloud VPC v1 client: %w", err)
 	}
 
 	var updateOpts subnets.UpdateOpts
@@ -303,12 +322,12 @@ func resourceVpcSubnetV1Update(ctx context.Context, d *schema.ResourceData, meta
 			OptValue: d.Get("ntp_addresses").(string),
 		}
 		extraDhcpRequests = append(extraDhcpRequests, extraDhcpReq)
-		updateOpts.ExtraDhcpOpts = extraDhcpRequests
+		updateOpts.ExtraDHCPOpts = extraDhcpRequests
 	}
 
 	vpcID := d.Get("vpc_id").(string)
 
-	_, err = subnets.Update(client, vpcID, d.Id(), updateOpts).Extract()
+	_, err = subnets.Update(client, vpcID, d.Id(), updateOpts)
 	if err != nil {
 		return fmterr.Errorf("error updating OpenTelekomCloud VPC Subnet: %w", err)
 	}
@@ -332,10 +351,10 @@ func resourceVpcSubnetV1Update(ctx context.Context, d *schema.ResourceData, meta
 func resourceVpcSubnetV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	config := meta.(*cfg.Config)
 	client, err := common.ClientFromCtx(ctx, keyClientV1, func() (*golangsdk.ServiceClient, error) {
-		return config.NetworkingV1Client(config.GetRegion(d))
+		return config.VpcV1Client(config.GetRegion(d))
 	})
 	if err != nil {
-		return fmterr.Errorf(errCreationV1Client, err)
+		return fmterr.Errorf("error creating OpenTelekomCloud VPC v1 client: %w", err)
 	}
 
 	vpcID := d.Get("vpc_id").(string)
@@ -360,7 +379,7 @@ func resourceVpcSubnetV1Delete(ctx context.Context, d *schema.ResourceData, meta
 
 func waitForVpcSubnetActive(client *golangsdk.ServiceClient, subnetID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		subnet, err := subnets.Get(client, subnetID).Extract()
+		subnet, err := subnets.Get(client, subnetID)
 		if err != nil {
 			return nil, "", err
 		}
@@ -370,7 +389,7 @@ func waitForVpcSubnetActive(client *golangsdk.ServiceClient, subnetID string) re
 		}
 
 		// If subnet status is other than Active, send error
-		if subnet.Status == "DOWN" || subnet.Status == "error" {
+		if subnet.Status == "DOWN" || subnet.Status == "ERROR" {
 			return nil, "", fmt.Errorf("subnet status: %s", subnet.Status)
 		}
 
@@ -380,7 +399,7 @@ func waitForVpcSubnetActive(client *golangsdk.ServiceClient, subnetID string) re
 
 func waitForVpcSubnetDelete(client *golangsdk.ServiceClient, vpcID string, subnetID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		subnet, err := subnets.Get(client, subnetID).Extract()
+		subnet, err := subnets.Get(client, subnetID)
 		if err != nil {
 			if _, ok := err.(golangsdk.ErrDefault404); ok {
 				log.Printf("[INFO] Successfully deleted OpenTelekomCloud subnet %s", subnetID)
@@ -389,7 +408,7 @@ func waitForVpcSubnetDelete(client *golangsdk.ServiceClient, vpcID string, subne
 			return subnet, "ACTIVE", err
 		}
 
-		if err := subnets.Delete(client, vpcID, subnetID).ExtractErr(); err != nil {
+		if err := subnets.Delete(client, vpcID, subnetID); err != nil {
 			switch err.(type) {
 			case golangsdk.ErrDefault404, golangsdk.ErrDefault400:
 				log.Printf("[INFO] Successfully deleted OpenTelekomCloud subnet %s", subnetID)
@@ -403,4 +422,13 @@ func waitForVpcSubnetDelete(client *golangsdk.ServiceClient, vpcID string, subne
 
 		return subnet, "ACTIVE", nil
 	}
+}
+
+func subnetNtpAddresses(opts []subnets.ExtraDHCPOpt) string {
+	for _, opt := range opts {
+		if opt.OptName == "ntp" {
+			return opt.OptValue
+		}
+	}
+	return ""
 }

--- a/opentelekomcloud/services/vpc/subnet_v1_test.go
+++ b/opentelekomcloud/services/vpc/subnet_v1_test.go
@@ -32,7 +32,7 @@ func TestFilterSubnets(t *testing.T) {
 		{
 			ID: "first", Name: "match", Description: "description", CIDR: "192.168.0.0/24",
 			Status: "ACTIVE", GatewayIP: "192.168.0.1", PrimaryDNS: "100.125.4.25",
-			SecondaryDNS: "100.125.129.199", AvailabilityZone: "eu-de-01", Scope: "center", VpcID: "vpc-id",
+			SecondaryDNS: "100.125.129.199", AvailabilityZone: "eu-de-01", Scope: "center",
 			ExtraDHCPOpts: []subnets.ExtraDHCPOpt{{OptName: "ntp", OptValue: "10.100.0.33"}},
 		},
 		{ID: "second", Name: "other", CIDR: "10.0.0.0/24", Status: "ACTIVE", VpcID: "other-vpc"},
@@ -50,15 +50,9 @@ func TestFilterSubnets(t *testing.T) {
 		AvailabilityZone: "eu-de-01",
 		NtpAddresses:     "10.100.0.33",
 		Scope:            "center",
-		VpcID:            "vpc-id",
 	})
 	if len(filtered) != 1 || filtered[0].ID != "first" {
 		t.Fatalf("unexpected filtered subnets: %#v", filtered)
-	}
-
-	filtered = filterSubnets(input, subnetFilters{VpcID: "other-vpc"})
-	if len(filtered) != 1 || filtered[0].ID != "second" {
-		t.Fatalf("unexpected VPC-filtered subnets: %#v", filtered)
 	}
 }
 

--- a/opentelekomcloud/services/vpc/subnet_v1_test.go
+++ b/opentelekomcloud/services/vpc/subnet_v1_test.go
@@ -1,0 +1,76 @@
+package vpc
+
+import (
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/vpc/v1/subnets"
+)
+
+func TestSubnetV1Schemas(t *testing.T) {
+	resourceSchema := ResourceVpcSubnetV1().Schema
+	for _, field := range []string{"scope", "tenant_id", "created_at", "updated_at"} {
+		if !resourceSchema[field].Computed || resourceSchema[field].Optional {
+			t.Fatalf("resource %s must be computed only", field)
+		}
+	}
+
+	dataSourceSchema := DataSourceVpcSubnetV1().Schema
+	for _, field := range []string{"tenant_id", "created_at", "updated_at"} {
+		if !dataSourceSchema[field].Computed || dataSourceSchema[field].Optional {
+			t.Fatalf("data source %s must be computed only", field)
+		}
+	}
+	for _, field := range []string{"description", "ntp_addresses", "scope"} {
+		if !dataSourceSchema[field].Computed || !dataSourceSchema[field].Optional {
+			t.Fatalf("data source %s must be optional and computed", field)
+		}
+	}
+}
+
+func TestFilterSubnets(t *testing.T) {
+	input := []subnets.Subnet{
+		{
+			ID: "first", Name: "match", Description: "description", CIDR: "192.168.0.0/24",
+			Status: "ACTIVE", GatewayIP: "192.168.0.1", PrimaryDNS: "100.125.4.25",
+			SecondaryDNS: "100.125.129.199", AvailabilityZone: "eu-de-01", Scope: "center", VpcID: "vpc-id",
+			ExtraDHCPOpts: []subnets.ExtraDHCPOpt{{OptName: "ntp", OptValue: "10.100.0.33"}},
+		},
+		{ID: "second", Name: "other", CIDR: "10.0.0.0/24", Status: "ACTIVE", VpcID: "other-vpc"},
+	}
+
+	filtered := filterSubnets(input, subnetFilters{
+		ID:               "first",
+		Name:             "match",
+		Description:      "description",
+		CIDR:             "192.168.0.0/24",
+		Status:           "ACTIVE",
+		GatewayIP:        "192.168.0.1",
+		PrimaryDNS:       "100.125.4.25",
+		SecondaryDNS:     "100.125.129.199",
+		AvailabilityZone: "eu-de-01",
+		NtpAddresses:     "10.100.0.33",
+		Scope:            "center",
+		VpcID:            "vpc-id",
+	})
+	if len(filtered) != 1 || filtered[0].ID != "first" {
+		t.Fatalf("unexpected filtered subnets: %#v", filtered)
+	}
+
+	filtered = filterSubnets(input, subnetFilters{VpcID: "other-vpc"})
+	if len(filtered) != 1 || filtered[0].ID != "second" {
+		t.Fatalf("unexpected VPC-filtered subnets: %#v", filtered)
+	}
+}
+
+func TestSubnetNtpAddresses(t *testing.T) {
+	opts := []subnets.ExtraDHCPOpt{
+		{OptName: "other", OptValue: "ignored"},
+		{OptName: "ntp", OptValue: "10.100.0.33,10.100.0.34"},
+	}
+	if actual := subnetNtpAddresses(opts); actual != "10.100.0.33,10.100.0.34" {
+		t.Fatalf("unexpected NTP addresses: %q", actual)
+	}
+	if actual := subnetNtpAddresses(nil); actual != "" {
+		t.Fatalf("expected empty NTP addresses, got %q", actual)
+	}
+}

--- a/releasenotes/notes/vpc-subnet-v1-modern-sdk-4b29a7c16e8d503f.yaml
+++ b/releasenotes/notes/vpc-subnet-v1-modern-sdk-4b29a7c16e8d503f.yaml
@@ -3,11 +3,14 @@ features:
   - |
     **[VPC]** Add description, NTP, scope, tenant, and timestamp attributes to
     ``data-source/opentelekomcloud_vpc_subnet_v1`` and expose subnet scope,
-    tenant, and timestamps on ``resource/opentelekomcloud_vpc_subnet_v1``.
+    tenant, and timestamps on ``resource/opentelekomcloud_vpc_subnet_v1``
+    (`#3534 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3534>`_)
 fixes:
   - |
     **[VPC]** Migrate ``resource/opentelekomcloud_vpc_subnet_v1`` and
     ``data-source/opentelekomcloud_vpc_subnet_v1`` to modern VPC v1 SDK operations.
+    (`#3534 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3534>`_)
   - |
     **[VPC]** Migrate ``data-source/opentelekomcloud_vpc_subnet_ids_v1`` to the
     modern VPC v1 subnet list operation.
+    (`#3534 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3534>`_)

--- a/releasenotes/notes/vpc-subnet-v1-modern-sdk-4b29a7c16e8d503f.yaml
+++ b/releasenotes/notes/vpc-subnet-v1-modern-sdk-4b29a7c16e8d503f.yaml
@@ -1,0 +1,13 @@
+---
+features:
+  - |
+    **[VPC]** Add description, NTP, scope, tenant, and timestamp attributes to
+    ``data-source/opentelekomcloud_vpc_subnet_v1`` and expose subnet scope,
+    tenant, and timestamps on ``resource/opentelekomcloud_vpc_subnet_v1``.
+fixes:
+  - |
+    **[VPC]** Migrate ``resource/opentelekomcloud_vpc_subnet_v1`` and
+    ``data-source/opentelekomcloud_vpc_subnet_v1`` to modern VPC v1 SDK operations.
+  - |
+    **[VPC]** Migrate ``data-source/opentelekomcloud_vpc_subnet_ids_v1`` to the
+    modern VPC v1 subnet list operation.


### PR DESCRIPTION
## Summary of the Pull Request


## PR Checklist

* [ ] Refers to: #xxx
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccVpcSubnetV1Basic
=== PAUSE TestAccVpcSubnetV1Basic
=== CONT  TestAccVpcSubnetV1Basic
--- PASS: TestAccVpcSubnetV1Basic (82.02s)
=== RUN   TestAccVpcSubnetV1Import
=== PAUSE TestAccVpcSubnetV1Import
=== CONT  TestAccVpcSubnetV1Import
--- PASS: TestAccVpcSubnetV1Import (67.21s)
=== RUN   TestAccVpcSubnetV1Timeout
=== PAUSE TestAccVpcSubnetV1Timeout
=== CONT  TestAccVpcSubnetV1Timeout
--- PASS: TestAccVpcSubnetV1Timeout (57.94s)
=== RUN   TestAccVpcSubnetV1Ipv6
=== PAUSE TestAccVpcSubnetV1Ipv6
=== CONT  TestAccVpcSubnetV1Ipv6
--- PASS: TestAccVpcSubnetV1Ipv6 (64.90s)
=== RUN   TestAccVpcSubnetV1DnsList
=== PAUSE TestAccVpcSubnetV1DnsList
=== CONT  TestAccVpcSubnetV1DnsList
--- PASS: TestAccVpcSubnetV1DnsList (78.62s)
PASS

Process finished with the exit code 0


=== RUN   TestAccVpcSubnetV1DataSource_basic
=== PAUSE TestAccVpcSubnetV1DataSource_basic
=== CONT  TestAccVpcSubnetV1DataSource_basic
--- PASS: TestAccVpcSubnetV1DataSource_basic (60.43s)
PASS

Process finished with the exit code 0

=== RUN   TestAccVpcSubnetIdsV1DataSource_basic
=== PAUSE TestAccVpcSubnetIdsV1DataSource_basic
=== CONT  TestAccVpcSubnetIdsV1DataSource_basic
--- PASS: TestAccVpcSubnetIdsV1DataSource_basic (81.90s)
PASS

Process finished with the exit code 0
```
