### PR TITLE
[Feat] CCE: Add arg ecs_group_id to cce_node_v3

### DIFF
--- a/docs/resources/cce_node_v3.md
+++ b/docs/resources/cce_node_v3.md
@@ -81,6 +81,9 @@ The following arguments are supported:
 
 * `subnet_id` - (Optional, ForceNew, String) The ID of the subnet to which the NIC belongs. Changing this parameter will create a new resource.
 
+* `ecs_group_id` - (Optional, ForceNew, String) Specifies the ECS group ID. If this parameter is specified, the node is created in the specified ECS group.
+  -> **NOTE:** This parameter is not supported when you add a node to a node pool or use CCE Turbo cluster.
+
 * `labels` - (Optional, ForceNew, Map) Node tag, key/value pair format. Changing this parameter will create a new resource.
 
 * `tags` - (Optional, Map) The field is alternative to `labels`, key/value pair format.

--- a/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_node_v3_test.go
+++ b/opentelekomcloud/acceptance/cce/resource_opentelekomcloud_cce_node_v3_test.go
@@ -2,6 +2,7 @@ package acceptance
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/apparentlymart/go-cidr/cidr"
@@ -514,6 +515,38 @@ func TestAccResourceCCENodesV3_extendParams(t *testing.T) {
 	})
 }
 
+func TestAccResourceCCENodesV3_ECSGroup(t *testing.T) {
+	ecsGroupId := os.Getenv("OS_ECS_GROUP_ID")
+	if ecsGroupId == "" {
+		t.Skip("Test requires env var OS_ECS_GROUP_ID")
+	}
+	var node nodes.Nodes
+
+	rc := common.InitResourceCheck(
+		resourceNameNode,
+		&node,
+		getCceNodeResourceFunc,
+	)
+
+	shared.BookCluster(t)
+	t.Parallel()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccCCEKeyPairPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCCENodeV3_EcsGroup(ecsGroupId),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceNameNode, "ecs_group_id", ecsGroupId),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckCCENodeV3Destroy(s *terraform.State) error {
 	config := common.TestAccProvider.Meta().(*cfg.Config)
 	client, err := config.CceV3Client(env.OS_REGION_NAME)
@@ -984,4 +1017,36 @@ resource "opentelekomcloud_cce_node_v3" "node_1" {
   private_ip = "%s"
 }
 `, shared.DataSourceCluster, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME, privateIP)
+}
+
+func testAccCCENodeV3_EcsGroup(ecsGroupId string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "opentelekomcloud_cce_node_v3" "node_1" {
+  cluster_id = data.opentelekomcloud_cce_cluster_v3.cluster.id
+  name       = "test-node"
+  flavor_id  = "s2.large.2"
+
+  availability_zone = "%s"
+  key_pair          = "%s"
+  runtime           = "containerd"
+  os                = "EulerOS 2.9"
+
+  root_volume {
+    size       = 40
+    volumetype = "SAS"
+  }
+
+  data_volumes {
+    size       = 100
+    volumetype = "SSD"
+    extend_params = {
+      "useType" = "docker"
+    }
+  }
+
+  ecs_group_id = "%s"
+}
+`, shared.DataSourceCluster, env.OS_AVAILABILITY_ZONE, env.OS_KEYPAIR_NAME, ecsGroupId)
 }

--- a/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_v3.go
+++ b/opentelekomcloud/services/cce/resource_opentelekomcloud_cce_node_v3.go
@@ -267,6 +267,11 @@ func ResourceCCENodeV3() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"ecs_group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 			"order_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -573,9 +578,10 @@ func resourceCCENodeV3Create(ctx context.Context, d *schema.ResourceData, meta i
 				DockerLVMConfigOverride: d.Get("docker_lvm_config_override").(string),
 				AgencyName:              d.Get("agency_name").(string),
 			},
-			UserTags: resourceCCENodeTags(d),
-			K8sTags:  resourceCCENodeK8sTags(d),
-			Taints:   resourceCCENodeTaints(d),
+			EcsGroupID: d.Get("ecs_group_id").(string),
+			UserTags:   resourceCCENodeTags(d),
+			K8sTags:    resourceCCENodeK8sTags(d),
+			Taints:     resourceCCENodeTaints(d),
 		},
 	}
 
@@ -709,6 +715,7 @@ func resourceCCENodeV3Read(ctx context.Context, d *schema.ResourceData, meta int
 		d.Set("flavor_id", node.Spec.Flavor),
 		d.Set("os", node.Spec.Os),
 		d.Set("availability_zone", node.Spec.Az),
+		d.Set("ecs_group_id", node.Spec.EcsGroupID),
 		d.Set("billing_mode", node.Spec.BillingMode),
 		d.Set("key_pair", node.Spec.Login.SshKey),
 		d.Set("server_id", serverID),

--- a/releasenotes/notes/cce-node-v3-add-arg-ecs-groip-id-56364f9f78318dd9.yaml
+++ b/releasenotes/notes/cce-node-v3-add-arg-ecs-groip-id-56364f9f78318dd9.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[CCE]** Add argument ``ecs_group_id`` in ``resource/opentelekomcloud_cce_node_v3`` (`#3535 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3535>`_)


### PR DESCRIPTION
## Summary of the Pull Request

Add argument `ecs_group_id` to resource `opentelekomcloud_cce_node_v3`

## PR Checklist

* [x] Refers to: #3519 
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccResourceCCENodesV3_ECSGroup
    resource_opentelekomcloud_cce_node_v3_test.go:531: Cluster is required by the test. 1 test(s) are using cluster.
    cluster.go:121: starting creating shared cluster
=== PAUSE TestAccResourceCCENodesV3_ECSGroup
=== CONT  TestAccResourceCCENodesV3_ECSGroup
    cluster.go:117: Cluster usage is 0 now, ready to delete the cluster
    cluster.go:80: starting deleting shared cluster
--- PASS: TestAccResourceCCENodesV3_ECSGroup (1031.34s)
PASS
```
