### PR TITLE
[Feat.] IAM: Support auth scope lookup without token

### DIFF
--- a/docs/data-sources/identity_auth_scope_v3.md
+++ b/docs/data-sources/identity_auth_scope_v3.md
@@ -26,8 +26,20 @@ data "opentelekomcloud_identity_auth_scope_v3" "scope" {
 * `name` - (Required) The name of the scope. This is an arbitrary name which is
   only used as a unique identifier so an actual token isn't used as the ID.
 
--> This data source requires `token` in order to get authentication information.
-You need to set `OS_TOKEN` env variable or fill it in terraform config.
+## Authentication
+
+The data source supports token, username/password, and permanent AK/SK authentication.
+
+With token or username/password authentication, the attributes are populated from the
+token representing the current authentication scope. Project attributes are empty for
+a domain-scoped token, and domain attributes are empty for a project-scoped token.
+
+With AK/SK authentication, no token is issued. The current user is resolved from the
+configured `access_key`, while the project and user domain attributes are obtained from
+the provider authentication context. The `roles`, `domain_id`, and `domain_name`
+attributes are empty because AK/SK authentication is project-scoped.
+
+-> Temporary AK/SK credentials configured with `security_token` are not supported.
 
 ## Attributes Reference
 
@@ -40,6 +52,10 @@ You need to set `OS_TOKEN` env variable or fill it in terraform config.
 * `user_domain_name` - The domain name of the user.
 
 * `user_domain_id` - The domain ID of the user.
+
+* `domain_name` - The domain name of the scope. Only set for a domain-scoped token, empty otherwise.
+
+* `domain_id` - The domain ID of the scope. Only set for a domain-scoped token, empty otherwise.
 
 * `project_name` - The project name of the scope.
 

--- a/opentelekomcloud/acceptance/iam/data_source_opentelekomcloud_identity_auth_scope_v3_test.go
+++ b/opentelekomcloud/acceptance/iam/data_source_opentelekomcloud_identity_auth_scope_v3_test.go
@@ -12,8 +12,7 @@ import (
 )
 
 func TestAccOpenTelekomCloudIdentityAuthScopeV3DataSource_basic(t *testing.T) {
-	userName := os.Getenv("OS_USERNAME")
-	projectName := os.Getenv("OS_PROJECT_NAME")
+	const dsName = "data.opentelekomcloud_identity_auth_scope_v3.token"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { common.TestAccPreCheck(t) },
@@ -22,15 +21,21 @@ func TestAccOpenTelekomCloudIdentityAuthScopeV3DataSource_basic(t *testing.T) {
 			{
 				Config: testAccOpenTelekomCloudIdentityAuthScopeV3DataSource_basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIdentityAuthScopeV3DataSourceID("data.opentelekomcloud_identity_auth_scope_v3.token"),
-					resource.TestCheckResourceAttr(
-						"data.opentelekomcloud_identity_auth_scope_v3.token", "user_name", userName),
-					resource.TestCheckResourceAttr(
-						"data.opentelekomcloud_identity_auth_scope_v3.token", "project_name", projectName),
+					testAccCheckIdentityAuthScopeV3DataSourceID(dsName),
+					resource.TestCheckResourceAttrSet(dsName, "user_id"),
+					checkAttrEqualsEnvOrSet(dsName, "user_name", "OS_USERNAME"),
+					checkAttrEqualsEnvOrSet(dsName, "project_name", "OS_PROJECT_NAME"),
 				),
 			},
 		},
 	})
+}
+
+func checkAttrEqualsEnvOrSet(name, key, envVar string) resource.TestCheckFunc {
+	if expected := os.Getenv(envVar); expected != "" {
+		return resource.TestCheckResourceAttr(name, key, expected)
+	}
+	return resource.TestCheckResourceAttrSet(name, key)
 }
 
 func testAccCheckIdentityAuthScopeV3DataSourceID(n string) resource.TestCheckFunc {

--- a/opentelekomcloud/services/iam/data_source_opentelekomcloud_identity_auth_scope_v3.go
+++ b/opentelekomcloud/services/iam/data_source_opentelekomcloud_identity_auth_scope_v3.go
@@ -2,13 +2,17 @@ package iam
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/identity/v3/credentials"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/identity/v3/tokens"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/identity/v3/users"
 
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/cfg"
 	"github.com/opentelekomcloud/terraform-provider-opentelekomcloud/opentelekomcloud/common/fmterr"
@@ -109,11 +113,33 @@ func dataSourceIdentityAuthScopeV3Read(_ context.Context, d *schema.ResourceData
 	if err != nil {
 		return fmterr.Errorf("error creating OpenTelekomCloud identity client: %s", err)
 	}
-	tokenID := config.Token
 
 	d.SetId(d.Get("name").(string))
+	if err := d.Set("region", config.GetRegion(d)); err != nil {
+		return diag.FromErr(err)
+	}
 
-	result := tokens.Get(identityClient, tokenID)
+	if tokenID := authScopeTokenID(config); tokenID != "" {
+		return authScopeFromToken(d, identityClient, tokenID)
+	}
+	return authScopeFromAKSK(d, config, identityClient)
+}
+
+func authScopeTokenID(config *cfg.Config) string {
+	if config.Token != "" {
+		return config.Token
+	}
+	if config.HwClient != nil && config.HwClient.Token() != "" {
+		return config.HwClient.Token()
+	}
+	if config.DomainClient != nil {
+		return config.DomainClient.Token()
+	}
+	return ""
+}
+
+func authScopeFromToken(d *schema.ResourceData, client *golangsdk.ServiceClient, tokenID string) diag.Diagnostics {
+	result := tokens.Get(client, tokenID)
 	if result.Err != nil {
 		return diag.FromErr(result.Err)
 	}
@@ -184,9 +210,92 @@ func dataSourceIdentityAuthScopeV3Read(_ context.Context, d *schema.ResourceData
 		log.Printf("[DEBUG] Unable to set opentelekomcloud_identity_auth_scope_v3 roles: %s", err)
 	}
 
-	_ = d.Set("region", config.GetRegion(d))
-
 	return nil
+}
+
+// authScopeFromAKSK resolves the auth scope for AK/SK authentication, which
+// provides no token to introspect. The owning user is looked up by the access
+// key, and the remaining scope is taken from the authenticated clients.
+func authScopeFromAKSK(d *schema.ResourceData, config *cfg.Config, client *golangsdk.ServiceClient) diag.Diagnostics {
+	// The identity client is derived from the domain client, so the domain client's
+	// options describe the credentials the lookup below is actually signed with.
+	// They differ from the provider configuration when an agency is assumed.
+	akskOpts := golangsdk.AKSKAuthOptions{}
+	if config.DomainClient != nil {
+		akskOpts = config.DomainClient.AKSKOptions()
+	}
+
+	if config.AgencyName != "" && config.AgencyDomainName != "" {
+		return fmterr.Errorf("unable to determine the auth scope: an agency assumed with AK/SK authentication is " +
+			"backed by temporary credentials which can't be resolved to a user, use username/password or " +
+			"token authentication")
+	}
+	if config.SecurityToken != "" || akskOpts.SecurityToken != "" {
+		return fmterr.Errorf("unable to determine the auth scope: temporary AK/SK credentials are not queryable, " +
+			"use permanent AK/SK, username/password or token authentication")
+	}
+	accessKey := akskOpts.AccessKey
+	if accessKey == "" {
+		accessKey = config.AccessKey
+	}
+	if accessKey == "" {
+		return fmterr.Errorf("unable to determine the auth scope: neither a token nor an access key is available")
+	}
+
+	credential, err := credentials.Get(client, accessKey).Extract()
+	if err != nil {
+		return fmterr.Errorf("error retrieving the user of the configured access key: %s", err)
+	}
+
+	projectOpts := golangsdk.AKSKAuthOptions{}
+	if config.HwClient != nil {
+		projectOpts = config.HwClient.AKSKOptions()
+	}
+	domainName := config.DomainName
+	if domainName == "" {
+		domainName = akskOpts.Domain
+	}
+
+	domainID := config.GetDomainID()
+
+	var diags diag.Diagnostics
+	userName := ""
+	user, err := users.Get(client, credential.UserID).Extract()
+	if err != nil {
+		log.Printf("[WARN] Unable to retrieve details of user %s: %s", credential.UserID, err)
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  "Unable to retrieve the name of the current user",
+			Detail: fmt.Sprintf("The IAM user owning the configured access key can't be read, so `user_name` is "+
+				"left empty. Querying an IAM user requires the corresponding IAM permissions: %s", err),
+		})
+	} else {
+		userName = user.Name
+		if user.DomainID != "" {
+			domainID = user.DomainID
+		}
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("user_id", credential.UserID),
+		d.Set("user_name", userName),
+		d.Set("user_domain_id", domainID),
+		d.Set("user_domain_name", domainName),
+		// AK/SK is always project-scoped, so the domain scope stays empty.
+		d.Set("domain_id", ""),
+		d.Set("domain_name", ""),
+		d.Set("project_id", projectOpts.ProjectId),
+		d.Set("project_name", projectOpts.ProjectName),
+		d.Set("project_domain_id", domainID),
+		d.Set("project_domain_name", domainName),
+		// Role assignments are only exposed by token introspection.
+		d.Set("roles", []map[string]string{}),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return diags
 }
 
 func flattenIdentityAuthScopeV3Roles(roles []tokens.Role) []map[string]string {

--- a/releasenotes/notes/iam-auth-scope-non-token-auth-3545.yaml
+++ b/releasenotes/notes/iam-auth-scope-non-token-auth-3545.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    **[IAM]** ``data_source/opentelekomcloud_identity_auth_scope_v3`` now works with username/password and AK/SK
+    authentication instead of requiring a token (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)

--- a/releasenotes/notes/iam-auth-scope-non-token-auth-3545.yaml
+++ b/releasenotes/notes/iam-auth-scope-non-token-auth-3545.yaml
@@ -2,4 +2,4 @@
 features:
   - |
     **[IAM]** ``data_source/opentelekomcloud_identity_auth_scope_v3`` now works with username/password and AK/SK
-    authentication instead of requiring a token (`# <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/>`_)
+    authentication instead of requiring a token (`#3553 <https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/3553>`_)


### PR DESCRIPTION
## Summary of the Pull Request
Extend `opentelekomcloud_identity_auth_scope_v3` to support username/password and permanent AK/SK authentication without requiring an explicitly configured token.
For AK/SK authentication, the data source resolves the current user from the configured access key. Roles and domain scope attributes remain empty because AK/SK authentication is project-scoped.    

## PR Checklist

* [x] Refers to: #3545
* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.
* [x] Release notes added.

## Acceptance Steps Performed

```
Username/password authentication

=== RUN   TestAccOpenTelekomCloudIdentityAuthScopeV3DataSource_basic
--- PASS: TestAccOpenTelekomCloudIdentityAuthScopeV3DataSource_basic (25.20s)
PASS

Process finished with exit code 0

AK/SK authentication

=== RUN   TestAccOpenTelekomCloudIdentityAuthScopeV3DataSource_basic
--- PASS: TestAccOpenTelekomCloudIdentityAuthScopeV3DataSource_basic (85.33s)
PASS

Process finished with exit code 0
```
