### PR TITLE
[Feat.] ECS: add ipv6 support

### DIFF
--- a/docs/resources/ecs_instance_v1.md
+++ b/docs/resources/ecs_instance_v1.md
@@ -151,6 +151,34 @@ resource "opentelekomcloud_networking_floatingip_associate_v2" "this" {
 }
 ```
 
+### Instance With IPv6 Shared Bandwidth
+
+```hcl
+resource "opentelekomcloud_vpc_bandwidth_v2" "ipv6" {
+  name = "ipv6-shared-bandwidth"
+  size = 5
+}
+
+resource "opentelekomcloud_ecs_instance_v1" "this" {
+  name     = "server_1"
+  image_id = "ad091b52-742f-469e-8f3c-fd81cadf0743"
+  flavor   = "s2.large.2"
+  vpc_id   = "8eed4fc7-e5e5-44a2-b5f2-23b3e5d46235"
+
+  nics {
+    network_id  = "55534eaa-533a-419d-9b40-ec427ea7195a"
+    ipv6_enable = true
+
+    ipv6_bandwidth {
+      id = opentelekomcloud_vpc_bandwidth_v2.ipv6.id
+    }
+  }
+
+  availability_zone = "eu-de-01"
+  key_name          = "KeyPair-test"
+}
+```
+
 ### Instance with User Data (cloud-init)
 
 ```hcl
@@ -323,6 +351,17 @@ The `nics` block supports:
 
   -> **NOTE:**
   IPV6 enable requires the subnet to have IPV6 enabled as well.
+
+* `ipv6_bandwidth` - (Optional, List, ForceNew) The shared bandwidth to associate with the NIC's IPv6 address.
+  This argument requires `ipv6_enable = true`. The structure is documented below.
+
+  -> **NOTE:**
+  Removing this block from the configuration does not detach the shared bandwidth: the value is kept as
+  reported by the API. Detaching requires the instance to be re-created.
+
+The `ipv6_bandwidth` block supports:
+
+* `id` - (Required, String, ForceNew) The ID of an existing shared bandwidth.
 
 The `metadata` block supports:
 

--- a/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_ecs_instance_v1_test.go
+++ b/opentelekomcloud/acceptance/ecs/resource_opentelekomcloud_ecs_instance_v1_test.go
@@ -119,6 +119,7 @@ func TestAccEcsV1InstanceIpv6(t *testing.T) {
 	}
 	var instance cloudservers.CloudServer
 	qts := serverQuotas(10+4, "s2.medium.1")
+	qts = append(qts, &quotas.ExpectedQuota{Q: quotas.SharedBandwidth, Count: 1})
 	t.Parallel()
 	quotas.BookMany(t, qts)
 
@@ -140,7 +141,18 @@ func TestAccEcsV1InstanceIpv6(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceInstanceV1Name, "availability_zone", env.OS_AVAILABILITY_ZONE),
 					resource.TestCheckResourceAttrSet(resourceInstanceV1Name, "nics.0.port_id"),
 					resource.TestCheckResourceAttrSet(resourceInstanceV1Name, "nics.0.ipv6_address"),
+					resource.TestCheckResourceAttrPair(
+						resourceInstanceV1Name, "nics.0.ipv6_bandwidth.0.id",
+						"opentelekomcloud_vpc_bandwidth_v2.ipv6", "id",
+					),
+					resource.TestCheckResourceAttr(
+						"data.opentelekomcloud_vpc_bandwidth_v2.ipv6", "publicip_info.#", "1",
+					),
 				),
+			},
+			{
+				Config:   testAccEcsV1InstanceIpv6(networkId),
+				PlanOnly: true,
 			},
 		},
 	})
@@ -838,6 +850,11 @@ data "opentelekomcloud_vpc_subnet_v1" "sub_1" {
   id = "%s"
 }
 
+resource "opentelekomcloud_vpc_bandwidth_v2" "ipv6" {
+  name = "ecs-ipv6-bandwidth"
+  size = 5
+}
+
 resource "opentelekomcloud_ecs_instance_v1" "instance_1" {
   name     = "server_1"
   image_id = data.opentelekomcloud_images_image_v2.latest_image.id
@@ -847,6 +864,10 @@ resource "opentelekomcloud_ecs_instance_v1" "instance_1" {
   nics {
     network_id  = data.opentelekomcloud_vpc_subnet_v1.sub_1.network_id
     ipv6_enable = true
+
+    ipv6_bandwidth {
+      id = opentelekomcloud_vpc_bandwidth_v2.ipv6.id
+    }
   }
 
   data_disks {
@@ -857,6 +878,12 @@ resource "opentelekomcloud_ecs_instance_v1" "instance_1" {
   password                    = "Password@123"
   availability_zone           = "%s"
   delete_disks_on_termination = true
+}
+
+data "opentelekomcloud_vpc_bandwidth_v2" "ipv6" {
+  depends_on = [opentelekomcloud_ecs_instance_v1.instance_1]
+
+  id = opentelekomcloud_vpc_bandwidth_v2.ipv6.id
 }
 	`, common.DataSourceImage, networkID, env.OS_AVAILABILITY_ZONE)
 }

--- a/opentelekomcloud/services/ecs/resource_opentelekomcloud_ecs_instance_v1.go
+++ b/opentelekomcloud/services/ecs/resource_opentelekomcloud_ecs_instance_v1.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -20,11 +21,14 @@ import (
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/ecs/v1/cloudservers"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/evs/v3/volumes"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/ports"
+	vpcBandwidths "github.com/opentelekomcloud/gophertelekomcloud/openstack/vpc/v1/bandwidths"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
 )
+
+const allGrantedEnterpriseProjects = "all_granted_eps"
 
 func ResourceEcsInstanceV1() *schema.Resource {
 	return &schema.Resource{
@@ -125,6 +129,22 @@ func ResourceEcsInstanceV1() *schema.Resource {
 						"ipv6_address": {
 							Type:     schema.TypeString,
 							Computed: true,
+						},
+						"ipv6_bandwidth": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": {
+										Type:     schema.TypeString,
+										Required: true,
+										ForceNew: true,
+									},
+								},
+							},
 						},
 						"mac_address": {
 							Type:     schema.TypeString,
@@ -858,6 +878,11 @@ func resourceInstanceNicsV1(d *schema.ResourceData) []cloudservers.Nic {
 			IpAddress:  nic["ip_address"].(string),
 			Ipv6Enable: nic["ipv6_enable"].(bool),
 		}
+		if ipv6Bandwidth := nic["ipv6_bandwidth"].([]interface{}); len(ipv6Bandwidth) > 0 {
+			nicRequest.Ipv6Bandwidth = cloudservers.Ipv6Bandwidth{
+				Id: ipv6Bandwidth[0].(map[string]interface{})["id"].(string),
+			}
+		}
 
 		nicRequests = append(nicRequests, nicRequest)
 	}
@@ -983,11 +1008,13 @@ func flattenInstanceNicsV1(d *schema.ResourceData, meta interface{}, addresses m
 			}
 
 			p, err := ports.Get(networkingClient, addr.PortID).Extract()
+			var ipv6BandwidthID string
 			if err != nil {
 				network = ""
 				log.Printf("[DEBUG] flattenInstanceNicsV1: failed to fetch port %s", addr.PortID)
 			} else {
 				network = p.NetworkID
+				ipv6BandwidthID = p.Ipv6BandwidthId
 			}
 
 			if addr.Version == "4" {
@@ -999,6 +1026,11 @@ func flattenInstanceNicsV1(d *schema.ResourceData, meta interface{}, addresses m
 					"type":         addr.Type,
 					"ipv6_enable":  false,
 					"ipv6_address": "",
+				}
+				if ipv6BandwidthID != "" {
+					v["ipv6_bandwidth"] = []map[string]interface{}{
+						{"id": ipv6BandwidthID},
+					}
 				}
 				nics = append(nics, v)
 			}
@@ -1019,6 +1051,58 @@ func flattenInstanceNicsV1(d *schema.ResourceData, meta interface{}, addresses m
 		}
 	}
 
+	resolveIPv6Bandwidth := newIPv6BandwidthResolver(d, config)
+	for _, nic := range nics {
+		if nic["ipv6_enable"] != true {
+			continue
+		}
+		if _, ok := nic["ipv6_bandwidth"]; ok {
+			continue
+		}
+		if id := resolveIPv6Bandwidth(nic["port_id"].(string)); id != "" {
+			nic["ipv6_bandwidth"] = []map[string]interface{}{
+				{"id": id},
+			}
+		}
+	}
+
 	log.Printf("[DEBUG] flattenInstanceNicsV1: %#v", nics)
 	return nics
+}
+
+func newIPv6BandwidthResolver(d *schema.ResourceData, config *cfg.Config) func(portID string) string {
+	var (
+		once             sync.Once
+		bandwidthsByPort map[string]string
+	)
+
+	return func(portID string) string {
+		once.Do(func() {
+			bandwidthsByPort = make(map[string]string)
+
+			client, err := config.VpcV1Client(config.GetRegion(d))
+			if err != nil {
+				log.Printf("[DEBUG] error creating OpenTelekomCloud VPC v1 client: %s", err)
+				return
+			}
+
+			bandwidths, err := vpcBandwidths.List(client, vpcBandwidths.ListOpts{
+				EnterpriseProjectId: config.GetEnterpriseProjectID(d, allGrantedEnterpriseProjects),
+			})
+			if err != nil {
+				log.Printf("[DEBUG] error listing IPv6 shared bandwidths: %s", err)
+				return
+			}
+
+			for _, bandwidth := range bandwidths {
+				for _, publicIP := range bandwidth.PublicipInfo {
+					if publicIP.IPVersion == 6 {
+						bandwidthsByPort[publicIP.PublicipId] = bandwidth.ID
+					}
+				}
+			}
+		})
+
+		return bandwidthsByPort[portID]
+	}
 }

--- a/releasenotes/notes/ecs-instance-ipv6-bandwidth-3384.yaml
+++ b/releasenotes/notes/ecs-instance-ipv6-bandwidth-3384.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    **[ECS]** Added ``nics/ipv6_bandwidth`` to ``resource/opentelekomcloud_ecs_instance_v1`` for associating an existing shared bandwidth with an IPv6 NIC (`#3384 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)

--- a/releasenotes/notes/ecs-instance-ipv6-bandwidth-3384.yaml
+++ b/releasenotes/notes/ecs-instance-ipv6-bandwidth-3384.yaml
@@ -1,4 +1,4 @@
 ---
 enhancements:
   - |
-    **[ECS]** Added ``nics/ipv6_bandwidth`` to ``resource/opentelekomcloud_ecs_instance_v1`` for associating an existing shared bandwidth with an IPv6 NIC (`#3384 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    **[ECS]** Added ``nics/ipv6_bandwidth`` to ``resource/opentelekomcloud_ecs_instance_v1`` for associating an existing shared bandwidth with an IPv6 NIC (`#3544 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3544>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Adds IPv6 shared bandwidth support to  opentelekomcloud_ecs_instance_v1  NICs via the new  ipv6_bandwidth  block.

## PR Checklist

* [x] Refers to: #3384
* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
 ● --- PASS: TestAccEcsV1InstanceIpv6 (152.81s)                                                                                                                ┃
   PASS                                                                                                                                                        ┃
   ok      github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/ecs 158.366s        
```
