### PR TITLE
[Fix.] CTS: send full configuration on tracker v3 update

### DIFF
--- a/docs/resources/cts_tracker_v3.md
+++ b/docs/resources/cts_tracker_v3.md
@@ -37,7 +37,9 @@ The following arguments are supported:
 
 * `is_lts_enabled` - (Optional, Boolean) Specifies whether to enable trace analysis.
 
-* `is_support_validate` (Optional, Boolean) Specifies whether trace file verification is enabled for trace transfer. When this function is enabled, integrity verification will be performed to check whether trace files in OBS buckets have been tampered with.
+* `is_support_validate` - (Optional, Boolean) Specifies whether trace file verification is enabled for trace transfer.
+  When this function is enabled, integrity verification will be performed to check whether trace files in OBS buckets
+  have been tampered with.
 
 * `bucket_name` - (Optional, String) The OBS bucket name for a tracker.
 
@@ -46,7 +48,7 @@ The following arguments are supported:
 * `is_obs_created` - (Optional, Boolean) Specifies whether the OBS bucket is automatically created by the tracker.
 
 * `is_sort_by_service` - (Optional, Boolean) Specifies whether to sort the path by cloud service. If this option is enabled,
-  the cloud service name is added to the transfer file path. Default: `true`.
+  the cloud service name is added to the transfer file path. If omitted, the value currently set on the tracker is kept.
 
 * `compress_type` - (Optional, String) Specifies the compression type. Default value is `gzip`.
   The valid values are as follows:

--- a/opentelekomcloud/acceptance/cts/resource_opentelekomcloud_cts_tracker_v3_test.go
+++ b/opentelekomcloud/acceptance/cts/resource_opentelekomcloud_cts_tracker_v3_test.go
@@ -65,10 +65,12 @@ func TestAccCTSTrackerV3_supportValidate(t *testing.T) {
 		CheckDestroy:      testAccCheckCTSTrackerV3Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCTSTrackerV3SupportValidate(bucketName, false),
+				Config: testAccCTSTrackerV3SupportValidate(bucketName, false, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCTSTrackerV3Exists(trackerV3Resource, &ctsTracker, env.OS_TENANT_NAME),
 					resource.TestCheckResourceAttr(trackerV3Resource, "bucket_name", bucketName),
+					resource.TestCheckResourceAttr(trackerV3Resource, "file_prefix_name", "yO8Q"),
+					resource.TestCheckResourceAttr(trackerV3Resource, "compress_type", "gzip"),
 					resource.TestCheckResourceAttr(trackerV3Resource, "is_lts_enabled", "true"),
 					resource.TestCheckResourceAttr(trackerV3Resource, "is_support_validate", "false"),
 					resource.TestCheckResourceAttr(trackerV3Resource, "is_sort_by_service", "false"),
@@ -78,13 +80,30 @@ func TestAccCTSTrackerV3_supportValidate(t *testing.T) {
 			{
 				// enabling `is_support_validate` alone must not reset the rest of
 				// the tracker configuration, see #3541
-				Config: testAccCTSTrackerV3SupportValidate(bucketName, true),
+				Config: testAccCTSTrackerV3SupportValidate(bucketName, true, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCTSTrackerV3Exists(trackerV3Resource, &ctsTracker, env.OS_TENANT_NAME),
 					resource.TestCheckResourceAttr(trackerV3Resource, "bucket_name", bucketName),
+					resource.TestCheckResourceAttr(trackerV3Resource, "file_prefix_name", "yO8Q"),
+					resource.TestCheckResourceAttr(trackerV3Resource, "compress_type", "gzip"),
 					resource.TestCheckResourceAttr(trackerV3Resource, "is_lts_enabled", "true"),
 					resource.TestCheckResourceAttr(trackerV3Resource, "is_support_validate", "true"),
 					resource.TestCheckResourceAttr(trackerV3Resource, "is_sort_by_service", "false"),
+					resource.TestCheckResourceAttr(trackerV3Resource, "status", "enabled"),
+				),
+			},
+			{
+				// the other half of the #3541 loop: changing an unrelated argument
+				// must not reset `is_support_validate` back to `false`
+				Config: testAccCTSTrackerV3SupportValidate(bucketName, true, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCTSTrackerV3Exists(trackerV3Resource, &ctsTracker, env.OS_TENANT_NAME),
+					resource.TestCheckResourceAttr(trackerV3Resource, "bucket_name", bucketName),
+					resource.TestCheckResourceAttr(trackerV3Resource, "file_prefix_name", "yO8Q"),
+					resource.TestCheckResourceAttr(trackerV3Resource, "compress_type", "gzip"),
+					resource.TestCheckResourceAttr(trackerV3Resource, "is_lts_enabled", "true"),
+					resource.TestCheckResourceAttr(trackerV3Resource, "is_support_validate", "true"),
+					resource.TestCheckResourceAttr(trackerV3Resource, "is_sort_by_service", "true"),
 					resource.TestCheckResourceAttr(trackerV3Resource, "status", "enabled"),
 				),
 			},
@@ -164,6 +183,10 @@ func testAccCheckCTSTrackerV3Exists(n string, trackers *tracker.Tracker, project
 			return err
 		}
 
+		if len(ctsTracker) == 0 {
+			return fmt.Errorf("CTS tracker not found")
+		}
+
 		if ctsTracker[0].TrackerName != rs.Primary.ID {
 			return fmt.Errorf("CTS tracker not found")
 		}
@@ -212,7 +235,7 @@ resource "opentelekomcloud_cts_tracker_v3" "tracker_v3" {
 `, bucketName)
 }
 
-func testAccCTSTrackerV3SupportValidate(bucketName string, supportValidate bool) string {
+func testAccCTSTrackerV3SupportValidate(bucketName string, supportValidate, sortByService bool) string {
 	return fmt.Sprintf(`
 resource "opentelekomcloud_obs_bucket" "bucket" {
   bucket        = "%s"
@@ -222,13 +245,15 @@ resource "opentelekomcloud_obs_bucket" "bucket" {
 
 resource "opentelekomcloud_cts_tracker_v3" "tracker_v3" {
   bucket_name         = opentelekomcloud_obs_bucket.bucket.bucket
+  file_prefix_name    = "yO8Q"
+  compress_type       = "gzip"
   is_lts_enabled      = true
   is_obs_created      = false
-  is_sort_by_service  = false
+  is_sort_by_service  = %t
   is_support_validate = %t
   status              = "enabled"
 }
-`, bucketName, supportValidate)
+`, bucketName, sortByService, supportValidate)
 }
 
 func testAccCTSTrackerV3ImportBasic(bucketName string) string {

--- a/opentelekomcloud/acceptance/cts/resource_opentelekomcloud_cts_tracker_v3_test.go
+++ b/opentelekomcloud/acceptance/cts/resource_opentelekomcloud_cts_tracker_v3_test.go
@@ -55,6 +55,43 @@ func TestAccCTSTrackerV3_basic(t *testing.T) {
 	})
 }
 
+func TestAccCTSTrackerV3_supportValidate(t *testing.T) {
+	var ctsTracker tracker.Tracker
+	var bucketName = fmt.Sprintf("terra-test-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { common.TestAccPreCheck(t) },
+		ProviderFactories: common.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckCTSTrackerV3Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCTSTrackerV3SupportValidate(bucketName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCTSTrackerV3Exists(trackerV3Resource, &ctsTracker, env.OS_TENANT_NAME),
+					resource.TestCheckResourceAttr(trackerV3Resource, "bucket_name", bucketName),
+					resource.TestCheckResourceAttr(trackerV3Resource, "is_lts_enabled", "true"),
+					resource.TestCheckResourceAttr(trackerV3Resource, "is_support_validate", "false"),
+					resource.TestCheckResourceAttr(trackerV3Resource, "is_sort_by_service", "false"),
+					resource.TestCheckResourceAttr(trackerV3Resource, "status", "enabled"),
+				),
+			},
+			{
+				// enabling `is_support_validate` alone must not reset the rest of
+				// the tracker configuration, see #3541
+				Config: testAccCTSTrackerV3SupportValidate(bucketName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCTSTrackerV3Exists(trackerV3Resource, &ctsTracker, env.OS_TENANT_NAME),
+					resource.TestCheckResourceAttr(trackerV3Resource, "bucket_name", bucketName),
+					resource.TestCheckResourceAttr(trackerV3Resource, "is_lts_enabled", "true"),
+					resource.TestCheckResourceAttr(trackerV3Resource, "is_support_validate", "true"),
+					resource.TestCheckResourceAttr(trackerV3Resource, "is_sort_by_service", "false"),
+					resource.TestCheckResourceAttr(trackerV3Resource, "status", "enabled"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccCTSTrackerV3_importBasic(t *testing.T) {
 	var bucketName = fmt.Sprintf("terra-test-%s", acctest.RandString(5))
 
@@ -173,6 +210,25 @@ resource "opentelekomcloud_cts_tracker_v3" "tracker_v3" {
   is_support_validate = true
 }
 `, bucketName)
+}
+
+func testAccCTSTrackerV3SupportValidate(bucketName string, supportValidate bool) string {
+	return fmt.Sprintf(`
+resource "opentelekomcloud_obs_bucket" "bucket" {
+  bucket        = "%s"
+  acl           = "public-read"
+  force_destroy = true
+}
+
+resource "opentelekomcloud_cts_tracker_v3" "tracker_v3" {
+  bucket_name         = opentelekomcloud_obs_bucket.bucket.bucket
+  is_lts_enabled      = true
+  is_obs_created      = false
+  is_sort_by_service  = false
+  is_support_validate = %t
+  status              = "enabled"
+}
+`, bucketName, supportValidate)
 }
 
 func testAccCTSTrackerV3ImportBasic(bucketName string) string {

--- a/opentelekomcloud/services/cts/resource_opentelekomcloud_cts_tracker_v3.go
+++ b/opentelekomcloud/services/cts/resource_opentelekomcloud_cts_tracker_v3.go
@@ -179,7 +179,13 @@ func resourceCTSTrackerV3Read(_ context.Context, d *schema.ResourceData, meta in
 
 	ctsTracker, err := tracker.List(client, trackerName)
 	if err != nil {
-		return fmterr.Errorf("error retrieving cts tracker: %w", err)
+		// a tracker deleted outside of terraform answers with 404 CTS.0214
+		return common.CheckDeletedDiag(d, err, "error retrieving cts tracker")
+	}
+
+	if len(ctsTracker) == 0 {
+		d.SetId("")
+		return nil
 	}
 
 	if len(ctsTracker) > 1 {

--- a/opentelekomcloud/services/cts/resource_opentelekomcloud_cts_tracker_v3.go
+++ b/opentelekomcloud/services/cts/resource_opentelekomcloud_cts_tracker_v3.go
@@ -144,17 +144,30 @@ func resourceCTSTrackerV3Create(ctx context.Context, d *schema.ResourceData, met
 	d.SetId(ctsTracker.TrackerName)
 
 	if d.Get("status").(string) == "disabled" {
-		_, err = tracker.Update(client, tracker.UpdateOpts{
-			TrackerType: trackerName,
-			TrackerName: trackerName,
-			Status:      "disabled",
-		})
-		if err != nil {
+		updateOpts := ctsTrackerV3UpdateOpts(d)
+		updateOpts.Status = "disabled"
+		if _, err = tracker.Update(client, updateOpts); err != nil {
 			return fmterr.Errorf("error setting CTS tracker status: %w", err)
 		}
 	}
 
 	return resourceCTSTrackerV3Read(ctx, d, meta)
+}
+
+func ctsTrackerV3UpdateOpts(d *schema.ResourceData) tracker.UpdateOpts {
+	return tracker.UpdateOpts{
+		TrackerType:       trackerName,
+		TrackerName:       trackerName,
+		IsLtsEnabled:      pointerto.Bool(d.Get("is_lts_enabled").(bool)),
+		IsSupportValidate: pointerto.Bool(d.Get("is_support_validate").(bool)),
+		ObsInfo: tracker.ObsInfo{
+			BucketName:      d.Get("bucket_name").(string),
+			FilePrefixName:  d.Get("file_prefix_name").(string),
+			IsObsCreated:    pointerto.Bool(d.Get("is_obs_created").(bool)),
+			CompressType:    d.Get("compress_type").(string),
+			IsSortByService: pointerto.Bool(d.Get("is_sort_by_service").(bool)),
+		},
+	}
 }
 
 func resourceCTSTrackerV3Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -204,65 +217,28 @@ func resourceCTSTrackerV3Update(ctx context.Context, d *schema.ResourceData, met
 	if err != nil {
 		return fmterr.Errorf(clientError, err)
 	}
-	updateOpts := tracker.UpdateOpts{
-		TrackerType: trackerName,
-		TrackerName: trackerName,
-	}
-
-	oldStatus, newStatus := d.GetChange("status")
-	if oldStatus.(string) == "disabled" {
-		// tracker needs to be enabled for other parameters to be applied
+	// a disabled tracker has to be enabled first, otherwise other parameters are not applied
+	if oldStatus, _ := d.GetChange("status"); oldStatus.(string) == "disabled" {
 		_, err = tracker.Update(client, tracker.UpdateOpts{
 			TrackerType: trackerName,
 			TrackerName: trackerName,
 			Status:      "enabled",
 		})
 		if err != nil {
-			return fmterr.Errorf("error updating CTS tracker: %w", err)
+			return fmterr.Errorf("error enabling CTS tracker: %w", err)
 		}
 	}
 
-	if d.HasChange("status") {
-		updateOpts.Status = d.Get("status").(string)
-	}
-	if d.HasChange("is_lts_enabled") {
-		updateOpts.IsLtsEnabled = pointerto.Bool(d.Get("is_lts_enabled").(bool))
-	}
-	if d.HasChange("is_support_validate") {
-		updateOpts.IsSupportValidate = pointerto.Bool(d.Get("is_support_validate").(bool))
-	}
-	if d.HasChange("bucket_name") {
-		updateOpts.ObsInfo.BucketName = d.Get("bucket_name").(string)
-	}
-	if d.HasChange("file_prefix_name") {
-		updateOpts.ObsInfo.FilePrefixName = d.Get("file_prefix_name").(string)
-		updateOpts.ObsInfo.BucketName = d.Get("bucket_name").(string)
-	}
-	if d.HasChange("is_obs_created") {
-		updateOpts.ObsInfo.IsObsCreated = pointerto.Bool(d.Get("is_obs_created").(bool))
-	}
+	updateOpts := ctsTrackerV3UpdateOpts(d)
+	updateOpts.Status = "enabled"
 
-	if d.HasChange("is_sort_by_service") {
-		updateOpts.ObsInfo.IsSortByService = pointerto.Bool(d.Get("is_sort_by_service").(bool))
-	}
-
-	if d.HasChange("compress_type") {
-		updateOpts.ObsInfo.CompressType = d.Get("compress_type").(string)
-	}
-
-	_, err = tracker.Update(client, updateOpts)
-	if err != nil {
+	if _, err = tracker.Update(client, updateOpts); err != nil {
 		return fmterr.Errorf("error updating CTS tracker: %w", err)
 	}
 
-	// disable tracker in case when status changed from enabled to disabled
-	if oldStatus.(string) != newStatus.(string) && newStatus.(string) == "disabled" {
-		_, err = tracker.Update(client, tracker.UpdateOpts{
-			TrackerType: trackerName,
-			TrackerName: trackerName,
-			Status:      "disabled",
-		})
-		if err != nil {
+	if d.Get("status").(string) == "disabled" {
+		updateOpts.Status = "disabled"
+		if _, err = tracker.Update(client, updateOpts); err != nil {
 			return fmterr.Errorf("error updating CTS tracker: %w", err)
 		}
 	}

--- a/releasenotes/notes/cts-tracker-v3-full-update-3541.yaml
+++ b/releasenotes/notes/cts-tracker-v3-full-update-3541.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    **[CTS]** Fix ``resource/opentelekomcloud_cts_tracker_v3`` resetting the whole tracker configuration when a
+    single argument is changed (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)

--- a/releasenotes/notes/cts-tracker-v3-full-update-3541.yaml
+++ b/releasenotes/notes/cts-tracker-v3-full-update-3541.yaml
@@ -2,4 +2,4 @@
 fixes:
   - |
     **[CTS]** Fix ``resource/opentelekomcloud_cts_tracker_v3`` resetting the whole tracker configuration when a
-    single argument is changed (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    single argument is changed (`#3548 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3548>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Update only sent changed fields, but the CTS PUT replaces the whole configuration so changing one argument wiped the OBS settings and left the tracker in a loop. Now the full configuration is sent.

## PR Checklist

* [x] Refers to: #3541
* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
=== RUN   TestAccCTSTrackerV3_supportValidate
--- PASS: TestAccCTSTrackerV3_supportValidate (244.41s)
PASS
ok    github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/cts 248.059s

=== RUN   TestAccCTSTrackerV3_basic
--- PASS: TestAccCTSTrackerV3_basic (171.83s)
=== RUN   TestAccCTSTrackerV3_importBasic
--- PASS: TestAccCTSTrackerV3_importBasic (120.41s)
PASS
ok    github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/acceptance/cts 295.964s
```
